### PR TITLE
fix: use dynamic oauth client in token exchange

### DIFF
--- a/.changeset/loud-spies-breathe.md
+++ b/.changeset/loud-spies-breathe.md
@@ -1,0 +1,5 @@
+---
+"caplets": patch
+---
+
+Fix MCP OAuth/OIDC token exchange for dynamically registered clients.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -287,11 +287,14 @@ export class FileOAuthProvider implements OAuthClientProvider {
     if (this.server.auth?.type !== "oauth2" && this.server.auth?.type !== "oidc") {
       return;
     }
-    if (this.server.auth.clientId) {
-      params.set("client_id", this.server.auth.clientId);
+    const clientInformation = this.clientInformation();
+    const clientId = clientInformation?.client_id;
+    const clientSecret = clientInformation?.client_secret;
+    if (clientId) {
+      params.set("client_id", clientId);
     }
-    if (this.server.auth.clientSecret) {
-      params.set("client_secret", this.server.auth.clientSecret);
+    if (clientSecret) {
+      params.set("client_secret", clientSecret);
     }
     headers.set("content-type", "application/x-www-form-urlencoded");
   };

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -170,6 +170,62 @@ describe("auth helpers", () => {
     expect(headers.get("content-type")).toBe("application/x-www-form-urlencoded");
   });
 
+  it.each(["oauth2", "oidc"] as const)(
+    "adds dynamically registered %s client information during SDK token exchange",
+    async (authType) => {
+      const server = parseConfig({
+        mcpServers: {
+          remote: {
+            name: "Remote",
+            description: "A useful remote server.",
+            transport: "http",
+            url: "https://example.com/mcp",
+            auth: { type: authType },
+          },
+        },
+      }).mcpServers.remote!;
+      const provider = new FileOAuthProvider(server, "http://127.0.0.1/callback", () => {});
+      provider.saveClientInformation({
+        client_id: "dynamic-client",
+        client_secret: "dynamic-secret",
+      });
+      const addClientAuthentication = provider.addClientAuthentication;
+      const headers = new Headers();
+      const params = new URLSearchParams();
+
+      await addClientAuthentication(headers, params);
+
+      expect(params.get("client_id")).toBe("dynamic-client");
+      expect(params.get("client_secret")).toBe("dynamic-secret");
+      expect(headers.get("content-type")).toBe("application/x-www-form-urlencoded");
+    },
+  );
+
+  it("does not mix dynamic public client ID with configured client secret", async () => {
+    const server = parseConfig({
+      mcpServers: {
+        remote: {
+          name: "Remote",
+          description: "A useful remote server.",
+          transport: "http",
+          url: "https://example.com/mcp",
+          auth: { type: "oauth2", clientId: "static-client", clientSecret: "static-secret" },
+        },
+      },
+    }).mcpServers.remote!;
+    const provider = new FileOAuthProvider(server, "http://127.0.0.1/callback", () => {});
+    provider.saveClientInformation({ client_id: "dynamic-client" });
+    const addClientAuthentication = provider.addClientAuthentication;
+    const headers = new Headers();
+    const params = new URLSearchParams();
+
+    await addClientAuthentication(headers, params);
+
+    expect(params.get("client_id")).toBe("dynamic-client");
+    expect(params.has("client_secret")).toBe(false);
+    expect(headers.get("content-type")).toBe("application/x-www-form-urlencoded");
+  });
+
   it("runs generic OIDC authorization code flow with discovery and dynamic client registration", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
     let baseUrl = "";


### PR DESCRIPTION
## Summary

Fix MCP OAuth/OIDC token exchange for dynamically registered clients, including Exa's OAuth flow.

## Root Cause

PR #12 fixed configured public clients by adding `server.auth.clientId` in `FileOAuthProvider.addClientAuthentication`. Exa does not configure a static client ID; the MCP SDK dynamically registers a client and saves the generated `client_id` on the provider. Because Caplets exposes `addClientAuthentication`, the SDK delegates token request client auth to Caplets, but our hook ignored the saved dynamic client information. The authorization URL used the generated `mcp_...` client ID, while the token exchange still omitted `client_id`.

## Changes

- Prefer saved dynamic OAuth client information when adding token exchange client params.
- Fall back to statically configured `clientId` / `clientSecret` for configured clients.
- Add regression coverage for dynamically registered OAuth client information.
- Add a patch changeset.

## Verification

- `pnpm test -- auth`
- `pnpm verify`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth/OIDC token exchange for dynamically registered clients so client credentials are used correctly during authentication.

* **Chores**
  * Bumped package patch version.

* **Tests**
  * Added tests validating token-exchange requests include the correct client_id/client_secret behavior and expected headers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spiritledsoftware/caplets/pull/14)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->