### PR TITLE
fix: use SDK OAuth provider for remote MCP

### DIFF
--- a/.changeset/tidy-otters-brush.md
+++ b/.changeset/tidy-otters-brush.md
@@ -1,0 +1,5 @@
+---
+"caplets": patch
+---
+
+Use the MCP SDK OAuth auth provider for remote OAuth MCP transports instead of precomputing static bearer headers, allowing SDK-managed refresh, resource metadata, and auth challenge handling.

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -8,7 +8,12 @@ import {
   type Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { CapletServerConfig } from "./config.js";
-import { classifyRemoteAuthError, oauthHeaders, staticRemoteHeaders } from "./auth.js";
+import {
+  classifyRemoteAuthError,
+  FileOAuthProvider,
+  readTokenBundle,
+  staticRemoteHeaders,
+} from "./auth.js";
 import { CapletsError, toSafeError } from "./errors.js";
 import type { ServerRegistry } from "./registry.js";
 
@@ -242,11 +247,9 @@ export class DownstreamManager {
       throw new CapletsError("CONFIG_INVALID", `${server.server} is missing url`);
     }
 
-    const headers = {
-      ...staticRemoteHeaders(server),
-      ...oauthHeaders(server, this.options.authDir),
-    };
+    const headers = staticRemoteHeaders(server);
     const requestInit = Object.keys(headers).length ? { headers } : undefined;
+    const authProvider = this.oauthProvider(server);
     const fetchWithAuthClassification = async (
       input: Parameters<typeof fetch>[0],
       init?: RequestInit,
@@ -259,23 +262,47 @@ export class DownstreamManager {
       return response;
     };
     if (server.transport === "http") {
-      return new StreamableHTTPClientTransport(
-        new URL(server.url),
-        requestInit
-          ? { requestInit, fetch: fetchWithAuthClassification }
-          : { fetch: fetchWithAuthClassification },
-      );
+      return new StreamableHTTPClientTransport(new URL(server.url), {
+        ...(requestInit ? { requestInit } : {}),
+        ...(authProvider ? { authProvider } : {}),
+        fetch: authProvider ? fetch : fetchWithAuthClassification,
+      });
     }
     if (server.transport === "sse") {
-      return new SSEClientTransport(
-        new URL(server.url),
-        requestInit
-          ? { requestInit, fetch: fetchWithAuthClassification }
-          : { fetch: fetchWithAuthClassification },
-      );
+      return new SSEClientTransport(new URL(server.url), {
+        ...(requestInit ? { requestInit } : {}),
+        ...(authProvider ? { authProvider } : {}),
+        fetch: authProvider ? fetch : fetchWithAuthClassification,
+      });
     }
 
     throw new CapletsError("UNSUPPORTED_TRANSPORT", `Unsupported transport for ${server.server}`);
+  }
+
+  private oauthProvider(server: CapletServerConfig): FileOAuthProvider | undefined {
+    if (server.auth?.type !== "oauth2" && server.auth?.type !== "oidc") {
+      return undefined;
+    }
+    const bundle = readTokenBundle(server.server, this.options.authDir);
+    if (!bundle?.accessToken && !bundle?.refreshToken) {
+      throw new CapletsError("AUTH_REQUIRED", `OAuth credentials required for ${server.server}`, {
+        server: server.server,
+        authType: server.auth.type,
+        nextAction: "run_caplets_auth_login",
+      });
+    }
+    return new FileOAuthProvider(
+      server,
+      server.auth.redirectUri ?? "http://127.0.0.1/callback",
+      () => {
+        throw new CapletsError("AUTH_REQUIRED", `OAuth credentials required for ${server.server}`, {
+          server: server.server,
+          authType: server.auth?.type,
+          nextAction: "run_caplets_auth_login",
+        });
+      },
+      this.options.authDir,
+    );
   }
 }
 

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -113,6 +113,10 @@ export class DownstreamManager {
         { timeout: server.callTimeoutMs },
       );
     } catch (error) {
+      if (isAuthRemediationError(error)) {
+        this.registry.setStatus(server.server, "unavailable", toSafeError(error));
+        throw error;
+      }
       if (isTimeoutLike(error)) {
         throw new CapletsError(
           "TOOL_CALL_TIMEOUT",
@@ -174,6 +178,9 @@ export class DownstreamManager {
         isTimeoutLike(error) ? "SERVER_START_TIMEOUT" : "DOWNSTREAM_PROTOCOL_ERROR",
       );
       this.registry.setStatus(server.server, "unavailable", safe);
+      if (isAuthRemediationError(error)) {
+        throw error;
+      }
       throw new CapletsError(safe.code, `Could not list tools for ${server.server}`, safe);
     }
   }
@@ -220,6 +227,9 @@ export class DownstreamManager {
       const code = isTimeoutLike(error) ? "SERVER_START_TIMEOUT" : "SERVER_UNAVAILABLE";
       const safe = toSafeError(error, code);
       this.registry.setStatus(server.server, "unavailable", safe);
+      if (isAuthRemediationError(error)) {
+        throw error;
+      }
       throw new CapletsError(code, `Could not start ${server.server}`, safe);
     }
   }
@@ -261,18 +271,31 @@ export class DownstreamManager {
       }
       return response;
     };
+    const fetchWithOAuthAuthClassification = async (
+      input: Parameters<typeof fetch>[0],
+      init?: RequestInit,
+    ) => {
+      const response = await fetch(input, init);
+      if (response.status === 403) {
+        const authError = classifyRemoteAuthError(server, response);
+        if (authError) {
+          throw authError;
+        }
+      }
+      return response;
+    };
     if (server.transport === "http") {
       return new StreamableHTTPClientTransport(new URL(server.url), {
         ...(requestInit ? { requestInit } : {}),
         ...(authProvider ? { authProvider } : {}),
-        fetch: authProvider ? fetch : fetchWithAuthClassification,
+        fetch: authProvider ? fetchWithOAuthAuthClassification : fetchWithAuthClassification,
       });
     }
     if (server.transport === "sse") {
       return new SSEClientTransport(new URL(server.url), {
         ...(requestInit ? { requestInit } : {}),
         ...(authProvider ? { authProvider } : {}),
-        fetch: authProvider ? fetch : fetchWithAuthClassification,
+        fetch: authProvider ? fetchWithOAuthAuthClassification : fetchWithAuthClassification,
       });
     }
 
@@ -317,4 +340,11 @@ function nearbyToolNames(tools: Tool[], needle: string): string[] {
 
 function isTimeoutLike(error: unknown): boolean {
   return error instanceof Error && /timeout|timed out|aborted/i.test(error.message);
+}
+
+function isAuthRemediationError(error: unknown): error is CapletsError {
+  return (
+    error instanceof CapletsError &&
+    (error.code === "AUTH_REQUIRED" || error.code === "AUTH_FAILED")
+  );
 }

--- a/src/downstream.ts
+++ b/src/downstream.ts
@@ -317,7 +317,7 @@ export class DownstreamManager {
     return new FileOAuthProvider(
       server,
       server.auth.redirectUri ?? "http://127.0.0.1/callback",
-      () => {
+      (_url: URL) => {
         throw new CapletsError("AUTH_REQUIRED", `OAuth credentials required for ${server.server}`, {
           server: server.server,
           authType: server.auth?.type,

--- a/test/downstream.test.ts
+++ b/test/downstream.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { join } from "node:path";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { parseConfig } from "../src/config.js";
 import { DownstreamManager } from "../src/downstream.js";
 import { ServerRegistry } from "../src/registry.js";
 import { CapletsError } from "../src/errors.js";
+import { writeTokenBundle } from "../src/auth.js";
 
 describe("downstream stdio lifecycle", () => {
   it("lazily starts stdio servers, caches metadata, forwards results, and refuses absent tools", async () => {
@@ -40,6 +44,102 @@ describe("downstream stdio lifecycle", () => {
       } satisfies Partial<CapletsError>);
     } finally {
       await manager.close();
+    }
+  });
+});
+
+describe("downstream remote OAuth lifecycle", () => {
+  it("uses the MCP SDK auth provider for stored OAuth tokens", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
+    const authDir = join(dir, "auth");
+    const authorizationHeaders: Array<string | undefined> = [];
+    let baseUrl = "";
+    const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      if (request.method === "GET") {
+        authorizationHeaders.push(request.headers.authorization);
+        response.statusCode = 405;
+        response.end();
+        return;
+      }
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        authorizationHeaders.push(request.headers.authorization);
+        const message = JSON.parse(body) as { id?: number; method?: string };
+        response.setHeader("content-type", "application/json");
+        if (message.method === "initialize") {
+          response.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: message.id,
+              result: {
+                protocolVersion: "2025-06-18",
+                capabilities: { tools: {} },
+                serverInfo: { name: "fixture-remote", version: "1.0.0" },
+              },
+            }),
+          );
+          return;
+        }
+        if (message.method === "tools/list") {
+          response.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: message.id,
+              result: { tools: [] },
+            }),
+          );
+          return;
+        }
+        response.statusCode = 202;
+        response.end();
+      });
+    });
+
+    try {
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Could not bind fixture server");
+      }
+      baseUrl = `http://127.0.0.1:${address.port}/mcp`;
+      writeTokenBundle(
+        {
+          server: "remote",
+          accessToken: "secret-oauth-token",
+          refreshToken: "secret-refresh-token",
+          tokenType: "Bearer",
+          expiresAt: "2999-01-01T00:00:00.000Z",
+        },
+        authDir,
+      );
+      const config = parseConfig({
+        mcpServers: {
+          remote: {
+            name: "Remote",
+            description: "A useful remote OAuth server.",
+            transport: "http",
+            url: baseUrl,
+            auth: { type: "oauth2" },
+          },
+        },
+      });
+      const registry = new ServerRegistry(config);
+      const manager = new DownstreamManager(registry, { authDir });
+
+      try {
+        await manager.listTools(config.mcpServers.remote!);
+      } finally {
+        await manager.close();
+      }
+
+      expect(authorizationHeaders).toContain("Bearer secret-oauth-token");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/test/downstream.test.ts
+++ b/test/downstream.test.ts
@@ -49,6 +49,125 @@ describe("downstream stdio lifecycle", () => {
 });
 
 describe("downstream remote OAuth lifecycle", () => {
+  it("surfaces missing OAuth credentials as AUTH_REQUIRED", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
+    try {
+      const config = parseConfig({
+        mcpServers: {
+          remote: {
+            name: "Remote",
+            description: "A useful remote OAuth server.",
+            transport: "http",
+            url: "http://127.0.0.1:9/mcp",
+            auth: { type: "oauth2" },
+          },
+        },
+      });
+      const registry = new ServerRegistry(config);
+      const manager = new DownstreamManager(registry, { authDir: join(dir, "auth") });
+
+      await expect(manager.listTools(config.mcpServers.remote!)).rejects.toMatchObject({
+        code: "AUTH_REQUIRED",
+        details: expect.objectContaining({
+          nextAction: "run_caplets_auth_login",
+        }),
+      } satisfies Partial<CapletsError>);
+      expect(registry.getStatus("remote")).toBe("unavailable");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies OAuth 403 responses as AUTH_FAILED", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
+    const authDir = join(dir, "auth");
+    const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        if (!body) {
+          response.statusCode = 202;
+          response.end();
+          return;
+        }
+        const message = JSON.parse(body) as { id?: number; method?: string };
+        response.setHeader("content-type", "application/json");
+        if (message.method === "initialize") {
+          response.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: message.id,
+              result: {
+                protocolVersion: "2025-06-18",
+                capabilities: { tools: {} },
+                serverInfo: { name: "fixture-remote", version: "1.0.0" },
+              },
+            }),
+          );
+          return;
+        }
+        if (message.method === "tools/list") {
+          response.statusCode = 403;
+          response.statusMessage = "Forbidden";
+          response.end();
+          return;
+        }
+        response.statusCode = 202;
+        response.end();
+      });
+    });
+
+    try {
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Could not bind fixture server");
+      }
+      writeTokenBundle(
+        {
+          server: "remote",
+          accessToken: "secret-oauth-token",
+          refreshToken: "secret-refresh-token",
+          tokenType: "Bearer",
+          expiresAt: "2999-01-01T00:00:00.000Z",
+        },
+        authDir,
+      );
+      const config = parseConfig({
+        mcpServers: {
+          remote: {
+            name: "Remote",
+            description: "A useful remote OAuth server.",
+            transport: "http",
+            url: `http://127.0.0.1:${address.port}/mcp`,
+            auth: { type: "oauth2" },
+          },
+        },
+      });
+      const registry = new ServerRegistry(config);
+      const manager = new DownstreamManager(registry, { authDir });
+
+      try {
+        await expect(manager.listTools(config.mcpServers.remote!)).rejects.toMatchObject({
+          code: "AUTH_FAILED",
+          details: expect.objectContaining({
+            nextAction: "run_caplets_auth_login",
+            status: 403,
+          }),
+        } satisfies Partial<CapletsError>);
+        expect(registry.getStatus("remote")).toBe("unavailable");
+      } finally {
+        await manager.close();
+      }
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("uses the MCP SDK auth provider for stored OAuth tokens", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
     const authDir = join(dir, "auth");


### PR DESCRIPTION
## Summary

- Use the MCP SDK OAuth auth provider for remote OAuth MCP transports instead of precomputing static bearer headers.
- Keep static bearer/header behavior for non-OAuth remote transports.
- Add a remote HTTP MCP regression test proving stored OAuth tokens flow through the SDK provider.
- Add a patch changeset.

## Root Cause

Caplets was manually reading stored OAuth tokens and injecting a static `Authorization` header into remote MCP transports. That bypassed the MCP SDK's OAuth handling for refresh, resource metadata, and auth challenge/upscope flows.

## Validation

- `pnpm vitest run test/downstream.test.ts test/auth.test.ts`
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint`
- `pnpm schema:check`
- `pnpm build`
- `pnpm test`
- Pre-push hook: `pnpm format:check && pnpm lint && pnpm typecheck && pnpm schema:check && pnpm test && pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote MCP OAuth now uses SDK-managed providers for token refresh, metadata, and auth challenge handling.

* **Bug Fixes**
  * Authentication failures are now surfaced explicitly (AUTH_REQUIRED/AUTH_FAILED) with actionable next steps when credentials are missing or rejected.

* **Tests**
  * Added integration tests for remote OAuth lifecycle, token persistence, 403 handling, and outgoing Authorization headers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spiritledsoftware/caplets/pull/19)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->