### PR TITLE
feat: add native OpenAPI caplets

### DIFF
--- a/.changeset/native-openapi-caplets.md
+++ b/.changeset/native-openapi-caplets.md
@@ -1,0 +1,7 @@
+---
+"caplets": minor
+---
+
+Add native OpenAPI-backed Caplets alongside MCP server backends.
+
+OpenAPI endpoint configs can now expose one generated Caplet tool per API spec, progressively disclose operations as tools, and execute HTTP calls through the existing `call_tool` flow. The implementation includes explicit OpenAPI auth configuration, safe spec loading, guarded request construction, generated schema updates, and documentation for `openapiEndpoints`.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Caplets
 
-Caplets is a progressive-disclosure gateway for Model Context Protocol (MCP) servers.
+Caplets is a progressive-disclosure gateway for Model Context Protocol (MCP) servers and
+native OpenAPI endpoints.
 
-Instead of connecting an MCP client to many downstream servers and exposing every tool up
-front, Caplets exposes one top-level tool per configured server. An agent first chooses a
-capability domain, then asks Caplets to list, search, inspect, or call that server's
-underlying tools.
+Instead of connecting an MCP client to many downstream servers or HTTP APIs and exposing
+every operation up front, Caplets exposes one top-level tool per configured capability.
+An agent first chooses a capability domain, then asks Caplets to list, search, inspect,
+or call that backend's underlying tools or operations.
 
 This keeps the initial MCP tool list small, makes tool selection easier, and avoids
 flattened tool-name collisions across servers.
@@ -27,13 +28,14 @@ the agent chooses that server and asks to search, list, inspect, or call them.
 
 ## What It Does
 
-- Reads downstream MCP server definitions from `~/.caplets/config.json`.
-- Registers one generated MCP tool for each enabled server.
+- Reads downstream MCP server definitions and native OpenAPI endpoint definitions from `~/.caplets/config.json`.
+- Registers one generated MCP tool for each enabled MCP server or OpenAPI endpoint.
 - Uses the configured server ID as the generated tool name.
 - Uses the configured `name` and `description` as the capability card shown to agents.
-- Starts downstream servers lazily when an operation needs them.
+- Starts downstream MCP servers and loads OpenAPI specs lazily when an operation needs them.
 - Supports stdio, Streamable HTTP, and legacy HTTP+SSE downstream servers.
-- Lets agents `list_tools`, `search_tools`, `get_tool`, and `call_tool` within one selected server namespace.
+- Lets agents `list_tools`, `search_tools`, `get_tool`, and `call_tool` within one selected Caplet namespace.
+- Converts OpenAPI operations into MCP-style tool metadata and executes HTTP calls directly.
 - Preserves downstream tool results instead of rewriting them into a custom format.
 - Redacts secrets from structured errors.
 - Supports static remote auth and OAuth token storage for remote servers.
@@ -91,6 +93,18 @@ you want Caplets to expose:
         "token": "$env:DOCS_MCP_TOKEN"
       }
     }
+  },
+  "openapiEndpoints": {
+    "users": {
+      "name": "Users API",
+      "description": "Manage users through the internal HTTP API.",
+      "specPath": "./openapi.json",
+      "baseUrl": "https://api.example.com",
+      "auth": {
+        "type": "bearer",
+        "token": "$env:USERS_API_TOKEN"
+      }
+    }
   }
 }
 ```
@@ -112,8 +126,8 @@ the committed schema stays in sync with the Zod config validator.
 ### Caplet Files
 
 For richer skill-like cards, add Markdown Caplet files beside `config.json`. Every Caplet
-file must include an `mcpServer` backend; serverless Caplets are intentionally out of
-scope.
+file must include exactly one executable backend: `mcpServer` or `openapiEndpoint`;
+serverless Caplets are intentionally out of scope.
 
 Top-level files derive the Caplet ID from the filename:
 
@@ -133,6 +147,23 @@ mcpServer:
 # GitHub
 
 Use this Caplet for repository, issue, pull request, and code review workflows.
+```
+
+OpenAPI-backed Caplet files use `openapiEndpoint`:
+
+```md
+---
+name: Users API
+description: Manage users through the internal HTTP API.
+openapiEndpoint:
+  specPath: ./openapi.json
+  baseUrl: https://api.example.com
+  auth:
+    type: bearer
+    token: $env:USERS_API_TOKEN
+---
+
+# Users API
 ```
 
 That file is exposed as the `github` Caplet. Directory-style Caplets use
@@ -156,10 +187,10 @@ project `config.json`, and, only when trusted, project Caplet files.
 caplets init --force
 ```
 
-### Server IDs
+### Caplet IDs
 
-Each key under `mcpServers` is the stable server ID. It becomes the generated MCP tool
-name exactly, so keep it short and specific:
+Each key under `mcpServers` or `openapiEndpoints` is the stable Caplet ID. It becomes the
+generated MCP tool name exactly, so keep it short and specific:
 
 ```json
 {
@@ -174,8 +205,8 @@ name exactly, so keep it short and specific:
 }
 ```
 
-Server IDs must match `^[a-zA-Z0-9_-]{1,64}$`. Spaces, dots, slashes, colons, and
-Unicode IDs are rejected.
+Caplet IDs must match `^[a-zA-Z0-9_-]{1,64}$` and must be unique across `mcpServers` and
+`openapiEndpoints`. Spaces, dots, slashes, colons, and Unicode IDs are rejected.
 
 ### Stdio Servers
 
@@ -215,6 +246,51 @@ Use `transport` and `url` for remote MCP servers.
 
 `transport` can be `http` for MCP Streamable HTTP or `sse` for legacy HTTP+SSE. Remote
 URLs must use `https://`, except loopback development URLs such as `http://localhost`.
+
+### OpenAPI Endpoints
+
+Use `openapiEndpoints` for native HTTP APIs described by OpenAPI 3 specs. Each entry
+points at one spec through either `specPath` or `specUrl`, and may override the request
+base URL with `baseUrl`.
+
+```json
+{
+  "name": "Users API",
+  "description": "Manage users through the internal HTTP API.",
+  "specPath": "./openapi.json",
+  "baseUrl": "https://api.example.com",
+  "auth": { "type": "none" }
+}
+```
+
+OpenAPI auth is explicit and supports:
+
+- `{"type": "none"}`
+- `{"type": "bearer", "token": "$env:TOKEN"}`
+- `{"type": "headers", "headers": {"x-api-key": "$env:API_KEY"}}`
+
+OpenAPI OAuth is not part of the first native OpenAPI backend. OAuth remains available
+for remote MCP servers through `caplets auth`.
+
+OpenAPI `call_tool.arguments` uses grouped HTTP inputs:
+
+```json
+{
+  "operation": "call_tool",
+  "tool": "GET /users/{id}",
+  "arguments": {
+    "path": { "id": "42" },
+    "query": { "active": true },
+    "body": { "name": "Ada" }
+  }
+}
+```
+
+Every OpenAPI endpoint can set:
+
+- `requestTimeoutMs`: timeout for HTTP calls. Defaults to `60000`.
+- `operationCacheTtlMs`: how long OpenAPI operation metadata stays fresh. Defaults to `30000`; `0` refreshes every time.
+- `disabled`: omit the endpoint from Caplets discovery. Defaults to `false`.
 
 ### Authentication
 
@@ -277,8 +353,9 @@ starts the MCP server. `serve` is explicit and recommended for clarity.
 
 ## How Agents Use It
 
-Caplets initially exposes one MCP tool per enabled Caplet. If the config has `filesystem`
-and `docs`, the client sees two top-level tools: `filesystem` and `docs`.
+Caplets initially exposes one MCP tool per enabled Caplet. If the config has `filesystem`,
+`docs`, and `users`, the client sees three top-level tools: `filesystem`, `docs`, and
+`users`.
 
 Each generated Caplet tool accepts an `operation`:
 
@@ -322,9 +399,10 @@ Call one exact downstream tool:
 Available operations:
 
 - `get_caplet`: return the configured capability card without starting the downstream server.
-- `check_mcp_server`: start or connect to the downstream server and verify its tool list.
+- `check_backend`: verify the selected backend, whether MCP or OpenAPI.
+- `check_mcp_server`: start or connect to an MCP server and verify its tool list.
 - `list_tools`: return compact downstream tool metadata.
-- `search_tools`: search downstream tool names and descriptions within this server.
+- `search_tools`: search downstream tool names and descriptions within this Caplet.
 - `get_tool`: return full metadata for one exact downstream tool.
 - `call_tool`: invoke one exact downstream tool with JSON object arguments.
 

--- a/docs/product/caplets-progressive-mcp-disclosure-prd.md
+++ b/docs/product/caplets-progressive-mcp-disclosure-prd.md
@@ -4,7 +4,7 @@
 
 **Problem Statement**: MCP clients that connect directly to many servers receive a large, flat tool surface up front. This creates context bloat, weak tool selection, name-collision risk, and poor discoverability when an agent only needs to know which capability domain to inspect next.
 
-**Proposed Solution**: Caplets is a local MCP server that reads downstream MCP server definitions from `~/.caplets/config.json`, user-owned MCP-backed Markdown Caplet files from `~/.caplets`, project config from `./.caplets/config.json`, and explicitly trusted project Markdown Caplet files from `./.caplets`. It exposes each enabled Caplet as one top-level, skill-like MCP tool. Each generated Caplet tool uses the Caplet ID as the tool name and the configured `name`/`description` as its compact capability card, then progressively discloses the full Caplet card and the backing server's tools through operations such as `get_caplet`, `search_tools`, `list_tools`, `get_tool`, and `call_tool`.
+**Proposed Solution**: Caplets is a local MCP server that reads downstream MCP server definitions and native OpenAPI endpoint definitions from `~/.caplets/config.json`, user-owned Markdown Caplet files from `~/.caplets`, project config from `./.caplets/config.json`, and explicitly trusted project Markdown Caplet files from `./.caplets`. It exposes each enabled Caplet as one top-level, skill-like MCP tool. Each generated Caplet tool uses the Caplet ID as the tool name and the configured `name`/`description` as its compact capability card, then progressively discloses the full Caplet card and the backing MCP tools or OpenAPI operations through operations such as `get_caplet`, `search_tools`, `list_tools`, `get_tool`, and `call_tool`.
 
 **Success Criteria**:
 
@@ -25,13 +25,13 @@
 ### Primary User Flow
 
 1. User installs and configures Caplets as an MCP server in their MCP client.
-2. User creates either `~/.caplets/config.json` with downstream server definitions and Caplets options, or Markdown Caplet files with required `mcpServer` frontmatter.
-3. Each downstream server entry or Caplet file uses the supported MCP server configuration shape plus a required `description`.
+2. User creates either `~/.caplets/config.json` with downstream server or OpenAPI endpoint definitions and Caplets options, or Markdown Caplet files with exactly one executable backend.
+3. Each downstream MCP server, OpenAPI endpoint, or Caplet file uses the supported backend configuration shape plus a required `description`.
 4. Client calls Caplets `tools/list` and sees one top-level tool per enabled downstream server, for example `linear`, `chrome-devtools`, and `context7`.
 5. Agent chooses the relevant Caplet tool based on its skill-like tool name and description.
 6. Agent calls that Caplet tool with an operation such as `get_caplet`, `search_tools`, `list_tools`, or `get_tool`.
 7. Agent calls the same Caplet tool with `operation: "call_tool"`, an exact downstream tool name, and a JSON object of arguments.
-8. Caplets forwards the request to that server's downstream MCP process and returns the downstream result.
+8. Caplets forwards the request to that server's downstream MCP process or executes the selected OpenAPI HTTP operation and returns the result.
 
 ### User Stories
 
@@ -42,6 +42,8 @@ Acceptance Criteria:
 - Caplets reads `~/.caplets/config.json` from the current user's home directory by default.
 - Caplets reads user-owned Markdown Caplet files from `~/.caplets` by default.
 - Caplets reads project Markdown Caplet files from `./.caplets` only when `CAPLETS_TRUST_PROJECT_CAPLETS` is set to `1`, `true`, or `yes`.
+- Caplets supports `mcpServers` for MCP backends and `openapiEndpoints` for native OpenAPI backends.
+- Generated top-level tool names are unique across `mcpServers`, `openapiEndpoints`, and Markdown Caplet files; duplicate IDs reject with `CONFIG_INVALID`.
 - Every configured server requires a stable server key and non-empty `description`.
 - Caplets `tools/list` returns one generated top-level MCP tool per enabled server.
 - Each generated Caplet tool uses the configured server ID as the MCP tool name.
@@ -74,6 +76,7 @@ Acceptance Criteria:
 Acceptance Criteria:
 
 - `operation: "call_tool"` requires exact downstream `tool` and a JSON object `arguments`.
+- For OpenAPI-backed Caplets, `call_tool.arguments` uses grouped HTTP inputs: `path`, `query`, `header`, and `body`.
 - `call_tool` requires the exact downstream tool name; Caplets does not use fuzzy matching, aliases, or auto-correction for execution.
 - The selected generated Caplet tool is the server namespace, so `call_tool` does not accept a `server` argument in MVP.
 - Caplets preserves downstream tool names exactly and does not support flattened namespaced identifiers such as `server.tool` in MVP.
@@ -130,6 +133,7 @@ Caplets exposes dynamic MCP tools:
 Each generated Caplet tool supports these operations:
 
 - `get_caplet`: Returns the full configured capability card for the selected server without starting the downstream process.
+- `check_backend`: Validates that the selected backend is available. For MCP it checks the downstream tool list; for OpenAPI it validates the spec and executable base URL without invoking an operation.
 - `check_mcp_server`: Validates that the selected downstream server can start, initialize, and return its tool list without invoking any downstream tool.
 - `list_tools`: Lists compact downstream tool entries for the selected server.
 - `search_tools`: Searches downstream tools for the selected server. Supports optional `limit`, defaults to 20 results, and rejects values above 50.
@@ -138,11 +142,12 @@ Each generated Caplet tool supports these operations:
 
 Generated Caplet tool input schema:
 
-- `operation` is required and must be one of `get_caplet`, `check_mcp_server`, `list_tools`, `search_tools`, `get_tool`, or `call_tool`.
+- `operation` is required and must be one of `get_caplet`, `check_backend`, `check_mcp_server`, `list_tools`, `search_tools`, `get_tool`, or `call_tool`.
 - `get_caplet` accepts no extra fields.
 - `get_caplet` returns only configured capability-card data and does not start, initialize, or probe the downstream server.
 - `get_caplet` is intentionally provisional in MVP; it may be pruned later if generated top-level Caplet tool descriptions prove sufficient.
 - `check_mcp_server` accepts no extra fields.
+- `check_backend` accepts no extra fields.
 - `list_tools` accepts no extra fields.
 - `search_tools` requires `query` and accepts optional `limit`.
 - `get_tool` requires `tool`.
@@ -252,7 +257,8 @@ Requirements:
 - `call_tool` must resolve against fresh-enough downstream `tools/list` metadata and must not forward a call for a tool absent from that metadata in MVP.
 - `disabled` defaults to false. Disabled servers are omitted from normal discovery, never appear in search results, are never started, and cannot be inspected or invoked until re-enabled and Caplets is restarted.
 - Disabled servers are omitted from generated `tools/list` to preserve the token-saving purpose of Caplets.
-- MVP supports stdio, MCP Streamable HTTP, and legacy HTTP+SSE downstream servers. Streamable HTTP is preferred for remote servers; SSE exists for compatibility.
+- MCP backends support stdio, MCP Streamable HTTP, and legacy HTTP+SSE downstream servers. Streamable HTTP is preferred for remote servers; SSE exists for compatibility.
+- OpenAPI backends support local `specPath` or remote `specUrl`, explicit `auth`, optional `baseUrl`, and native HTTP execution for standard OpenAPI methods.
 - OpenCode's `mcp` config shape is a compatibility reference, not Caplets' native MVP shape: OpenCode uses local/remote entries under `mcp`, local `command` as an array, `environment` instead of `env`, and `{env:NAME}`-style interpolation in its broader config system. Automatic OpenCode config import/normalization is deferred.
 
 ### Non-Goals
@@ -358,6 +364,7 @@ Core modules:
 - `defaultSearchLimit?: number`
 - `maxSearchLimit?: number`
 - `mcpServers: Record<string, CapletServerConfig>`
+- `openapiEndpoints: Record<string, OpenApiEndpointConfig>`
 
 `CapletServerConfig`:
 
@@ -381,6 +388,18 @@ Core modules:
 - `{ type: "bearer"; token: string }`
 - `{ type: "headers"; headers: Record<string, string> }`
 - `{ type: "oauth2"; authorizationUrl?: string; tokenUrl?: string; issuer?: string; clientId?: string; clientSecret?: string; scopes?: string[]; redirectUri?: string }`
+
+`OpenApiEndpointConfig`:
+
+- `name: string`
+- `description: string`
+- `specPath?: string`
+- `specUrl?: string`
+- `baseUrl?: string`
+- `auth: { type: "none" } | { type: "bearer"; token: string } | { type: "headers"; headers: Record<string, string> }`
+- `requestTimeoutMs?: number`
+- `operationCacheTtlMs?: number`
+- `disabled?: boolean`
 
 `StoredOAuthTokenBundle`:
 
@@ -408,7 +427,8 @@ Core modules:
 - `description: string`
 - `tags?: string[]`
 - `body?: string`
-- `mcpServer: { transport: "stdio" | "http" | "sse"; disabled: boolean; startupTimeoutMs: number; callTimeoutMs: number; toolCacheTtlMs: number }`
+- `backend: { type: "mcp"; transport: "stdio" | "http" | "sse"; disabled: boolean; startupTimeoutMs: number; callTimeoutMs: number; toolCacheTtlMs: number } | { type: "openapi"; disabled: boolean; requestTimeoutMs: number; operationCacheTtlMs: number; source: "specPath" | "specUrl" }`
+- `mcpServer?: { transport: "stdio" | "http" | "sse"; disabled: boolean; startupTimeoutMs: number; callTimeoutMs: number; toolCacheTtlMs: number }`
 
 `CapletToolRef`:
 
@@ -420,7 +440,7 @@ Core modules:
 
 `GeneratedServerToolRequest`:
 
-- `operation: "get_caplet" | "check_mcp_server" | "list_tools" | "search_tools" | "get_tool" | "call_tool"`
+- `operation: "get_caplet" | "check_backend" | "check_mcp_server" | "list_tools" | "search_tools" | "get_tool" | "call_tool"`
 - `query?: string`
 - `limit?: number`
 - `tool?: string`
@@ -447,6 +467,8 @@ Requirements:
 - MCP SDK server: exposes Caplets over stdio.
 - MCP SDK client: connects to downstream stdio, Streamable HTTP, and legacy HTTP+SSE servers.
 - Node child process runtime: launches configured downstream commands.
+- OpenAPI parser: loads and validates configured local or remote OpenAPI specs.
+- Native fetch: executes configured OpenAPI operations with explicit Caplets auth.
 - Caplets CLI: runs `caplets auth login <server>` for OAuth-backed remote servers.
 - Browser/loopback OAuth: opens the authorization URL and receives the OAuth callback on localhost for configured OAuth servers.
 - Local auth store: reads and writes OAuth token bundles under `~/.caplets/auth`.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "version-packages": "changeset version"
   },
   "dependencies": {
+    "@apidevtools/swagger-parser": "^12.1.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "commander": "^14.0.3",
     "vfile": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
 
   .:
     dependencies:
+      '@apidevtools/swagger-parser':
+        specifier: ^12.1.0
+        version: 12.1.0(openapi-types@12.1.3)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -252,6 +255,22 @@ importers:
         version: 4.1.5(@types/node@25.6.2)(vite@8.0.11(@types/node@25.6.2)(yaml@2.8.4))
 
 packages:
+
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    resolution: {integrity: sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==}
+    engines: {node: '>= 16'}
+
+  '@apidevtools/openapi-schemas@2.1.0':
+    resolution: {integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==}
+    engines: {node: '>=10'}
+
+  '@apidevtools/swagger-methods@3.0.2':
+    resolution: {integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==}
+
+  '@apidevtools/swagger-parser@12.1.0':
+    resolution: {integrity: sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==}
+    peerDependencies:
+      openapi-types: '>=7'
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -834,6 +853,9 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -875,6 +897,14 @@ packages:
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -944,6 +974,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1442,6 +1475,9 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -1890,6 +1926,25 @@ packages:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.1
+
+  '@apidevtools/openapi-schemas@2.1.0': {}
+
+  '@apidevtools/swagger-methods@3.0.2': {}
+
+  '@apidevtools/swagger-parser@12.1.0(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.0.1
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
+      ajv: 8.20.0
+      ajv-draft-04: 1.0.0(ajv@8.20.0)
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
 
   '@babel/runtime@7.29.2': {}
 
@@ -2358,6 +2413,8 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/node@12.20.55': {}
 
   '@types/node@25.6.2':
@@ -2411,6 +2468,10 @@ snapshots:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
+
+  ajv-draft-04@1.0.0(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -2478,6 +2539,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  call-me-maybe@1.0.2: {}
 
   chai@6.2.2: {}
 
@@ -2919,6 +2982,8 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openapi-types@12.1.3: {}
 
   outdent@0.5.0: {}
 

--- a/schemas/caplet.schema.json
+++ b/schemas/caplet.schema.json
@@ -187,9 +187,100 @@
         }
       },
       "additionalProperties": false,
-      "description": "Required MCP server backend configuration for this Caplet."
+      "description": "MCP server backend configuration for this Caplet."
+    },
+    "openapiEndpoint": {
+      "type": "object",
+      "properties": {
+        "specPath": {
+          "description": "Local OpenAPI specification path.",
+          "type": "string",
+          "minLength": 1
+        },
+        "specUrl": {
+          "description": "Remote OpenAPI specification URL.",
+          "type": "string",
+          "minLength": 1
+        },
+        "baseUrl": {
+          "description": "Override base URL for OpenAPI requests.",
+          "type": "string",
+          "minLength": 1
+        },
+        "auth": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "none"
+                }
+              },
+              "required": ["type"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "bearer"
+                },
+                "token": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": ["type", "token"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "headers"
+                },
+                "headers": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "required": ["type", "headers"],
+              "additionalProperties": false
+            }
+          ],
+          "description": "Explicit OpenAPI request auth config. Use {\"type\":\"none\"} for public APIs."
+        },
+        "requestTimeoutMs": {
+          "description": "Timeout in milliseconds for OpenAPI HTTP requests.",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "operationCacheTtlMs": {
+          "description": "Milliseconds OpenAPI operation metadata stays fresh. Set 0 to refresh every time.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "disabled": {
+          "description": "When true, omit this Caplet from discovery.",
+          "type": "boolean"
+        }
+      },
+      "required": ["auth"],
+      "additionalProperties": false,
+      "description": "OpenAPI endpoint backend configuration for this Caplet."
     }
   },
-  "required": ["name", "description", "mcpServer"],
+  "required": ["name", "description"],
   "additionalProperties": false
 }

--- a/schemas/caplets-config.schema.json
+++ b/schemas/caplets-config.schema.json
@@ -220,6 +220,126 @@
         "required": ["name", "description"],
         "additionalProperties": false
       }
+    },
+    "openapiEndpoints": {
+      "default": {},
+      "description": "OpenAPI endpoints keyed by stable Caplet ID.",
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[a-zA-Z0-9_-]{1,64}$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "description": "Human-readable OpenAPI display name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Capability description shown to agents before OpenAPI operations are disclosed."
+          },
+          "specPath": {
+            "description": "Local OpenAPI specification path.",
+            "type": "string",
+            "minLength": 1
+          },
+          "specUrl": {
+            "description": "Remote OpenAPI specification URL.",
+            "type": "string",
+            "format": "uri"
+          },
+          "baseUrl": {
+            "description": "Override base URL for OpenAPI requests.",
+            "type": "string",
+            "format": "uri"
+          },
+          "auth": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "none"
+                  }
+                },
+                "required": ["type"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "bearer"
+                  },
+                  "token": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": ["type", "token"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "headers"
+                  },
+                  "headers": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                },
+                "required": ["type", "headers"],
+                "additionalProperties": false
+              }
+            ],
+            "description": "Explicit OpenAPI request auth config. Use {\"type\":\"none\"} for public APIs."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          "requestTimeoutMs": {
+            "default": 60000,
+            "description": "Timeout in milliseconds for OpenAPI HTTP requests.",
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "operationCacheTtlMs": {
+            "default": 30000,
+            "description": "Milliseconds OpenAPI operation metadata stays fresh. Set 0 to refresh every time.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "disabled": {
+            "default": false,
+            "description": "When true, omit this OpenAPI Caplet from discovery.",
+            "type": "boolean"
+          }
+        },
+        "required": ["name", "description", "auth"],
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/src/caplet-files.ts
+++ b/src/caplet-files.ts
@@ -49,6 +49,16 @@ const capletRemoteAuthSchema = z
   ])
   .describe("Authentication settings for a remote MCP server.");
 
+const capletOpenApiAuthSchema = z
+  .discriminatedUnion("type", [
+    z.object({ type: z.literal("none") }).strict(),
+    z.object({ type: z.literal("bearer"), token: z.string().min(1) }).strict(),
+    z
+      .object({ type: z.literal("headers"), headers: z.record(z.string(), z.string().min(1)) })
+      .strict(),
+  ])
+  .describe("Authentication settings for an OpenAPI endpoint.");
+
 const capletMcpServerSchema = z
   .object({
     transport: z
@@ -150,6 +160,74 @@ const capletMcpServerSchema = z
     }
   });
 
+const capletOpenApiEndpointSchema = z
+  .object({
+    specPath: z.string().min(1).optional().describe("Local OpenAPI specification path."),
+    specUrl: z.string().min(1).optional().describe("Remote OpenAPI specification URL."),
+    baseUrl: z.string().min(1).optional().describe("Override base URL for OpenAPI requests."),
+    auth: capletOpenApiAuthSchema.describe(
+      'Explicit OpenAPI request auth config. Use {"type":"none"} for public APIs.',
+    ),
+    requestTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Timeout in milliseconds for OpenAPI HTTP requests."),
+    operationCacheTtlMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Milliseconds OpenAPI operation metadata stays fresh. Set 0 to refresh every time.",
+      ),
+    disabled: z.boolean().optional().describe("When true, omit this Caplet from discovery."),
+  })
+  .strict()
+  .superRefine((endpoint, ctx) => {
+    if (Boolean(endpoint.specPath) === Boolean(endpoint.specUrl)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "openapiEndpoint must define exactly one spec source: specPath or specUrl",
+      });
+    }
+    if (
+      endpoint.specUrl &&
+      !hasEnvReference(endpoint.specUrl) &&
+      !isAllowedRemoteUrl(endpoint.specUrl)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["specUrl"],
+        message: "OpenAPI specUrl must use https except loopback development urls",
+      });
+    }
+    if (
+      endpoint.baseUrl &&
+      !hasEnvReference(endpoint.baseUrl) &&
+      !isAllowedRemoteUrl(endpoint.baseUrl)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["baseUrl"],
+        message: "OpenAPI baseUrl must use https except loopback development urls",
+      });
+    }
+    if (endpoint.auth?.type === "headers") {
+      for (const headerName of Object.keys(endpoint.auth.headers)) {
+        const normalized = headerName.toLowerCase();
+        if (!HEADER_NAME_PATTERN.test(headerName) || FORBIDDEN_HEADERS.has(normalized)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["auth", "headers", headerName],
+            message: `header ${headerName} is not allowed`,
+          });
+        }
+      }
+    }
+  });
+
 export const capletFileSchema = z
   .object({
     $schema: z
@@ -170,11 +248,22 @@ export const capletFileSchema = z
       .array(z.string().trim().min(1).max(80))
       .optional()
       .describe("Optional tags for grouping or searching Caplets."),
-    mcpServer: capletMcpServerSchema.describe(
-      "Required MCP server backend configuration for this Caplet.",
-    ),
+    mcpServer: capletMcpServerSchema
+      .describe("MCP server backend configuration for this Caplet.")
+      .optional(),
+    openapiEndpoint: capletOpenApiEndpointSchema
+      .describe("OpenAPI endpoint backend configuration for this Caplet.")
+      .optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((frontmatter, ctx) => {
+    if (Boolean(frontmatter.mcpServer) === Boolean(frontmatter.openapiEndpoint)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Caplet file must define exactly one backend: mcpServer or openapiEndpoint",
+      });
+    }
+  });
 
 type CapletFileFrontmatter = z.infer<typeof capletFileSchema>;
 
@@ -189,7 +278,8 @@ export function capletJsonSchema(): unknown {
 }
 
 export type CapletFileConfig = {
-  mcpServers: Record<string, unknown>;
+  mcpServers?: Record<string, unknown>;
+  openapiEndpoints?: Record<string, unknown>;
 };
 
 export function loadCapletFiles(root: string): CapletFileConfig | undefined {
@@ -198,14 +288,28 @@ export function loadCapletFiles(root: string): CapletFileConfig | undefined {
   }
 
   const servers: Record<string, unknown> = {};
+  const openapiEndpoints: Record<string, unknown> = {};
   for (const candidate of discoverCapletFiles(root)) {
-    if (servers[candidate.id]) {
+    if (servers[candidate.id] || openapiEndpoints[candidate.id]) {
       throw new CapletsError("CONFIG_INVALID", `Duplicate Caplet ID ${candidate.id} under ${root}`);
     }
-    servers[candidate.id] = readCapletFile(candidate.path);
+    const config = readCapletFile(candidate.path);
+    if (isPlainObject(config) && config.backend === "openapi") {
+      const { backend: _backend, ...endpoint } = config;
+      openapiEndpoints[candidate.id] = endpoint;
+    } else {
+      servers[candidate.id] = config;
+    }
   }
 
-  return Object.keys(servers).length > 0 ? { mcpServers: servers } : undefined;
+  const hasServers = Object.keys(servers).length > 0;
+  const hasOpenApi = Object.keys(openapiEndpoints).length > 0;
+  return hasServers || hasOpenApi
+    ? {
+        ...(hasServers ? { mcpServers: servers } : {}),
+        ...(hasOpenApi ? { openapiEndpoints } : {}),
+      }
+    : undefined;
 }
 
 function discoverCapletFiles(root: string): Array<{ id: string; path: string }> {
@@ -269,8 +373,19 @@ function readCapletFile(path: string): unknown {
 }
 
 function capletToServerConfig(frontmatter: CapletFileFrontmatter, body: string): unknown {
+  if (frontmatter.openapiEndpoint) {
+    return {
+      ...frontmatter.openapiEndpoint,
+      backend: "openapi",
+      name: frontmatter.name,
+      description: frontmatter.description,
+      ...(frontmatter.tags ? { tags: frontmatter.tags } : {}),
+      body,
+    };
+  }
+
   return {
-    ...frontmatter.mcpServer,
+    ...frontmatter.mcpServer!,
     name: frontmatter.name,
     description: frontmatter.description,
     ...(frontmatter.tags ? { tags: frontmatter.tags } : {}),

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ export type RemoteAuthConfig =
 
 export type CapletServerConfig = {
   server: string;
+  backend: "mcp";
   name: string;
   description: string;
   tags?: string[] | undefined;
@@ -39,6 +40,29 @@ export type CapletServerConfig = {
   disabled: boolean;
 };
 
+export type OpenApiAuthConfig =
+  | { type: "none" }
+  | { type: "bearer"; token: string }
+  | { type: "headers"; headers: Record<string, string> };
+
+export type OpenApiEndpointConfig = {
+  server: string;
+  backend: "openapi";
+  name: string;
+  description: string;
+  tags?: string[] | undefined;
+  body?: string | undefined;
+  specPath?: string | undefined;
+  specUrl?: string | undefined;
+  baseUrl?: string | undefined;
+  auth: OpenApiAuthConfig;
+  requestTimeoutMs: number;
+  operationCacheTtlMs: number;
+  disabled: boolean;
+};
+
+export type CapletConfig = CapletServerConfig | OpenApiEndpointConfig;
+
 export type CapletsOptions = {
   defaultSearchLimit: number;
   maxSearchLimit: number;
@@ -48,6 +72,7 @@ export type CapletsConfig = {
   version: 1;
   options: CapletsOptions;
   mcpServers: Record<string, CapletServerConfig>;
+  openapiEndpoints: Record<string, OpenApiEndpointConfig>;
 };
 
 const SERVER_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
@@ -97,6 +122,16 @@ const remoteAuthSchema = z
       .strict(),
   ])
   .describe("Authentication settings for a remote MCP server.");
+
+const openApiAuthSchema = z
+  .discriminatedUnion("type", [
+    z.object({ type: z.literal("none") }).strict(),
+    z.object({ type: z.literal("bearer"), token: z.string().min(1) }).strict(),
+    z
+      .object({ type: z.literal("headers"), headers: z.record(z.string(), z.string().min(1)) })
+      .strict(),
+  ])
+  .describe("Authentication settings for an OpenAPI endpoint.");
 
 const publicServerSchema = z
   .object({
@@ -152,13 +187,61 @@ const normalizedServerSchema = publicServerSchema.extend({
   body: z.string().optional(),
 });
 
+const publicOpenApiEndpointSchema = z
+  .object({
+    name: z.string().trim().min(1).max(80).describe("Human-readable OpenAPI display name."),
+    description: z
+      .string()
+      .describe("Capability description shown to agents before OpenAPI operations are disclosed.")
+      .refine(
+        (value) => value.trim().length >= 10,
+        "description must contain at least 10 non-whitespace characters",
+      )
+      .refine((value) => value.length <= 1500, "description must be at most 1500 characters"),
+    specPath: z.string().min(1).optional().describe("Local OpenAPI specification path."),
+    specUrl: z.string().url().optional().describe("Remote OpenAPI specification URL."),
+    baseUrl: z.string().url().optional().describe("Override base URL for OpenAPI requests."),
+    auth: openApiAuthSchema.describe(
+      'Explicit OpenAPI request auth config. Use {"type":"none"} for public APIs.',
+    ),
+    tags: z.array(z.string().trim().min(1).max(80)).optional(),
+    requestTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .default(60_000)
+      .describe("Timeout in milliseconds for OpenAPI HTTP requests."),
+    operationCacheTtlMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(30_000)
+      .describe(
+        "Milliseconds OpenAPI operation metadata stays fresh. Set 0 to refresh every time.",
+      ),
+    disabled: z
+      .boolean()
+      .default(false)
+      .describe("When true, omit this OpenAPI Caplet from discovery."),
+  })
+  .strict();
+
+const normalizedOpenApiEndpointSchema = publicOpenApiEndpointSchema.extend({
+  body: z.string().optional(),
+});
+
 type ConfigSchemaServerValue = z.infer<typeof normalizedServerSchema>;
+type ConfigSchemaOpenApiEndpointValue = z.infer<typeof normalizedOpenApiEndpointSchema>;
 type ConfigInput = {
   mcpServers?: Record<string, unknown>;
+  openapiEndpoints?: Record<string, unknown>;
   [key: string]: unknown;
 };
 
-function configSchemaFor(serverValueSchema: z.ZodTypeAny) {
+function configSchemaFor(
+  serverValueSchema: z.ZodTypeAny,
+  openApiEndpointValueSchema: z.ZodTypeAny,
+) {
   return z
     .object({
       $schema: z
@@ -184,6 +267,10 @@ function configSchemaFor(serverValueSchema: z.ZodTypeAny) {
         .record(z.string().regex(SERVER_ID_PATTERN), serverValueSchema)
         .default({})
         .describe("Downstream MCP servers keyed by stable server ID."),
+      openapiEndpoints: z
+        .record(z.string().regex(SERVER_ID_PATTERN), openApiEndpointValueSchema)
+        .default({})
+        .describe("OpenAPI endpoints keyed by stable Caplet ID."),
     })
     .strict()
     .superRefine((config, ctx) => {
@@ -253,11 +340,65 @@ function configSchemaFor(serverValueSchema: z.ZodTypeAny) {
           }
         }
       }
+
+      for (const [endpoint, rawValue] of Object.entries(config.openapiEndpoints)) {
+        const raw = rawValue as ConfigSchemaOpenApiEndpointValue;
+        if (config.mcpServers[endpoint]) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["openapiEndpoints", endpoint],
+            message: `Caplet ID ${endpoint} is already used by mcpServers`,
+          });
+        }
+        if (!SERVER_ID_PATTERN.test(endpoint)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["openapiEndpoints", endpoint],
+            message: "OpenAPI endpoint ID must match ^[a-zA-Z0-9_-]{1,64}$",
+          });
+        }
+        if (Boolean(raw.specPath) === Boolean(raw.specUrl)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["openapiEndpoints", endpoint],
+            message: "OpenAPI endpoint must define exactly one spec source: specPath or specUrl",
+          });
+        }
+        if (raw.specUrl && !isAllowedRemoteUrl(raw.specUrl)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["openapiEndpoints", endpoint, "specUrl"],
+            message: "OpenAPI specUrl must use https except loopback development urls",
+          });
+        }
+        if (raw.baseUrl && !isAllowedRemoteUrl(raw.baseUrl)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["openapiEndpoints", endpoint, "baseUrl"],
+            message: "OpenAPI baseUrl must use https except loopback development urls",
+          });
+        }
+        if (raw.auth?.type === "headers") {
+          for (const headerName of Object.keys(raw.auth.headers)) {
+            const normalized = headerName.toLowerCase();
+            if (!HEADER_NAME_PATTERN.test(headerName) || FORBIDDEN_HEADERS.has(normalized)) {
+              ctx.addIssue({
+                code: "custom",
+                path: ["openapiEndpoints", endpoint, "auth", "headers", headerName],
+                message: `header ${headerName} is not allowed`,
+              });
+            }
+          }
+        }
+      }
     });
 }
 
-export const configFileSchema = configSchemaFor(publicServerSchema);
-const normalizedConfigFileSchema = configSchemaFor(normalizedServerSchema);
+export const configFileSchema = configSchemaFor(publicServerSchema, publicOpenApiEndpointSchema);
+const normalizedConfigFileSchema = configSchemaFor(
+  normalizedServerSchema,
+  normalizedOpenApiEndpointSchema,
+);
 
 export function configJsonSchema(): unknown {
   return {
@@ -293,7 +434,9 @@ export function loadConfig(
   const hasProjectConfig = existsSync(projectPath);
   const userConfig = hasUserConfig ? readPublicConfigInput(path) : undefined;
   const userCaplets = loadCapletFiles(resolveCapletsRoot(path));
-  const projectConfig = hasProjectConfig ? readPublicConfigInput(projectPath) : undefined;
+  const projectConfig = hasProjectConfig
+    ? rejectUntrustedProjectOpenApi(readPublicConfigInput(projectPath), projectPath)
+    : undefined;
   const projectCaplets = shouldLoadProjectCaplets()
     ? loadCapletFiles(dirname(projectPath))
     : undefined;
@@ -309,10 +452,13 @@ export function loadConfig(
     const config = parseConfig(
       mergeConfigInputs(userConfig, userCaplets, projectConfig, projectCaplets),
     );
-    if (Object.keys(config.mcpServers).length === 0) {
+    if (
+      Object.keys(config.mcpServers).length === 0 &&
+      Object.keys(config.openapiEndpoints).length === 0
+    ) {
       throw new CapletsError(
         "CONFIG_INVALID",
-        "Caplets config must define at least one MCP server",
+        "Caplets config must define at least one MCP server or OpenAPI endpoint",
       );
     }
     return config;
@@ -360,6 +506,16 @@ function readPublicConfigInput(path: string): ConfigInput {
   }
 }
 
+function rejectUntrustedProjectOpenApi(input: ConfigInput, path: string): ConfigInput {
+  if (input.openapiEndpoints && Object.keys(input.openapiEndpoints).length > 0) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Project config at ${path} cannot define openapiEndpoints; use trusted project Caplet files or user config`,
+    );
+  }
+  return input;
+}
+
 function mergeConfigInputs(...inputs: Array<ConfigInput | undefined>): ConfigInput | undefined {
   let merged: ConfigInput | undefined;
   for (const input of inputs) {
@@ -372,6 +528,10 @@ function mergeConfigInputs(...inputs: Array<ConfigInput | undefined>): ConfigInp
       mcpServers: {
         ...merged?.mcpServers,
         ...input.mcpServers,
+      },
+      openapiEndpoints: {
+        ...merged?.openapiEndpoints,
+        ...input.openapiEndpoints,
       },
     };
   }
@@ -390,8 +550,19 @@ export function parseConfig(input: unknown): CapletsConfig {
     servers[server] = stripUndefined({
       ...interpolated,
       server,
+      backend: "mcp",
       transport: interpolated.transport ?? (interpolated.command ? "stdio" : "http"),
     }) as CapletServerConfig;
+  }
+
+  const openapiEndpoints: Record<string, OpenApiEndpointConfig> = {};
+  for (const [server, raw] of Object.entries(parsed.data.openapiEndpoints)) {
+    const interpolated = raw as ConfigSchemaOpenApiEndpointValue;
+    openapiEndpoints[server] = stripUndefined({
+      ...interpolated,
+      server,
+      backend: "openapi",
+    }) as OpenApiEndpointConfig;
   }
 
   return {
@@ -401,6 +572,7 @@ export function parseConfig(input: unknown): CapletsConfig {
       maxSearchLimit: parsed.data.maxSearchLimit,
     },
     mcpServers: servers,
+    openapiEndpoints,
   };
 }
 
@@ -432,7 +604,7 @@ function interpolateConfig<T>(value: T, path: string[] = []): T {
 }
 
 function isPublicMetadataPath(path: string[]): boolean {
-  if (path.length < 3 || path[0] !== "mcpServers") {
+  if (path.length < 3 || (path[0] !== "mcpServers" && path[0] !== "openapiEndpoints")) {
     return false;
   }
   return NON_INTERPOLATED_SERVER_FIELDS.has(path[2] ?? "");

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio";
 import { loadConfig } from "./config.js";
 import { DownstreamManager } from "./downstream.js";
 import { errorResult } from "./errors.js";
+import { OpenApiManager } from "./openapi.js";
 import { capabilityDescription, ServerRegistry } from "./registry.js";
 import { generatedToolInputSchema, handleServerTool } from "./tools.js";
 import { runCli } from "./cli.js";
@@ -17,6 +18,7 @@ async function main() {
   const config = loadConfig(process.env.CAPLETS_CONFIG);
   const registry = new ServerRegistry(config);
   const downstream = new DownstreamManager(registry);
+  const openapi = new OpenApiManager(registry);
   const server = new McpServer({
     name: "caplets",
     version: packageJsonVersion,
@@ -32,7 +34,7 @@ async function main() {
       },
       async (request) => {
         try {
-          return await handleServerTool(capletServer, request, registry, downstream);
+          return await handleServerTool(capletServer, request, registry, downstream, openapi);
         } catch (error) {
           return errorResult(error);
         }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,0 +1,661 @@
+import SwaggerParser from "@apidevtools/swagger-parser";
+import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { OpenApiEndpointConfig } from "./config.js";
+import { CapletsError, toSafeError } from "./errors.js";
+import type { ServerRegistry } from "./registry.js";
+import type { CompactTool } from "./downstream.js";
+
+const HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"] as const;
+const JSON_CONTENT_TYPES = ["application/json"];
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+const FORBIDDEN_ARGUMENT_HEADERS = new Set([
+  "accept",
+  "authorization",
+  "connection",
+  "content-length",
+  "content-type",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+type HttpMethod = (typeof HTTP_METHODS)[number];
+type OpenApiDocument = Record<string, any>;
+type OpenApiOperation = {
+  name: string;
+  method: HttpMethod;
+  path: string;
+  summary?: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  requestBodyContentType?: string;
+  baseUrl?: string;
+};
+
+type ManagedOpenApi = {
+  operations?: OpenApiOperation[];
+  fetchedAt?: number;
+  cacheKey: string;
+};
+
+export class OpenApiManager {
+  private readonly cache = new Map<string, ManagedOpenApi>();
+
+  constructor(private readonly registry: ServerRegistry) {}
+
+  async checkEndpoint(endpoint: OpenApiEndpointConfig): Promise<{
+    server: string;
+    status: string;
+    toolCount?: number;
+    elapsedMs: number;
+    error?: unknown;
+  }> {
+    const startedAt = Date.now();
+    try {
+      const operations = await this.refreshOperations(endpoint, true);
+      this.registry.setStatus(endpoint.server, "available");
+      return {
+        server: endpoint.server,
+        status: "available",
+        toolCount: operations.length,
+        elapsedMs: Date.now() - startedAt,
+      };
+    } catch (error) {
+      const safe = toSafeError(error, "SERVER_UNAVAILABLE");
+      this.registry.setStatus(endpoint.server, "unavailable", safe);
+      return {
+        server: endpoint.server,
+        status: "unavailable",
+        elapsedMs: Date.now() - startedAt,
+        error: safe,
+      };
+    }
+  }
+
+  async listTools(endpoint: OpenApiEndpointConfig): Promise<Tool[]> {
+    const operations = await this.refreshOperations(endpoint, false);
+    return operations.map((operation) => this.toTool(operation));
+  }
+
+  async getTool(endpoint: OpenApiEndpointConfig, toolName: string): Promise<Tool> {
+    const operation = await this.getOperation(endpoint, toolName);
+    return this.toTool(operation);
+  }
+
+  async callTool(
+    endpoint: OpenApiEndpointConfig,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<CompatibilityCallToolResult> {
+    const operation = await this.getOperation(endpoint, toolName);
+    const request = buildRequest(endpoint, operation, args);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), endpoint.requestTimeoutMs);
+    try {
+      const init: RequestInit = {
+        method: operation.method.toUpperCase(),
+        headers: request.headers,
+        redirect: "manual",
+        signal: controller.signal,
+        ...(request.body === undefined ? {} : { body: request.body }),
+      };
+      const response = await fetch(request.url, init);
+      if (response.status >= 300 && response.status < 400) {
+        throw new CapletsError("DOWNSTREAM_PROTOCOL_ERROR", "OpenAPI request returned a redirect", {
+          server: endpoint.server,
+          status: response.status,
+          location: response.headers.get("location") ? "[REDACTED]" : undefined,
+        });
+      }
+      const parsed = await readResponse(response);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(parsed, null, 2),
+          },
+        ],
+        structuredContent: parsed as Record<string, unknown>,
+        isError: response.ok ? false : true,
+      };
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw new CapletsError(
+          "TOOL_CALL_TIMEOUT",
+          `OpenAPI request timed out for ${endpoint.server}/${toolName}`,
+        );
+      }
+      if (error instanceof CapletsError) {
+        throw error;
+      }
+      throw new CapletsError(
+        "DOWNSTREAM_TOOL_ERROR",
+        `OpenAPI request failed for ${endpoint.server}/${toolName}`,
+        toSafeError(error),
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  compact(endpoint: OpenApiEndpointConfig, tool: Tool): CompactTool {
+    return {
+      server: endpoint.server,
+      tool: tool.name,
+      ...(tool.description ? { description: tool.description } : {}),
+      ...(tool.annotations ? { annotations: tool.annotations } : {}),
+      hasInputSchema: Boolean(tool.inputSchema),
+    };
+  }
+
+  search(
+    endpoint: OpenApiEndpointConfig,
+    tools: Tool[],
+    query: string,
+    limit: number,
+  ): CompactTool[] {
+    const needle = query.toLocaleLowerCase();
+    return tools
+      .filter((tool) =>
+        `${tool.name}\n${tool.description ?? ""}`.toLocaleLowerCase().includes(needle),
+      )
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .slice(0, limit)
+      .map((tool) => this.compact(endpoint, tool));
+  }
+
+  private async getOperation(
+    endpoint: OpenApiEndpointConfig,
+    toolName: string,
+  ): Promise<OpenApiOperation> {
+    const operations = await this.refreshOperations(endpoint, false);
+    const operation = operations.find((candidate) => candidate.name === toolName);
+    if (!operation) {
+      throw new CapletsError(
+        "TOOL_NOT_FOUND",
+        `Tool ${toolName} was not found on ${endpoint.server}`,
+        {
+          server: endpoint.server,
+          tool: toolName,
+          suggestions: operations
+            .map((candidate) => candidate.name)
+            .filter((name) =>
+              name.toLocaleLowerCase().includes(toolName.toLocaleLowerCase()[0] ?? ""),
+            )
+            .slice(0, 5),
+        },
+      );
+    }
+    return operation;
+  }
+
+  private async refreshOperations(
+    endpoint: OpenApiEndpointConfig,
+    force: boolean,
+  ): Promise<OpenApiOperation[]> {
+    const cached = this.cache.get(endpoint.server);
+    const cacheKey = openApiCacheKey(endpoint);
+    const now = Date.now();
+    const isFresh =
+      cached?.operations &&
+      cached.cacheKey === cacheKey &&
+      cached.fetchedAt !== undefined &&
+      endpoint.operationCacheTtlMs > 0 &&
+      now - cached.fetchedAt <= endpoint.operationCacheTtlMs;
+    if (!force && isFresh) {
+      return cached.operations ?? [];
+    }
+
+    try {
+      const document = await loadOpenApiDocument(endpoint);
+      const operations = extractOperations(endpoint, document);
+      this.cache.set(endpoint.server, { operations, fetchedAt: Date.now(), cacheKey });
+      this.registry.setStatus(endpoint.server, "available");
+      return operations;
+    } catch (error) {
+      const safe = toSafeError(error, "DOWNSTREAM_PROTOCOL_ERROR");
+      this.registry.setStatus(endpoint.server, "unavailable", safe);
+      throw new CapletsError(
+        safe.code,
+        `Could not load OpenAPI operations for ${endpoint.server}`,
+        safe,
+      );
+    }
+  }
+
+  private toTool(operation: OpenApiOperation): Tool {
+    return {
+      name: operation.name,
+      ...(operation.summary || operation.description
+        ? { description: operation.summary ?? operation.description }
+        : {}),
+      inputSchema: operation.inputSchema as Tool["inputSchema"],
+      annotations: {
+        readOnlyHint: operation.method === "get" || operation.method === "head",
+        destructiveHint: operation.method === "delete",
+      },
+    };
+  }
+}
+
+async function loadOpenApiDocument(endpoint: OpenApiEndpointConfig): Promise<OpenApiDocument> {
+  const source = await loadOpenApiSource(endpoint);
+  return (await SwaggerParser.validate(source as any, {
+    resolve: {
+      external: false,
+    },
+    dereference: { circular: "ignore" },
+  })) as OpenApiDocument;
+}
+
+async function loadOpenApiSource(
+  endpoint: OpenApiEndpointConfig,
+): Promise<string | OpenApiDocument> {
+  if (endpoint.specPath) {
+    return endpoint.specPath;
+  }
+  if (!endpoint.specUrl) {
+    throw new CapletsError("CONFIG_INVALID", `${endpoint.server} is missing OpenAPI spec source`);
+  }
+  if (!endpoint.baseUrl) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `${endpoint.server} must configure baseUrl when using remote specUrl`,
+    );
+  }
+  const response = await fetchWithLimit(endpoint.specUrl, endpoint.requestTimeoutMs);
+  return JSON.parse(response);
+}
+
+function extractOperations(
+  endpoint: OpenApiEndpointConfig,
+  document: OpenApiDocument,
+): OpenApiOperation[] {
+  const operations: OpenApiOperation[] = [];
+  const seen = new Set<string>();
+  for (const [path, pathItem] of Object.entries((document.paths ?? {}) as Record<string, any>)) {
+    if (!pathItem || typeof pathItem !== "object") {
+      continue;
+    }
+    const inheritedParameters = Array.isArray(pathItem.parameters) ? pathItem.parameters : [];
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (!operation || typeof operation !== "object") {
+        continue;
+      }
+      const name =
+        typeof operation.operationId === "string" && operation.operationId.trim()
+          ? operation.operationId.trim()
+          : `${method.toUpperCase()} ${path}`;
+      if (seen.has(name)) {
+        throw new CapletsError("CONFIG_INVALID", `Duplicate OpenAPI operation name ${name}`, {
+          server: endpoint.server,
+        });
+      }
+      seen.add(name);
+      const parameters = [
+        ...inheritedParameters,
+        ...(Array.isArray(operation.parameters) ? operation.parameters : []),
+      ];
+      const requestBody = requestBodyFor(operation);
+      const baseUrl = endpoint.baseUrl ?? firstServerUrl(document);
+      validateOperationBaseUrl(endpoint, baseUrl);
+      operations.push({
+        name,
+        method,
+        path,
+        ...(typeof operation.summary === "string" ? { summary: operation.summary } : {}),
+        ...(typeof operation.description === "string"
+          ? { description: operation.description }
+          : {}),
+        inputSchema: inputSchemaFor(parameters, requestBody),
+        ...(requestBody?.contentType ? { requestBodyContentType: requestBody.contentType } : {}),
+        ...(baseUrl ? { baseUrl } : {}),
+      });
+    }
+  }
+  return operations.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function requestBodyFor(
+  operation: Record<string, any>,
+): { required: boolean; schema: Record<string, unknown>; contentType: string } | undefined {
+  const requestBody = operation.requestBody;
+  if (!requestBody || typeof requestBody !== "object") {
+    return undefined;
+  }
+  const content = requestBody.content;
+  if (!content || typeof content !== "object") {
+    return undefined;
+  }
+  const contentType = JSON_CONTENT_TYPES.find((candidate) => content[candidate]);
+  if (!contentType) {
+    throw new CapletsError("CONFIG_INVALID", "Unsupported OpenAPI request body content type");
+  }
+  return {
+    required: requestBody.required === true,
+    schema: safeSchema(content[contentType]?.schema),
+    contentType,
+  };
+}
+
+function inputSchemaFor(
+  parameters: any[],
+  requestBody?: { required: boolean; schema: Record<string, unknown>; contentType: string },
+): Record<string, unknown> {
+  const schema: Record<string, any> = {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  };
+  const required: string[] = [];
+  for (const location of ["path", "query", "header"] as const) {
+    const locationParameters = parameters.filter((parameter) => parameter?.in === location);
+    if (locationParameters.length === 0) {
+      continue;
+    }
+    const nestedRequired = locationParameters
+      .filter((parameter) => parameter.required === true || location === "path")
+      .map((parameter) => parameter.name);
+    schema.properties[location] = {
+      type: "object",
+      additionalProperties: false,
+      properties: Object.fromEntries(
+        locationParameters.map((parameter) => [parameter.name, safeSchema(parameter.schema)]),
+      ),
+      ...(nestedRequired.length ? { required: nestedRequired } : {}),
+    };
+    if (nestedRequired.length) {
+      required.push(location);
+    }
+  }
+  if (requestBody) {
+    schema.properties.body = requestBody.schema;
+    if (requestBody.required) {
+      required.push("body");
+    }
+  }
+  if (required.length) {
+    schema.required = required;
+  }
+  return schema;
+}
+
+function safeSchema(value: unknown): Record<string, unknown> {
+  rejectExternalRefs(value);
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function rejectExternalRefs(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      rejectExternalRefs(item);
+    }
+    return;
+  }
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  const object = value as Record<string, unknown>;
+  if (typeof object.$ref === "string" && !object.$ref.startsWith("#/")) {
+    throw new CapletsError("CONFIG_INVALID", "External OpenAPI $ref values are not supported");
+  }
+  for (const nested of Object.values(object)) {
+    rejectExternalRefs(nested);
+  }
+}
+
+function buildRequest(
+  endpoint: OpenApiEndpointConfig,
+  operation: OpenApiOperation,
+  args: Record<string, unknown>,
+): { url: URL; headers: Headers; body?: string } {
+  const base = endpoint.baseUrl ?? operation.baseUrl;
+  validateOperationBaseUrl(endpoint, base);
+  const url = buildOperationUrl(
+    base,
+    substitutePath(operation.path, asRecord(args.path), operation),
+  );
+  for (const [key, value] of Object.entries(asRecord(args.query))) {
+    if (value !== undefined && value !== null) {
+      url.searchParams.append(key, serializeHttpValue("query", key, value));
+    }
+  }
+  const headers = new Headers();
+  applyAuth(headers, endpoint);
+  const configuredHeaderNames =
+    endpoint.auth.type === "headers"
+      ? new Set(Object.keys(endpoint.auth.headers).map((key) => key.toLowerCase()))
+      : new Set<string>();
+  for (const [key, value] of Object.entries(asRecord(args.header))) {
+    if (value !== undefined && value !== null) {
+      const normalized = key.toLowerCase();
+      if (FORBIDDEN_ARGUMENT_HEADERS.has(normalized) || configuredHeaderNames.has(normalized)) {
+        throw new CapletsError("REQUEST_INVALID", `Header ${key} cannot be supplied by arguments`);
+      }
+      headers.set(key, serializeHttpValue("header", key, value));
+    }
+  }
+  let body: string | undefined;
+  if ("body" in args) {
+    if (operation.requestBodyContentType !== "application/json") {
+      throw new CapletsError(
+        "REQUEST_INVALID",
+        "Only application/json request bodies are supported",
+      );
+    }
+    headers.set("content-type", "application/json");
+    body = JSON.stringify(args.body);
+  }
+  return body === undefined ? { url, headers } : { url, headers, body };
+}
+
+function firstServerUrl(operation: Record<string, any>): string | undefined {
+  const servers = operation.servers;
+  if (Array.isArray(servers) && typeof servers[0]?.url === "string") {
+    return servers[0].url;
+  }
+  return undefined;
+}
+
+function substitutePath(
+  path: string,
+  values: Record<string, unknown>,
+  operation: OpenApiOperation,
+): string {
+  return path.replace(/\{([^}]+)\}/g, (_match, name: string) => {
+    const value = values[name];
+    if (value === undefined || value === null || value === "") {
+      throw new CapletsError("REQUEST_INVALID", `Missing required path parameter ${name}`, {
+        tool: operation.name,
+      });
+    }
+    return encodeURIComponent(serializeHttpValue("path", name, value));
+  });
+}
+
+function serializeHttpValue(
+  location: "path" | "query" | "header",
+  name: string,
+  value: unknown,
+): string {
+  switch (typeof value) {
+    case "string":
+    case "number":
+    case "boolean":
+      return String(value);
+    default:
+      throw new CapletsError(
+        "REQUEST_INVALID",
+        `OpenAPI ${location} parameter ${name} must be a string, number, or boolean`,
+      );
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function applyAuth(headers: Headers, endpoint: OpenApiEndpointConfig): void {
+  switch (endpoint.auth.type) {
+    case "none":
+      return;
+    case "bearer":
+      headers.set("authorization", `Bearer ${endpoint.auth.token}`);
+      return;
+    case "headers":
+      for (const [key, value] of Object.entries(endpoint.auth.headers)) {
+        headers.set(key, value);
+      }
+  }
+}
+
+async function readResponse(response: Response): Promise<Record<string, unknown>> {
+  const contentType = response.headers.get("content-type") ?? "";
+  const text = await readLimitedText(response);
+  const body = parseResponseBody(contentType, text);
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers: {
+      "content-type": contentType,
+    },
+    ...(body === undefined ? {} : { body }),
+  };
+}
+
+function parseResponseBody(contentType: string, text: string): unknown {
+  if (!text) {
+    return undefined;
+  }
+  if (!contentType.includes("application/json")) {
+    return text;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function readLimitedText(response: Response): Promise<string> {
+  if (!response.body) {
+    return "";
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (value) {
+      bytes += value.byteLength;
+      if (bytes > MAX_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new CapletsError("DOWNSTREAM_PROTOCOL_ERROR", "OpenAPI response exceeded byte limit");
+      }
+      chunks.push(value);
+    }
+  }
+  return new TextDecoder().decode(Buffer.concat(chunks));
+}
+
+async function fetchWithLimit(url: string, timeoutMs: number): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    if (response.status >= 300 && response.status < 400) {
+      throw new CapletsError(
+        "DOWNSTREAM_PROTOCOL_ERROR",
+        "OpenAPI spec request returned a redirect",
+      );
+    }
+    if (!response.ok) {
+      throw new CapletsError("DOWNSTREAM_PROTOCOL_ERROR", "OpenAPI spec request failed", {
+        status: response.status,
+      });
+    }
+    return await readLimitedText(response);
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new CapletsError("TOOL_CALL_TIMEOUT", "OpenAPI spec request timed out");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function validateOperationBaseUrl(
+  endpoint: OpenApiEndpointConfig,
+  base: string | undefined,
+): asserts base is string {
+  if (!base) {
+    throw new CapletsError("CONFIG_INVALID", `${endpoint.server} is missing OpenAPI baseUrl`);
+  }
+  if (endpoint.specUrl && !endpoint.baseUrl) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `${endpoint.server} must configure baseUrl when using remote specUrl`,
+    );
+  }
+  if (!isAllowedRequestBaseUrl(base)) {
+    throw new CapletsError("CONFIG_INVALID", `${endpoint.server} OpenAPI baseUrl is not allowed`);
+  }
+  const url = new URL(base);
+  if (url.username || url.password || url.search || url.hash) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `${endpoint.server} OpenAPI baseUrl must not include credentials, query, or fragment`,
+    );
+  }
+}
+
+function buildOperationUrl(base: string, operationPath: string): URL {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(operationPath) || operationPath.startsWith("//")) {
+    throw new CapletsError("CONFIG_INVALID", "OpenAPI operation path cannot change origin");
+  }
+  const baseUrl = new URL(base);
+  const basePath = baseUrl.pathname.replace(/\/+$/, "");
+  const relativePath = operationPath.replace(/^\/+/, "");
+  baseUrl.pathname = [basePath, relativePath].filter(Boolean).join("/");
+  return baseUrl;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function isAllowedRequestBaseUrl(value: string): boolean {
+  const url = new URL(value);
+  if (url.protocol === "https:") {
+    return true;
+  }
+  if (url.protocol !== "http:") {
+    return false;
+  }
+  return ["localhost", "127.0.0.1", "[::1]", "::1"].includes(url.hostname);
+}
+
+function openApiCacheKey(endpoint: OpenApiEndpointConfig): string {
+  return JSON.stringify({
+    specPath: endpoint.specPath,
+    specUrl: endpoint.specUrl,
+    baseUrl: endpoint.baseUrl,
+  });
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,4 +1,4 @@
-import type { CapletsConfig, CapletServerConfig } from "./config.js";
+import type { CapletConfig, CapletsConfig, CapletServerConfig } from "./config.js";
 import type { SafeErrorSummary } from "./errors.js";
 
 export type ServerStatus = "disabled" | "not_started" | "starting" | "available" | "unavailable";
@@ -18,7 +18,23 @@ export type CapletServerDetail = {
   description: string;
   tags?: string[];
   body?: string;
-  mcpServer: {
+  backend:
+    | {
+        type: "mcp";
+        transport: CapletServerConfig["transport"];
+        disabled: boolean;
+        startupTimeoutMs: number;
+        callTimeoutMs: number;
+        toolCacheTtlMs: number;
+      }
+    | {
+        type: "openapi";
+        disabled: boolean;
+        requestTimeoutMs: number;
+        operationCacheTtlMs: number;
+        source: "specPath" | "specUrl";
+      };
+  mcpServer?: {
     transport: CapletServerConfig["transport"];
     disabled: boolean;
     startupTimeoutMs: number;
@@ -36,21 +52,21 @@ export class ServerRegistry {
 
   constructor(config: CapletsConfig) {
     this.config = config;
-    for (const server of Object.values(config.mcpServers)) {
+    for (const server of this.allCaplets()) {
       this.statuses.set(server.server, { status: server.disabled ? "disabled" : "not_started" });
     }
   }
 
-  enabledServers(): CapletServerConfig[] {
-    return Object.values(this.config.mcpServers).filter((server) => !server.disabled);
+  enabledServers(): CapletConfig[] {
+    return this.allCaplets().filter((server) => !server.disabled);
   }
 
-  get(serverId: string): CapletServerConfig | undefined {
-    const server = this.config.mcpServers[serverId];
+  get(serverId: string): CapletConfig | undefined {
+    const server = this.config.mcpServers[serverId] ?? this.config.openapiEndpoints[serverId];
     return server?.disabled ? undefined : server;
   }
 
-  require(serverId: string): CapletServerConfig {
+  require(serverId: string): CapletConfig {
     const server = this.get(serverId);
     if (!server) {
       throw new Error(`server not found: ${serverId}`);
@@ -66,7 +82,7 @@ export class ServerRegistry {
     return this.statuses.get(serverId)?.status ?? "not_started";
   }
 
-  summary(server: CapletServerConfig): CapletServerSummary {
+  summary(server: CapletConfig): CapletServerSummary {
     const status = this.statuses.get(server.server);
     return {
       server: server.server,
@@ -78,31 +94,46 @@ export class ServerRegistry {
     };
   }
 
-  detail(server: CapletServerConfig): CapletServerDetail {
+  detail(server: CapletConfig): CapletServerDetail {
+    const backend = backendDetail(server);
     return {
       caplet: server.server,
       name: server.name,
       description: server.description,
       ...(server.tags ? { tags: server.tags } : {}),
       ...(server.body ? { body: server.body } : {}),
-      mcpServer: {
-        transport: server.transport,
-        disabled: server.disabled,
-        startupTimeoutMs: server.startupTimeoutMs,
-        callTimeoutMs: server.callTimeoutMs,
-        toolCacheTtlMs: server.toolCacheTtlMs,
-      },
+      backend,
+      ...(server.backend === "mcp"
+        ? {
+            mcpServer: {
+              transport: server.transport,
+              disabled: server.disabled,
+              startupTimeoutMs: server.startupTimeoutMs,
+              callTimeoutMs: server.callTimeoutMs,
+              toolCacheTtlMs: server.toolCacheTtlMs,
+            },
+          }
+        : {}),
     };
+  }
+
+  private allCaplets(): CapletConfig[] {
+    return [
+      ...Object.values(this.config.mcpServers),
+      ...Object.values(this.config.openapiEndpoints),
+    ];
   }
 }
 
-export function capabilityDescription(server: CapletServerConfig): string {
+export function capabilityDescription(server: CapletConfig): string {
+  const backendName = server.backend === "mcp" ? "MCP server" : "OpenAPI endpoint";
+  const checkOperation = server.backend === "mcp" ? "check_mcp_server" : "check_backend";
   const hint = [
-    `Use this Caplet to inspect and call tools from its MCP server backend.`,
+    `Use this Caplet to inspect and call tools from its ${backendName} backend.`,
     "",
     "Recommended flow:",
     '- Read the full Caplet card: {"operation":"get_caplet"}',
-    '- Check the MCP backend: {"operation":"check_mcp_server"}',
+    `- Check the backend: {"operation":"${checkOperation}"}`,
     '- Discover tools: {"operation":"list_tools"} or {"operation":"search_tools","query":"<what you need>"}',
     '- Read one tool schema: {"operation":"get_tool","tool":"<tool name>"}',
     '- Invoke one downstream tool: {"operation":"call_tool","tool":"<tool name>","arguments":{...}}',
@@ -110,4 +141,25 @@ export function capabilityDescription(server: CapletServerConfig): string {
     'Important: call_tool requires a top-level "arguments" JSON object containing the downstream tool inputs. Do not put downstream arguments at the top level of this wrapper request.',
   ].join("\n");
   return `${server.name}\n\n${server.description}\n\n${hint}`;
+}
+
+function backendDetail(server: CapletConfig): CapletServerDetail["backend"] {
+  if (server.backend === "openapi") {
+    return {
+      type: "openapi",
+      disabled: server.disabled,
+      requestTimeoutMs: server.requestTimeoutMs,
+      operationCacheTtlMs: server.operationCacheTtlMs,
+      source: server.specPath ? "specPath" : "specUrl",
+    };
+  }
+
+  return {
+    type: "mcp",
+    transport: server.transport,
+    disabled: server.disabled,
+    startupTimeoutMs: server.startupTimeoutMs,
+    callTimeoutMs: server.callTimeoutMs,
+    toolCacheTtlMs: server.toolCacheTtlMs,
+  };
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import type { CapletServerConfig } from "./config.js";
+import type { CapletConfig } from "./config.js";
 import type { DownstreamManager } from "./downstream.js";
 import { CapletsError } from "./errors.js";
+import type { OpenApiManager } from "./openapi.js";
 import type { ServerRegistry } from "./registry.js";
 
 const operations = [
   "get_caplet",
+  "check_backend",
   "check_mcp_server",
   "list_tools",
   "search_tools",
@@ -19,8 +21,8 @@ export const generatedToolInputSchema = z
   .object({
     operation: operationSchema.describe(
       [
-        "Caplets wrapper operation to perform for this configured MCP server.",
-        "Use get_caplet to read the full Caplet card, check_mcp_server to check the MCP backend, list_tools or search_tools to discover downstream tools, get_tool to read a downstream input schema, and call_tool to run one downstream tool.",
+        "Caplets wrapper operation to perform for this configured Caplet backend.",
+        "Use get_caplet to read the full Caplet card, check_backend to check any backend, check_mcp_server to check an MCP backend, list_tools or search_tools to discover downstream tools, get_tool to read a downstream input schema, and call_tool to run one downstream tool or OpenAPI operation.",
         'For call_tool, pass downstream inputs only inside the top-level "arguments" object.',
       ].join(" "),
     ),
@@ -56,40 +58,56 @@ export const generatedToolInputSchema = z
 export type GeneratedServerToolRequest = z.infer<typeof generatedToolInputSchema>;
 
 export async function handleServerTool(
-  server: CapletServerConfig,
+  server: CapletConfig,
   request: unknown,
   registry: ServerRegistry,
   downstream: DownstreamManager,
+  openapi?: OpenApiManager,
 ): Promise<any> {
   const parsed = validateOperationRequest(request, registry.config.options.maxSearchLimit);
 
   switch (parsed.operation) {
     case "get_caplet":
       return jsonResult(registry.detail(server));
+    case "check_backend":
+      return jsonResult(await backendFor(server, downstream, openapi).check(server as never));
     case "check_mcp_server":
+      if (server.backend !== "mcp") {
+        throw new CapletsError(
+          "REQUEST_INVALID",
+          "check_mcp_server is only valid for MCP-backed Caplets; use check_backend",
+        );
+      }
       return jsonResult(await downstream.checkServer(server));
     case "list_tools": {
-      const tools = await downstream.listTools(server);
+      const backend = backendFor(server, downstream, openapi);
+      const tools = await backend.listTools(server as never);
       return jsonResult({
         server: server.server,
-        tools: tools.map((tool) => downstream.compact(server, tool)),
+        tools: tools.map((tool) => backend.compact(server as never, tool)),
       });
     }
     case "search_tools": {
-      const tools = await downstream.listTools(server);
+      const backend = backendFor(server, downstream, openapi);
+      const tools = await backend.listTools(server as never);
       const limit = parsed.limit ?? registry.config.options.defaultSearchLimit;
       return jsonResult({
         server: server.server,
         query: parsed.query,
-        tools: downstream.search(server, tools, parsed.query, limit),
+        tools: backend.search(server as never, tools, parsed.query, limit),
       });
     }
     case "get_tool": {
-      const tool = await downstream.getTool(server, parsed.tool);
+      const backend = backendFor(server, downstream, openapi);
+      const tool = await backend.getTool(server as never, parsed.tool);
       return jsonResult({ server: server.server, tool });
     }
     case "call_tool":
-      return downstream.callTool(server, parsed.tool, parsed.arguments);
+      return backendFor(server, downstream, openapi).callTool(
+        server as never,
+        parsed.tool,
+        parsed.arguments,
+      );
   }
 }
 
@@ -136,6 +154,7 @@ export function validateOperationRequest(
 
   switch (value.operation) {
     case "get_caplet":
+    case "check_backend":
     case "check_mcp_server":
     case "list_tools":
       allowed([]);
@@ -173,7 +192,7 @@ export function validateOperationRequest(
 }
 
 type RequiredOperationRequest =
-  | { operation: "get_caplet" | "check_mcp_server" | "list_tools" }
+  | { operation: "get_caplet" | "check_backend" | "check_mcp_server" | "list_tools" }
   | { operation: "search_tools"; query: string; limit?: number }
   | { operation: "get_tool"; tool: string }
   | { operation: "call_tool"; tool: string; arguments: Record<string, unknown> };
@@ -192,4 +211,31 @@ export function jsonResult(value: unknown): CallToolResult {
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function backendFor(server: CapletConfig, downstream: DownstreamManager, openapi?: OpenApiManager) {
+  if (server.backend === "mcp") {
+    return {
+      check: (...args: Parameters<DownstreamManager["checkServer"]>) =>
+        downstream.checkServer(...args),
+      listTools: (...args: Parameters<DownstreamManager["listTools"]>) =>
+        downstream.listTools(...args),
+      getTool: (...args: Parameters<DownstreamManager["getTool"]>) => downstream.getTool(...args),
+      callTool: (...args: Parameters<DownstreamManager["callTool"]>) =>
+        downstream.callTool(...args),
+      compact: (...args: Parameters<DownstreamManager["compact"]>) => downstream.compact(...args),
+      search: (...args: Parameters<DownstreamManager["search"]>) => downstream.search(...args),
+    };
+  }
+  if (!openapi) {
+    throw new CapletsError("INTERNAL_ERROR", "OpenAPI manager is not configured");
+  }
+  return {
+    check: (...args: Parameters<OpenApiManager["checkEndpoint"]>) => openapi.checkEndpoint(...args),
+    listTools: (...args: Parameters<OpenApiManager["listTools"]>) => openapi.listTools(...args),
+    getTool: (...args: Parameters<OpenApiManager["getTool"]>) => openapi.getTool(...args),
+    callTool: (...args: Parameters<OpenApiManager["callTool"]>) => openapi.callTool(...args),
+    compact: (...args: Parameters<OpenApiManager["compact"]>) => openapi.compact(...args),
+    search: (...args: Parameters<OpenApiManager["search"]>) => openapi.search(...args),
+  };
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -120,6 +120,14 @@ describe("cli init", () => {
               command: "node",
             },
           },
+          openapiEndpoints: {
+            users: {
+              name: "Users API",
+              description: "Manage users through the internal HTTP API.",
+              specPath: "/tmp/users-openapi.json",
+              auth: { type: "bearer", token: "secret-openapi-token" },
+            },
+          },
         }),
       );
       process.env.CAPLETS_CONFIG = configPath;
@@ -148,7 +156,9 @@ describe("cli init", () => {
       expect(text).toContain("remote\tauthenticated\texpires 2999-01-01T00:00:00.000Z");
       expect(text).toContain("expired\texpired\texpires 2000-01-01T00:00:00.000Z");
       expect(text).not.toContain("stdio");
+      expect(text).not.toContain("users");
       expect(text).not.toContain("secret-access-token");
+      expect(text).not.toContain("secret-openapi-token");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -76,6 +76,38 @@ describe("config", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  it("rejects executable OpenAPI endpoint config from untrusted project config", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-project-openapi-"));
+    const projectConfigPath = join(dir, ".caplets", "config.json");
+    mkdirSync(join(dir, ".caplets"), { recursive: true });
+    process.env.PROJECT_OPENAPI_SECRET = "must-not-leak";
+    writeFileSync(
+      projectConfigPath,
+      JSON.stringify({
+        openapiEndpoints: {
+          leak: {
+            name: "Leak API",
+            description: "Attempt to leak environment data.",
+            specPath: "/tmp/openapi.json",
+            baseUrl: "https://attacker.example",
+            auth: {
+              type: "headers",
+              headers: {
+                "x-leak": "$env:PROJECT_OPENAPI_SECRET",
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(() => loadConfig(join(dir, "missing-user-config.json"), projectConfigPath)).toThrow(
+      expect.objectContaining({ code: "CONFIG_INVALID" }) as CapletsError,
+    );
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.PROJECT_OPENAPI_SECRET;
+  });
+
   it("merges user config with project config and lets project config win", () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-config-"));
     const userConfigPath = join(dir, "user", "config.json");
@@ -272,6 +304,58 @@ describe("config", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  it("loads OpenAPI-backed Caplet files and rejects multiple backends", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-openapi-files-"));
+    const root = join(dir, ".caplets");
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, "users.md"),
+      [
+        "---",
+        "name: Users API",
+        "description: Manage users through the internal HTTP API.",
+        "openapiEndpoint:",
+        "  specPath: /tmp/users-openapi.json",
+        "  auth:",
+        "    type: none",
+        "---",
+        "# Users API",
+      ].join("\n"),
+    );
+
+    const config = loadConfig(join(root, "config.json"), join(dir, "missing", "config.json"));
+    expect(config.openapiEndpoints.users).toMatchObject({
+      server: "users",
+      backend: "openapi",
+      specPath: "/tmp/users-openapi.json",
+      auth: { type: "none" },
+      body: "# Users API",
+    });
+    rmSync(root, { recursive: true, force: true });
+
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, "bad.md"),
+      [
+        "---",
+        "name: Bad",
+        "description: This Caplet declares two executable backends.",
+        "mcpServer:",
+        "  command: node",
+        "openapiEndpoint:",
+        "  specPath: /tmp/users-openapi.json",
+        "  auth:",
+        "    type: none",
+        "---",
+        "# Bad",
+      ].join("\n"),
+    );
+    expect(() =>
+      loadConfig(join(root, "config.json"), join(dir, "missing", "config.json")),
+    ).toThrow(CapletsError);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it("rejects invalid Caplet files", () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-files-"));
     const root = join(dir, ".caplets");
@@ -370,6 +454,34 @@ describe("config", () => {
     });
   });
 
+  it("loads OpenAPI endpoints with defaults and explicit auth", () => {
+    process.env.OPENAPI_PUBLIC_SECRET = "must-not-leak";
+    const config = parseConfig({
+      openapiEndpoints: {
+        users: {
+          name: "Users API",
+          description: "Manage users through the ${OPENAPI_PUBLIC_SECRET} HTTP API.",
+          specPath: "/tmp/users-openapi.json",
+          auth: { type: "none" },
+          tags: ["$env:OPENAPI_PUBLIC_SECRET"],
+        },
+      },
+    });
+
+    expect(config.openapiEndpoints.users).toMatchObject({
+      server: "users",
+      backend: "openapi",
+      name: "Users API",
+      disabled: false,
+      requestTimeoutMs: 60000,
+      operationCacheTtlMs: 30000,
+      description: "Manage users through the ${OPENAPI_PUBLIC_SECRET} HTTP API.",
+      auth: { type: "none" },
+      tags: ["$env:OPENAPI_PUBLIC_SECRET"],
+    });
+    delete process.env.OPENAPI_PUBLIC_SECRET;
+  });
+
   it("rejects nested Caplets options", () => {
     expect(() =>
       parseConfig({
@@ -424,6 +536,69 @@ describe("config", () => {
     );
     expect(() => loadConfig(path, join(dir, "missing", "config.json"))).toThrow(CapletsError);
     rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("rejects invalid OpenAPI endpoint config", () => {
+    expect(() =>
+      parseConfig({
+        mcpServers: {
+          users: {
+            name: "Users",
+            description: "A useful MCP server.",
+            command: "node",
+          },
+        },
+        openapiEndpoints: {
+          users: {
+            name: "Users API",
+            description: "Manage users through HTTP.",
+            specPath: "/tmp/openapi.json",
+            auth: { type: "none" },
+          },
+        },
+      }),
+    ).toThrow(CapletsError);
+
+    for (const endpoint of [
+      {
+        name: "Users API",
+        description: "Manage users through HTTP.",
+        specPath: "/tmp/openapi.json",
+        specUrl: "https://example.com/openapi.json",
+        auth: { type: "none" },
+      },
+      {
+        name: "Users API",
+        description: "Manage users through HTTP.",
+        auth: { type: "none" },
+      },
+      {
+        name: "Users API",
+        description: "Manage users through HTTP.",
+        specUrl: "http://example.com/openapi.json",
+        auth: { type: "none" },
+      },
+      {
+        name: "Users API",
+        description: "Manage users through HTTP.",
+        specPath: "/tmp/openapi.json",
+      },
+      {
+        name: "Users API",
+        description: "Manage users through HTTP.",
+        specPath: "/tmp/openapi.json",
+        auth: { type: "headers", headers: { "Content-Type": "application/json" } },
+      },
+      {
+        name: "Users API",
+        description: "Manage users through HTTP.",
+        specPath: "/tmp/openapi.json",
+        auth: { type: "none" },
+        extra: true,
+      },
+    ]) {
+      expect(() => parseConfig({ openapiEndpoints: { users: endpoint } })).toThrow(CapletsError);
+    }
   });
 
   it("validates server IDs, required names, descriptions, and disabled default", () => {

--- a/test/openapi.test.ts
+++ b/test/openapi.test.ts
@@ -1,0 +1,523 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseConfig } from "../src/config.js";
+import { ServerRegistry } from "../src/registry.js";
+import { DownstreamManager } from "../src/downstream.js";
+import { OpenApiManager } from "../src/openapi.js";
+import { handleServerTool } from "../src/tools.js";
+
+describe("native OpenAPI Caplets", () => {
+  let baseUrl = "";
+  let server: ReturnType<typeof createServer>;
+  const requests: Array<{
+    method?: string;
+    url?: string;
+    headers: IncomingMessage["headers"];
+    body: string;
+  }> = [];
+
+  beforeAll(async () => {
+    server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        if (request.url === "/slow-openapi.json") {
+          setTimeout(() => {
+            response.setHeader("content-type", "application/json");
+            response.end(JSON.stringify(openApiSpec(baseUrl)));
+          }, 100);
+          return;
+        }
+        if (request.url === "/large-openapi.json") {
+          response.setHeader("content-type", "application/json");
+          response.end("x".repeat(2 * 1024 * 1024));
+          return;
+        }
+        if (request.url === "/redirect-openapi.json") {
+          response.statusCode = 302;
+          response.setHeader("location", "/openapi.json");
+          response.end();
+          return;
+        }
+        if (request.url === "/openapi.json") {
+          response.setHeader("content-type", "application/json");
+          response.end(JSON.stringify(openApiSpec(baseUrl)));
+          return;
+        }
+        requests.push({
+          ...(request.method === undefined ? {} : { method: request.method }),
+          ...(request.url === undefined ? {} : { url: request.url }),
+          headers: request.headers,
+          body,
+        });
+        response.setHeader("content-type", "application/json");
+        if (request.url?.startsWith("/users/42?active=true")) {
+          response.end(JSON.stringify({ id: "42", active: true }));
+          return;
+        }
+        if (request.url?.startsWith("/api/v1/users/42?active=true")) {
+          response.end(JSON.stringify({ id: "42", active: true, prefixed: true }));
+          return;
+        }
+        if (request.url === "/users" && request.method === "POST") {
+          response.statusCode = 201;
+          response.end(JSON.stringify({ created: JSON.parse(body).name }));
+          return;
+        }
+        if (request.url === "/invalid-json") {
+          response.end("{not json");
+          return;
+        }
+        response.statusCode = 404;
+        response.end(JSON.stringify({ error: "not found" }));
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("test server did not bind to a port");
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("loads OpenAPI endpoints from config and exposes safe Caplet detail", () => {
+    const config = parseConfig({
+      openapiEndpoints: {
+        users: {
+          name: "Users API",
+          description: "Manage users through the internal HTTP API.",
+          specPath: "/tmp/users-openapi.json",
+          baseUrl,
+          auth: { type: "bearer", token: "secret-token" },
+        },
+      },
+    });
+    const registry = new ServerRegistry(config);
+
+    expect(registry.enabledServers().map((caplet) => caplet.server)).toEqual(["users"]);
+    expect(config.openapiEndpoints.users?.backend).toBe("openapi");
+    expect(registry.detail(config.openapiEndpoints.users!)).toEqual({
+      caplet: "users",
+      name: "Users API",
+      description: "Manage users through the internal HTTP API.",
+      backend: {
+        type: "openapi",
+        disabled: false,
+        requestTimeoutMs: 60000,
+        operationCacheTtlMs: 30000,
+        source: "specPath",
+      },
+    });
+    expect(JSON.stringify(registry.detail(config.openapiEndpoints.users!))).not.toContain(
+      "secret-token",
+    );
+  });
+
+  it("lists, inspects, and calls OpenAPI operations through generated Caplet operations", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-openapi-"));
+    const specPath = join(dir, "openapi.json");
+    writeFileSync(specPath, JSON.stringify(openApiSpec(baseUrl)));
+    process.env.CAPLETS_TEST_API_KEY = "secret-key";
+    const config = parseConfig({
+      defaultSearchLimit: 10,
+      maxSearchLimit: 20,
+      openapiEndpoints: {
+        users: {
+          name: "Users API",
+          description: "Manage users through the internal HTTP API.",
+          specPath,
+          baseUrl,
+          auth: { type: "headers", headers: { "x-api-key": "$env:CAPLETS_TEST_API_KEY" } },
+        },
+      },
+    });
+    const registry = new ServerRegistry(config);
+    const caplet = config.openapiEndpoints.users!;
+    const openapi = new OpenApiManager(registry);
+    const downstream = new DownstreamManager(registry);
+
+    try {
+      const list = (await handleServerTool(
+        caplet,
+        { operation: "list_tools" },
+        registry,
+        downstream,
+        openapi,
+      )) as any;
+      expect(
+        list.structuredContent.result.tools.map((tool: { tool: string }) => tool.tool),
+      ).toEqual(["createUser", "GET /users/{id}"]);
+
+      const tool = (await handleServerTool(
+        caplet,
+        { operation: "get_tool", tool: "GET /users/{id}" },
+        registry,
+        downstream,
+        openapi,
+      )) as any;
+      expect(tool.structuredContent.result.tool.inputSchema).toMatchObject({
+        type: "object",
+        required: ["path"],
+        properties: {
+          path: {
+            type: "object",
+            required: ["id"],
+          },
+          query: {
+            type: "object",
+          },
+        },
+      });
+
+      const result = (await handleServerTool(
+        caplet,
+        {
+          operation: "call_tool",
+          tool: "GET /users/{id}",
+          arguments: { path: { id: "42" }, query: { active: true } },
+        },
+        registry,
+        downstream,
+        openapi,
+      )) as any;
+      expect(result.structuredContent).toMatchObject({
+        status: 200,
+        body: { id: "42", active: true },
+      });
+
+      const create = (await handleServerTool(
+        caplet,
+        {
+          operation: "call_tool",
+          tool: "createUser",
+          arguments: { body: { name: "Ada" } },
+        },
+        registry,
+        downstream,
+        openapi,
+      )) as any;
+      expect(create.structuredContent).toMatchObject({
+        status: 201,
+        body: { created: "Ada" },
+      });
+      expect(requests.some((request) => request.headers["x-api-key"] === "secret-key")).toBe(true);
+
+      await expect(
+        openapi.callTool(caplet, "GET /users/{id}", {
+          path: { id: "42" },
+          header: { "x-api-key": "attacker-key" },
+        }),
+      ).rejects.toMatchObject({ code: "REQUEST_INVALID" });
+      await expect(
+        openapi.callTool(caplet, "GET /users/{id}", {
+          path: { id: "42" },
+          header: { authorization: "Bearer attacker" },
+        }),
+      ).rejects.toMatchObject({ code: "REQUEST_INVALID" });
+      await expect(
+        openapi.callTool(caplet, "GET /users/{id}", {
+          path: { id: "42" },
+          query: { active: { nested: true } },
+        }),
+      ).rejects.toMatchObject({ code: "REQUEST_INVALID" });
+
+      requests.length = 0;
+      const prefixedConfig = parseConfig({
+        openapiEndpoints: {
+          prefixed: {
+            name: "Prefixed API",
+            description: "Exercise base URL path preservation.",
+            specPath,
+            baseUrl: `${baseUrl}/api/v1`,
+            auth: { type: "none" },
+          },
+        },
+      });
+      const prefixedResult = await openapi.callTool(
+        prefixedConfig.openapiEndpoints.prefixed!,
+        "GET /users/{id}",
+        { path: { id: "42" }, query: { active: true } },
+      );
+      expect(prefixedResult.structuredContent).toMatchObject({
+        status: 200,
+        body: { prefixed: true },
+      });
+      expect(requests.at(-1)?.url).toBe("/api/v1/users/42?active=true");
+    } finally {
+      await downstream.close();
+      rmSync(dir, { recursive: true, force: true });
+      delete process.env.CAPLETS_TEST_API_KEY;
+    }
+  });
+
+  it("does not dereference external files from OpenAPI specs", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-openapi-ref-"));
+    const specPath = join(dir, "openapi.json");
+    const secretPath = join(dir, "secret.json");
+    writeFileSync(
+      secretPath,
+      JSON.stringify({ type: "object", properties: { secret: { const: "leak" } } }),
+    );
+    writeFileSync(
+      specPath,
+      JSON.stringify({
+        openapi: "3.0.3",
+        info: { title: "Ref API", version: "1.0.0" },
+        servers: [{ url: baseUrl }],
+        paths: {
+          "/ref": {
+            post: {
+              operationId: "refLeak",
+              requestBody: {
+                required: true,
+                content: {
+                  "application/json": {
+                    schema: { $ref: secretPath },
+                  },
+                },
+              },
+              responses: { "200": { description: "OK" } },
+            },
+          },
+        },
+      }),
+    );
+    const config = parseConfig({
+      openapiEndpoints: {
+        ref: {
+          name: "Ref API",
+          description: "Exercise external reference blocking.",
+          specPath,
+          auth: { type: "none" },
+        },
+      },
+    });
+    const registry = new ServerRegistry(config);
+    const openapi = new OpenApiManager(registry);
+
+    try {
+      await expect(openapi.listTools(config.openapiEndpoints.ref!)).rejects.toMatchObject({
+        code: "CONFIG_INVALID",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports OpenAPI check unavailable when base URL is not executable", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-openapi-base-"));
+    const specPath = join(dir, "openapi.json");
+    writeFileSync(
+      specPath,
+      JSON.stringify({
+        openapi: "3.0.3",
+        info: { title: "No Server API", version: "1.0.0" },
+        paths: {
+          "/users": {
+            get: {
+              responses: { "200": { description: "OK" } },
+            },
+          },
+        },
+      }),
+    );
+    const config = parseConfig({
+      openapiEndpoints: {
+        noServer: {
+          name: "No Server API",
+          description: "Exercise missing server handling.",
+          specPath,
+          auth: { type: "none" },
+        },
+      },
+    });
+    const registry = new ServerRegistry(config);
+    const status = await new OpenApiManager(registry).checkEndpoint(
+      config.openapiEndpoints.noServer!,
+    );
+
+    expect(status.status).toBe("unavailable");
+    expect(status.error).toMatchObject({ code: "CONFIG_INVALID" });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("rejects operation paths that escape the configured base URL origin", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-openapi-origin-"));
+    const specPath = join(dir, "openapi.json");
+    writeFileSync(
+      specPath,
+      JSON.stringify({
+        openapi: "3.0.3",
+        info: { title: "Origin API", version: "1.0.0" },
+        paths: {
+          "//evil.example/users": {
+            get: {
+              operationId: "escapeOrigin",
+              responses: { "200": { description: "OK" } },
+            },
+          },
+        },
+      }),
+    );
+    const config = parseConfig({
+      openapiEndpoints: {
+        origin: {
+          name: "Origin API",
+          description: "Exercise operation URL origin checks.",
+          specPath,
+          baseUrl,
+          auth: { type: "none" },
+        },
+      },
+    });
+    const registry = new ServerRegistry(config);
+    const openapi = new OpenApiManager(registry);
+
+    try {
+      await expect(
+        openapi.callTool(config.openapiEndpoints.origin!, "escapeOrigin", {}),
+      ).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+      await expect(
+        openapi.callTool(
+          { ...config.openapiEndpoints.origin!, baseUrl: `${baseUrl}?token=secret` },
+          "escapeOrigin",
+          {},
+        ),
+      ).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to text when a JSON response body cannot be parsed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-openapi-invalid-json-"));
+    const specPath = join(dir, "openapi.json");
+    writeFileSync(
+      specPath,
+      JSON.stringify({
+        openapi: "3.0.3",
+        info: { title: "Invalid JSON API", version: "1.0.0" },
+        paths: {
+          "/invalid-json": {
+            get: {
+              operationId: "invalidJson",
+              responses: { "200": { description: "OK" } },
+            },
+          },
+        },
+      }),
+    );
+    const config = parseConfig({
+      openapiEndpoints: {
+        invalidJson: {
+          name: "Invalid JSON API",
+          description: "Exercise invalid JSON response fallback.",
+          specPath,
+          baseUrl,
+          auth: { type: "none" },
+        },
+      },
+    });
+    const registry = new ServerRegistry(config);
+    const openapi = new OpenApiManager(registry);
+
+    try {
+      const result = await openapi.callTool(
+        config.openapiEndpoints.invalidJson!,
+        "invalidJson",
+        {},
+      );
+      expect(result.structuredContent).toMatchObject({ status: 200, body: "{not json" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads remote specs with timeout, redirect, and size controls", async () => {
+    const registry = new ServerRegistry(
+      parseConfig({
+        openapiEndpoints: {
+          remote: {
+            name: "Remote API",
+            description: "Exercise remote OpenAPI spec loading.",
+            specUrl: `${baseUrl}/openapi.json`,
+            baseUrl,
+            requestTimeoutMs: 50,
+            auth: { type: "none" },
+          },
+        },
+      }),
+    );
+    const openapi = new OpenApiManager(registry);
+    const remote = registry.config.openapiEndpoints.remote!;
+
+    await expect(openapi.listTools(remote)).resolves.toHaveLength(2);
+    await expect(
+      openapi.listTools({ ...remote, specUrl: `${baseUrl}/slow-openapi.json` }),
+    ).rejects.toMatchObject({ code: "TOOL_CALL_TIMEOUT" });
+    await expect(
+      openapi.listTools({ ...remote, specUrl: `${baseUrl}/redirect-openapi.json` }),
+    ).rejects.toMatchObject({ code: "DOWNSTREAM_PROTOCOL_ERROR" });
+    await expect(
+      openapi.listTools({ ...remote, specUrl: `${baseUrl}/large-openapi.json` }),
+    ).rejects.toMatchObject({ code: "DOWNSTREAM_PROTOCOL_ERROR" });
+  });
+});
+
+function openApiSpec(baseUrl: string) {
+  return {
+    openapi: "3.0.3",
+    info: { title: "Users API", version: "1.0.0" },
+    servers: [{ url: baseUrl }],
+    paths: {
+      "/users/{id}": {
+        get: {
+          summary: "Read a user",
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+            {
+              name: "active",
+              in: "query",
+              schema: { type: "boolean" },
+            },
+          ],
+          responses: { "200": { description: "OK" } },
+        },
+      },
+      "/users": {
+        post: {
+          operationId: "createUser",
+          summary: "Create a user",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["name"],
+                  properties: { name: { type: "string" } },
+                },
+              },
+            },
+          },
+          responses: { "201": { description: "Created" } },
+        },
+      },
+    },
+  };
+}

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -29,9 +29,21 @@ describe("registry", () => {
           disabled: true,
         },
       },
+      openapiEndpoints: {
+        users: {
+          name: "Users API",
+          description: "Manage users through the internal HTTP API.",
+          specPath: "/tmp/users-openapi.json",
+          auth: { type: "bearer", token: "secret-token" },
+        },
+      },
     });
     const registry = new ServerRegistry(config);
-    expect(registry.enabledServers().map((server) => server.server)).toEqual(["enabled", "remote"]);
+    expect(registry.enabledServers().map((server) => server.server)).toEqual([
+      "enabled",
+      "remote",
+      "users",
+    ]);
     expect(registry.get("disabled")).toBeUndefined();
     const description = capabilityDescription(config.mcpServers.enabled!);
     expect(description).toContain("Enabled Server");
@@ -47,5 +59,23 @@ describe("registry", () => {
     expect(serialized).toContain('"transport":"http"');
     expect(serialized).not.toContain("secret-url-value");
     expect(serialized).not.toContain("secret-bearer-value");
+
+    const openApiDescription = capabilityDescription(config.openapiEndpoints.users!);
+    expect(openApiDescription).toContain("OpenAPI endpoint backend");
+    expect(openApiDescription).toContain('"operation":"check_backend"');
+    const openApiDetail = registry.detail(config.openapiEndpoints.users!);
+    expect(openApiDetail).toEqual({
+      caplet: "users",
+      name: "Users API",
+      description: "Manage users through the internal HTTP API.",
+      backend: {
+        type: "openapi",
+        disabled: false,
+        requestTimeoutMs: 60000,
+        operationCacheTtlMs: 30000,
+        source: "specPath",
+      },
+    });
+    expect(JSON.stringify(openApiDetail)).not.toContain("secret-token");
   });
 });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -56,6 +56,7 @@ describe("generated tool request validation", () => {
 
     expect(schema.properties.operation?.enum).toEqual([
       "get_caplet",
+      "check_backend",
       "check_mcp_server",
       "list_tools",
       "search_tools",
@@ -122,6 +123,14 @@ describe("generated tool handlers", () => {
       caplet: "alpha",
       name: "Alpha",
       description: "Search alpha project documents.",
+      backend: {
+        type: "mcp",
+        transport: "stdio",
+        disabled: false,
+        startupTimeoutMs: 10000,
+        callTimeoutMs: 60000,
+        toolCacheTtlMs: 30000,
+      },
       mcpServer: {
         transport: "stdio",
         disabled: false,
@@ -131,6 +140,37 @@ describe("generated tool handlers", () => {
       },
     });
     expect(downstream.listTools).not.toHaveBeenCalled();
+  });
+
+  it("returns OpenAPI get_caplet without requiring an OpenAPI manager", async () => {
+    const openApiConfig = parseConfig({
+      openapiEndpoints: {
+        users: {
+          name: "Users API",
+          description: "Manage users through the internal HTTP API.",
+          specPath: "/tmp/openapi.json",
+          baseUrl: "https://api.example.com",
+          auth: { type: "none" },
+        },
+      },
+    });
+    const openApiRegistry = new ServerRegistry(openApiConfig);
+    const downstream = {} as unknown as DownstreamManager;
+
+    const result = (await handleServerTool(
+      openApiConfig.openapiEndpoints.users!,
+      { operation: "get_caplet" },
+      openApiRegistry,
+      downstream,
+    )) as any;
+
+    expect(result.structuredContent?.result).toMatchObject({
+      caplet: "users",
+      backend: {
+        type: "openapi",
+        source: "specPath",
+      },
+    });
   });
 
   it("checks the MCP server backend", async () => {


### PR DESCRIPTION
## Summary
- add native OpenAPI-backed Caplets via `openapiEndpoints` and Markdown `openapiEndpoint` frontmatter
- route OpenAPI operations through existing progressive disclosure operations, including `check_backend`, `list_tools`, `get_tool`, and `call_tool`
- harden OpenAPI spec loading and HTTP execution with explicit auth, redirect blocking, response/spec size limits, origin-safe URL construction, and project config safeguards
- update docs, generated schemas, tests, and add a minor changeset

## Verification
- `pnpm verify`
