### PR TITLE
feat: add mcp-backed caplet files

### DIFF
--- a/.changeset/brave-caplets-spark.md
+++ b/.changeset/brave-caplets-spark.md
@@ -1,0 +1,5 @@
+---
+"caplets": minor
+---
+
+Add MCP-backed Markdown Caplet files with Caplet-first discovery operations.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,47 @@ The optional `$schema` field points editors at the generated JSON Schema in
 [`schemas/caplets-config.schema.json`](schemas/caplets-config.schema.json). CI verifies that
 the committed schema stays in sync with the Zod config validator.
 
+### Caplet Files
+
+For richer skill-like cards, add Markdown Caplet files beside `config.json`. Every Caplet
+file must include an `mcpServer` backend; serverless Caplets are intentionally out of
+scope.
+
+Top-level files derive the Caplet ID from the filename:
+
+```md
+---
+$schema: https://raw.githubusercontent.com/spiritledsoftware/caplets/main/schemas/caplet.schema.json
+name: GitHub
+description: Interact with GitHub repositories, issues, and pull requests.
+tags:
+  - code
+  - review
+mcpServer:
+  command: npx
+  args: ["-y", "github-mcp-server"]
+---
+
+# GitHub
+
+Use this Caplet for repository, issue, pull request, and code review workflows.
+```
+
+That file is exposed as the `github` Caplet. Directory-style Caplets use
+`linear/CAPLET.md`, which is exposed as `linear`; sibling files can be referenced with
+normal Markdown links from `CAPLET.md`.
+
+Caplets always loads user Caplet files from `~/.caplets`. Project `./.caplets/config.json`
+is still loaded as project config, but project Markdown Caplet files are executable
+configuration and are ignored unless explicitly trusted:
+
+```sh
+CAPLETS_TRUST_PROJECT_CAPLETS=1 caplets serve
+```
+
+Later sources override earlier ones in this order: user `config.json`, user Caplet files,
+project `config.json`, and, only when trusted, project Caplet files.
+
 `caplets init` refuses to overwrite an existing config. To intentionally replace the file:
 
 ```sh
@@ -236,10 +277,10 @@ starts the MCP server. `serve` is explicit and recommended for clarity.
 
 ## How Agents Use It
 
-Caplets initially exposes one MCP tool per enabled server. If the config has `filesystem`
+Caplets initially exposes one MCP tool per enabled Caplet. If the config has `filesystem`
 and `docs`, the client sees two top-level tools: `filesystem` and `docs`.
 
-Each generated server tool accepts an `operation`:
+Each generated Caplet tool accepts an `operation`:
 
 ```json
 {
@@ -280,8 +321,8 @@ Call one exact downstream tool:
 
 Available operations:
 
-- `get_server`: return the configured capability card without starting the downstream server.
-- `check_server`: start or connect to the downstream server and verify its tool list.
+- `get_caplet`: return the configured capability card without starting the downstream server.
+- `check_mcp_server`: start or connect to the downstream server and verify its tool list.
 - `list_tools`: return compact downstream tool metadata.
 - `search_tools`: search downstream tool names and descriptions within this server.
 - `get_tool`: return full metadata for one exact downstream tool.

--- a/docs/plans/2026-05-12-mcp-backed-caplet-files.md
+++ b/docs/plans/2026-05-12-mcp-backed-caplet-files.md
@@ -1,0 +1,93 @@
+# MCP-Backed Caplet Files Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Add skill-like Markdown Caplet files while keeping every Caplet backed by exactly one MCP server.
+
+**Architecture:** Caplets remain executable MCP capability wrappers, not standalone skills. Existing `config.json` entries are normalized into Caplets, and Markdown files add richer capability cards with required `mcpServer` frontmatter. Runtime operations become Caplet-first: `get_caplet` and `check_mcp_server` replace `get_server` and `check_server`.
+
+**Tech Stack:** TypeScript ESM, Node.js 22+, `@modelcontextprotocol/sdk`, Zod, `vfile-matter`, Vitest, rolldown, oxfmt, oxlint.
+
+---
+
+## Task 1: Add Caplet File Loading
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `src/config.ts`
+- Create: `src/caplet-files.ts`
+- Test: `test/config.test.ts`
+
+- [x] Add the `vfile-matter` runtime dependency.
+- [x] Create a Caplet frontmatter schema that requires fenced YAML frontmatter with `name`, `description`, and `mcpServer`.
+- [x] Discover top-level `*.md` files and one-level `*/CAPLET.md` files under both the user Caplets directory and project `.caplets` directory.
+- [x] Derive IDs from paths: `github.md` -> `github`, `linear/CAPLET.md` -> `linear`.
+- [x] Reject duplicate Caplet IDs within the same root.
+- [x] Normalize Caplet files into the existing `mcpServers` map shape, with `name` and `description` outside `mcpServer`.
+- [x] Merge source precedence as user config, user Caplet files, project config, trusted project Caplet files.
+- [x] Preserve Markdown body and `tags` on normalized Caplet config.
+- [x] Add tests for loading top-level and directory Caplets, project override precedence, same-ID config override, missing `mcpServer`, and duplicate IDs.
+
+## Task 2: Rename Runtime Operations To Caplet-First Language
+
+**Files:**
+
+- Modify: `src/tools.ts`
+- Modify: `src/registry.ts`
+- Modify: `src/index.ts`
+- Test: `test/tools.test.ts`
+- Test: `test/registry.test.ts`
+- Test: `test/benchmark.test.ts`
+
+- [x] Rename operation `get_server` to `get_caplet`.
+- [x] Rename operation `check_server` to `check_mcp_server`.
+- [x] Do not keep compatibility aliases for old operation names.
+- [x] Update request validation, operation descriptions, examples, errors, and tests.
+- [x] Return full Caplet detail from `get_caplet`, including `caplet`, `name`, `description`, optional `tags`, optional `body`, and safe `mcpServer` metadata. Do not expose local source paths.
+- [x] Ensure `get_caplet` does not start or probe the downstream MCP server.
+- [x] Keep `list_tools`, `search_tools`, `get_tool`, and `call_tool` behavior unchanged.
+
+## Task 3: Add Caplet Schema Generation
+
+**Files:**
+
+- Modify: `src/config.ts`
+- Modify: `scripts/generate-config-schema.ts`
+- Create: `schemas/caplet.schema.json`
+- Test: `test/config.test.ts`
+
+- [x] Export a generated JSON Schema for Caplet frontmatter.
+- [x] Update schema generation/checking to maintain both `schemas/caplets-config.schema.json` and `schemas/caplet.schema.json`.
+- [x] Add a drift test for the committed Caplet schema.
+- [x] Run schema generation after implementation.
+
+## Task 4: Update CLI Starters And Documentation
+
+**Files:**
+
+- Modify: `src/cli.ts`
+- Modify: `README.md`
+- Modify: `docs/product/caplets-progressive-mcp-disclosure-prd.md`
+- Test: `test/cli.test.ts`
+
+- [x] Keep `caplets init` writing the existing plain `config.json` starter.
+- [x] Add README documentation for Markdown Caplet files and directory Caplets.
+- [x] Document that every Caplet file must include `mcpServer`; serverless Caplets are out of scope.
+- [x] Update documented operations to `get_caplet` and `check_mcp_server`.
+- [x] Ensure CLI tests still validate starter config behavior.
+
+## Task 5: Verification And Final Review
+
+**Files:**
+
+- All touched files.
+
+- [x] Run `pnpm install` if the lockfile needs the new `vfile-matter` dependency.
+- [x] Run `pnpm format:check`.
+- [x] Run `pnpm lint`.
+- [x] Run `pnpm typecheck`.
+- [x] Run `pnpm schema:check`.
+- [x] Run `pnpm test`.
+- [x] Run `pnpm build`.
+- [x] Perform a final review for secret leakage in `get_caplet` safe backend metadata.

--- a/docs/product/caplets-progressive-mcp-disclosure-prd.md
+++ b/docs/product/caplets-progressive-mcp-disclosure-prd.md
@@ -4,7 +4,7 @@
 
 **Problem Statement**: MCP clients that connect directly to many servers receive a large, flat tool surface up front. This creates context bloat, weak tool selection, name-collision risk, and poor discoverability when an agent only needs to know which capability domain to inspect next.
 
-**Proposed Solution**: Caplets is a local MCP server that reads downstream MCP server definitions from `~/.caplets/config.json` and exposes each enabled downstream server as one top-level, skill-like MCP tool. Each generated server tool uses the configured server ID as the tool name and the configured `name`/`description` as its capability card, then progressively discloses that server's underlying tools through operations such as `search_tools`, `list_tools`, `get_tool`, and `call_tool`.
+**Proposed Solution**: Caplets is a local MCP server that reads downstream MCP server definitions from `~/.caplets/config.json`, user-owned MCP-backed Markdown Caplet files from `~/.caplets`, project config from `./.caplets/config.json`, and explicitly trusted project Markdown Caplet files from `./.caplets`. It exposes each enabled Caplet as one top-level, skill-like MCP tool. Each generated Caplet tool uses the Caplet ID as the tool name and the configured `name`/`description` as its compact capability card, then progressively discloses the full Caplet card and the backing server's tools through operations such as `get_caplet`, `search_tools`, `list_tools`, `get_tool`, and `call_tool`.
 
 **Success Criteria**:
 
@@ -25,12 +25,12 @@
 ### Primary User Flow
 
 1. User installs and configures Caplets as an MCP server in their MCP client.
-2. User creates `~/.caplets/config.json` with downstream server definitions and Caplets options.
-3. Each downstream server entry uses the supported MCP server configuration shape plus a required `description`.
+2. User creates either `~/.caplets/config.json` with downstream server definitions and Caplets options, or Markdown Caplet files with required `mcpServer` frontmatter.
+3. Each downstream server entry or Caplet file uses the supported MCP server configuration shape plus a required `description`.
 4. Client calls Caplets `tools/list` and sees one top-level tool per enabled downstream server, for example `linear`, `chrome-devtools`, and `context7`.
-5. Agent chooses the relevant server tool based on its skill-like tool name and description.
-6. Agent calls that server tool with an operation such as `get_server`, `search_tools`, `list_tools`, or `get_tool`.
-7. Agent calls the same server tool with `operation: "call_tool"`, an exact downstream tool name, and a JSON object of arguments.
+5. Agent chooses the relevant Caplet tool based on its skill-like tool name and description.
+6. Agent calls that Caplet tool with an operation such as `get_caplet`, `search_tools`, `list_tools`, or `get_tool`.
+7. Agent calls the same Caplet tool with `operation: "call_tool"`, an exact downstream tool name, and a JSON object of arguments.
 8. Caplets forwards the request to that server's downstream MCP process and returns the downstream result.
 
 ### User Stories
@@ -40,14 +40,16 @@
 Acceptance Criteria:
 
 - Caplets reads `~/.caplets/config.json` from the current user's home directory by default.
+- Caplets reads user-owned Markdown Caplet files from `~/.caplets` by default.
+- Caplets reads project Markdown Caplet files from `./.caplets` only when `CAPLETS_TRUST_PROJECT_CAPLETS` is set to `1`, `true`, or `yes`.
 - Every configured server requires a stable server key and non-empty `description`.
 - Caplets `tools/list` returns one generated top-level MCP tool per enabled server.
-- Each generated server tool uses the configured server ID as the MCP tool name.
-- Each generated server tool description includes the configured display `name` and Markdown-capable `description`.
+- Each generated Caplet tool uses the configured server ID as the MCP tool name.
+- Each generated Caplet tool description includes the configured display `name` and Markdown-capable `description`.
 - Disabled servers are omitted from `tools/list`.
-- Caplets `tools/list` never exposes raw command arguments, env values, headers, tokens, full raw config, or downstream server tools directly.
+- Caplets `tools/list` never exposes raw command arguments, env values, headers, tokens, full raw config, or downstream Caplet tools directly.
 - Caplets process startup validates config but does not block on starting every downstream server.
-- The first live operation against a generated server tool starts or connects to the relevant downstream server.
+- The first live operation against a generated Caplet tool starts or connects to the relevant downstream server.
 - Successfully started stdio servers stay running alongside Caplets until Caplets exits or the downstream process dies.
 - If a downstream stdio process dies, Caplets marks cached status unavailable and the next relevant operation may attempt one restart with backoff.
 - Remote HTTP/SSE servers are connected lazily and reused when supported by the MCP SDK transport.
@@ -56,16 +58,16 @@ Acceptance Criteria:
 
 Acceptance Criteria:
 
-- Each generated server tool supports `operation: "list_tools"` and returns a compact list of that server's MCP tools.
-- Each generated server tool supports `operation: "get_tool"` and returns one downstream tool's full metadata by exact downstream tool name.
+- Each generated Caplet tool supports `operation: "list_tools"` and returns a compact list of that server's MCP tools.
+- Each generated Caplet tool supports `operation: "get_tool"` and returns one downstream tool's full metadata by exact downstream tool name.
 - `get_tool` refreshes stale downstream tool metadata according to `toolCacheTtlMs` before resolving the exact downstream tool name.
 - Tool results preserve downstream `name`, `description`, `inputSchema`, and annotations when available.
 - Caplets forwards downstream tool annotations as-is and does not infer, normalize, or add Caplets-specific risk labels in MVP.
 - `operation: "search_tools"` supports deterministic case-insensitive lexical search across that server's downstream tool names and descriptions.
-- `search_tools` is scoped to the selected generated server tool; MVP does not provide cross-server tool search because `tools/list` is already the server discovery layer.
+- `search_tools` is scoped to the selected generated Caplet tool; MVP does not provide cross-Caplet tool search because `tools/list` is already the server discovery layer.
 - `search_tools` supports an optional `limit`, defaults to 20 results, and rejects values above 50.
 - `search_tools` uses fresh cached tool metadata from that server's managed downstream process and starts that server if needed.
-- Duplicate downstream tool names across different servers are supported because tool names are only resolved inside a generated server tool.
+- Duplicate downstream tool names across different servers are supported because tool names are only resolved inside a generated Caplet tool.
 
 **Story 3**: As an agent, I want to call an underlying tool through Caplets so that I can use downstream MCP capabilities without connecting to each server directly.
 
@@ -73,7 +75,7 @@ Acceptance Criteria:
 
 - `operation: "call_tool"` requires exact downstream `tool` and a JSON object `arguments`.
 - `call_tool` requires the exact downstream tool name; Caplets does not use fuzzy matching, aliases, or auto-correction for execution.
-- The selected generated server tool is the server namespace, so `call_tool` does not accept a `server` argument in MVP.
+- The selected generated Caplet tool is the server namespace, so `call_tool` does not accept a `server` argument in MVP.
 - Caplets preserves downstream tool names exactly and does not support flattened namespaced identifiers such as `server.tool` in MVP.
 - Caplets forwards calls to downstream MCP `tools/call` using the selected server connection.
 - Before `call_tool` resolves the exact downstream tool name, Caplets refreshes stale downstream tool metadata according to `toolCacheTtlMs`.
@@ -92,8 +94,8 @@ Acceptance Criteria:
 
 - Caplets validates config with clear errors before serving discovery results.
 - Unsupported transports or unsupported config fields produce actionable validation messages.
-- Each generated server tool supports `operation: "check_server"`, verifies or starts/connects to that managed downstream server if needed, calls downstream `tools/list`, refreshes cached status and tool metadata, and returns server availability status, tool count when available, safe error details when unavailable, and elapsed timing data.
-- `check_server` must not invoke any downstream tool.
+- Each generated Caplet tool supports `operation: "check_mcp_server"`, verifies or starts/connects to that managed downstream server if needed, calls downstream `tools/list`, refreshes cached status and tool metadata, and returns server availability status, tool count when available, safe error details when unavailable, and elapsed timing data.
+- `check_mcp_server` must not invoke any downstream tool.
 - Env values, tokens, headers, and secret-looking fields are redacted from errors and logs.
 - Downstream server startup has a default timeout of 10 seconds and can be overridden per server.
 - Tool calls have a default timeout of 60 seconds and can be overridden per server.
@@ -125,28 +127,28 @@ Caplets exposes dynamic MCP tools:
 - Disabled servers are omitted from Caplets `tools/list`.
 - Caplets does not expose every downstream tool directly in its own `tools/list`.
 
-Each generated server tool supports these operations:
+Each generated Caplet tool supports these operations:
 
-- `get_server`: Returns the full configured capability card for the selected server without starting the downstream process.
-- `check_server`: Validates that the selected downstream server can start, initialize, and return its tool list without invoking any downstream tool.
+- `get_caplet`: Returns the full configured capability card for the selected server without starting the downstream process.
+- `check_mcp_server`: Validates that the selected downstream server can start, initialize, and return its tool list without invoking any downstream tool.
 - `list_tools`: Lists compact downstream tool entries for the selected server.
 - `search_tools`: Searches downstream tools for the selected server. Supports optional `limit`, defaults to 20 results, and rejects values above 50.
 - `get_tool`: Returns full metadata for one exact downstream tool.
 - `call_tool`: Invokes one exact downstream tool with a JSON object of arguments.
 
-Generated server tool input schema:
+Generated Caplet tool input schema:
 
-- `operation` is required and must be one of `get_server`, `check_server`, `list_tools`, `search_tools`, `get_tool`, or `call_tool`.
-- `get_server` accepts no extra fields.
-- `get_server` returns only configured capability-card data and does not start, initialize, or probe the downstream server.
-- `get_server` is intentionally provisional in MVP; it may be pruned later if generated top-level server tool descriptions prove sufficient.
-- `check_server` accepts no extra fields.
+- `operation` is required and must be one of `get_caplet`, `check_mcp_server`, `list_tools`, `search_tools`, `get_tool`, or `call_tool`.
+- `get_caplet` accepts no extra fields.
+- `get_caplet` returns only configured capability-card data and does not start, initialize, or probe the downstream server.
+- `get_caplet` is intentionally provisional in MVP; it may be pruned later if generated top-level Caplet tool descriptions prove sufficient.
+- `check_mcp_server` accepts no extra fields.
 - `list_tools` accepts no extra fields.
 - `search_tools` requires `query` and accepts optional `limit`.
 - `get_tool` requires `tool`.
 - `call_tool` requires `tool` and `arguments`; `arguments` must be a JSON object and is not optional.
 - `tool` fields are plain strings, not enums of downstream tool names.
-- Generated server tool schemas must remain stable even when downstream tool lists change.
+- Generated Caplet tool schemas must remain stable even when downstream tool lists change.
 - Unknown operations return `UNKNOWN_OPERATION`.
 - Operation-specific request validation is strict: fields not defined for the selected `operation` are rejected as malformed Caplets request shapes.
 
@@ -196,13 +198,13 @@ MVP supports one documented config file at `~/.caplets/config.json`:
 
 Requirements:
 
-- `mcpServers` is required for MVP.
+- `mcpServers` is optional when one or more valid Markdown Caplet files are present.
 - `$schema` is optional and exists only for JSON Schema-aware editor validation.
 - `version` is optional for MVP and defaults to 1 when omitted. If present, MVP accepts only `1` and rejects unsupported versions with `CONFIG_INVALID`.
 - Allowed top-level keys in MVP are `$schema`, `version`, `defaultSearchLimit`, `maxSearchLimit`, and `mcpServers`; unknown top-level keys are rejected with `CONFIG_INVALID`.
 - The committed JSON Schema lives at `schemas/caplets-config.schema.json`, is generated from the Zod runtime config schema, and CI must fail when the committed schema drifts from the generated output.
 - Unknown keys inside each server config are rejected with `CONFIG_INVALID`, except fields that belong to the tracked standard MCP server schema plus Caplets-owned additions documented here.
-- `mcpServers` is the only accepted top-level server configuration key for downstream MCP servers in MVP.
+- `mcpServers` is the only accepted top-level server configuration key for plain JSON downstream MCP servers in MVP.
 - `defaultSearchLimit` and `maxSearchLimit` are optional top-level Caplets options. Future Caplets options should remain top-level unless they are specific to one downstream server.
 - Caplets' native config shape follows the shared/standard `mcpServers` convention used by tools such as Pi's MCP adapter, with Caplets-specific metadata added per server.
 - Each server key is the stable server ID. It must match `^[a-zA-Z0-9_-]{1,64}$` and be unique within the file.
@@ -214,6 +216,7 @@ Requirements:
 - `description` must be at most 1500 characters and is returned exactly as configured.
 - `description` may contain Markdown syntax because the primary reader is an LLM, but MVP treats it as opaque text: Caplets does not render, sanitize, transform, or interpret Markdown.
 - Caplets should reuse or closely track existing MCP server config validation semantics where practical rather than inventing a new dialect.
+- Markdown Caplet files are executable configuration because their required `mcpServer` backend can start a downstream server. User Caplet files are trusted by location. Project Caplet files require explicit process-level trust through `CAPLETS_TRUST_PROJECT_CAPLETS`.
 - Each server config must define exactly one connection shape:
   - Stdio: `command` is required; optional `args`, `env`, and `cwd` are allowed.
   - Remote: `url` is required and `transport` must be `http` or `sse`.
@@ -235,7 +238,7 @@ Requirements:
 - OAuth authorization requests must include a state parameter and PKCE challenge. OAuth token requests must verify state and include the PKCE verifier.
 - For MCP-compliant OAuth servers, Caplets must include the target server resource indicator in authorization and token requests when required by the MCP authorization specification.
 - The default OAuth token store is `~/.caplets/auth/<server>.json`; files must be created with owner-only permissions when the platform supports it.
-- Token bundles are runtime auth state, not server description state. They must not be embedded in generated MCP tool descriptions, `get_server`, logs, or structured errors.
+- Token bundles are runtime auth state, not server description state. They must not be embedded in generated MCP tool descriptions, `get_caplet`, logs, or structured errors.
 - The Caplets MCP server reads OAuth tokens from the auth store lazily before remote operations. Updating tokens with `caplets auth login <server>` should not require editing config and should be designed to work without restarting Caplets when practical.
 - `caplets auth list` reports configured OAuth remote servers as missing, authenticated, or expired and must not enumerate arbitrary orphan token files outside the configured server set.
 - `caplets auth logout <server>` removes the local token bundle for a configured OAuth remote server and is allowed even when the server is currently disabled.
@@ -265,7 +268,7 @@ Requirements:
 - No permissions engine, policy language, sandboxing, or general-purpose credential manager beyond the local OAuth token store required for remote MCP auth.
 - No semantic/vector search in MVP.
 - No MCP resources, prompts, sampling, elicitation, roots, or Apps support in MVP.
-- No cross-server tool composition, planning, or result summarization.
+- No cross-Caplet tool composition, planning, or result summarization.
 - No automatic trust scoring of downstream servers or tools.
 - No multi-user daemon mode.
 
@@ -273,7 +276,7 @@ Requirements:
 
 ### Tool Requirements
 
-Caplets is itself an MCP server and must implement the MCP server tools surface using `@modelcontextprotocol/sdk`.
+Caplets is itself an MCP server and must implement the MCP Caplet tools surface using `@modelcontextprotocol/sdk`.
 
 Downstream interactions required for MVP:
 
@@ -281,7 +284,7 @@ Downstream interactions required for MVP:
 - Initialize downstream MCP clients over stdio, Streamable HTTP, or legacy HTTP+SSE with bounded concurrency and structured status for servers that fail to start or authenticate.
 - Resolve configured bearer/header auth and stored OAuth tokens before remote HTTP/SSE operations.
 - Call downstream `tools/list` for selected servers.
-- Call downstream `tools/call` for `operation: "call_tool"` inside a generated server tool.
+- Call downstream `tools/call` for `operation: "call_tool"` inside a generated Caplet tool.
 - Refresh stale downstream tool metadata before `get_tool` and `call_tool` exact-name resolution according to `toolCacheTtlMs`.
 - Require downstream tools to be present in fresh-enough `tools/list` metadata before forwarding `call_tool`.
 - Preserve downstream schemas and result content.
@@ -292,9 +295,9 @@ Downstream interactions required for MVP:
 Caplets must optimize the first cognitive layer for the agent:
 
 - Level 0: Caplets `tools/list` exposes only generated server/caplet tools, one per enabled downstream server.
-- Level 1: The agent selects a generated server tool by server ID, display name, and description.
-- Level 2: The selected server tool discloses its full capability card and downstream tool metadata through `get_server`, `list_tools`, `search_tools`, and `get_tool`.
-- Level 3: The selected server tool invokes one downstream tool through `operation: "call_tool"` with exact downstream `tool` and a JSON object `arguments`.
+- Level 1: The agent selects a generated Caplet tool by server ID, display name, and description.
+- Level 2: The selected Caplet tool discloses its full capability card and downstream tool metadata through `get_caplet`, `list_tools`, `search_tools`, and `get_tool`.
+- Level 3: The selected Caplet tool invokes one downstream tool through `operation: "call_tool"` with exact downstream `tool` and a JSON object `arguments`.
 
 Progressive disclosure is not a security boundary. The PRD treats it as a context-management and tool-selection strategy.
 
@@ -338,7 +341,7 @@ flowchart LR
 Core modules:
 
 - `src/cli.ts`: CLI entrypoint, including `caplets auth login <server>` for OAuth setup.
-- `src/index.ts`: MCP server bootstrap and dynamic generated server-tool registration.
+- `src/index.ts`: MCP server bootstrap and dynamic generated Caplet-tool registration.
 - `src/config.ts`: Config loading, schema validation, defaults, and redaction helpers.
 - `src/auth.ts`: Remote auth resolution, OAuth flow orchestration, token storage, token refresh, and auth redaction helpers.
 - `src/registry.ts`: Server metadata registry and search over server descriptions.
@@ -400,9 +403,12 @@ Core modules:
 
 `CapletServerDetail`:
 
-- `server: string`
+- `caplet: string`
 - `name: string`
 - `description: string`
+- `tags?: string[]`
+- `body?: string`
+- `mcpServer: { transport: "stdio" | "http" | "sse"; disabled: boolean; startupTimeoutMs: number; callTimeoutMs: number; toolCacheTtlMs: number }`
 
 `CapletToolRef`:
 
@@ -414,7 +420,7 @@ Core modules:
 
 `GeneratedServerToolRequest`:
 
-- `operation: "get_server" | "check_server" | "list_tools" | "search_tools" | "get_tool" | "call_tool"`
+- `operation: "get_caplet" | "check_mcp_server" | "list_tools" | "search_tools" | "get_tool" | "call_tool"`
 - `query?: string`
 - `limit?: number`
 - `tool?: string`
@@ -427,13 +433,13 @@ Requirements:
 - Operation-specific fields are exclusive to their operations. For example, `tool` is invalid on `list_tools`, `query` is invalid on `get_tool`, and `arguments` is invalid outside `call_tool`.
 - `server` is the exact configured Caplets server key and the generated top-level MCP tool name.
 - Caplets does not invent escaped, flattened, or globally unique tool names in MVP.
-- Caplets does not expose downstream tool names as enum values in generated server tool input schemas.
+- Caplets does not expose downstream tool names as enum values in generated Caplet tool input schemas.
 - `list_tools` returns compact downstream tool entries: `tool`, `description`, annotations when available, and `hasInputSchema`.
 - `get_tool` returns full downstream metadata for one exact downstream tool in the selected server.
 - `get_tool` and `call_tool` both use fresh-enough cached metadata for exact downstream tool-name resolution.
 - `call_tool` returns `TOOL_NOT_FOUND` without forwarding when the exact downstream tool name is absent from fresh-enough metadata.
 - `search_tools` returns compact matches by default: `tool`, `description`, annotations when available, and `hasInputSchema`, but not full `inputSchema`.
-- `search_tools` results are scoped to the generated server tool that was called.
+- `search_tools` results are scoped to the generated Caplet tool that was called.
 
 ### Integration Points
 
@@ -483,7 +489,7 @@ Caplets errors should be structured and stable:
 - Caplets should avoid unnecessary restarts or repeated process churn once a downstream stdio server is successfully managed.
 - Caplets should terminate managed downstream stdio server processes when Caplets exits.
 - Caplets should cache each managed server's `tools/list` metadata for `toolCacheTtlMs` and refresh stale metadata on tool metadata operations.
-- `check_server` should always refresh downstream `tools/list` for the selected server and update cached metadata/status.
+- `check_mcp_server` should always refresh downstream `tools/list` for the selected server and update cached metadata/status.
 
 ### Testing Requirements
 
@@ -497,7 +503,7 @@ Add automated tests for:
 - Server ID validation covers allowed hyphens/underscores and rejects spaces, dots, slashes, colons, and Unicode.
 - Required display `name` validation.
 - Display name vs server ID routing behavior.
-- Generated server tool operation discriminator validation.
+- Generated Caplet tool operation discriminator validation.
 - Strict operation-specific request-shape validation, including rejection of extra fields on otherwise valid operations.
 - Missing config and invalid config.
 - Required `description` validation.
@@ -516,12 +522,12 @@ Add automated tests for:
 - Remote auth error payload shape includes only `server`, `status`, `message`, `authType`, redacted `challenge`, and `nextAction` when relevant.
 - Streamable HTTP protocol-version and session-header behavior is covered by transport tests.
 - Generated `tools/list` exposes one safe capability card per enabled server and omits disabled servers.
-- `get_server` returns exact full server descriptions without starting, initializing, or probing downstream processes.
+- `get_caplet` returns exact full server descriptions without starting, initializing, or probing downstream processes.
 - `list_tools` returns compact downstream tool metadata and `get_tool` preserves full downstream tool metadata including `inputSchema`.
 - Server-scoped `search_tools` deterministic lexical matching.
 - Capped search result behavior: default `limit` 20, max `limit` 50, no pagination in MVP.
 - Server-scoped `search_tools` startup and failure behavior.
-- `check_server` success, unavailable server, timeout, and secret redaction behavior.
+- `check_mcp_server` success, unavailable server, timeout, and secret redaction behavior.
 - `toolCacheTtlMs` behavior, including default TTL, stale refresh, and `0` refresh-every-time mode.
 - `get_tool` and `call_tool` refresh stale metadata before exact downstream tool-name resolution.
 - Disabled server behavior: omitted from generated `tools/list`, not callable, never returned by search, and never started.
@@ -556,7 +562,7 @@ If no test runner exists yet, implementation must add one before claiming MVP co
 - Validate `mcpServers` config with required descriptions.
 - Require restart after config changes while keeping config loading, registry construction, and downstream client lifecycle modular enough for later hot reload.
 - Expose one generated top-level MCP tool per enabled downstream server.
-- Support server-scoped diagnostics, tool listing, lexical search, tool metadata lookup, and explicit tool invocation through each generated server tool.
+- Support server-scoped diagnostics, tool listing, lexical search, tool metadata lookup, and explicit tool invocation through each generated Caplet tool.
 - Support managed downstream stdio server lifecycles, remote HTTP/SSE transports, startup/call timeouts, structured errors, and secret redaction.
 - Support bearer, static-header, and OAuth2 auth for remote HTTP/SSE servers.
 - Provide `caplets auth login <server>` for OAuth browser/PKCE setup and local token storage.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "commander": "^14.0.3",
+    "vfile": "^6.0.3",
+    "vfile-matter": "^5.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,12 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vfile-matter:
+        specifier: ^5.0.1
+        version: 5.0.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -833,6 +839,9 @@ packages:
 
   '@types/node@25.6.2':
     resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
@@ -1738,6 +1747,9 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -1749,6 +1761,15 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-matter@5.0.1:
+    resolution: {integrity: sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.11:
     resolution: {integrity: sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==}
@@ -2342,6 +2363,8 @@ snapshots:
   '@types/node@25.6.2':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/unist@3.0.3': {}
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -3246,11 +3269,30 @@ snapshots:
 
   undici-types@7.19.2: {}
 
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
   universalify@0.1.2: {}
 
   unpipe@1.0.0: {}
 
   vary@1.1.2: {}
+
+  vfile-matter@5.0.1:
+    dependencies:
+      vfile: 6.0.3
+      yaml: 2.8.4
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.11(@types/node@25.6.2)(yaml@2.8.4):
     dependencies:
@@ -3314,8 +3356,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  yaml@2.8.4:
-    optional: true
+  yaml@2.8.4: {}
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:

--- a/schemas/caplet.schema.json
+++ b/schemas/caplet.schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/spiritledsoftware/caplets/main/schemas/caplet.schema.json",
+  "title": "Caplet file frontmatter",
+  "description": "YAML frontmatter schema for a Markdown Caplet file.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "description": "Optional JSON Schema URL for editor validation.",
+      "type": "string",
+      "format": "uri"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80,
+      "description": "Human-readable Caplet display name."
+    },
+    "description": {
+      "type": "string",
+      "description": "Compact capability description shown before the full Caplet card is disclosed."
+    },
+    "tags": {
+      "description": "Optional tags for grouping or searching Caplets.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 80
+      }
+    },
+    "mcpServer": {
+      "type": "object",
+      "properties": {
+        "transport": {
+          "description": "Downstream MCP transport. Defaults to stdio when command is present.",
+          "type": "string",
+          "enum": ["stdio", "http", "sse"]
+        },
+        "command": {
+          "description": "Executable command for stdio servers.",
+          "type": "string",
+          "minLength": 1
+        },
+        "args": {
+          "description": "Arguments passed to the stdio command.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "description": "Environment variables for stdio servers. Supports ${VAR} and $env:VAR.",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "cwd": {
+          "description": "Working directory for stdio servers.",
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "description": "Remote MCP server URL for http or sse transport.",
+          "type": "string",
+          "minLength": 1
+        },
+        "auth": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "none"
+                }
+              },
+              "required": ["type"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "bearer"
+                },
+                "token": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": ["type", "token"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "headers"
+                },
+                "headers": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "required": ["type", "headers"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "oauth2"
+                },
+                "authorizationUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "tokenUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "issuer": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "clientId": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "clientSecret": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "scopes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "redirectUri": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": ["type"],
+              "additionalProperties": false
+            }
+          ],
+          "description": "Authentication settings for a remote MCP server."
+        },
+        "startupTimeoutMs": {
+          "description": "Timeout in milliseconds for starting or checking a downstream server.",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "callTimeoutMs": {
+          "description": "Timeout in milliseconds for downstream tool calls.",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "toolCacheTtlMs": {
+          "description": "Milliseconds downstream tool metadata stays fresh. Set 0 to refresh every time.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "disabled": {
+          "description": "When true, omit this Caplet from discovery and do not start its MCP server.",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Required MCP server backend configuration for this Caplet."
+    }
+  },
+  "required": ["name", "description", "mcpServer"],
+  "additionalProperties": false
+}

--- a/schemas/caplets-config.schema.json
+++ b/schemas/caplets-config.schema.json
@@ -31,6 +31,8 @@
       "maximum": 50
     },
     "mcpServers": {
+      "default": {},
+      "description": "Downstream MCP servers keyed by stable server ID.",
       "type": "object",
       "propertyNames": {
         "type": "string",
@@ -180,6 +182,14 @@
             ],
             "description": "Authentication settings for a remote MCP server."
           },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
           "startupTimeoutMs": {
             "default": 10000,
             "description": "Timeout in milliseconds for starting or checking a downstream server.",
@@ -209,10 +219,8 @@
         },
         "required": ["name", "description"],
         "additionalProperties": false
-      },
-      "description": "Downstream MCP servers keyed by stable server ID."
+      }
     }
   },
-  "required": ["mcpServers"],
   "additionalProperties": false
 }

--- a/scripts/generate-config-schema.ts
+++ b/scripts/generate-config-schema.ts
@@ -3,20 +3,29 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { configJsonSchema } from "../src/config.js";
+import { capletJsonSchema } from "../src/caplet-files.js";
 
-const schemaPath = "schemas/caplets-config.schema.json";
-const next = formatJson(`${JSON.stringify(configJsonSchema(), null, 2)}\n`);
+const schemas = [
+  { path: "schemas/caplets-config.schema.json", schema: configJsonSchema() },
+  { path: "schemas/caplet.schema.json", schema: capletJsonSchema() },
+];
 
 if (process.argv.includes("--check")) {
-  const current = existsSync(schemaPath) ? readFileSync(schemaPath, "utf8") : "";
-  if (current !== next) {
-    console.error(`${schemaPath} is out of date. Run pnpm schema:generate.`);
-    process.exitCode = 1;
+  for (const entry of schemas) {
+    const next = formatJson(`${JSON.stringify(entry.schema, null, 2)}\n`);
+    const current = existsSync(entry.path) ? readFileSync(entry.path, "utf8") : "";
+    if (current !== next) {
+      console.error(`${entry.path} is out of date. Run pnpm schema:generate.`);
+      process.exitCode = 1;
+    }
   }
 } else {
-  mkdirSync(dirname(schemaPath), { recursive: true });
-  writeFileSync(schemaPath, next);
-  console.log(`Generated ${schemaPath}`);
+  for (const entry of schemas) {
+    const next = formatJson(`${JSON.stringify(entry.schema, null, 2)}\n`);
+    mkdirSync(dirname(entry.path), { recursive: true });
+    writeFileSync(entry.path, next);
+    console.log(`Generated ${entry.path}`);
+  }
 }
 
 function formatJson(value: string): string {

--- a/src/caplet-files.ts
+++ b/src/caplet-files.ts
@@ -1,0 +1,343 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, extname, join } from "node:path";
+import { VFile } from "vfile";
+import { matter as parseMatter } from "vfile-matter";
+import { z } from "zod";
+import { CapletsError, redactSecrets } from "./errors.js";
+
+const MAX_CAPLET_FILE_BYTES = 128 * 1024;
+const MAX_CAPLET_BODY_CHARS = 64 * 1024;
+const SERVER_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const FORBIDDEN_HEADERS = new Set([
+  "accept",
+  "authorization",
+  "connection",
+  "content-length",
+  "content-type",
+  "host",
+  "keep-alive",
+  "mcp-protocol-version",
+  "mcp-session-id",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const capletRemoteAuthSchema = z
+  .discriminatedUnion("type", [
+    z.object({ type: z.literal("none") }).strict(),
+    z.object({ type: z.literal("bearer"), token: z.string().min(1) }).strict(),
+    z
+      .object({ type: z.literal("headers"), headers: z.record(z.string(), z.string().min(1)) })
+      .strict(),
+    z
+      .object({
+        type: z.literal("oauth2"),
+        authorizationUrl: z.string().min(1).optional(),
+        tokenUrl: z.string().min(1).optional(),
+        issuer: z.string().min(1).optional(),
+        clientId: z.string().min(1).optional(),
+        clientSecret: z.string().min(1).optional(),
+        scopes: z.array(z.string().min(1)).optional(),
+        redirectUri: z.string().min(1).optional(),
+      })
+      .strict(),
+  ])
+  .describe("Authentication settings for a remote MCP server.");
+
+const capletMcpServerSchema = z
+  .object({
+    transport: z
+      .enum(["stdio", "http", "sse"])
+      .optional()
+      .describe("Downstream MCP transport. Defaults to stdio when command is present."),
+    command: z.string().min(1).optional().describe("Executable command for stdio servers."),
+    args: z.array(z.string()).optional().describe("Arguments passed to the stdio command."),
+    env: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe("Environment variables for stdio servers. Supports ${VAR} and $env:VAR."),
+    cwd: z.string().min(1).optional().describe("Working directory for stdio servers."),
+    url: z.string().min(1).optional().describe("Remote MCP server URL for http or sse transport."),
+    auth: capletRemoteAuthSchema.optional(),
+    startupTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Timeout in milliseconds for starting or checking a downstream server."),
+    callTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Timeout in milliseconds for downstream tool calls."),
+    toolCacheTtlMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe("Milliseconds downstream tool metadata stays fresh. Set 0 to refresh every time."),
+    disabled: z
+      .boolean()
+      .optional()
+      .describe("When true, omit this Caplet from discovery and do not start its MCP server."),
+  })
+  .strict()
+  .superRefine((server, ctx) => {
+    const effectiveTransport = server.transport ?? (server.command ? "stdio" : undefined);
+    const hasStdio = Boolean(server.command);
+    const hasRemote = Boolean(server.url);
+    if (hasStdio === hasRemote) {
+      ctx.addIssue({
+        code: "custom",
+        message: "mcpServer must define exactly one connection shape: command or url",
+      });
+    }
+
+    if (effectiveTransport === "stdio" && !server.command) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["command"],
+        message: "stdio servers require command",
+      });
+    }
+
+    if ((effectiveTransport === "http" || effectiveTransport === "sse") && !server.url) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["url"],
+        message: "remote servers require url",
+      });
+    }
+
+    if (server.url && !hasEnvReference(server.url) && !isAllowedRemoteUrl(server.url)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["url"],
+        message: "remote url must use https except loopback development urls",
+      });
+    }
+
+    if (server.auth?.type === "oauth2") {
+      for (const field of ["authorizationUrl", "tokenUrl", "issuer", "redirectUri"] as const) {
+        const value = server.auth[field];
+        if (value && !hasEnvReference(value) && !isUrl(value)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["auth", field],
+            message: `${field} must be a URL or environment reference`,
+          });
+        }
+      }
+    }
+
+    if (server.auth?.type === "headers") {
+      for (const headerName of Object.keys(server.auth.headers)) {
+        const normalized = headerName.toLowerCase();
+        if (!HEADER_NAME_PATTERN.test(headerName) || FORBIDDEN_HEADERS.has(normalized)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["auth", "headers", headerName],
+            message: `header ${headerName} is not allowed`,
+          });
+        }
+      }
+    }
+  });
+
+export const capletFileSchema = z
+  .object({
+    $schema: z
+      .string()
+      .url()
+      .optional()
+      .describe("Optional JSON Schema URL for editor validation."),
+    name: z.string().trim().min(1).max(80).describe("Human-readable Caplet display name."),
+    description: z
+      .string()
+      .describe("Compact capability description shown before the full Caplet card is disclosed.")
+      .refine(
+        (value) => value.trim().length >= 10,
+        "description must contain at least 10 non-whitespace characters",
+      )
+      .refine((value) => value.length <= 1500, "description must be at most 1500 characters"),
+    tags: z
+      .array(z.string().trim().min(1).max(80))
+      .optional()
+      .describe("Optional tags for grouping or searching Caplets."),
+    mcpServer: capletMcpServerSchema.describe(
+      "Required MCP server backend configuration for this Caplet.",
+    ),
+  })
+  .strict();
+
+type CapletFileFrontmatter = z.infer<typeof capletFileSchema>;
+
+export function capletJsonSchema(): unknown {
+  return {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    $id: "https://raw.githubusercontent.com/spiritledsoftware/caplets/main/schemas/caplet.schema.json",
+    title: "Caplet file frontmatter",
+    description: "YAML frontmatter schema for a Markdown Caplet file.",
+    ...z.toJSONSchema(capletFileSchema, { io: "input" }),
+  };
+}
+
+export type CapletFileConfig = {
+  mcpServers: Record<string, unknown>;
+};
+
+export function loadCapletFiles(root: string): CapletFileConfig | undefined {
+  if (!existsSync(root)) {
+    return undefined;
+  }
+
+  const servers: Record<string, unknown> = {};
+  for (const candidate of discoverCapletFiles(root)) {
+    if (servers[candidate.id]) {
+      throw new CapletsError("CONFIG_INVALID", `Duplicate Caplet ID ${candidate.id} under ${root}`);
+    }
+    servers[candidate.id] = readCapletFile(candidate.path);
+  }
+
+  return Object.keys(servers).length > 0 ? { mcpServers: servers } : undefined;
+}
+
+function discoverCapletFiles(root: string): Array<{ id: string; path: string }> {
+  const entries = readdirSync(root, { withFileTypes: true }).sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+  const candidates: Array<{ id: string; path: string }> = [];
+  function addCandidate(id: string, path: string): void {
+    validateCapletId(id, path);
+    candidates.push({ id, path });
+  }
+
+  for (const entry of entries) {
+    if (entry.name === "auth" || entry.name === "config.json") {
+      continue;
+    }
+
+    const path = join(root, entry.name);
+    if (entry.isFile() && extname(entry.name).toLowerCase() === ".md") {
+      addCandidate(basename(entry.name, extname(entry.name)), path);
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      const capletPath = join(path, "CAPLET.md");
+      if (existsSync(capletPath) && statSync(capletPath).isFile()) {
+        addCandidate(entry.name, capletPath);
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function readCapletFile(path: string): unknown {
+  const stat = statSync(path);
+  if (stat.size > MAX_CAPLET_FILE_BYTES) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Caplet file at ${path} exceeds the ${MAX_CAPLET_FILE_BYTES} byte limit`,
+    );
+  }
+  const text = readFileSync(path, "utf8");
+  const { frontmatter, body } = parseFrontmatter(text, path);
+  if (body.length > MAX_CAPLET_BODY_CHARS) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Caplet file at ${path} body exceeds the ${MAX_CAPLET_BODY_CHARS} character limit`,
+    );
+  }
+  const parsed = capletFileSchema.safeParse(frontmatter);
+  if (!parsed.success) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Caplet file at ${path} has invalid frontmatter`,
+      parsed.error.issues,
+    );
+  }
+
+  return capletToServerConfig(parsed.data, body);
+}
+
+function capletToServerConfig(frontmatter: CapletFileFrontmatter, body: string): unknown {
+  return {
+    ...frontmatter.mcpServer,
+    name: frontmatter.name,
+    description: frontmatter.description,
+    ...(frontmatter.tags ? { tags: frontmatter.tags } : {}),
+    body,
+  };
+}
+
+function parseFrontmatter(text: string, path: string): { frontmatter: unknown; body: string } {
+  if (!text.startsWith("---\n") && !text.startsWith("---\r\n")) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Caplet file at ${path} must start with fenced YAML frontmatter`,
+    );
+  }
+
+  try {
+    const file = new VFile({ path, value: text });
+    parseMatter(file, { strip: true });
+    if (!isPlainObject(file.data.matter) || Object.keys(file.data.matter).length === 0) {
+      throw new Error("empty frontmatter");
+    }
+    return {
+      frontmatter: file.data.matter,
+      body: String(file),
+    };
+  } catch (error) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Caplet file at ${path} has invalid YAML frontmatter`,
+      redactSecrets(error),
+    );
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function validateCapletId(id: string, path: string): void {
+  if (!SERVER_ID_PATTERN.test(id)) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Caplet file at ${path} derives invalid ID ${id}; ID must match ^[a-zA-Z0-9_-]{1,64}$`,
+    );
+  }
+}
+
+function hasEnvReference(value: string): boolean {
+  return /\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$env:[A-Za-z_][A-Za-z0-9_]*/.test(value);
+}
+
+function isUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isAllowedRemoteUrl(value: string): boolean {
+  const url = new URL(value);
+  if (url.protocol === "https:") {
+    return true;
+  }
+  if (url.protocol !== "http:") {
+    return false;
+  }
+  return ["localhost", "127.0.0.1", "[::1]", "::1"].includes(url.hostname);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { z } from "zod";
+import { loadCapletFiles } from "./caplet-files.js";
 import { CapletsError, redactSecrets } from "./errors.js";
 
 export type RemoteAuthConfig =
@@ -23,6 +24,8 @@ export type CapletServerConfig = {
   server: string;
   name: string;
   description: string;
+  tags?: string[] | undefined;
+  body?: string | undefined;
   transport: "stdio" | "http" | "sse";
   command?: string | undefined;
   args?: string[] | undefined;
@@ -66,10 +69,12 @@ const FORBIDDEN_HEADERS = new Set([
   "transfer-encoding",
   "upgrade",
 ]);
+const NON_INTERPOLATED_SERVER_FIELDS = new Set(["name", "description", "tags", "body"]);
 
 export const DEFAULT_CONFIG_PATH = join(homedir(), ".caplets", "config.json");
 export const DEFAULT_AUTH_DIR = join(homedir(), ".caplets", "auth");
 export const PROJECT_CONFIG_FILE = join(".caplets", "config.json");
+export const TRUST_PROJECT_CAPLETS_ENV = "CAPLETS_TRUST_PROJECT_CAPLETS";
 
 const remoteAuthSchema = z
   .discriminatedUnion("type", [
@@ -93,7 +98,7 @@ const remoteAuthSchema = z
   ])
   .describe("Authentication settings for a remote MCP server.");
 
-const serverSchema = z
+const publicServerSchema = z
   .object({
     name: z.string().trim().min(1).max(80).describe("Human-readable server display name."),
     description: z
@@ -117,6 +122,7 @@ const serverSchema = z
     cwd: z.string().min(1).optional().describe("Working directory for stdio servers."),
     url: z.string().url().optional().describe("Remote MCP server URL for http or sse transport."),
     auth: remoteAuthSchema.optional(),
+    tags: z.array(z.string().trim().min(1).max(80)).optional(),
     startupTimeoutMs: z
       .number()
       .int()
@@ -142,99 +148,116 @@ const serverSchema = z
   })
   .strict();
 
-export const configFileSchema = z
-  .object({
-    $schema: z
-      .string()
-      .url()
-      .optional()
-      .describe("Optional JSON Schema URL for editor validation."),
-    version: z.literal(1).default(1).describe("Caplets config schema version."),
-    defaultSearchLimit: z
-      .number()
-      .int()
-      .positive()
-      .default(20)
-      .describe("Default maximum number of same-server search results."),
-    maxSearchLimit: z
-      .number()
-      .int()
-      .positive()
-      .max(50)
-      .default(50)
-      .describe("Maximum accepted search_tools limit."),
-    mcpServers: z
-      .record(z.string().regex(SERVER_ID_PATTERN), serverSchema)
-      .describe("Downstream MCP servers keyed by stable server ID."),
-  })
-  .strict()
-  .superRefine((config, ctx) => {
-    if (config.defaultSearchLimit > config.maxSearchLimit) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["defaultSearchLimit"],
-        message: "defaultSearchLimit must be <= maxSearchLimit",
-      });
-    }
+const normalizedServerSchema = publicServerSchema.extend({
+  body: z.string().optional(),
+});
 
-    for (const [server, raw] of Object.entries(config.mcpServers)) {
-      if (!SERVER_ID_PATTERN.test(server)) {
+type ConfigSchemaServerValue = z.infer<typeof normalizedServerSchema>;
+type ConfigInput = {
+  mcpServers?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+function configSchemaFor(serverValueSchema: z.ZodTypeAny) {
+  return z
+    .object({
+      $schema: z
+        .string()
+        .url()
+        .optional()
+        .describe("Optional JSON Schema URL for editor validation."),
+      version: z.literal(1).default(1).describe("Caplets config schema version."),
+      defaultSearchLimit: z
+        .number()
+        .int()
+        .positive()
+        .default(20)
+        .describe("Default maximum number of same-server search results."),
+      maxSearchLimit: z
+        .number()
+        .int()
+        .positive()
+        .max(50)
+        .default(50)
+        .describe("Maximum accepted search_tools limit."),
+      mcpServers: z
+        .record(z.string().regex(SERVER_ID_PATTERN), serverValueSchema)
+        .default({})
+        .describe("Downstream MCP servers keyed by stable server ID."),
+    })
+    .strict()
+    .superRefine((config, ctx) => {
+      if (config.defaultSearchLimit > config.maxSearchLimit) {
         ctx.addIssue({
           code: "custom",
-          path: ["mcpServers", server],
-          message: "server ID must match ^[a-zA-Z0-9_-]{1,64}$",
+          path: ["defaultSearchLimit"],
+          message: "defaultSearchLimit must be <= maxSearchLimit",
         });
       }
 
-      const effectiveTransport = raw.transport ?? (raw.command ? "stdio" : undefined);
-      const hasStdio = Boolean(raw.command);
-      const hasRemote = Boolean(raw.url);
-      if (hasStdio === hasRemote) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["mcpServers", server],
-          message: "server must define exactly one connection shape: command or url",
-        });
-      }
+      for (const [server, rawValue] of Object.entries(config.mcpServers)) {
+        const raw = rawValue as ConfigSchemaServerValue;
+        if (!SERVER_ID_PATTERN.test(server)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["mcpServers", server],
+            message: "server ID must match ^[a-zA-Z0-9_-]{1,64}$",
+          });
+        }
 
-      if (effectiveTransport === "stdio" && !raw.command) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["mcpServers", server, "command"],
-          message: "stdio servers require command",
-        });
-      }
+        const effectiveTransport = raw.transport ?? (raw.command ? "stdio" : undefined);
+        const hasStdio = Boolean(raw.command);
+        const hasRemote = Boolean(raw.url);
+        if (hasStdio === hasRemote) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["mcpServers", server],
+            message: "server must define exactly one connection shape: command or url",
+          });
+        }
 
-      if ((effectiveTransport === "http" || effectiveTransport === "sse") && !raw.url) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["mcpServers", server, "url"],
-          message: "remote servers require url",
-        });
-      }
+        if (effectiveTransport === "stdio" && !raw.command) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["mcpServers", server, "command"],
+            message: "stdio servers require command",
+          });
+        }
 
-      if (raw.url && !isAllowedRemoteUrl(raw.url)) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["mcpServers", server, "url"],
-          message: "remote url must use https except loopback development urls",
-        });
-      }
+        if ((effectiveTransport === "http" || effectiveTransport === "sse") && !raw.url) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["mcpServers", server, "url"],
+            message: "remote servers require url",
+          });
+        }
 
-      if (raw.auth?.type === "headers") {
-        for (const headerName of Object.keys(raw.auth.headers)) {
-          const normalized = headerName.toLowerCase();
-          if (!HEADER_NAME_PATTERN.test(headerName) || FORBIDDEN_HEADERS.has(normalized)) {
-            ctx.addIssue({
-              code: "custom",
-              path: ["mcpServers", server, "auth", "headers", headerName],
-              message: `header ${headerName} is not allowed`,
-            });
+        if (raw.url && !isAllowedRemoteUrl(raw.url)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["mcpServers", server, "url"],
+            message: "remote url must use https except loopback development urls",
+          });
+        }
+
+        if (raw.auth?.type === "headers") {
+          for (const headerName of Object.keys(raw.auth.headers)) {
+            const normalized = headerName.toLowerCase();
+            if (!HEADER_NAME_PATTERN.test(headerName) || FORBIDDEN_HEADERS.has(normalized)) {
+              ctx.addIssue({
+                code: "custom",
+                path: ["mcpServers", server, "auth", "headers", headerName],
+                message: `header ${headerName} is not allowed`,
+              });
+            }
           }
         }
       }
-    }
-  });
+    });
+}
+
+export const configFileSchema = configSchemaFor(publicServerSchema);
+const normalizedConfigFileSchema = configSchemaFor(normalizedServerSchema);
 
 export function configJsonSchema(): unknown {
   return {
@@ -254,14 +277,28 @@ export function resolveProjectConfigPath(cwd = process.cwd()): string {
   return join(cwd, PROJECT_CONFIG_FILE);
 }
 
+export function resolveCapletsRoot(configPath = resolveConfigPath()): string {
+  return dirname(configPath);
+}
+
+export function resolveProjectCapletsRoot(cwd = process.cwd()): string {
+  return join(cwd, ".caplets");
+}
+
 export function loadConfig(
   path = resolveConfigPath(),
   projectPath = resolveProjectConfigPath(),
 ): CapletsConfig {
   const hasUserConfig = existsSync(path);
   const hasProjectConfig = existsSync(projectPath);
+  const userConfig = hasUserConfig ? readPublicConfigInput(path) : undefined;
+  const userCaplets = loadCapletFiles(resolveCapletsRoot(path));
+  const projectConfig = hasProjectConfig ? readPublicConfigInput(projectPath) : undefined;
+  const projectCaplets = shouldLoadProjectCaplets()
+    ? loadCapletFiles(dirname(projectPath))
+    : undefined;
 
-  if (!hasUserConfig && !hasProjectConfig) {
+  if (!hasUserConfig && !hasProjectConfig && !userCaplets && !projectCaplets) {
     throw new CapletsError(
       "CONFIG_NOT_FOUND",
       `Caplets config not found at ${path} or ${projectPath}`,
@@ -269,9 +306,16 @@ export function loadConfig(
   }
 
   try {
-    const projectConfig = hasProjectConfig ? readConfigFile(projectPath) : undefined;
-    const userConfig = hasUserConfig ? readConfigFile(path) : undefined;
-    return parseConfig(mergeConfigInputs(projectConfig, userConfig));
+    const config = parseConfig(
+      mergeConfigInputs(userConfig, userCaplets, projectConfig, projectCaplets),
+    );
+    if (Object.keys(config.mcpServers).length === 0) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        "Caplets config must define at least one MCP server",
+      );
+    }
+    return config;
   } catch (error) {
     if (error instanceof CapletsError) {
       throw error;
@@ -284,10 +328,30 @@ export function loadConfig(
   }
 }
 
-function readConfigFile(path: string): unknown {
+function shouldLoadProjectCaplets(): boolean {
+  return isTrustedEnvEnabled(process.env[TRUST_PROJECT_CAPLETS_ENV]);
+}
+
+function isTrustedEnvEnabled(value: string | undefined): boolean {
+  return value === "1" || value?.toLowerCase() === "true" || value?.toLowerCase() === "yes";
+}
+
+function readPublicConfigInput(path: string): ConfigInput {
   try {
-    return JSON.parse(readFileSync(path, "utf8"));
+    const input = JSON.parse(readFileSync(path, "utf8"));
+    const parsed = configFileSchema.safeParse(interpolateConfig(input));
+    if (!parsed.success) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        `Caplets config at ${path} is invalid`,
+        parsed.error.issues,
+      );
+    }
+    return input as ConfigInput;
   } catch (error) {
+    if (error instanceof CapletsError) {
+      throw error;
+    }
     throw new CapletsError(
       "CONFIG_INVALID",
       `Caplets config at ${path} is not valid JSON`,
@@ -296,43 +360,33 @@ function readConfigFile(path: string): unknown {
   }
 }
 
-function mergeConfigInputs(projectConfig: unknown, userConfig: unknown): unknown {
-  if (projectConfig === undefined) {
-    return userConfig;
+function mergeConfigInputs(...inputs: Array<ConfigInput | undefined>): ConfigInput | undefined {
+  let merged: ConfigInput | undefined;
+  for (const input of inputs) {
+    if (input === undefined) {
+      continue;
+    }
+    merged = {
+      ...merged,
+      ...input,
+      mcpServers: {
+        ...merged?.mcpServers,
+        ...input.mcpServers,
+      },
+    };
   }
-  if (userConfig === undefined) {
-    return projectConfig;
-  }
-  if (!isPlainConfigObject(projectConfig) || !isPlainConfigObject(userConfig)) {
-    return userConfig;
-  }
-
-  return {
-    ...userConfig,
-    ...projectConfig,
-    mcpServers: {
-      ...userConfig.mcpServers,
-      ...projectConfig.mcpServers,
-    },
-  };
-}
-
-function isPlainConfigObject(value: unknown): value is {
-  mcpServers?: Record<string, unknown>;
-  [key: string]: unknown;
-} {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  return merged;
 }
 
 export function parseConfig(input: unknown): CapletsConfig {
-  const parsed = configFileSchema.safeParse(interpolateServer(input));
+  const parsed = normalizedConfigFileSchema.safeParse(interpolateConfig(input));
   if (!parsed.success) {
     throw new CapletsError("CONFIG_INVALID", "Caplets config is invalid", parsed.error.issues);
   }
 
   const servers: Record<string, CapletServerConfig> = {};
   for (const [server, raw] of Object.entries(parsed.data.mcpServers)) {
-    const interpolated = raw;
+    const interpolated = raw as ConfigSchemaServerValue;
     servers[server] = stripUndefined({
       ...interpolated,
       server,
@@ -356,19 +410,32 @@ function stripUndefined<T extends Record<string, unknown>>(value: T): T {
   ) as T;
 }
 
-function interpolateServer<T>(value: T): T {
+function interpolateConfig<T>(value: T, path: string[] = []): T {
+  if (isPublicMetadataPath(path)) {
+    return value;
+  }
   if (typeof value === "string") {
     return interpolateEnv(value) as T;
   }
   if (Array.isArray(value)) {
-    return value.map((item) => interpolateServer(item)) as T;
+    return value.map((item, index) => interpolateConfig(item, [...path, String(index)])) as T;
   }
   if (value && typeof value === "object") {
     return Object.fromEntries(
-      Object.entries(value).map(([key, nested]) => [key, interpolateServer(nested)]),
+      Object.entries(value).map(([nestedKey, nested]) => [
+        nestedKey,
+        interpolateConfig(nested, [...path, nestedKey]),
+      ]),
     ) as T;
   }
   return value;
+}
+
+function isPublicMetadataPath(path: string[]): boolean {
+  if (path.length < 3 || path[0] !== "mcpServers") {
+    return false;
+  }
+  return NON_INTERPOLATED_SERVER_FIELDS.has(path[2] ?? "");
 }
 
 export function interpolateEnv(value: string): string {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -13,9 +13,18 @@ export type CapletServerSummary = {
 };
 
 export type CapletServerDetail = {
-  server: string;
+  caplet: string;
   name: string;
   description: string;
+  tags?: string[];
+  body?: string;
+  mcpServer: {
+    transport: CapletServerConfig["transport"];
+    disabled: boolean;
+    startupTimeoutMs: number;
+    callTimeoutMs: number;
+    toolCacheTtlMs: number;
+  };
 };
 
 export class ServerRegistry {
@@ -71,18 +80,29 @@ export class ServerRegistry {
 
   detail(server: CapletServerConfig): CapletServerDetail {
     return {
-      server: server.server,
+      caplet: server.server,
       name: server.name,
       description: server.description,
+      ...(server.tags ? { tags: server.tags } : {}),
+      ...(server.body ? { body: server.body } : {}),
+      mcpServer: {
+        transport: server.transport,
+        disabled: server.disabled,
+        startupTimeoutMs: server.startupTimeoutMs,
+        callTimeoutMs: server.callTimeoutMs,
+        toolCacheTtlMs: server.toolCacheTtlMs,
+      },
     };
   }
 }
 
 export function capabilityDescription(server: CapletServerConfig): string {
   const hint = [
-    `Use this Caplets wrapper to inspect and call tools from ${server.server}.`,
+    `Use this Caplet to inspect and call tools from its MCP server backend.`,
     "",
     "Recommended flow:",
+    '- Read the full Caplet card: {"operation":"get_caplet"}',
+    '- Check the MCP backend: {"operation":"check_mcp_server"}',
     '- Discover tools: {"operation":"list_tools"} or {"operation":"search_tools","query":"<what you need>"}',
     '- Read one tool schema: {"operation":"get_tool","tool":"<tool name>"}',
     '- Invoke one downstream tool: {"operation":"call_tool","tool":"<tool name>","arguments":{...}}',

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6,8 +6,8 @@ import { CapletsError } from "./errors.js";
 import type { ServerRegistry } from "./registry.js";
 
 const operations = [
-  "get_server",
-  "check_server",
+  "get_caplet",
+  "check_mcp_server",
   "list_tools",
   "search_tools",
   "get_tool",
@@ -20,7 +20,7 @@ export const generatedToolInputSchema = z
     operation: operationSchema.describe(
       [
         "Caplets wrapper operation to perform for this configured MCP server.",
-        "Use list_tools or search_tools to discover downstream tools, get_tool to read a downstream input schema, and call_tool to run one downstream tool.",
+        "Use get_caplet to read the full Caplet card, check_mcp_server to check the MCP backend, list_tools or search_tools to discover downstream tools, get_tool to read a downstream input schema, and call_tool to run one downstream tool.",
         'For call_tool, pass downstream inputs only inside the top-level "arguments" object.',
       ].join(" "),
     ),
@@ -64,9 +64,9 @@ export async function handleServerTool(
   const parsed = validateOperationRequest(request, registry.config.options.maxSearchLimit);
 
   switch (parsed.operation) {
-    case "get_server":
+    case "get_caplet":
       return jsonResult(registry.detail(server));
-    case "check_server":
+    case "check_mcp_server":
       return jsonResult(await downstream.checkServer(server));
     case "list_tools": {
       const tools = await downstream.listTools(server);
@@ -135,8 +135,8 @@ export function validateOperationRequest(
   };
 
   switch (value.operation) {
-    case "get_server":
-    case "check_server":
+    case "get_caplet":
+    case "check_mcp_server":
     case "list_tools":
       allowed([]);
       return { operation: value.operation };
@@ -173,7 +173,7 @@ export function validateOperationRequest(
 }
 
 type RequiredOperationRequest =
-  | { operation: "get_server" | "check_server" | "list_tools" }
+  | { operation: "get_caplet" | "check_mcp_server" | "list_tools" }
   | { operation: "search_tools"; query: string; limit?: number }
   | { operation: "get_tool"; tool: string }
   | { operation: "call_tool"; tool: string; arguments: Record<string, unknown> };

--- a/test/benchmark.test.ts
+++ b/test/benchmark.test.ts
@@ -24,8 +24,8 @@ describe("progressive disclosure benchmark fixture", () => {
           properties: {
             operation: {
               enum: [
-                "get_server",
-                "check_server",
+                "get_caplet",
+                "check_mcp_server",
                 "list_tools",
                 "search_tools",
                 "get_tool",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -2,14 +2,17 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { capletJsonSchema } from "../src/caplet-files.js";
 import { configJsonSchema, loadConfig, parseConfig } from "../src/config.js";
 import { CapletsError } from "../src/errors.js";
 
 describe("config", () => {
   const originalEnv = process.env.EXAMPLE_TOKEN;
+  const originalTrustProjectCaplets = process.env.CAPLETS_TRUST_PROJECT_CAPLETS;
 
   beforeEach(() => {
     process.env.EXAMPLE_TOKEN = "secret-value";
+    delete process.env.CAPLETS_TRUST_PROJECT_CAPLETS;
   });
 
   afterEach(() => {
@@ -17,6 +20,11 @@ describe("config", () => {
       delete process.env.EXAMPLE_TOKEN;
     } else {
       process.env.EXAMPLE_TOKEN = originalEnv;
+    }
+    if (originalTrustProjectCaplets === undefined) {
+      delete process.env.CAPLETS_TRUST_PROJECT_CAPLETS;
+    } else {
+      process.env.CAPLETS_TRUST_PROJECT_CAPLETS = originalTrustProjectCaplets;
     }
   });
 
@@ -119,6 +127,234 @@ describe("config", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  it("loads top-level and directory Caplet files with project Caplets winning", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-files-"));
+    const userRoot = join(dir, "user");
+    const projectRoot = join(dir, "project", ".caplets");
+    mkdirSync(join(userRoot, "linear"), { recursive: true });
+    mkdirSync(join(projectRoot, "linear"), { recursive: true });
+    process.env.CAPLETS_TRUST_PROJECT_CAPLETS = "1";
+    writeFileSync(
+      join(userRoot, "github.md"),
+      [
+        "---",
+        "name: GitHub",
+        "description: Use GitHub repositories, issues, and ${EXAMPLE_TOKEN}.",
+        "tags:",
+        "  - code",
+        "  - $env:EXAMPLE_TOKEN",
+        "mcpServer:",
+        "  command: user-github",
+        "  env:",
+        "    name: $env:EXAMPLE_TOKEN",
+        "---",
+        "# GitHub Card",
+        "Use this for GitHub work with ${EXAMPLE_TOKEN} in prose.",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(userRoot, "linear", "CAPLET.md"),
+      [
+        "---",
+        "name: Linear User",
+        "description: Use Linear for user issue planning.",
+        "mcpServer:",
+        "  command: user-linear",
+        "---",
+        "# User Linear",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(projectRoot, "linear", "CAPLET.md"),
+      [
+        "---",
+        "name: Linear Project",
+        "description: Use Linear for project issue planning.",
+        "mcpServer:",
+        "  command: project-linear",
+        "---",
+        "# Project Linear",
+      ].join("\n"),
+    );
+
+    const config = loadConfig(join(userRoot, "config.json"), join(projectRoot, "config.json"));
+
+    expect(config.mcpServers.github).toMatchObject({
+      server: "github",
+      name: "GitHub",
+      description: "Use GitHub repositories, issues, and ${EXAMPLE_TOKEN}.",
+      command: "user-github",
+      env: { name: "secret-value" },
+      tags: ["code", "$env:EXAMPLE_TOKEN"],
+      body: "# GitHub Card\nUse this for GitHub work with ${EXAMPLE_TOKEN} in prose.",
+    });
+    expect(config.mcpServers.github?.description).toContain("${EXAMPLE_TOKEN}");
+    expect(config.mcpServers.github?.tags).toContain("$env:EXAMPLE_TOKEN");
+    expect(config.mcpServers.github?.body).toContain("${EXAMPLE_TOKEN}");
+    expect(config.mcpServers.linear).toMatchObject({
+      server: "linear",
+      name: "Linear Project",
+      command: "project-linear",
+      body: "# Project Linear",
+    });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not load project Caplet files without explicit trust", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-files-"));
+    const userRoot = join(dir, "user");
+    const projectRoot = join(dir, "project", ".caplets");
+    mkdirSync(userRoot, { recursive: true });
+    mkdirSync(projectRoot, { recursive: true });
+    writeFileSync(
+      join(userRoot, "config.json"),
+      JSON.stringify({
+        mcpServers: {
+          github: {
+            name: "GitHub User",
+            description: "Use GitHub from trusted user config.",
+            command: "user-github",
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      join(projectRoot, "github.md"),
+      [
+        "---",
+        "name: GitHub Project",
+        "description: Use GitHub from untrusted project Caplet.",
+        "mcpServer:",
+        "  command: project-github",
+        "---",
+        "# GitHub Project",
+      ].join("\n"),
+    );
+
+    const config = loadConfig(join(userRoot, "config.json"), join(projectRoot, "config.json"));
+    expect(config.mcpServers.github?.name).toBe("GitHub User");
+    expect(config.mcpServers.github?.command).toBe("user-github");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("lets Caplet files override same-root config entries", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-files-"));
+    const root = join(dir, ".caplets");
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, "config.json"),
+      JSON.stringify({
+        mcpServers: {
+          github: {
+            name: "GitHub Config",
+            description: "Use GitHub from plain config.",
+            command: "config-github",
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      join(root, "github.md"),
+      [
+        "---",
+        "name: GitHub File",
+        "description: Use GitHub from the Caplet file.",
+        "mcpServer:",
+        "  command: file-github",
+        "---",
+        "# GitHub File",
+      ].join("\n"),
+    );
+
+    const config = loadConfig(join(root, "config.json"), join(dir, "missing", "config.json"));
+    expect(config.mcpServers.github?.name).toBe("GitHub File");
+    expect(config.mcpServers.github?.command).toBe("file-github");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("rejects invalid Caplet files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-files-"));
+    const root = join(dir, ".caplets");
+    mkdirSync(join(root, "github"), { recursive: true });
+    writeFileSync(
+      join(root, "missing-server.md"),
+      ["---", "name: Missing", "description: Missing backend config.", "---", "# Missing"].join(
+        "\n",
+      ),
+    );
+    expect(() =>
+      loadConfig(join(root, "config.json"), join(dir, "missing", "config.json")),
+    ).toThrow(CapletsError);
+    rmSync(root, { recursive: true, force: true });
+
+    mkdirSync(join(root, "github"), { recursive: true });
+    writeFileSync(
+      join(root, "github.md"),
+      [
+        "---",
+        "name: GitHub",
+        "description: Use GitHub repositories and issues.",
+        "mcpServer:",
+        "  command: node",
+        "---",
+        "# GitHub",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(root, "github", "CAPLET.md"),
+      [
+        "---",
+        "name: GitHub Directory",
+        "description: Use GitHub repositories and issues.",
+        "mcpServer:",
+        "  command: node",
+        "---",
+        "# GitHub",
+      ].join("\n"),
+    );
+    expect(() =>
+      loadConfig(join(root, "config.json"), join(dir, "missing", "config.json")),
+    ).toThrow(CapletsError);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("rejects oversized Caplet files and bodies", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-files-"));
+    const root = join(dir, ".caplets");
+    mkdirSync(root, { recursive: true });
+    const frontmatter = [
+      "---",
+      "name: Big",
+      "description: Use this oversized Caplet fixture.",
+      "mcpServer:",
+      "  command: node",
+      "---",
+      "",
+    ].join("\n");
+    writeFileSync(join(root, "big.md"), `${frontmatter}${"x".repeat(130 * 1024)}`);
+
+    expect(() =>
+      loadConfig(join(root, "config.json"), join(dir, "missing", "config.json")),
+    ).toThrow(CapletsError);
+    rmSync(root, { recursive: true, force: true });
+
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, "big.md"), `${frontmatter}${"x".repeat(65 * 1024)}`);
+    expect(() =>
+      loadConfig(join(root, "config.json"), join(dir, "missing", "config.json")),
+    ).toThrow(CapletsError);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("rejects empty config files when no Caplet files exist", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-config-"));
+    const path = join(dir, "config.json");
+    writeFileSync(path, "{}");
+
+    expect(() => loadConfig(path, join(dir, "missing", "config.json"))).toThrow(CapletsError);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it("loads top-level Caplets options", () => {
     const config = parseConfig({
       $schema:
@@ -150,6 +386,9 @@ describe("config", () => {
     expect(JSON.parse(readFileSync("schemas/caplets-config.schema.json", "utf8"))).toEqual(
       configJsonSchema(),
     );
+    expect(JSON.parse(readFileSync("schemas/caplet.schema.json", "utf8"))).toEqual(
+      capletJsonSchema(),
+    );
   });
 
   it("rejects unsupported versions and unknown keys", () => {
@@ -167,6 +406,24 @@ describe("config", () => {
         },
       }),
     ).toThrow(CapletsError);
+
+    const dir = mkdtempSync(join(tmpdir(), "caplets-config-"));
+    const path = join(dir, "config.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        mcpServers: {
+          plain: {
+            name: "Plain",
+            description: "A useful plain downstream server.",
+            command: "node",
+            body: "Caplet file-only field.",
+          },
+        },
+      }),
+    );
+    expect(() => loadConfig(path, join(dir, "missing", "config.json"))).toThrow(CapletsError);
+    rmSync(dir, { recursive: true, force: true });
   });
 
   it("validates server IDs, required names, descriptions, and disabled default", () => {

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -4,13 +4,23 @@ import { capabilityDescription, ServerRegistry } from "../src/registry.js";
 
 describe("registry", () => {
   it("omits disabled servers and builds safe capability cards", () => {
+    process.env.SECRET_TOKEN = "secret-env-value";
     const config = parseConfig({
       mcpServers: {
         enabled: {
           name: "Enabled Server",
           description: "A useful enabled server.",
           command: "node",
-          args: ["secret-arg"],
+          args: ["secret-arg", "$env:SECRET_TOKEN"],
+          env: { SECRET_TOKEN: "$env:SECRET_TOKEN" },
+          auth: undefined,
+        },
+        remote: {
+          name: "Remote Server",
+          description: "A useful remote server.",
+          transport: "http",
+          url: "https://example.com/mcp?token=secret-url-value",
+          auth: { type: "bearer", token: "secret-bearer-value" },
         },
         disabled: {
           name: "Disabled Server",
@@ -21,7 +31,7 @@ describe("registry", () => {
       },
     });
     const registry = new ServerRegistry(config);
-    expect(registry.enabledServers().map((server) => server.server)).toEqual(["enabled"]);
+    expect(registry.enabledServers().map((server) => server.server)).toEqual(["enabled", "remote"]);
     expect(registry.get("disabled")).toBeUndefined();
     const description = capabilityDescription(config.mcpServers.enabled!);
     expect(description).toContain("Enabled Server");
@@ -30,5 +40,12 @@ describe("registry", () => {
     );
     expect(description).toContain("Do not put downstream arguments at the top level");
     expect(description).not.toContain("secret-arg");
+    expect(description).not.toContain("secret-env-value");
+
+    const remoteDetail = registry.detail(config.mcpServers.remote!);
+    const serialized = JSON.stringify(remoteDetail);
+    expect(serialized).toContain('"transport":"http"');
+    expect(serialized).not.toContain("secret-url-value");
+    expect(serialized).not.toContain("secret-bearer-value");
   });
 });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -41,6 +41,27 @@ describe("generated tool request validation", () => {
     expect(() => validateOperationRequest({ operation: "explode" }, 50)).toThrow(
       expect.objectContaining({ code: "UNKNOWN_OPERATION" }),
     );
+    expect(() => validateOperationRequest({ operation: "get_server" }, 50)).toThrow(
+      expect.objectContaining({ code: "UNKNOWN_OPERATION" }),
+    );
+    expect(() => validateOperationRequest({ operation: "check_server" }, 50)).toThrow(
+      expect.objectContaining({ code: "UNKNOWN_OPERATION" }),
+    );
+  });
+
+  it("exposes the Caplet-first operation enum", () => {
+    const schema = z.toJSONSchema(generatedToolInputSchema, { io: "input" }) as {
+      properties: Record<string, { enum?: string[] }>;
+    };
+
+    expect(schema.properties.operation?.enum).toEqual([
+      "get_caplet",
+      "check_mcp_server",
+      "list_tools",
+      "search_tools",
+      "get_tool",
+      "call_tool",
+    ]);
   });
 
   it("describes the nested call_tool argument shape to agents", () => {
@@ -89,20 +110,47 @@ describe("generated tool handlers", () => {
     },
   ];
 
-  it("returns get_server without starting downstream", async () => {
+  it("returns get_caplet without starting downstream", async () => {
     const downstream = { checkServer: vi.fn(), listTools: vi.fn() } as unknown as DownstreamManager;
     const result = (await handleServerTool(
       server,
-      { operation: "get_server" },
+      { operation: "get_caplet" },
       registry,
       downstream,
     )) as any;
     expect(result.structuredContent?.result).toEqual({
-      server: "alpha",
+      caplet: "alpha",
       name: "Alpha",
       description: "Search alpha project documents.",
+      mcpServer: {
+        transport: "stdio",
+        disabled: false,
+        startupTimeoutMs: 10000,
+        callTimeoutMs: 60000,
+        toolCacheTtlMs: 30000,
+      },
     });
     expect(downstream.listTools).not.toHaveBeenCalled();
+  });
+
+  it("checks the MCP server backend", async () => {
+    const status = { server: "alpha", status: "available", toolCount: 2, elapsedMs: 5 };
+    const downstream = {
+      checkServer: vi.fn().mockResolvedValue(status),
+      listTools: vi.fn(),
+      callTool: vi.fn(),
+    } as unknown as DownstreamManager;
+    const result = (await handleServerTool(
+      server,
+      { operation: "check_mcp_server" },
+      registry,
+      downstream,
+    )) as any;
+
+    expect(result.structuredContent?.result).toEqual(status);
+    expect(downstream.checkServer).toHaveBeenCalledWith(server);
+    expect(downstream.listTools).not.toHaveBeenCalled();
+    expect(downstream.callTool).not.toHaveBeenCalled();
   });
 
   it("lists compact metadata and preserves full get_tool metadata", async () => {


### PR DESCRIPTION
## Summary

Adds skill-like Markdown Caplet files while preserving the rule that every Caplet is backed by an MCP server. Caplets can now be defined as top-level `*.md` files or one-level `*/CAPLET.md` directories with required frontmatter and optional Markdown body content.

Also renames runtime operations to Caplet-first language, adds generated schema support for Caplet frontmatter, documents project Caplet trust behavior, and hardens `get_caplet` so it only returns safe backend metadata.

## Security and behavior notes

- Project Markdown Caplet files require process-level opt-in through `CAPLETS_TRUST_PROJECT_CAPLETS=1`, `true`, or `yes`.
- Serverless Caplets are intentionally unsupported.
- `get_caplet` does not expose raw command, args, env, URL, auth, tokens, headers, source paths, or other executable backend details.
- Public metadata fields are not environment-interpolated to avoid accidental secret disclosure in discovery responses.
- `gray-matter` was avoided in favor of `vfile` and `vfile-matter`.

## Verification

- `npm exec pnpm -- schema:generate`
- `npm exec pnpm -- format:check`
- `npm exec pnpm -- lint`
- `npm exec pnpm -- typecheck`
- `npm exec pnpm -- schema:check`
- `npm exec pnpm -- test`
- `npm exec pnpm -- build`
- `npm exec pnpm -- audit --prod`
- `git diff --check`

Note: local Husky pre-commit/pre-push hooks were disabled for commit/push because this shell cannot resolve a direct `pnpm` binary, but the equivalent and broader checks above passed via `npm exec pnpm -- ...`.