### PR TITLE
fix: merge project config and bind oauth auth callback

### DIFF
--- a/.changeset/project-config-oauth-schema.md
+++ b/.changeset/project-config-oauth-schema.md
@@ -1,0 +1,5 @@
+---
+"caplets": patch
+---
+
+Load project config from `./.caplets/config.json` alongside user config, with project values taking precedence while preserving user-only servers. Fix OAuth login token exchange for clients with secret authentication, and clarify generated Caplets tool descriptions so downstream tool inputs are passed under `call_tool.arguments`.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -218,13 +218,13 @@ export class FileOAuthProvider implements OAuthClientProvider {
     return this.verifier;
   }
 
-  async addClientAuthentication(headers: Headers, params: URLSearchParams): Promise<void> {
+  addClientAuthentication = async (headers: Headers, params: URLSearchParams): Promise<void> => {
     if (this.server.auth?.type !== "oauth2" || !this.server.auth.clientSecret) {
       return;
     }
     params.set("client_secret", this.server.auth.clientSecret);
     headers.set("content-type", "application/x-www-form-urlencoded");
-  }
+  };
 }
 
 export async function runOAuthFlow(

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,6 +69,7 @@ const FORBIDDEN_HEADERS = new Set([
 
 export const DEFAULT_CONFIG_PATH = join(homedir(), ".caplets", "config.json");
 export const DEFAULT_AUTH_DIR = join(homedir(), ".caplets", "auth");
+export const PROJECT_CONFIG_FILE = join(".caplets", "config.json");
 
 const remoteAuthSchema = z
   .discriminatedUnion("type", [
@@ -249,13 +250,28 @@ export function resolveConfigPath(path?: string): string {
   return path ?? join(homedir(), ".caplets", "config.json");
 }
 
-export function loadConfig(path = resolveConfigPath()): CapletsConfig {
-  if (!existsSync(path)) {
-    throw new CapletsError("CONFIG_NOT_FOUND", `Caplets config not found at ${path}`);
+export function resolveProjectConfigPath(cwd = process.cwd()): string {
+  return join(cwd, PROJECT_CONFIG_FILE);
+}
+
+export function loadConfig(
+  path = resolveConfigPath(),
+  projectPath = resolveProjectConfigPath(),
+): CapletsConfig {
+  const hasUserConfig = existsSync(path);
+  const hasProjectConfig = existsSync(projectPath);
+
+  if (!hasUserConfig && !hasProjectConfig) {
+    throw new CapletsError(
+      "CONFIG_NOT_FOUND",
+      `Caplets config not found at ${path} or ${projectPath}`,
+    );
   }
 
   try {
-    return parseConfig(JSON.parse(readFileSync(path, "utf8")));
+    const projectConfig = hasProjectConfig ? readConfigFile(projectPath) : undefined;
+    const userConfig = hasUserConfig ? readConfigFile(path) : undefined;
+    return parseConfig(mergeConfigInputs(projectConfig, userConfig));
   } catch (error) {
     if (error instanceof CapletsError) {
       throw error;
@@ -266,6 +282,46 @@ export function loadConfig(path = resolveConfigPath()): CapletsConfig {
       redactSecrets(error),
     );
   }
+}
+
+function readConfigFile(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Caplets config at ${path} is not valid JSON`,
+      redactSecrets(error),
+    );
+  }
+}
+
+function mergeConfigInputs(projectConfig: unknown, userConfig: unknown): unknown {
+  if (projectConfig === undefined) {
+    return userConfig;
+  }
+  if (userConfig === undefined) {
+    return projectConfig;
+  }
+  if (!isPlainConfigObject(projectConfig) || !isPlainConfigObject(userConfig)) {
+    return userConfig;
+  }
+
+  return {
+    ...userConfig,
+    ...projectConfig,
+    mcpServers: {
+      ...userConfig.mcpServers,
+      ...projectConfig.mcpServers,
+    },
+  };
+}
+
+function isPlainConfigObject(value: unknown): value is {
+  mcpServers?: Record<string, unknown>;
+  [key: string]: unknown;
+} {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 export function parseConfig(input: unknown): CapletsConfig {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -79,6 +79,15 @@ export class ServerRegistry {
 }
 
 export function capabilityDescription(server: CapletServerConfig): string {
-  const hint = `Use this tool to inspect and call tools from ${server.server}. Start with search_tools or list_tools; use get_tool for schema; use call_tool to invoke.`;
+  const hint = [
+    `Use this Caplets wrapper to inspect and call tools from ${server.server}.`,
+    "",
+    "Recommended flow:",
+    '- Discover tools: {"operation":"list_tools"} or {"operation":"search_tools","query":"<what you need>"}',
+    '- Read one tool schema: {"operation":"get_tool","tool":"<tool name>"}',
+    '- Invoke one downstream tool: {"operation":"call_tool","tool":"<tool name>","arguments":{...}}',
+    "",
+    'Important: call_tool requires a top-level "arguments" JSON object containing the downstream tool inputs. Do not put downstream arguments at the top level of this wrapper request.',
+  ].join("\n");
   return `${server.name}\n\n${server.description}\n\n${hint}`;
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -17,19 +17,39 @@ const operationSchema = z.enum(operations);
 
 export const generatedToolInputSchema = z
   .object({
-    operation: operationSchema.describe("Operation to perform for this configured MCP server."),
-    query: z.string().optional().describe("Required for search_tools."),
+    operation: operationSchema.describe(
+      [
+        "Caplets wrapper operation to perform for this configured MCP server.",
+        "Use list_tools or search_tools to discover downstream tools, get_tool to read a downstream input schema, and call_tool to run one downstream tool.",
+        'For call_tool, pass downstream inputs only inside the top-level "arguments" object.',
+      ].join(" "),
+    ),
+    query: z
+      .string()
+      .optional()
+      .describe(
+        'Required only for search_tools. Example: {"operation":"search_tools","query":"web search","limit":5}. Do not use query for call_tool; put downstream query values under arguments.query.',
+      ),
     limit: z
       .number()
       .int()
       .positive()
       .optional()
-      .describe("Optional for search_tools; defaults to configured limit."),
-    tool: z.string().optional().describe("Exact downstream tool name for get_tool or call_tool."),
+      .describe(
+        "Optional only for search_tools; defaults to the configured search limit. For downstream result limits, use call_tool.arguments with the downstream schema field name.",
+      ),
+    tool: z
+      .string()
+      .optional()
+      .describe(
+        'Exact downstream tool name for get_tool or call_tool. Example: {"operation":"get_tool","tool":"web_search_exa"} before calling it.',
+      ),
     arguments: z
       .record(z.string(), z.unknown())
       .optional()
-      .describe("JSON object arguments for call_tool."),
+      .describe(
+        'Required JSON object only for call_tool. Put every downstream tool input inside this object. Example: {"operation":"call_tool","tool":"web_search_exa","arguments":{"query":"latest MCP docs","numResults":3}}. Do not send downstream inputs as top-level query, limit, url, path, or other fields.',
+      ),
   })
   .strict();
 

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { classifyRemoteAuthError, extractCompletion, oauthHeaders } from "../src/auth.js";
+import {
+  classifyRemoteAuthError,
+  extractCompletion,
+  FileOAuthProvider,
+  oauthHeaders,
+} from "../src/auth.js";
 import { parseConfig } from "../src/config.js";
 
 describe("auth helpers", () => {
@@ -54,5 +59,28 @@ describe("auth helpers", () => {
 
     const forbidden = classifyRemoteAuthError(server, new Response("", { status: 403 }));
     expect(forbidden).toMatchObject({ code: "AUTH_FAILED" });
+  });
+
+  it("keeps OAuth client authentication callback bound when SDK calls it detached", async () => {
+    const server = parseConfig({
+      mcpServers: {
+        remote: {
+          name: "Remote",
+          description: "A useful remote server.",
+          transport: "http",
+          url: "https://example.com/mcp",
+          auth: { type: "oauth2", clientId: "client", clientSecret: "secret" },
+        },
+      },
+    }).mcpServers.remote!;
+    const provider = new FileOAuthProvider(server, "http://127.0.0.1/callback", () => {});
+    const addClientAuthentication = provider.addClientAuthentication;
+    const headers = new Headers();
+    const params = new URLSearchParams();
+
+    await addClientAuthentication(headers, params);
+
+    expect(params.get("client_secret")).toBe("secret");
+    expect(headers.get("content-type")).toBe("application/x-www-form-urlencoded");
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { configJsonSchema, loadConfig, parseConfig } from "../src/config.js";
@@ -43,6 +43,79 @@ describe("config", () => {
     expect(config.options.defaultSearchLimit).toBe(20);
     expect(config.mcpServers["my-server_1"]?.transport).toBe("stdio");
     expect(config.mcpServers["my-server_1"]?.env?.EXAMPLE_TOKEN).toBe("secret-value");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("loads project config when user config does not exist", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-config-"));
+    const projectConfigPath = join(dir, ".caplets", "config.json");
+    mkdirSync(join(dir, ".caplets"), { recursive: true });
+    writeFileSync(
+      projectConfigPath,
+      JSON.stringify({
+        mcpServers: {
+          project: {
+            name: "Project Server",
+            description: "A useful project downstream server.",
+            command: "node",
+          },
+        },
+      }),
+    );
+
+    const config = loadConfig(join(dir, "missing-user-config.json"), projectConfigPath);
+    expect(config.mcpServers.project?.name).toBe("Project Server");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("merges user config with project config and lets project config win", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-config-"));
+    const userConfigPath = join(dir, "user", "config.json");
+    const projectConfigPath = join(dir, ".caplets", "config.json");
+    mkdirSync(join(dir, "user"), { recursive: true });
+    mkdirSync(join(dir, ".caplets"), { recursive: true });
+    writeFileSync(
+      projectConfigPath,
+      JSON.stringify({
+        defaultSearchLimit: 7,
+        maxSearchLimit: 40,
+        mcpServers: {
+          shared: {
+            name: "Project Shared",
+            description: "A useful project shared downstream server.",
+            command: "project-shared",
+          },
+          projectOnly: {
+            name: "Project Only",
+            description: "A useful project-only downstream server.",
+            command: "project-only",
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      userConfigPath,
+      JSON.stringify({
+        defaultSearchLimit: 3,
+        mcpServers: {
+          shared: {
+            name: "User Shared",
+            description: "A useful user shared downstream server.",
+            command: "user-shared",
+          },
+          userOnly: {
+            name: "User Only",
+            description: "A useful user-only downstream server.",
+            command: "user-only",
+          },
+        },
+      }),
+    );
+
+    const config = loadConfig(userConfigPath, projectConfigPath);
+    expect(config.options).toEqual({ defaultSearchLimit: 7, maxSearchLimit: 40 });
+    expect(Object.keys(config.mcpServers).sort()).toEqual(["projectOnly", "shared", "userOnly"]);
+    expect(config.mcpServers.shared?.command).toBe("project-shared");
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -23,7 +23,12 @@ describe("registry", () => {
     const registry = new ServerRegistry(config);
     expect(registry.enabledServers().map((server) => server.server)).toEqual(["enabled"]);
     expect(registry.get("disabled")).toBeUndefined();
-    expect(capabilityDescription(config.mcpServers.enabled!)).toContain("Enabled Server");
-    expect(capabilityDescription(config.mcpServers.enabled!)).not.toContain("secret-arg");
+    const description = capabilityDescription(config.mcpServers.enabled!);
+    expect(description).toContain("Enabled Server");
+    expect(description).toContain(
+      '{"operation":"call_tool","tool":"<tool name>","arguments":{...}}',
+    );
+    expect(description).toContain("Do not put downstream arguments at the top level");
+    expect(description).not.toContain("secret-arg");
   });
 });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
 import { parseConfig } from "../src/config.js";
 import { DownstreamManager } from "../src/downstream.js";
 import { CapletsError } from "../src/errors.js";
 import { ServerRegistry } from "../src/registry.js";
-import { handleServerTool, validateOperationRequest } from "../src/tools.js";
+import {
+  generatedToolInputSchema,
+  handleServerTool,
+  validateOperationRequest,
+} from "../src/tools.js";
 
 describe("generated tool request validation", () => {
   it("rejects operation-specific extra fields", () => {
@@ -36,6 +41,24 @@ describe("generated tool request validation", () => {
     expect(() => validateOperationRequest({ operation: "explode" }, 50)).toThrow(
       expect.objectContaining({ code: "UNKNOWN_OPERATION" }),
     );
+  });
+
+  it("describes the nested call_tool argument shape to agents", () => {
+    const schema = z.toJSONSchema(generatedToolInputSchema, { io: "input" }) as {
+      properties: Record<string, { description?: string }>;
+    };
+
+    const operationDescription = schema.properties.operation?.description;
+    const toolDescription = schema.properties.tool?.description;
+    const argumentsDescription = schema.properties.arguments?.description;
+
+    expect(operationDescription).toContain("call_tool");
+    expect(toolDescription).toContain("Exact downstream tool name");
+    expect(argumentsDescription).toContain("arguments");
+    expect(argumentsDescription).toContain(
+      '"operation":"call_tool","tool":"web_search_exa","arguments":{"query":"latest MCP docs","numResults":3}}',
+    );
+    expect(argumentsDescription).toContain("top-level query");
   });
 });
 


### PR DESCRIPTION
## Summary
- load both user and project config files, with project config overriding user config when both exist
- merge MCP server maps so user-only servers remain available under project overrides
- bind the OAuth client authentication callback so SDK token exchange cannot lose provider context
- clarify generated Caplets tool descriptions so agents put downstream inputs under call_tool.arguments

## Verification
- pnpm verify