### PR TITLE
[codex] fix OAuth public client token exchange

### DIFF
--- a/.changeset/soft-eels-relate.md
+++ b/.changeset/soft-eels-relate.md
@@ -1,0 +1,5 @@
+---
+"caplets": patch
+---
+
+Fix MCP OAuth/OIDC login for configured public clients by including the client ID in the token exchange.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -284,13 +284,15 @@ export class FileOAuthProvider implements OAuthClientProvider {
   }
 
   addClientAuthentication = async (headers: Headers, params: URLSearchParams): Promise<void> => {
-    if (
-      (this.server.auth?.type !== "oauth2" && this.server.auth?.type !== "oidc") ||
-      !this.server.auth.clientSecret
-    ) {
+    if (this.server.auth?.type !== "oauth2" && this.server.auth?.type !== "oidc") {
       return;
     }
-    params.set("client_secret", this.server.auth.clientSecret);
+    if (this.server.auth.clientId) {
+      params.set("client_id", this.server.auth.clientId);
+    }
+    if (this.server.auth.clientSecret) {
+      params.set("client_secret", this.server.auth.clientSecret);
+    }
     headers.set("content-type", "application/x-www-form-urlencoded");
   };
 }

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -141,6 +141,7 @@ describe("auth helpers", () => {
 
     await addClientAuthentication(headers, params);
 
+    expect(params.get("client_id")).toBe("client");
     expect(params.get("client_secret")).toBe("secret");
     expect(headers.get("content-type")).toBe("application/x-www-form-urlencoded");
   });

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -145,6 +145,30 @@ describe("auth helpers", () => {
     expect(headers.get("content-type")).toBe("application/x-www-form-urlencoded");
   });
 
+  it("adds configured OAuth public client ID during SDK token exchange", async () => {
+    const server = parseConfig({
+      mcpServers: {
+        remote: {
+          name: "Remote",
+          description: "A useful remote server.",
+          transport: "http",
+          url: "https://example.com/mcp",
+          auth: { type: "oauth2", clientId: "client" },
+        },
+      },
+    }).mcpServers.remote!;
+    const provider = new FileOAuthProvider(server, "http://127.0.0.1/callback", () => {});
+    const addClientAuthentication = provider.addClientAuthentication;
+    const headers = new Headers();
+    const params = new URLSearchParams();
+
+    await addClientAuthentication(headers, params);
+
+    expect(params.get("client_id")).toBe("client");
+    expect(params.has("client_secret")).toBe(false);
+    expect(headers.get("content-type")).toBe("application/x-www-form-urlencoded");
+  });
+
   it("runs generic OIDC authorization code flow with discovery and dynamic client registration", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
     let baseUrl = "";


### PR DESCRIPTION
## Summary

Fix MCP OAuth/OIDC login for configured public clients by including the configured `client_id` when the MCP SDK delegates token request authentication to Caplets.

## Root Cause

`FileOAuthProvider` always exposes `addClientAuthentication`, which causes the MCP SDK to skip its built-in public-client token request handling. For public clients without a secret, the Caplets hook returned without adding `client_id`, so token endpoints such as Exa rejected the authorization-code exchange as missing required parameters.

## Changes

- Add `client_id` to token exchange params for configured OAuth/OIDC clients.
- Continue adding `client_secret` for confidential clients.
- Add a regression test covering public OAuth clients using the SDK callback path.
- Add a patch changeset for the fix.

## Verification

- `pnpm test -- auth`
- `pnpm typecheck`
- `pnpm verify`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth/OIDC login for public clients by ensuring configured client credentials (client_id when present) are included in token exchange requests.

* **Tests**
  * Added and extended tests to validate that public client credentials and proper form-encoded headers are set during OAuth token exchanges.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spiritledsoftware/caplets/pull/12)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spiritledsoftware/caplets/pull/12)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->