### PR TITLE
feat: add HTTP actions backend

### DIFF
--- a/.changeset/calm-otters-act.md
+++ b/.changeset/calm-otters-act.md
@@ -1,0 +1,5 @@
+---
+"caplets": minor
+---
+
+Add native HTTP actions for explicitly configured non-OpenAPI APIs.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Caplets
 
 Caplets is a progressive-disclosure gateway for Model Context Protocol (MCP) servers,
-native OpenAPI endpoints, and native GraphQL endpoints.
+native OpenAPI endpoints, native GraphQL endpoints, and explicitly configured HTTP APIs.
 
 Instead of connecting an MCP client to many downstream servers or HTTP APIs and exposing
 every operation up front, Caplets exposes one top-level tool per configured capability.
@@ -28,8 +28,8 @@ the agent chooses that server and asks to search, list, inspect, or call them.
 
 ## What It Does
 
-- Reads downstream MCP server definitions, native OpenAPI endpoint definitions, and native GraphQL endpoint definitions from `~/.caplets/config.json`.
-- Registers one generated MCP tool for each enabled MCP server, OpenAPI endpoint, or GraphQL endpoint.
+- Reads downstream MCP server definitions, native OpenAPI endpoint definitions, native GraphQL endpoint definitions, and explicit HTTP API action definitions from `~/.caplets/config.json`.
+- Registers one generated MCP tool for each enabled MCP server, OpenAPI endpoint, GraphQL endpoint, or HTTP API.
 - Uses the configured server ID as the generated tool name.
 - Uses the configured `name` and `description` as the capability card shown to agents.
 - Starts downstream MCP servers and loads OpenAPI specs lazily when an operation needs them.
@@ -37,6 +37,7 @@ the agent chooses that server and asks to search, list, inspect, or call them.
 - Lets agents `list_tools`, `search_tools`, `get_tool`, and `call_tool` within one selected Caplet namespace.
 - Converts OpenAPI operations into MCP-style tool metadata and executes HTTP calls directly.
 - Converts configured GraphQL operations into MCP-style tool metadata, and can auto-generate GraphQL tools from schema root query and mutation fields.
+- Converts explicitly configured HTTP actions into MCP-style tool metadata and executes HTTP calls directly.
 - Preserves downstream tool results instead of rewriting them into a custom format.
 - Redacts secrets from structured errors.
 - Supports static remote auth and OAuth token storage for remote servers.
@@ -118,6 +119,26 @@ you want Caplets to expose:
         "issuer": "https://login.example.com"
       }
     }
+  },
+  "httpApis": {
+    "status": {
+      "name": "Status API",
+      "description": "Read deployment status from a simple HTTP API.",
+      "baseUrl": "https://api.example.com",
+      "auth": { "type": "none" },
+      "actions": {
+        "get_status": {
+          "method": "GET",
+          "path": "/status/{service}",
+          "description": "Fetch status for one service.",
+          "inputSchema": {
+            "type": "object",
+            "properties": { "service": { "type": "string" } },
+            "required": ["service"]
+          }
+        }
+      }
+    }
   }
 }
 ```
@@ -150,8 +171,8 @@ the committed schema stays in sync with the Zod config validator.
 ### Caplet Files
 
 For richer skill-like cards, add Markdown Caplet files beside `config.json`. Every Caplet
-file must include exactly one executable backend: `mcpServer`, `openapiEndpoint`, or
-`graphqlEndpoint`;
+file must include exactly one executable backend: `mcpServer`, `openapiEndpoint`,
+`graphqlEndpoint`, or `httpApi`;
 serverless Caplets are intentionally out of scope.
 
 Top-level files derive the Caplet ID from the filename:
@@ -208,6 +229,32 @@ graphqlEndpoint:
 # Catalog GraphQL
 ```
 
+HTTP action Caplet files use `httpApi`:
+
+```md
+---
+name: Status API
+description: Read deployment status from a simple HTTP API.
+httpApi:
+  baseUrl: https://api.example.com
+  auth:
+    type: none
+  actions:
+    get_status:
+      method: GET
+      path: /status/{service}
+      description: Fetch status for one service.
+      inputSchema:
+        type: object
+        properties:
+          service:
+            type: string
+        required: [service]
+---
+
+# Status API
+```
+
 Top-level files derive their Caplet ID from the filename. Directory-style Caplets use
 `linear/CAPLET.md`, which is exposed as `linear`; sibling files can be referenced with
 normal Markdown links from `CAPLET.md`.
@@ -255,8 +302,8 @@ caplets init --force
 
 ### Caplet IDs
 
-Each key under `mcpServers` or `openapiEndpoints` is the stable Caplet ID. It becomes the
-generated MCP tool name exactly, so keep it short and specific:
+Each key under `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, or `httpApis` is the
+stable Caplet ID. It becomes the generated MCP tool name exactly, so keep it short and specific:
 
 ```json
 {
@@ -272,7 +319,7 @@ generated MCP tool name exactly, so keep it short and specific:
 ```
 
 Caplet IDs must match `^[a-zA-Z0-9_-]{1,64}$` and must be unique across `mcpServers`,
-`openapiEndpoints`, and `graphqlEndpoints`. Spaces, dots, slashes, colons, and Unicode IDs are rejected.
+`openapiEndpoints`, `graphqlEndpoints`, and `httpApis`. Spaces, dots, slashes, colons, and Unicode IDs are rejected.
 
 ### Stdio Servers
 
@@ -391,6 +438,57 @@ Every GraphQL endpoint can set:
 - `selectionDepth`: maximum depth for generated selection sets. Defaults to `2`; maximum `5`.
 - `disabled`: omit the endpoint from Caplets discovery. Defaults to `false`.
 
+### HTTP APIs
+
+Use `httpApis` for simple HTTP APIs that do not have an OpenAPI spec. Each action is an
+explicitly configured tool; Caplets does not discover routes, import curl commands, or execute
+shell snippets.
+
+```json
+{
+  "name": "Status API",
+  "description": "Read and update deployment status through HTTP actions.",
+  "baseUrl": "https://api.example.com",
+  "auth": { "type": "bearer", "token": "$env:STATUS_API_TOKEN" },
+  "maxResponseBytes": 1000000,
+  "actions": {
+    "get_status": {
+      "method": "GET",
+      "path": "/status/{service}",
+      "description": "Fetch status for one service.",
+      "inputSchema": {
+        "type": "object",
+        "properties": { "service": { "type": "string" }, "verbose": { "type": "boolean" } },
+        "required": ["service"]
+      },
+      "query": { "verbose": "$input.verbose" }
+    },
+    "set_status": {
+      "method": "POST",
+      "path": "/status/{service}",
+      "jsonBody": { "state": "$input.state", "note": "$input.note" }
+    }
+  }
+}
+```
+
+HTTP API actions support `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`. `baseUrl` must be HTTPS
+except loopback URLs, must not include credentials, query, or fragment, and action `path` values
+must start with `/` and be URL paths that cannot change origin or escape the base URL path.
+
+Action mappings can set `query`, `headers`, and `jsonBody`. `query` and `headers` must resolve
+to object maps whose values are strings, numbers, or booleans. `jsonBody` may use literals,
+nested arrays/objects, `$input.field` references, or `$input` for the whole argument object.
+Path placeholders such as `{service}` are read directly from `call_tool.arguments` and URL-encoded.
+Configured action headers cannot set managed headers such as `authorization`, `host`,
+`content-length`, `connection`, or `content-type`; JSON bodies set `content-type` automatically.
+
+HTTP API auth supports `none`, `bearer`, `headers`, `oauth2`, and `oidc`, matching OpenAPI and
+GraphQL. Responses are returned as structured content with `status`, `statusText`, safe headers,
+parsed `body` when present, and `elapsedMs`; non-2xx responses set `isError`, redirects are rejected,
+timeouts are enforced, response bodies are capped by `maxResponseBytes` (default `1000000`), and
+errors redact secrets.
+
 ### Authentication
 
 Remote servers can use:
@@ -401,7 +499,7 @@ Remote servers can use:
 - `{"type": "oauth2", ...}`
 - `{"type": "oidc", ...}`
 
-For OAuth/OIDC-backed MCP, OpenAPI, and GraphQL Caplets, authenticate once with:
+For OAuth/OIDC-backed MCP, OpenAPI, GraphQL, and HTTP API Caplets, authenticate once with:
 
 ```sh
 caplets auth login <server>

--- a/docs/plans/2026-05-13-http-actions-backend.md
+++ b/docs/plans/2026-05-13-http-actions-backend.md
@@ -1,0 +1,93 @@
+# HTTP Actions Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a native HTTP actions backend for non-OpenAPI APIs, where each Caplet exposes explicitly configured HTTP actions as discoverable tools.
+
+**Architecture:** Caplets gains a fourth backend family, `http`, alongside MCP, OpenAPI, and GraphQL. HTTP action Caplets define a `baseUrl`, auth, timeout/output limits, and a map of named actions. Each action becomes one MCP-style tool. Calls build an HTTP request from structured argument mappings, execute it directly, and return structured status, headers, body, and timing data.
+
+**Tech Stack:** TypeScript ESM, Node.js 22+, `@modelcontextprotocol/sdk`, Zod, Vitest, rolldown, oxfmt, oxlint.
+
+---
+
+## Task 1: Add HTTP Actions Config And Caplet File Support
+
+**Files:**
+
+- Modify: `src/config.ts`
+- Modify: `src/caplet-files.ts`
+- Modify: `scripts/generate-config-schema.ts` if needed
+- Modify: `schemas/caplets-config.schema.json`
+- Modify: `schemas/caplet.schema.json`
+- Test: `test/config.test.ts`
+
+- [x] Add `HttpApiConfig` and `HttpActionConfig` types.
+- [x] Add top-level `httpApis` config keyed by Caplet ID.
+- [x] Add Markdown frontmatter key `httpApi`.
+- [x] Keep v1 explicit-config-only: no discovery, imports, or manifests.
+- [x] Require `baseUrl`, `auth`, and at least one action.
+- [x] Support auth types `none`, `bearer`, `headers`, `oauth2`, and `oidc`, matching OpenAPI/GraphQL.
+- [x] Validate HTTPS except loopback for `baseUrl`.
+- [x] Reject duplicate Caplet IDs across `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, and `httpApis`.
+- [x] Reject untrusted project `httpApis`, matching OpenAPI/GraphQL project-config safety.
+- [x] Normalize relative Caplet/config local paths only where needed; HTTP paths are URL paths, not filesystem paths.
+- [x] Regenerate committed JSON schemas.
+
+## Task 2: Implement HTTP Actions Manager
+
+**Files:**
+
+- Create: `src/http-actions.ts`
+- Modify: `src/tools.ts`
+- Modify: `src/registry.ts`
+- Modify: `src/runtime.ts`
+- Test: `test/http-actions.test.ts`
+- Test: `test/tools.test.ts`
+- Test: `test/registry.test.ts`
+- Test: `test/runtime.test.ts`
+
+- [x] Create `HttpActionManager` with `checkApi`, `listTools`, `getTool`, `callTool`, `compact`, `search`, and `invalidate` methods.
+- [x] Convert configured actions into MCP-style tools using each action's `inputSchema`.
+- [x] Support HTTP methods `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`.
+- [x] Build URLs from `baseUrl` plus action `path`, preserving origin and rejecting origin changes.
+- [x] Resolve `{field}` path placeholders from `call_tool.arguments` and URL-encode values.
+- [x] Support `query`, `headers`, and `jsonBody` mappings.
+- [x] Support mapping values as literals, nested arrays/objects, `$input.field` references, and `$input` for the full argument object.
+- [x] Reject forbidden request headers such as `authorization`, `host`, `content-length`, `connection`, and `content-type` when user-configured headers would conflict with managed headers.
+- [x] Apply static bearer/header auth and generic OAuth/OIDC headers.
+- [x] Reject redirects.
+- [x] Enforce request timeouts and maximum response byte limits.
+- [x] Return structured `{ status, statusText, headers, body, elapsedMs }` responses and mark `isError` for non-2xx status.
+- [x] Redact secrets from errors.
+- [x] Route `backend: "http"` through generated Caplet operations.
+- [x] Add safe registry detail for HTTP APIs without exposing `baseUrl`, auth, or sensitive mappings.
+- [x] Include HTTP APIs in runtime registration, reload comparison, and cache invalidation.
+
+## Task 3: Documentation And Verification
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/product/caplets-progressive-mcp-disclosure-prd.md`
+- Modify: `docs/plans/2026-05-13-http-actions-backend.md`
+
+- [x] Document `httpApis` JSON config and `httpApi` Caplet files.
+- [x] Document explicit action configuration, request mappings, auth support, and safety constraints.
+- [x] Document response shape and error behavior.
+- [x] Run `pnpm schema:generate`.
+- [x] Run `pnpm format:check`.
+- [x] Run `pnpm lint`.
+- [x] Run `pnpm typecheck`.
+- [x] Run `pnpm schema:check`.
+- [x] Run `pnpm test`.
+- [x] Run `pnpm build`.
+
+## Assumptions
+
+- The top-level config key is `httpApis` and Caplet file key is `httpApi`.
+- Runtime backend discriminator is `backend: "http"`.
+- `check_backend` validates configured actions and returns a tool count without making network calls.
+- v1 does not support action discovery, imports, manifests, raw shell/curl execution, form bodies, file upload, streaming, cookies, or custom redirect following.
+- `inputSchema` defaults to `{ "type": "object", "additionalProperties": true }` when omitted.
+- JSON request bodies set `content-type: application/json` automatically when `jsonBody` is configured.
+- HTTP response parsing matches OpenAPI behavior: JSON content is parsed as JSON; other content is text.

--- a/docs/product/caplets-progressive-mcp-disclosure-prd.md
+++ b/docs/product/caplets-progressive-mcp-disclosure-prd.md
@@ -432,7 +432,6 @@ Core modules:
 - `actions: Record<string, { method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE"; path: string; description?: string; inputSchema?: Record<string, unknown>; query?: unknown; headers?: unknown; jsonBody?: unknown }>`
 - `requestTimeoutMs?: number`
 - `maxResponseBytes?: number`
-- `operationCacheTtlMs?: number`
 - `disabled?: boolean`
 
 `StoredOAuthTokenBundle`:
@@ -465,7 +464,7 @@ Core modules:
 - `description: string`
 - `tags?: string[]`
 - `body?: string`
-- `backend: { type: "mcp"; transport: "stdio" | "http" | "sse"; disabled: boolean; startupTimeoutMs: number; callTimeoutMs: number; toolCacheTtlMs: number } | { type: "openapi"; disabled: boolean; requestTimeoutMs: number; operationCacheTtlMs: number; source: "specPath" | "specUrl" } | { type: "graphql"; disabled: boolean; requestTimeoutMs: number; operationCacheTtlMs: number; source: "schemaPath" | "schemaUrl" | "introspection"; configuredOperations: boolean } | { type: "http"; disabled: boolean; requestTimeoutMs: number; operationCacheTtlMs: number; configuredActions: number }`
+- `backend: { type: "mcp"; transport: "stdio" | "http" | "sse"; disabled: boolean; startupTimeoutMs: number; callTimeoutMs: number; toolCacheTtlMs: number } | { type: "openapi"; disabled: boolean; requestTimeoutMs: number; operationCacheTtlMs: number; source: "specPath" | "specUrl" } | { type: "graphql"; disabled: boolean; requestTimeoutMs: number; operationCacheTtlMs: number; source: "schemaPath" | "schemaUrl" | "introspection"; configuredOperations: boolean } | { type: "http"; disabled: boolean; requestTimeoutMs: number; configuredActions: number }`
 - `mcpServer?: { transport: "stdio" | "http" | "sse"; disabled: boolean; startupTimeoutMs: number; callTimeoutMs: number; toolCacheTtlMs: number }`
 
 `CapletToolRef`:

--- a/docs/product/caplets-progressive-mcp-disclosure-prd.md
+++ b/docs/product/caplets-progressive-mcp-disclosure-prd.md
@@ -4,7 +4,7 @@
 
 **Problem Statement**: MCP clients that connect directly to many servers receive a large, flat tool surface up front. This creates context bloat, weak tool selection, name-collision risk, and poor discoverability when an agent only needs to know which capability domain to inspect next.
 
-**Proposed Solution**: Caplets is a local MCP server that reads downstream MCP server definitions, native OpenAPI endpoint definitions, and native GraphQL endpoint definitions from `~/.caplets/config.json`, user-owned Markdown Caplet files from `~/.caplets`, project config from `./.caplets/config.json`, and explicitly trusted project Markdown Caplet files from `./.caplets`. It exposes each enabled Caplet as one top-level, skill-like MCP tool. Each generated Caplet tool uses the Caplet ID as the tool name and the configured `name`/`description` as its compact capability card, then progressively discloses the full Caplet card and the backing MCP tools, OpenAPI operations, or GraphQL operations through operations such as `get_caplet`, `search_tools`, `list_tools`, `get_tool`, and `call_tool`.
+**Proposed Solution**: Caplets is a local MCP server that reads downstream MCP server definitions, native OpenAPI endpoint definitions, native GraphQL endpoint definitions, and explicit HTTP API action definitions from `~/.caplets/config.json`, user-owned Markdown Caplet files from `~/.caplets`, project config from `./.caplets/config.json`, and explicitly trusted project Markdown Caplet files from `./.caplets`. It exposes each enabled Caplet as one top-level, skill-like MCP tool. Each generated Caplet tool uses the Caplet ID as the tool name and the configured `name`/`description` as its compact capability card, then progressively discloses the full Caplet card and the backing MCP tools, OpenAPI operations, GraphQL operations, or HTTP actions through operations such as `get_caplet`, `search_tools`, `list_tools`, `get_tool`, and `call_tool`.
 
 **Success Criteria**:
 
@@ -25,13 +25,13 @@
 ### Primary User Flow
 
 1. User installs and configures Caplets as an MCP server in their MCP client.
-2. User creates either `~/.caplets/config.json` with downstream server or OpenAPI endpoint definitions and Caplets options, or Markdown Caplet files with exactly one executable backend.
-3. Each downstream MCP server, OpenAPI endpoint, or Caplet file uses the supported backend configuration shape plus a required `description`.
+2. User creates either `~/.caplets/config.json` with downstream server, OpenAPI endpoint, GraphQL endpoint, or HTTP API action definitions and Caplets options, or Markdown Caplet files with exactly one executable backend.
+3. Each downstream MCP server, OpenAPI endpoint, GraphQL endpoint, HTTP API, or Caplet file uses the supported backend configuration shape plus a required `description`.
 4. Client calls Caplets `tools/list` and sees one top-level tool per enabled downstream server, for example `linear`, `chrome-devtools`, and `context7`.
 5. Agent chooses the relevant Caplet tool based on its skill-like tool name and description.
 6. Agent calls that Caplet tool with an operation such as `get_caplet`, `search_tools`, `list_tools`, or `get_tool`.
 7. Agent calls the same Caplet tool with `operation: "call_tool"`, an exact downstream tool name, and a JSON object of arguments.
-8. Caplets forwards the request to that server's downstream MCP process or executes the selected OpenAPI HTTP operation and returns the result.
+8. Caplets forwards the request to that server's downstream MCP process or executes the selected OpenAPI, GraphQL, or explicit HTTP action and returns the result.
 
 ### User Stories
 
@@ -42,8 +42,8 @@ Acceptance Criteria:
 - Caplets reads `~/.caplets/config.json` from the current user's home directory by default.
 - Caplets reads user-owned Markdown Caplet files from `~/.caplets` by default.
 - Caplets reads project Markdown Caplet files from `./.caplets` only when `CAPLETS_TRUST_PROJECT_CAPLETS` is set to `1`, `true`, or `yes`.
-- Caplets supports `mcpServers` for MCP backends, `openapiEndpoints` for native OpenAPI backends, and `graphqlEndpoints` for native GraphQL backends.
-- Generated top-level tool names are unique across `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, and Markdown Caplet files; duplicate IDs reject with `CONFIG_INVALID`.
+- Caplets supports `mcpServers` for MCP backends, `openapiEndpoints` for native OpenAPI backends, `graphqlEndpoints` for native GraphQL backends, and `httpApis` for explicitly configured HTTP actions.
+- Generated top-level tool names are unique across `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, `httpApis`, and Markdown Caplet files; duplicate IDs reject with `CONFIG_INVALID`.
 - Every configured server requires a stable server key and non-empty `description`.
 - Caplets `tools/list` returns one generated top-level MCP tool per enabled server.
 - Each generated Caplet tool uses the configured server ID as the MCP tool name.
@@ -78,6 +78,7 @@ Acceptance Criteria:
 - `operation: "call_tool"` requires exact downstream `tool` and a JSON object `arguments`.
 - For OpenAPI-backed Caplets, `call_tool.arguments` uses grouped HTTP inputs: `path`, `query`, `header`, and `body`.
 - For GraphQL-backed Caplets, configured operation `call_tool.arguments` is the GraphQL variables object directly; auto-generated operation `call_tool.arguments` is the root field arguments object directly.
+- For HTTP action Caplets, `call_tool.arguments` is the action input object directly; path placeholders read top-level argument fields and configured request mappings can reference `$input.field` or `$input`.
 - `call_tool` requires the exact downstream tool name; Caplets does not use fuzzy matching, aliases, or auto-correction for execution.
 - The selected generated Caplet tool is the server namespace, so `call_tool` does not accept a `server` argument in MVP.
 - Caplets preserves downstream tool names exactly and does not support flattened namespaced identifiers such as `server.tool` in MVP.
@@ -207,7 +208,7 @@ Requirements:
 - `mcpServers` is optional when one or more valid Markdown Caplet files are present.
 - `$schema` is optional and exists only for JSON Schema-aware editor validation.
 - `version` is optional for MVP and defaults to 1 when omitted. If present, MVP accepts only `1` and rejects unsupported versions with `CONFIG_INVALID`.
-- Allowed top-level keys in MVP are `$schema`, `version`, `defaultSearchLimit`, `maxSearchLimit`, and `mcpServers`; unknown top-level keys are rejected with `CONFIG_INVALID`.
+- Allowed top-level keys in MVP are `$schema`, `version`, `defaultSearchLimit`, `maxSearchLimit`, `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, and `httpApis`; unknown top-level keys are rejected with `CONFIG_INVALID`.
 - The committed JSON Schema lives at `schemas/caplets-config.schema.json`, is generated from the Zod runtime config schema, and CI must fail when the committed schema drifts from the generated output.
 - Unknown keys inside each server config are rejected with `CONFIG_INVALID`, except fields that belong to the tracked standard MCP server schema plus Caplets-owned additions documented here.
 - `mcpServers` is the only accepted top-level server configuration key for plain JSON downstream MCP servers in MVP.
@@ -261,6 +262,9 @@ Requirements:
 - MCP backends support stdio, MCP Streamable HTTP, and legacy HTTP+SSE downstream servers. Streamable HTTP is preferred for remote servers; SSE exists for compatibility.
 - OpenAPI backends support local `specPath` or remote `specUrl`, explicit `auth`, optional `baseUrl`, and native HTTP execution for standard OpenAPI methods.
 - GraphQL backends support local `schemaPath`, remote `schemaUrl`, or endpoint introspection, configured operations, auto-generated query/mutation tools, explicit `auth`, and native GraphQL HTTP execution.
+- HTTP action backends support explicit `httpApis` config or Markdown `httpApi` frontmatter with `baseUrl`, `auth`, and one or more named actions. Each action defines `method`, `path`, optional `description`, optional `inputSchema`, and optional `query`, `headers`, and `jsonBody` mappings.
+- HTTP action `query` and `headers` mappings must resolve to object maps whose values are strings, numbers, or booleans. HTTP action `jsonBody` mappings support literal values, nested arrays/objects, `$input.field` references, and `$input` for the complete argument object. HTTP action paths may contain `{field}` placeholders resolved from top-level arguments.
+- HTTP action requests require HTTPS except loopback URLs, reject origin-changing paths and redirects, reject managed configured headers, enforce timeouts and response byte limits, and return structured `{ status, statusText, headers, body, elapsedMs }` content with `isError` set for non-2xx status.
 - OpenCode's `mcp` config shape is a compatibility reference, not Caplets' native MVP shape: OpenCode uses local/remote entries under `mcp`, local `command` as an array, `environment` instead of `env`, and `{env:NAME}`-style interpolation in its broader config system. Automatic OpenCode config import/normalization is deferred.
 
 ### Non-Goals
@@ -368,6 +372,7 @@ Core modules:
 - `mcpServers: Record<string, CapletServerConfig>`
 - `openapiEndpoints: Record<string, OpenApiEndpointConfig>`
 - `graphqlEndpoints: Record<string, GraphQlEndpointConfig>`
+- `httpApis: Record<string, HttpApiConfig>`
 
 `CapletServerConfig`:
 
@@ -418,6 +423,18 @@ Core modules:
 - `selectionDepth?: number`
 - `disabled?: boolean`
 
+`HttpApiConfig`:
+
+- `name: string`
+- `description: string`
+- `baseUrl: string`
+- `auth: { type: "none" } | { type: "bearer"; token: string } | { type: "headers"; headers: Record<string, string> } | { type: "oauth2" | "oidc"; ... }`
+- `actions: Record<string, { method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE"; path: string; description?: string; inputSchema?: Record<string, unknown>; query?: unknown; headers?: unknown; jsonBody?: unknown }>`
+- `requestTimeoutMs?: number`
+- `maxResponseBytes?: number`
+- `operationCacheTtlMs?: number`
+- `disabled?: boolean`
+
 `StoredOAuthTokenBundle`:
 
 - `server: string`
@@ -448,7 +465,7 @@ Core modules:
 - `description: string`
 - `tags?: string[]`
 - `body?: string`
-- `backend: { type: "mcp"; transport: "stdio" | "http" | "sse"; disabled: boolean; startupTimeoutMs: number; callTimeoutMs: number; toolCacheTtlMs: number } | { type: "openapi"; disabled: boolean; requestTimeoutMs: number; operationCacheTtlMs: number; source: "specPath" | "specUrl" } | { type: "graphql"; disabled: boolean; requestTimeoutMs: number; operationCacheTtlMs: number; source: "schemaPath" | "schemaUrl" | "introspection"; configuredOperations: boolean }`
+- `backend: { type: "mcp"; transport: "stdio" | "http" | "sse"; disabled: boolean; startupTimeoutMs: number; callTimeoutMs: number; toolCacheTtlMs: number } | { type: "openapi"; disabled: boolean; requestTimeoutMs: number; operationCacheTtlMs: number; source: "specPath" | "specUrl" } | { type: "graphql"; disabled: boolean; requestTimeoutMs: number; operationCacheTtlMs: number; source: "schemaPath" | "schemaUrl" | "introspection"; configuredOperations: boolean } | { type: "http"; disabled: boolean; requestTimeoutMs: number; operationCacheTtlMs: number; configuredActions: number }`
 - `mcpServer?: { transport: "stdio" | "http" | "sse"; disabled: boolean; startupTimeoutMs: number; callTimeoutMs: number; toolCacheTtlMs: number }`
 
 `CapletToolRef`:
@@ -490,6 +507,7 @@ Requirements:
 - Node child process runtime: launches configured downstream commands.
 - OpenAPI parser: loads and validates configured local or remote OpenAPI specs.
 - Native fetch: executes configured OpenAPI operations with explicit Caplets auth.
+- Native fetch: executes configured HTTP actions with explicit Caplets auth.
 - Caplets CLI: runs `caplets auth login <server>` for OAuth-backed remote servers.
 - Browser/loopback OAuth: opens the authorization URL and receives the OAuth callback on localhost for configured OAuth servers.
 - Local auth store: reads and writes OAuth token bundles under `~/.caplets/auth`.

--- a/schemas/caplet.schema.json
+++ b/schemas/caplet.schema.json
@@ -902,10 +902,44 @@
                 "additionalProperties": {}
               },
               "query": {
-                "description": "Query parameter mapping."
+                "description": "Query parameter mapping.",
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ]
+                }
               },
               "headers": {
-                "description": "Request header mapping."
+                "description": "Request header mapping.",
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ]
+                }
               },
               "jsonBody": {
                 "description": "JSON request body mapping."

--- a/schemas/caplet.schema.json
+++ b/schemas/caplet.schema.json
@@ -697,6 +697,251 @@
       "required": ["endpointUrl", "auth"],
       "additionalProperties": false,
       "description": "GraphQL endpoint backend configuration for this Caplet."
+    },
+    "httpApi": {
+      "type": "object",
+      "properties": {
+        "baseUrl": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(?![a-zA-Z][a-zA-Z0-9+.-]*:\\/\\/[^/?#]*@)[^?#]*$",
+          "description": "Base URL for HTTP action requests."
+        },
+        "auth": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "none"
+                }
+              },
+              "required": ["type"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "bearer"
+                },
+                "token": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": ["type", "token"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "headers"
+                },
+                "headers": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "required": ["type", "headers"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "oauth2"
+                },
+                "authorizationUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "tokenUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "issuer": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "resourceMetadataUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "authorizationServerMetadataUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "openidConfigurationUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "clientId": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "clientSecret": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "scopes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "redirectUri": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": ["type"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "oidc"
+                },
+                "authorizationUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "tokenUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "issuer": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "resourceMetadataUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "authorizationServerMetadataUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "openidConfigurationUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "clientId": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "clientSecret": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "scopes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "redirectUri": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": ["type"],
+              "additionalProperties": false
+            }
+          ],
+          "description": "Explicit HTTP API request auth config. Use {\"type\":\"none\"} for public APIs."
+        },
+        "actions": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]{1,64}$"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "method": {
+                "type": "string",
+                "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+                "description": "HTTP method used for this action."
+              },
+              "path": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^\\/",
+                "description": "URL path appended to the HTTP API baseUrl."
+              },
+              "description": {
+                "description": "Action capability description.",
+                "type": "string",
+                "minLength": 1
+              },
+              "inputSchema": {
+                "description": "JSON Schema for call_tool arguments.",
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              },
+              "query": {
+                "description": "Query parameter mapping."
+              },
+              "headers": {
+                "description": "Request header mapping."
+              },
+              "jsonBody": {
+                "description": "JSON request body mapping."
+              }
+            },
+            "required": ["method", "path"],
+            "additionalProperties": false
+          },
+          "description": "Configured HTTP actions keyed by stable tool name.",
+          "minProperties": 1
+        },
+        "requestTimeoutMs": {
+          "description": "Timeout in milliseconds for HTTP action requests.",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "maxResponseBytes": {
+          "description": "Maximum HTTP action response body bytes to read.",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "operationCacheTtlMs": {
+          "description": "Milliseconds HTTP action metadata stays fresh. Set 0 to refresh every time.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "disabled": {
+          "description": "When true, omit this Caplet from discovery.",
+          "type": "boolean"
+        }
+      },
+      "required": ["baseUrl", "auth", "actions"],
+      "additionalProperties": false,
+      "description": "HTTP API backend configuration for this Caplet."
     }
   },
   "required": ["name", "description"],

--- a/schemas/caplet.schema.json
+++ b/schemas/caplet.schema.json
@@ -705,7 +705,8 @@
           "type": "string",
           "minLength": 1,
           "pattern": "^(?![a-zA-Z][a-zA-Z0-9+.-]*:\\/\\/[^/?#]*@)[^?#]*$",
-          "description": "Base URL for HTTP action requests."
+          "description": "Base URL for HTTP action requests.",
+          "format": "uri"
         },
         "auth": {
           "oneOf": [
@@ -926,12 +927,6 @@
           "description": "Maximum HTTP action response body bytes to read.",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991
-        },
-        "operationCacheTtlMs": {
-          "description": "Milliseconds HTTP action metadata stays fresh. Set 0 to refresh every time.",
-          "type": "integer",
-          "minimum": 0,
           "maximum": 9007199254740991
         },
         "disabled": {

--- a/schemas/caplets-config.schema.json
+++ b/schemas/caplets-config.schema.json
@@ -1010,10 +1010,44 @@
                   "additionalProperties": {}
                 },
                 "query": {
-                  "description": "Query parameter mapping."
+                  "description": "Query parameter mapping.",
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
+                  }
                 },
                 "headers": {
-                  "description": "Request header mapping."
+                  "description": "Request header mapping.",
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
+                  }
                 },
                 "jsonBody": {
                   "description": "JSON request body mapping."

--- a/schemas/caplets-config.schema.json
+++ b/schemas/caplets-config.schema.json
@@ -788,6 +788,280 @@
         "required": ["name", "description", "endpointUrl", "auth"],
         "additionalProperties": false
       }
+    },
+    "httpApis": {
+      "default": {},
+      "description": "HTTP APIs keyed by stable Caplet ID.",
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[a-zA-Z0-9_-]{1,64}$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "description": "Human-readable HTTP API display name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Capability description shown to agents before HTTP actions are disclosed."
+          },
+          "baseUrl": {
+            "type": "string",
+            "pattern": "^(?![a-zA-Z][a-zA-Z0-9+.-]*:\\/\\/[^/?#]*@)[^?#]*$",
+            "description": "Base URL for HTTP action requests."
+          },
+          "auth": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "none"
+                  }
+                },
+                "required": ["type"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "bearer"
+                  },
+                  "token": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": ["type", "token"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "headers"
+                  },
+                  "headers": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                },
+                "required": ["type", "headers"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "oauth2"
+                  },
+                  "authorizationUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "tokenUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "issuer": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "resourceMetadataUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "authorizationServerMetadataUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "openidConfigurationUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "clientId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "clientSecret": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "scopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "redirectUri": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "required": ["type"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "oidc"
+                  },
+                  "authorizationUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "tokenUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "issuer": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "resourceMetadataUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "authorizationServerMetadataUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "openidConfigurationUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "clientId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "clientSecret": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "scopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "redirectUri": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "required": ["type"],
+                "additionalProperties": false
+              }
+            ],
+            "description": "Explicit HTTP API request auth config. Use {\"type\":\"none\"} for public APIs."
+          },
+          "actions": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9_-]{1,64}$"
+            },
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "method": {
+                  "type": "string",
+                  "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+                  "description": "HTTP method used for this action."
+                },
+                "path": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^\\/",
+                  "description": "URL path appended to the HTTP API baseUrl."
+                },
+                "description": {
+                  "description": "Action capability description.",
+                  "type": "string",
+                  "minLength": 1
+                },
+                "inputSchema": {
+                  "description": "JSON Schema for call_tool arguments.",
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {}
+                },
+                "query": {
+                  "description": "Query parameter mapping."
+                },
+                "headers": {
+                  "description": "Request header mapping."
+                },
+                "jsonBody": {
+                  "description": "JSON request body mapping."
+                }
+              },
+              "required": ["method", "path"],
+              "additionalProperties": false
+            },
+            "description": "Configured HTTP actions keyed by stable tool name.",
+            "minProperties": 1
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          "requestTimeoutMs": {
+            "default": 60000,
+            "description": "Timeout in milliseconds for HTTP action requests.",
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "maxResponseBytes": {
+            "default": 1000000,
+            "description": "Maximum HTTP action response body bytes to read.",
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "operationCacheTtlMs": {
+            "default": 30000,
+            "description": "Milliseconds HTTP action metadata stays fresh. Set 0 to refresh every time.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "disabled": {
+            "default": false,
+            "description": "When true, omit this HTTP API Caplet.",
+            "type": "boolean"
+          }
+        },
+        "required": ["name", "description", "baseUrl", "auth", "actions"],
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/schemas/caplets-config.schema.json
+++ b/schemas/caplets-config.schema.json
@@ -813,7 +813,8 @@
           "baseUrl": {
             "type": "string",
             "pattern": "^(?![a-zA-Z][a-zA-Z0-9+.-]*:\\/\\/[^/?#]*@)[^?#]*$",
-            "description": "Base URL for HTTP action requests."
+            "description": "Base URL for HTTP action requests.",
+            "format": "uri"
           },
           "auth": {
             "oneOf": [
@@ -1044,13 +1045,6 @@
             "description": "Maximum HTTP action response body bytes to read.",
             "type": "integer",
             "exclusiveMinimum": 0,
-            "maximum": 9007199254740991
-          },
-          "operationCacheTtlMs": {
-            "default": 30000,
-            "description": "Milliseconds HTTP action metadata stays fresh. Set 0 to refresh every time.",
-            "type": "integer",
-            "minimum": 0,
             "maximum": 9007199254740991
           },
           "disabled": {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -46,7 +46,7 @@ type OAuthLikeAuthConfig = {
 
 export type GenericAuthTarget = {
   server: string;
-  backend: "openapi" | "graphql";
+  backend: "openapi" | "graphql" | "http";
   url?: string | undefined;
   baseUrl?: string | undefined;
   specUrl?: string | undefined;

--- a/src/caplet-files.ts
+++ b/src/caplet-files.ts
@@ -10,8 +10,10 @@ import {
   SERVER_ID_PATTERN,
   isAllowedHttpBaseUrl,
   isAllowedRemoteUrl,
+  isUrl,
 } from "./config/validation.js";
 import { CapletsError, redactSecrets } from "./errors.js";
+import { nestedSchema, schemaPath } from "./schema-utils.js";
 
 const MAX_CAPLET_FILE_BYTES = 128 * 1024;
 const MAX_CAPLET_BODY_CHARS = 64 * 1024;
@@ -349,6 +351,11 @@ const capletGraphQlEndpointSchema = z
     validateEndpointAuthHeaders(endpoint.auth, ctx);
   });
 
+const httpScalarMappingSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.number(), z.boolean()]),
+);
+
 const capletHttpActionSchema = z
   .object({
     method: z
@@ -365,8 +372,8 @@ const capletHttpActionSchema = z
       .record(z.string(), z.unknown())
       .optional()
       .describe("JSON Schema for call_tool arguments."),
-    query: z.unknown().optional().describe("Query parameter mapping."),
-    headers: z.unknown().optional().describe("Request header mapping."),
+    query: httpScalarMappingSchema.optional().describe("Query parameter mapping."),
+    headers: httpScalarMappingSchema.optional().describe("Request header mapping."),
     jsonBody: z.unknown().optional().describe("JSON request body mapping."),
   })
   .strict();
@@ -416,6 +423,11 @@ const capletHttpApiSchema = z
       });
     }
     validateEndpointAuthHeaders(api.auth, ctx);
+    for (const [actionName, action] of Object.entries(api.actions)) {
+      if (action.headers) {
+        validateHttpActionHeaders(action.headers, ctx, ["actions", actionName, "headers"]);
+      }
+    }
   });
 
 export const capletFileSchema = z
@@ -691,6 +703,23 @@ function validateEndpointAuthHeaders(
   }
 }
 
+function validateHttpActionHeaders(
+  headers: Record<string, unknown>,
+  ctx: z.RefinementCtx,
+  path: Array<string>,
+): void {
+  for (const headerName of Object.keys(headers)) {
+    const normalized = headerName.toLowerCase();
+    if (!HEADER_NAME_PATTERN.test(headerName) || FORBIDDEN_HEADERS.has(normalized)) {
+      ctx.addIssue({
+        code: "custom",
+        path: [...path, headerName],
+        message: `header ${headerName} is not allowed`,
+      });
+    }
+  }
+}
+
 function parseFrontmatter(text: string, path: string): { frontmatter: unknown; body: string } {
   if (!text.startsWith("---\n") && !text.startsWith("---\r\n")) {
     throw new CapletsError(
@@ -735,15 +764,6 @@ function hasEnvReference(value: string): boolean {
   return /\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$env:[A-Za-z_][A-Za-z0-9_]*/.test(value);
 }
 
-function isUrl(value: string): boolean {
-  try {
-    new URL(value);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function patchHttpApiJsonSchema<T>(schema: T): T {
   const httpApiProperties = schemaPath<Record<string, unknown>>(schema, [
     "properties",
@@ -759,22 +779,4 @@ function patchHttpApiJsonSchema<T>(schema: T): T {
     baseUrl.format = "uri";
   }
   return schema;
-}
-
-function nestedSchema<T>(value: unknown, key: string): T | undefined {
-  if (!isPlainObject(value)) {
-    return undefined;
-  }
-  return value[key] as T | undefined;
-}
-
-function schemaPath<T>(value: unknown, path: string[]): T | undefined {
-  let current = value;
-  for (const segment of path) {
-    current = nestedSchema(current, segment);
-    if (current === undefined) {
-      return undefined;
-    }
-  }
-  return current as T;
 }

--- a/src/caplet-files.ts
+++ b/src/caplet-files.ts
@@ -403,12 +403,6 @@ const capletHttpApiSchema = z
       .positive()
       .optional()
       .describe("Maximum HTTP action response body bytes to read."),
-    operationCacheTtlMs: z
-      .number()
-      .int()
-      .nonnegative()
-      .optional()
-      .describe("Milliseconds HTTP action metadata stays fresh. Set 0 to refresh every time."),
     disabled: z.boolean().optional().describe("When true, omit this Caplet from discovery."),
   })
   .strict()
@@ -476,7 +470,7 @@ export const capletFileSchema = z
 type CapletFileFrontmatter = z.infer<typeof capletFileSchema>;
 
 export function capletJsonSchema(): unknown {
-  return withHttpActionMinProperties({
+  return patchHttpApiJsonSchema({
     $schema: "https://json-schema.org/draft/2020-12/schema",
     $id: "https://raw.githubusercontent.com/spiritledsoftware/caplets/main/schemas/caplet.schema.json",
     title: "Caplet file frontmatter",
@@ -750,28 +744,37 @@ function isUrl(value: string): boolean {
   }
 }
 
-function withHttpActionMinProperties<T>(schema: T): T {
-  const actions = findHttpActionsSchema(schema);
+function patchHttpApiJsonSchema<T>(schema: T): T {
+  const httpApiProperties = schemaPath<Record<string, unknown>>(schema, [
+    "properties",
+    "httpApi",
+    "properties",
+  ]);
+  const actions = nestedSchema<Record<string, unknown>>(httpApiProperties, "actions");
   if (actions) {
     actions.minProperties = 1;
+  }
+  const baseUrl = nestedSchema<Record<string, unknown>>(httpApiProperties, "baseUrl");
+  if (baseUrl) {
+    baseUrl.format = "uri";
   }
   return schema;
 }
 
-function findHttpActionsSchema(value: unknown): Record<string, unknown> | undefined {
+function nestedSchema<T>(value: unknown, key: string): T | undefined {
   if (!isPlainObject(value)) {
     return undefined;
   }
-  if (value.description === "Configured HTTP actions keyed by stable tool name.") {
-    return value;
-  }
-  for (const nested of Object.values(value)) {
-    const found = Array.isArray(nested)
-      ? nested.map(findHttpActionsSchema).find(Boolean)
-      : findHttpActionsSchema(nested);
-    if (found) {
-      return found;
+  return value[key] as T | undefined;
+}
+
+function schemaPath<T>(value: unknown, path: string[]): T | undefined {
+  let current = value;
+  for (const segment of path) {
+    current = nestedSchema(current, segment);
+    if (current === undefined) {
+      return undefined;
     }
   }
-  return undefined;
+  return current as T;
 }

--- a/src/caplet-files.ts
+++ b/src/caplet-files.ts
@@ -11,6 +11,7 @@ import {
   isAllowedHttpBaseUrl,
   isAllowedRemoteUrl,
   isUrl,
+  validateHttpActionHeaders,
 } from "./config/validation.js";
 import { CapletsError, redactSecrets } from "./errors.js";
 import { nestedSchema, schemaPath } from "./schema-utils.js";
@@ -697,23 +698,6 @@ function validateEndpointAuthHeaders(
       ctx.addIssue({
         code: "custom",
         path: ["auth", "headers", headerName],
-        message: `header ${headerName} is not allowed`,
-      });
-    }
-  }
-}
-
-function validateHttpActionHeaders(
-  headers: Record<string, unknown>,
-  ctx: z.RefinementCtx,
-  path: Array<string>,
-): void {
-  for (const headerName of Object.keys(headers)) {
-    const normalized = headerName.toLowerCase();
-    if (!HEADER_NAME_PATTERN.test(headerName) || FORBIDDEN_HEADERS.has(normalized)) {
-      ctx.addIssue({
-        code: "custom",
-        path: [...path, headerName],
         message: `header ${headerName} is not allowed`,
       });
     }

--- a/src/caplet-files.ts
+++ b/src/caplet-files.ts
@@ -6,7 +6,9 @@ import { z } from "zod";
 import {
   FORBIDDEN_HEADERS,
   HEADER_NAME_PATTERN,
+  HTTP_BASE_URL_PATTERN,
   SERVER_ID_PATTERN,
+  isAllowedHttpBaseUrl,
   isAllowedRemoteUrl,
 } from "./config/validation.js";
 import { CapletsError, redactSecrets } from "./errors.js";
@@ -347,6 +349,81 @@ const capletGraphQlEndpointSchema = z
     validateEndpointAuthHeaders(endpoint.auth, ctx);
   });
 
+const capletHttpActionSchema = z
+  .object({
+    method: z
+      .enum(["GET", "POST", "PUT", "PATCH", "DELETE"])
+      .describe("HTTP method used for this action."),
+    path: z
+      .string()
+      .min(1)
+      .regex(/^\//, "HTTP action path must start with /")
+      .describe("URL path appended to the HTTP API baseUrl.")
+      .refine((value) => !isUrl(value), "HTTP action path must be a URL path, not a URL"),
+    description: z.string().min(1).optional().describe("Action capability description."),
+    inputSchema: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe("JSON Schema for call_tool arguments."),
+    query: z.unknown().optional().describe("Query parameter mapping."),
+    headers: z.unknown().optional().describe("Request header mapping."),
+    jsonBody: z.unknown().optional().describe("JSON request body mapping."),
+  })
+  .strict();
+
+const capletHttpApiSchema = z
+  .object({
+    baseUrl: z
+      .string()
+      .min(1)
+      .regex(
+        HTTP_BASE_URL_PATTERN,
+        "HTTP API baseUrl must not include credentials, query, or fragment",
+      )
+      .describe("Base URL for HTTP action requests."),
+    auth: capletEndpointAuthSchema.describe(
+      'Explicit HTTP API request auth config. Use {"type":"none"} for public APIs.',
+    ),
+    actions: z
+      .record(z.string().regex(SERVER_ID_PATTERN), capletHttpActionSchema)
+      .refine(
+        (actions) => Object.keys(actions).length > 0,
+        "HTTP API must define at least one action",
+      )
+      .describe("Configured HTTP actions keyed by stable tool name."),
+    requestTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Timeout in milliseconds for HTTP action requests."),
+    maxResponseBytes: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Maximum HTTP action response body bytes to read."),
+    operationCacheTtlMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe("Milliseconds HTTP action metadata stays fresh. Set 0 to refresh every time."),
+    disabled: z.boolean().optional().describe("When true, omit this Caplet from discovery."),
+  })
+  .strict()
+  .superRefine((api, ctx) => {
+    if (api.baseUrl && !hasEnvReference(api.baseUrl) && !isAllowedHttpBaseUrl(api.baseUrl)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["baseUrl"],
+        message:
+          "HTTP API baseUrl must use https except loopback development urls and must not include credentials, query, or fragment",
+      });
+    }
+    validateEndpointAuthHeaders(api.auth, ctx);
+  });
+
 export const capletFileSchema = z
   .object({
     $schema: z
@@ -376,18 +453,22 @@ export const capletFileSchema = z
     graphqlEndpoint: capletGraphQlEndpointSchema
       .describe("GraphQL endpoint backend configuration for this Caplet.")
       .optional(),
+    httpApi: capletHttpApiSchema
+      .describe("HTTP API backend configuration for this Caplet.")
+      .optional(),
   })
   .strict()
   .superRefine((frontmatter, ctx) => {
     const backendCount =
       Number(Boolean(frontmatter.mcpServer)) +
       Number(Boolean(frontmatter.openapiEndpoint)) +
-      Number(Boolean(frontmatter.graphqlEndpoint));
+      Number(Boolean(frontmatter.graphqlEndpoint)) +
+      Number(Boolean(frontmatter.httpApi));
     if (backendCount !== 1) {
       ctx.addIssue({
         code: "custom",
         message:
-          "Caplet file must define exactly one backend: mcpServer, openapiEndpoint, or graphqlEndpoint",
+          "Caplet file must define exactly one backend: mcpServer, openapiEndpoint, graphqlEndpoint, or httpApi",
       });
     }
   });
@@ -395,19 +476,20 @@ export const capletFileSchema = z
 type CapletFileFrontmatter = z.infer<typeof capletFileSchema>;
 
 export function capletJsonSchema(): unknown {
-  return {
+  return withHttpActionMinProperties({
     $schema: "https://json-schema.org/draft/2020-12/schema",
     $id: "https://raw.githubusercontent.com/spiritledsoftware/caplets/main/schemas/caplet.schema.json",
     title: "Caplet file frontmatter",
     description: "YAML frontmatter schema for a Markdown Caplet file.",
     ...z.toJSONSchema(capletFileSchema, { io: "input" }),
-  };
+  });
 }
 
 export type CapletFileConfig = {
   mcpServers?: Record<string, unknown>;
   openapiEndpoints?: Record<string, unknown>;
   graphqlEndpoints?: Record<string, unknown>;
+  httpApis?: Record<string, unknown>;
 };
 
 export function loadCapletFiles(root: string): CapletFileConfig | undefined {
@@ -418,8 +500,14 @@ export function loadCapletFiles(root: string): CapletFileConfig | undefined {
   const servers: Record<string, unknown> = {};
   const openapiEndpoints: Record<string, unknown> = {};
   const graphqlEndpoints: Record<string, unknown> = {};
+  const httpApis: Record<string, unknown> = {};
   for (const candidate of discoverCapletFiles(root)) {
-    if (servers[candidate.id] || openapiEndpoints[candidate.id] || graphqlEndpoints[candidate.id]) {
+    if (
+      servers[candidate.id] ||
+      openapiEndpoints[candidate.id] ||
+      graphqlEndpoints[candidate.id] ||
+      httpApis[candidate.id]
+    ) {
       throw new CapletsError("CONFIG_INVALID", `Duplicate Caplet ID ${candidate.id} under ${root}`);
     }
     const config = readCapletFile(candidate.path);
@@ -429,6 +517,9 @@ export function loadCapletFiles(root: string): CapletFileConfig | undefined {
     } else if (isPlainObject(config) && config.backend === "graphql") {
       const { backend: _backend, ...endpoint } = config;
       graphqlEndpoints[candidate.id] = endpoint;
+    } else if (isPlainObject(config) && config.backend === "http") {
+      const { backend: _backend, ...endpoint } = config;
+      httpApis[candidate.id] = endpoint;
     } else {
       servers[candidate.id] = config;
     }
@@ -437,11 +528,13 @@ export function loadCapletFiles(root: string): CapletFileConfig | undefined {
   const hasServers = Object.keys(servers).length > 0;
   const hasOpenApi = Object.keys(openapiEndpoints).length > 0;
   const hasGraphQl = Object.keys(graphqlEndpoints).length > 0;
-  return hasServers || hasOpenApi || hasGraphQl
+  const hasHttpApis = Object.keys(httpApis).length > 0;
+  return hasServers || hasOpenApi || hasGraphQl || hasHttpApis
     ? {
         ...(hasServers ? { mcpServers: servers } : {}),
         ...(hasOpenApi ? { openapiEndpoints } : {}),
         ...(hasGraphQl ? { graphqlEndpoints } : {}),
+        ...(hasHttpApis ? { httpApis } : {}),
       }
     : undefined;
 }
@@ -533,6 +626,17 @@ function capletToServerConfig(
       schemaPath: normalizeLocalPath(frontmatter.graphqlEndpoint.schemaPath, baseDir),
       operations: normalizeGraphQlOperations(frontmatter.graphqlEndpoint.operations, baseDir),
       backend: "graphql",
+      name: frontmatter.name,
+      description: frontmatter.description,
+      ...(frontmatter.tags ? { tags: frontmatter.tags } : {}),
+      body,
+    };
+  }
+
+  if (frontmatter.httpApi) {
+    return {
+      ...frontmatter.httpApi,
+      backend: "http",
       name: frontmatter.name,
       description: frontmatter.description,
       ...(frontmatter.tags ? { tags: frontmatter.tags } : {}),
@@ -644,4 +748,30 @@ function isUrl(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+function withHttpActionMinProperties<T>(schema: T): T {
+  const actions = findHttpActionsSchema(schema);
+  if (actions) {
+    actions.minProperties = 1;
+  }
+  return schema;
+}
+
+function findHttpActionsSchema(value: unknown): Record<string, unknown> | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+  if (value.description === "Configured HTTP actions keyed by stable tool name.") {
+    return value;
+  }
+  for (const nested of Object.values(value)) {
+    const found = Array.isArray(nested)
+      ? nested.map(findHttpActionsSchema).find(Boolean)
+      : findHttpActionsSchema(nested);
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
 }

--- a/src/caplet-files.ts
+++ b/src/caplet-files.ts
@@ -377,7 +377,16 @@ const capletHttpActionSchema = z
     headers: httpScalarMappingSchema.optional().describe("Request header mapping."),
     jsonBody: z.unknown().optional().describe("JSON request body mapping."),
   })
-  .strict();
+  .strict()
+  .superRefine((action, ctx) => {
+    if (action.method === "GET" && action.jsonBody !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["jsonBody"],
+        message: "HTTP GET actions must not define jsonBody",
+      });
+    }
+  });
 
 const capletHttpApiSchema = z
   .object({

--- a/src/caplet-files.ts
+++ b/src/caplet-files.ts
@@ -367,6 +367,7 @@ const capletHttpActionSchema = z
       .min(1)
       .regex(/^\//, "HTTP action path must start with /")
       .describe("URL path appended to the HTTP API baseUrl.")
+      .refine((value) => !value.startsWith("//"), "HTTP action path must not start with //")
       .refine((value) => !isUrl(value), "HTTP action path must be a URL path, not a URL"),
     description: z.string().min(1).optional().describe("Action capability description."),
     inputSchema: z

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -8,7 +8,7 @@ import {
   runOAuthFlow,
   type GenericAuthTarget,
 } from "../auth.js";
-import { loadConfig, type GraphQlEndpointConfig } from "../config.js";
+import { loadConfig, type GraphQlEndpointConfig, type HttpApiConfig } from "../config.js";
 import { CapletsError, toSafeError } from "../errors.js";
 
 type AuthTarget = ReturnType<typeof authTargets>[number];
@@ -108,6 +108,9 @@ function authTargets(config: ReturnType<typeof loadConfig>) {
     ...Object.values(config.graphqlEndpoints)
       .filter((endpoint) => endpoint.auth?.type === "oauth2" || endpoint.auth?.type === "oidc")
       .map(graphQlAuthTarget),
+    ...Object.values(config.httpApis)
+      .filter((api) => api.auth?.type === "oauth2" || api.auth?.type === "oidc")
+      .map(httpAuthTarget),
   ];
 }
 
@@ -117,6 +120,13 @@ function graphQlAuthTarget(
   return {
     ...endpoint,
     url: endpoint.endpointUrl,
+  };
+}
+
+function httpAuthTarget(api: HttpApiConfig): HttpApiConfig & GenericAuthTarget {
+  return {
+    ...api,
+    baseUrl: api.baseUrl,
   };
 }
 

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -124,10 +124,7 @@ function graphQlAuthTarget(
 }
 
 function httpAuthTarget(api: HttpApiConfig): HttpApiConfig & GenericAuthTarget {
-  return {
-    ...api,
-    baseUrl: api.baseUrl,
-  };
+  return { ...api };
 }
 
 function assertLoginTarget(

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,9 @@ import {
 import {
   FORBIDDEN_HEADERS,
   HEADER_NAME_PATTERN,
+  HTTP_BASE_URL_PATTERN,
   SERVER_ID_PATTERN,
+  isAllowedHttpBaseUrl,
   isAllowedRemoteUrl,
 } from "./config/validation.js";
 import { CapletsError, redactSecrets } from "./errors.js";
@@ -128,7 +130,37 @@ export type GraphQlEndpointConfig = {
   disabled: boolean;
 };
 
-export type CapletConfig = CapletServerConfig | OpenApiEndpointConfig | GraphQlEndpointConfig;
+export type HttpActionConfig = {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  path: string;
+  description?: string | undefined;
+  inputSchema?: Record<string, unknown> | undefined;
+  query?: unknown;
+  headers?: unknown;
+  jsonBody?: unknown;
+};
+
+export type HttpApiConfig = {
+  server: string;
+  backend: "http";
+  name: string;
+  description: string;
+  tags?: string[] | undefined;
+  body?: string | undefined;
+  baseUrl: string;
+  auth: OpenApiAuthConfig;
+  actions: Record<string, HttpActionConfig>;
+  requestTimeoutMs: number;
+  maxResponseBytes: number;
+  operationCacheTtlMs: number;
+  disabled: boolean;
+};
+
+export type CapletConfig =
+  | CapletServerConfig
+  | OpenApiEndpointConfig
+  | GraphQlEndpointConfig
+  | HttpApiConfig;
 
 export type CapletsOptions = {
   defaultSearchLimit: number;
@@ -141,6 +173,7 @@ export type CapletsConfig = {
   mcpServers: Record<string, CapletServerConfig>;
   openapiEndpoints: Record<string, OpenApiEndpointConfig>;
   graphqlEndpoints: Record<string, GraphQlEndpointConfig>;
+  httpApis: Record<string, HttpApiConfig>;
 };
 
 const NON_INTERPOLATED_SERVER_FIELDS = new Set(["name", "description", "tags", "body"]);
@@ -412,13 +445,93 @@ const normalizedGraphQlEndpointSchema = publicGraphQlEndpointSchema.extend({
   body: z.string().optional(),
 });
 
+const httpActionSchema = z
+  .object({
+    method: z
+      .enum(["GET", "POST", "PUT", "PATCH", "DELETE"])
+      .describe("HTTP method used for this action."),
+    path: z
+      .string()
+      .min(1)
+      .regex(/^\//, "HTTP action path must start with /")
+      .describe("URL path appended to the HTTP API baseUrl.")
+      .refine((value) => !isUrl(value), "HTTP action path must be a URL path, not a URL"),
+    description: z.string().min(1).optional().describe("Action capability description."),
+    inputSchema: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe("JSON Schema for call_tool arguments."),
+    query: z.unknown().optional().describe("Query parameter mapping."),
+    headers: z.unknown().optional().describe("Request header mapping."),
+    jsonBody: z.unknown().optional().describe("JSON request body mapping."),
+  })
+  .strict();
+
+const publicHttpApiSchema = z
+  .object({
+    name: z.string().trim().min(1).max(80).describe("Human-readable HTTP API display name."),
+    description: z
+      .string()
+      .describe("Capability description shown to agents before HTTP actions are disclosed.")
+      .refine(
+        (value) => value.trim().length >= 10,
+        "description must contain at least 10 non-whitespace characters",
+      )
+      .refine((value) => value.length <= 1500, "description must be at most 1500 characters"),
+    baseUrl: z
+      .string()
+      .url()
+      .regex(
+        HTTP_BASE_URL_PATTERN,
+        "HTTP API baseUrl must not include credentials, query, or fragment",
+      )
+      .describe("Base URL for HTTP action requests."),
+    auth: openApiAuthSchema.describe(
+      'Explicit HTTP API request auth config. Use {"type":"none"} for public APIs.',
+    ),
+    actions: z
+      .record(z.string().regex(SERVER_ID_PATTERN), httpActionSchema)
+      .refine(
+        (actions) => Object.keys(actions).length > 0,
+        "HTTP API must define at least one action",
+      )
+      .describe("Configured HTTP actions keyed by stable tool name."),
+    tags: z.array(z.string().trim().min(1).max(80)).optional(),
+    requestTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .default(60_000)
+      .describe("Timeout in milliseconds for HTTP action requests."),
+    maxResponseBytes: z
+      .number()
+      .int()
+      .positive()
+      .default(1_000_000)
+      .describe("Maximum HTTP action response body bytes to read."),
+    operationCacheTtlMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(30_000)
+      .describe("Milliseconds HTTP action metadata stays fresh. Set 0 to refresh every time."),
+    disabled: z.boolean().default(false).describe("When true, omit this HTTP API Caplet."),
+  })
+  .strict();
+
+const normalizedHttpApiSchema = publicHttpApiSchema.extend({
+  body: z.string().optional(),
+});
+
 type ConfigSchemaServerValue = z.infer<typeof normalizedServerSchema>;
 type ConfigSchemaOpenApiEndpointValue = z.infer<typeof normalizedOpenApiEndpointSchema>;
 type ConfigSchemaGraphQlEndpointValue = z.infer<typeof normalizedGraphQlEndpointSchema>;
+type ConfigSchemaHttpApiValue = z.infer<typeof normalizedHttpApiSchema>;
 type ConfigInput = {
   mcpServers?: Record<string, unknown>;
   openapiEndpoints?: Record<string, unknown>;
   graphqlEndpoints?: Record<string, unknown>;
+  httpApis?: Record<string, unknown>;
   [key: string]: unknown;
 };
 
@@ -426,6 +539,7 @@ function configSchemaFor(
   serverValueSchema: z.ZodTypeAny,
   openApiEndpointValueSchema: z.ZodTypeAny,
   graphQlEndpointValueSchema: z.ZodTypeAny,
+  httpApiValueSchema: z.ZodTypeAny,
 ) {
   return z
     .object({
@@ -460,6 +574,10 @@ function configSchemaFor(
         .record(z.string().regex(SERVER_ID_PATTERN), graphQlEndpointValueSchema)
         .default({})
         .describe("GraphQL endpoints keyed by stable Caplet ID."),
+      httpApis: z
+        .record(z.string().regex(SERVER_ID_PATTERN), httpApiValueSchema)
+        .default({})
+        .describe("HTTP APIs keyed by stable Caplet ID."),
     })
     .strict()
     .superRefine((config, ctx) => {
@@ -630,6 +748,40 @@ function configSchemaFor(
         }
         validateEndpointAuthHeaders(raw.auth, ctx, ["graphqlEndpoints", endpoint, "auth"]);
       }
+
+      for (const [endpoint, rawValue] of Object.entries(config.httpApis)) {
+        const raw = rawValue as ConfigSchemaHttpApiValue;
+        const duplicateBackend = config.mcpServers[endpoint]
+          ? "mcpServers"
+          : config.openapiEndpoints[endpoint]
+            ? "openapiEndpoints"
+            : config.graphqlEndpoints[endpoint]
+              ? "graphqlEndpoints"
+              : undefined;
+        if (duplicateBackend) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["httpApis", endpoint],
+            message: `Caplet ID ${endpoint} is already used by ${duplicateBackend}`,
+          });
+        }
+        if (!SERVER_ID_PATTERN.test(endpoint)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["httpApis", endpoint],
+            message: "HTTP API ID must match ^[a-zA-Z0-9_-]{1,64}$",
+          });
+        }
+        if (raw.baseUrl && !isAllowedHttpBaseUrl(raw.baseUrl)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["httpApis", endpoint, "baseUrl"],
+            message:
+              "HTTP API baseUrl must use https except loopback development urls and must not include credentials, query, or fragment",
+          });
+        }
+        validateEndpointAuthHeaders(raw.auth, ctx, ["httpApis", endpoint, "auth"]);
+      }
     });
 }
 
@@ -637,21 +789,23 @@ export const configFileSchema = configSchemaFor(
   publicServerSchema,
   publicOpenApiEndpointSchema,
   publicGraphQlEndpointSchema,
+  publicHttpApiSchema,
 );
 const normalizedConfigFileSchema = configSchemaFor(
   normalizedServerSchema,
   normalizedOpenApiEndpointSchema,
   normalizedGraphQlEndpointSchema,
+  normalizedHttpApiSchema,
 );
 
 export function configJsonSchema(): unknown {
-  return {
+  return withHttpActionMinProperties({
     $schema: "https://json-schema.org/draft/2020-12/schema",
     $id: "https://raw.githubusercontent.com/spiritledsoftware/caplets/main/schemas/caplets-config.schema.json",
     title: "Caplets config",
     description: "Configuration file for the Caplets progressive MCP disclosure gateway.",
     ...z.toJSONSchema(configFileSchema, { io: "input" }),
-  };
+  });
 }
 
 export function loadConfig(
@@ -683,11 +837,12 @@ export function loadConfig(
     if (
       Object.keys(config.mcpServers).length === 0 &&
       Object.keys(config.openapiEndpoints).length === 0 &&
-      Object.keys(config.graphqlEndpoints).length === 0
+      Object.keys(config.graphqlEndpoints).length === 0 &&
+      Object.keys(config.httpApis).length === 0
     ) {
       throw new CapletsError(
         "CONFIG_INVALID",
-        "Caplets config must define at least one MCP server, OpenAPI endpoint, or GraphQL endpoint",
+        "Caplets config must define at least one MCP server, OpenAPI endpoint, GraphQL endpoint, or HTTP API",
       );
     }
     return config;
@@ -810,6 +965,12 @@ function rejectUntrustedProjectExecutableBackends(input: ConfigInput, path: stri
       `Project config at ${path} cannot define graphqlEndpoints; use trusted project Caplet files or user config`,
     );
   }
+  if (input.httpApis && Object.keys(input.httpApis).length > 0) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Project config at ${path} cannot define httpApis; use trusted project Caplet files or user config`,
+    );
+  }
   return input;
 }
 
@@ -833,6 +994,10 @@ function mergeConfigInputs(...inputs: Array<ConfigInput | undefined>): ConfigInp
       graphqlEndpoints: {
         ...merged?.graphqlEndpoints,
         ...input.graphqlEndpoints,
+      },
+      httpApis: {
+        ...merged?.httpApis,
+        ...input.httpApis,
       },
     };
   }
@@ -876,6 +1041,16 @@ export function parseConfig(input: unknown): CapletsConfig {
     }) as GraphQlEndpointConfig;
   }
 
+  const httpApis: Record<string, HttpApiConfig> = {};
+  for (const [server, raw] of Object.entries(parsed.data.httpApis)) {
+    const interpolated = raw as ConfigSchemaHttpApiValue;
+    httpApis[server] = stripUndefined({
+      ...interpolated,
+      server,
+      backend: "http",
+    }) as HttpApiConfig;
+  }
+
   return {
     version: parsed.data.version,
     options: {
@@ -885,6 +1060,7 @@ export function parseConfig(input: unknown): CapletsConfig {
     mcpServers: servers,
     openapiEndpoints,
     graphqlEndpoints,
+    httpApis,
   };
 }
 
@@ -938,7 +1114,10 @@ function interpolateConfig<T>(value: T, path: string[] = []): T {
 function isPublicMetadataPath(path: string[]): boolean {
   if (
     path.length < 3 ||
-    (path[0] !== "mcpServers" && path[0] !== "openapiEndpoints" && path[0] !== "graphqlEndpoints")
+    (path[0] !== "mcpServers" &&
+      path[0] !== "openapiEndpoints" &&
+      path[0] !== "graphqlEndpoints" &&
+      path[0] !== "httpApis")
   ) {
     return false;
   }
@@ -951,6 +1130,41 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function hasEnvReference(value: string): boolean {
   return /\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$env:[A-Za-z_][A-Za-z0-9_]*/.test(value);
+}
+
+function isUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function withHttpActionMinProperties<T>(schema: T): T {
+  const actions = findHttpActionsSchema(schema);
+  if (actions) {
+    actions.minProperties = 1;
+  }
+  return schema;
+}
+
+function findHttpActionsSchema(value: unknown): Record<string, unknown> | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+  if (value.description === "Configured HTTP actions keyed by stable tool name.") {
+    return value;
+  }
+  for (const nested of Object.values(value)) {
+    const found = Array.isArray(nested)
+      ? nested.map(findHttpActionsSchema).find(Boolean)
+      : findHttpActionsSchema(nested);
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
 }
 
 export function interpolateEnv(value: string): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ import {
   isAllowedHttpBaseUrl,
   isAllowedRemoteUrl,
   isUrl,
+  validateHttpActionHeaders,
 } from "./config/validation.js";
 import { CapletsError, redactSecrets } from "./errors.js";
 import { nestedSchema, schemaPath } from "./schema-utils.js";
@@ -1089,23 +1090,6 @@ function validateEndpointAuthHeaders(
       ctx.addIssue({
         code: "custom",
         path: [...path, "headers", headerName],
-        message: `header ${headerName} is not allowed`,
-      });
-    }
-  }
-}
-
-function validateHttpActionHeaders(
-  headers: Record<string, unknown>,
-  ctx: z.RefinementCtx,
-  path: Array<string>,
-): void {
-  for (const headerName of Object.keys(headers)) {
-    const normalized = headerName.toLowerCase();
-    if (!HEADER_NAME_PATTERN.test(headerName) || FORBIDDEN_HEADERS.has(normalized)) {
-      ctx.addIssue({
-        code: "custom",
-        path: [...path, headerName],
         message: `header ${headerName} is not allowed`,
       });
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,8 +16,10 @@ import {
   SERVER_ID_PATTERN,
   isAllowedHttpBaseUrl,
   isAllowedRemoteUrl,
+  isUrl,
 } from "./config/validation.js";
 import { CapletsError, redactSecrets } from "./errors.js";
+import { nestedSchema, schemaPath } from "./schema-utils.js";
 
 export {
   DEFAULT_AUTH_DIR,
@@ -135,8 +137,8 @@ export type HttpActionConfig = {
   path: string;
   description?: string | undefined;
   inputSchema?: Record<string, unknown> | undefined;
-  query?: unknown;
-  headers?: unknown;
+  query?: Record<string, string | number | boolean> | undefined;
+  headers?: Record<string, string | number | boolean> | undefined;
   jsonBody?: unknown;
 };
 
@@ -444,6 +446,11 @@ const normalizedGraphQlEndpointSchema = publicGraphQlEndpointSchema.extend({
   body: z.string().optional(),
 });
 
+const httpScalarMappingSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.number(), z.boolean()]),
+);
+
 const httpActionSchema = z
   .object({
     method: z
@@ -460,8 +467,8 @@ const httpActionSchema = z
       .record(z.string(), z.unknown())
       .optional()
       .describe("JSON Schema for call_tool arguments."),
-    query: z.unknown().optional().describe("Query parameter mapping."),
-    headers: z.unknown().optional().describe("Request header mapping."),
+    query: httpScalarMappingSchema.optional().describe("Query parameter mapping."),
+    headers: httpScalarMappingSchema.optional().describe("Request header mapping."),
     jsonBody: z.unknown().optional().describe("JSON request body mapping."),
   })
   .strict();
@@ -774,6 +781,17 @@ function configSchemaFor(
           });
         }
         validateEndpointAuthHeaders(raw.auth, ctx, ["httpApis", endpoint, "auth"]);
+        for (const [actionName, action] of Object.entries(raw.actions)) {
+          if (action.headers) {
+            validateHttpActionHeaders(action.headers, ctx, [
+              "httpApis",
+              endpoint,
+              "actions",
+              actionName,
+              "headers",
+            ]);
+          }
+        }
       }
     });
 }
@@ -1077,6 +1095,23 @@ function validateEndpointAuthHeaders(
   }
 }
 
+function validateHttpActionHeaders(
+  headers: Record<string, unknown>,
+  ctx: z.RefinementCtx,
+  path: Array<string>,
+): void {
+  for (const headerName of Object.keys(headers)) {
+    const normalized = headerName.toLowerCase();
+    if (!HEADER_NAME_PATTERN.test(headerName) || FORBIDDEN_HEADERS.has(normalized)) {
+      ctx.addIssue({
+        code: "custom",
+        path: [...path, headerName],
+        message: `header ${headerName} is not allowed`,
+      });
+    }
+  }
+}
+
 function stripUndefined<T extends Record<string, unknown>>(value: T): T {
   return Object.fromEntries(
     Object.entries(value).filter(([, nested]) => nested !== undefined),
@@ -1125,15 +1160,6 @@ function hasEnvReference(value: string): boolean {
   return /\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$env:[A-Za-z_][A-Za-z0-9_]*/.test(value);
 }
 
-function isUrl(value: string): boolean {
-  try {
-    new URL(value);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function patchHttpApiJsonSchema<T>(schema: T): T {
   const httpApiProperties = schemaPath<Record<string, unknown>>(schema, [
     "properties",
@@ -1150,24 +1176,6 @@ function patchHttpApiJsonSchema<T>(schema: T): T {
     baseUrl.format = "uri";
   }
   return schema;
-}
-
-function nestedSchema<T>(value: unknown, key: string): T | undefined {
-  if (!isPlainObject(value)) {
-    return undefined;
-  }
-  return value[key] as T | undefined;
-}
-
-function schemaPath<T>(value: unknown, path: string[]): T | undefined {
-  let current = value;
-  for (const segment of path) {
-    current = nestedSchema(current, segment);
-    if (current === undefined) {
-      return undefined;
-    }
-  }
-  return current as T;
 }
 
 export function interpolateEnv(value: string): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -462,6 +462,7 @@ const httpActionSchema = z
       .min(1)
       .regex(/^\//, "HTTP action path must start with /")
       .describe("URL path appended to the HTTP API baseUrl.")
+      .refine((value) => !value.startsWith("//"), "HTTP action path must not start with //")
       .refine((value) => !isUrl(value), "HTTP action path must be a URL path, not a URL"),
     description: z.string().min(1).optional().describe("Action capability description."),
     inputSchema: z

--- a/src/config.ts
+++ b/src/config.ts
@@ -472,7 +472,16 @@ const httpActionSchema = z
     headers: httpScalarMappingSchema.optional().describe("Request header mapping."),
     jsonBody: z.unknown().optional().describe("JSON request body mapping."),
   })
-  .strict();
+  .strict()
+  .superRefine((action, ctx) => {
+    if (action.method === "GET" && action.jsonBody !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["jsonBody"],
+        message: "HTTP GET actions must not define jsonBody",
+      });
+    }
+  });
 
 const publicHttpApiSchema = z
   .object({

--- a/src/config.ts
+++ b/src/config.ts
@@ -152,7 +152,6 @@ export type HttpApiConfig = {
   actions: Record<string, HttpActionConfig>;
   requestTimeoutMs: number;
   maxResponseBytes: number;
-  operationCacheTtlMs: number;
   disabled: boolean;
 };
 
@@ -509,12 +508,6 @@ const publicHttpApiSchema = z
       .positive()
       .default(1_000_000)
       .describe("Maximum HTTP action response body bytes to read."),
-    operationCacheTtlMs: z
-      .number()
-      .int()
-      .nonnegative()
-      .default(30_000)
-      .describe("Milliseconds HTTP action metadata stays fresh. Set 0 to refresh every time."),
     disabled: z.boolean().default(false).describe("When true, omit this HTTP API Caplet."),
   })
   .strict();
@@ -799,7 +792,7 @@ const normalizedConfigFileSchema = configSchemaFor(
 );
 
 export function configJsonSchema(): unknown {
-  return withHttpActionMinProperties({
+  return patchHttpApiJsonSchema({
     $schema: "https://json-schema.org/draft/2020-12/schema",
     $id: "https://raw.githubusercontent.com/spiritledsoftware/caplets/main/schemas/caplets-config.schema.json",
     title: "Caplets config",
@@ -1141,30 +1134,40 @@ function isUrl(value: string): boolean {
   }
 }
 
-function withHttpActionMinProperties<T>(schema: T): T {
-  const actions = findHttpActionsSchema(schema);
+function patchHttpApiJsonSchema<T>(schema: T): T {
+  const httpApiProperties = schemaPath<Record<string, unknown>>(schema, [
+    "properties",
+    "httpApis",
+    "additionalProperties",
+    "properties",
+  ]);
+  const actions = nestedSchema<Record<string, unknown>>(httpApiProperties, "actions");
   if (actions) {
     actions.minProperties = 1;
+  }
+  const baseUrl = nestedSchema<Record<string, unknown>>(httpApiProperties, "baseUrl");
+  if (baseUrl) {
+    baseUrl.format = "uri";
   }
   return schema;
 }
 
-function findHttpActionsSchema(value: unknown): Record<string, unknown> | undefined {
+function nestedSchema<T>(value: unknown, key: string): T | undefined {
   if (!isPlainObject(value)) {
     return undefined;
   }
-  if (value.description === "Configured HTTP actions keyed by stable tool name.") {
-    return value;
-  }
-  for (const nested of Object.values(value)) {
-    const found = Array.isArray(nested)
-      ? nested.map(findHttpActionsSchema).find(Boolean)
-      : findHttpActionsSchema(nested);
-    if (found) {
-      return found;
+  return value[key] as T | undefined;
+}
+
+function schemaPath<T>(value: unknown, path: string[]): T | undefined {
+  let current = value;
+  for (const segment of path) {
+    current = nestedSchema(current, segment);
+    if (current === undefined) {
+      return undefined;
     }
   }
-  return undefined;
+  return current as T;
 }
 
 export function interpolateEnv(value: string): string {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,5 +1,6 @@
 export const SERVER_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
 export const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+export const HTTP_BASE_URL_PATTERN = /^(?![a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^/?#]*@)[^?#]*$/;
 export const FORBIDDEN_HEADERS = new Set([
   "accept",
   "authorization",
@@ -31,4 +32,14 @@ export function isAllowedRemoteUrl(value: string): boolean {
   return (
     url.protocol === "http:" && ["localhost", "127.0.0.1", "[::1]", "::1"].includes(url.hostname)
   );
+}
+
+export function isAllowedHttpBaseUrl(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  return isAllowedRemoteUrl(value) && !url.username && !url.password && !url.search && !url.hash;
 }

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -19,6 +19,27 @@ export const FORBIDDEN_HEADERS = new Set([
   "upgrade",
 ]);
 
+type ValidationIssueSink = {
+  addIssue(issue: { code: "custom"; path: Array<string>; message: string }): void;
+};
+
+export function validateHttpActionHeaders(
+  headers: Record<string, unknown>,
+  ctx: ValidationIssueSink,
+  path: Array<string>,
+): void {
+  for (const headerName of Object.keys(headers)) {
+    const normalized = headerName.toLowerCase();
+    if (!HEADER_NAME_PATTERN.test(headerName) || FORBIDDEN_HEADERS.has(normalized)) {
+      ctx.addIssue({
+        code: "custom",
+        path: [...path, headerName],
+        message: `header ${headerName} is not allowed`,
+      });
+    }
+  }
+}
+
 export function isAllowedRemoteUrl(value: string): boolean {
   let url: URL;
   try {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -43,3 +43,12 @@ export function isAllowedHttpBaseUrl(value: string): boolean {
   }
   return isAllowedRemoteUrl(value) && !url.username && !url.password && !url.search && !url.hash;
 }
+
+export function isUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/http-actions.ts
+++ b/src/http-actions.ts
@@ -33,6 +33,7 @@ export class HttpActionManager {
     try {
       const operations = operationsFor(api);
       validateBaseUrl(api);
+      authHeaders(api, this.options.authDir);
       for (const operation of operations) {
         validateAction(api, operation);
       }
@@ -182,7 +183,9 @@ function buildRequest(
 ): { url: URL; headers: Headers; body?: string } {
   validateBaseUrl(api);
   validateAction(api, operation);
-  const url = buildActionUrl(api.baseUrl, substitutePath(operation.path, args, operation));
+  const url = buildActionUrl(api.baseUrl, substitutePath(operation.path, args, operation), {
+    allowEncodedSlash: true,
+  });
   const query = resolveMappingToRecord(operation.query, args, "query");
   for (const [key, value] of Object.entries(query)) {
     if (value !== undefined && value !== null) {
@@ -394,7 +397,11 @@ function validateBaseUrl(api: HttpApiConfig): void {
   }
 }
 
-function buildActionUrl(base: string, actionPath: string): URL {
+function buildActionUrl(
+  base: string,
+  actionPath: string,
+  options: { allowEncodedSlash?: boolean } = {},
+): URL {
   if (/^[a-z][a-z0-9+.-]*:/i.test(actionPath) || actionPath.startsWith("//")) {
     throw new CapletsError("CONFIG_INVALID", "HTTP action path cannot change origin");
   }
@@ -405,7 +412,11 @@ function buildActionUrl(base: string, actionPath: string): URL {
     } catch {
       throw new CapletsError("CONFIG_INVALID", "HTTP action path contains invalid encoding");
     }
-    if (segment === "." || segment === ".." || segment.includes("/")) {
+    if (
+      segment === "." ||
+      segment === ".." ||
+      (!options.allowEncodedSlash && segment.includes("/"))
+    ) {
       throw new CapletsError("CONFIG_INVALID", "HTTP action path cannot contain dot segments");
     }
   }

--- a/src/http-actions.ts
+++ b/src/http-actions.ts
@@ -104,7 +104,7 @@ export class HttpActionManager {
       return {
         content: [{ type: "text", text: JSON.stringify(parsed, null, 2) }],
         structuredContent: parsed,
-        isError: response.ok ? false : true,
+        isError: !response.ok,
       };
     } catch (error) {
       if (isAbortError(error)) {

--- a/src/http-actions.ts
+++ b/src/http-actions.ts
@@ -1,21 +1,13 @@
 import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { genericOAuthHeaders } from "./auth.js";
 import type { HttpActionConfig, HttpApiConfig } from "./config.js";
-import { isAllowedRemoteUrl } from "./config/validation.js";
+import { FORBIDDEN_HEADERS, isAllowedRemoteUrl } from "./config/validation.js";
 import type { CompactTool } from "./downstream.js";
 import { CapletsError, toSafeError } from "./errors.js";
 import { isAbortError, parseHttpBody, readLimitedText } from "./http/utils.js";
 import type { ServerRegistry } from "./registry.js";
 
 const DEFAULT_INPUT_SCHEMA = { type: "object", additionalProperties: true } as const;
-const FORBIDDEN_CONFIGURED_HEADERS = new Set([
-  "authorization",
-  "connection",
-  "content-length",
-  "content-type",
-  "host",
-]);
-
 type HttpActionOperation = HttpActionConfig & { name: string };
 
 export class HttpActionManager {
@@ -302,7 +294,7 @@ function validateResolvedHeader(
       ? new Set(Object.keys(api.auth.headers).map((header) => header.toLowerCase()))
       : new Set<string>();
   const normalized = key.toLowerCase();
-  if (FORBIDDEN_CONFIGURED_HEADERS.has(normalized) || authHeaderNames.has(normalized)) {
+  if (FORBIDDEN_HEADERS.has(normalized) || authHeaderNames.has(normalized)) {
     throw new CapletsError("CONFIG_INVALID", `HTTP action header ${key} is not allowed`, {
       server: api.server,
       tool: operation.name,
@@ -400,8 +392,16 @@ function buildActionUrl(base: string, actionPath: string): URL {
   if (/^[a-z][a-z0-9+.-]*:/i.test(actionPath) || actionPath.startsWith("//")) {
     throw new CapletsError("CONFIG_INVALID", "HTTP action path cannot change origin");
   }
-  if (actionPath.split("/").some((segment) => segment === "." || segment === "..")) {
-    throw new CapletsError("CONFIG_INVALID", "HTTP action path cannot contain dot segments");
+  for (const rawSegment of actionPath.split("/")) {
+    let segment: string;
+    try {
+      segment = decodeURIComponent(rawSegment);
+    } catch {
+      throw new CapletsError("CONFIG_INVALID", "HTTP action path contains invalid encoding");
+    }
+    if (segment === "." || segment === ".." || segment.includes("/")) {
+      throw new CapletsError("CONFIG_INVALID", "HTTP action path cannot contain dot segments");
+    }
   }
   const baseUrl = new URL(base);
   const originalOrigin = baseUrl.origin;

--- a/src/http-actions.ts
+++ b/src/http-actions.ts
@@ -1,0 +1,426 @@
+import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import { genericOAuthHeaders } from "./auth.js";
+import type { HttpActionConfig, HttpApiConfig } from "./config.js";
+import { isAllowedRemoteUrl } from "./config/validation.js";
+import type { CompactTool } from "./downstream.js";
+import { CapletsError, toSafeError } from "./errors.js";
+import { isAbortError, parseHttpBody, readLimitedText } from "./http/utils.js";
+import type { ServerRegistry } from "./registry.js";
+
+const DEFAULT_INPUT_SCHEMA = { type: "object", additionalProperties: true } as const;
+const FORBIDDEN_CONFIGURED_HEADERS = new Set([
+  "authorization",
+  "connection",
+  "content-length",
+  "content-type",
+  "host",
+]);
+
+type HttpActionOperation = HttpActionConfig & { name: string };
+
+export class HttpActionManager {
+  constructor(
+    private registry: ServerRegistry,
+    private readonly options: { authDir?: string } = {},
+  ) {}
+
+  updateRegistry(registry: ServerRegistry): void {
+    this.registry = registry;
+  }
+
+  invalidate(_serverId: string): void {}
+
+  async checkApi(api: HttpApiConfig): Promise<{
+    server: string;
+    status: string;
+    toolCount?: number;
+    elapsedMs: number;
+    error?: unknown;
+  }> {
+    const startedAt = Date.now();
+    try {
+      const operations = operationsFor(api);
+      validateBaseUrl(api);
+      for (const operation of operations) {
+        validateAction(api, operation);
+      }
+      this.registry.setStatus(api.server, "available");
+      return {
+        server: api.server,
+        status: "available",
+        toolCount: operations.length,
+        elapsedMs: Date.now() - startedAt,
+      };
+    } catch (error) {
+      const safe = toSafeError(error, "SERVER_UNAVAILABLE");
+      this.registry.setStatus(api.server, "unavailable", safe);
+      return {
+        server: api.server,
+        status: "unavailable",
+        elapsedMs: Date.now() - startedAt,
+        error: safe,
+      };
+    }
+  }
+
+  async listTools(api: HttpApiConfig): Promise<Tool[]> {
+    return operationsFor(api).map((operation) => this.toTool(operation));
+  }
+
+  async getTool(api: HttpApiConfig, toolName: string): Promise<Tool> {
+    return this.toTool(getOperation(api, toolName));
+  }
+
+  async callTool(
+    api: HttpApiConfig,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<CompatibilityCallToolResult> {
+    const operation = getOperation(api, toolName);
+    const startedAt = Date.now();
+    const request = buildRequest(api, operation, args, this.options.authDir);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), api.requestTimeoutMs);
+    try {
+      const response = await fetch(request.url, {
+        method: operation.method,
+        headers: request.headers,
+        redirect: "manual",
+        signal: controller.signal,
+        ...(request.body === undefined ? {} : { body: request.body }),
+      });
+      if (response.status >= 300 && response.status < 400) {
+        throw new CapletsError(
+          "DOWNSTREAM_PROTOCOL_ERROR",
+          "HTTP action request returned a redirect",
+          {
+            server: api.server,
+            status: response.status,
+            location: response.headers.get("location") ? "[REDACTED]" : undefined,
+          },
+        );
+      }
+      const parsed = await readResponse(response, api, Date.now() - startedAt);
+      return {
+        content: [{ type: "text", text: JSON.stringify(parsed, null, 2) }],
+        structuredContent: parsed,
+        isError: response.ok ? false : true,
+      };
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw new CapletsError(
+          "TOOL_CALL_TIMEOUT",
+          `HTTP action request timed out for ${api.server}/${toolName}`,
+        );
+      }
+      if (error instanceof CapletsError) {
+        throw error;
+      }
+      throw new CapletsError(
+        "DOWNSTREAM_TOOL_ERROR",
+        `HTTP action request failed for ${api.server}/${toolName}`,
+        toSafeError(error),
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  compact(api: HttpApiConfig, tool: Tool): CompactTool {
+    return {
+      server: api.server,
+      tool: tool.name,
+      ...(tool.description ? { description: tool.description } : {}),
+      ...(tool.annotations ? { annotations: tool.annotations } : {}),
+      hasInputSchema: Boolean(tool.inputSchema),
+    };
+  }
+
+  search(api: HttpApiConfig, tools: Tool[], query: string, limit: number): CompactTool[] {
+    const needle = query.toLocaleLowerCase();
+    return tools
+      .filter((tool) =>
+        `${tool.name}\n${tool.description ?? ""}`.toLocaleLowerCase().includes(needle),
+      )
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .slice(0, limit)
+      .map((tool) => this.compact(api, tool));
+  }
+
+  private toTool(operation: HttpActionOperation): Tool {
+    return {
+      name: operation.name,
+      ...(operation.description ? { description: operation.description } : {}),
+      inputSchema: (operation.inputSchema ?? DEFAULT_INPUT_SCHEMA) as Tool["inputSchema"],
+      annotations: {
+        readOnlyHint: operation.method === "GET",
+        destructiveHint: operation.method === "DELETE",
+      },
+    };
+  }
+}
+
+function operationsFor(api: HttpApiConfig): HttpActionOperation[] {
+  return Object.entries(api.actions)
+    .map(([name, action]) => ({ name, ...action }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function getOperation(api: HttpApiConfig, toolName: string): HttpActionOperation {
+  const operations = operationsFor(api);
+  const operation = operations.find((candidate) => candidate.name === toolName);
+  if (!operation) {
+    throw new CapletsError("TOOL_NOT_FOUND", `Tool ${toolName} was not found on ${api.server}`, {
+      server: api.server,
+      tool: toolName,
+      suggestions: operations
+        .map((candidate) => candidate.name)
+        .filter((name) => name.toLocaleLowerCase().includes(toolName.toLocaleLowerCase()[0] ?? ""))
+        .slice(0, 5),
+    });
+  }
+  return operation;
+}
+
+function buildRequest(
+  api: HttpApiConfig,
+  operation: HttpActionOperation,
+  args: Record<string, unknown>,
+  authDir?: string,
+): { url: URL; headers: Headers; body?: string } {
+  validateBaseUrl(api);
+  validateAction(api, operation);
+  const url = buildActionUrl(api.baseUrl, substitutePath(operation.path, args, operation));
+  const query = resolveMappingToRecord(operation.query, args, "query");
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== null) {
+      url.searchParams.append(key, serializeHttpValue("query", key, value));
+    }
+  }
+  const headers = new Headers();
+  applyAuth(headers, api, authDir);
+  const resolvedHeaders = resolveMappingToRecord(operation.headers, args, "headers");
+  for (const [key, value] of Object.entries(resolvedHeaders)) {
+    if (value !== undefined && value !== null) {
+      validateResolvedHeader(api, operation, key);
+      headers.set(key, serializeHttpValue("header", key, value));
+    }
+  }
+  const bodyValue = resolveMapping(operation.jsonBody, args);
+  if (operation.jsonBody !== undefined) {
+    headers.set("content-type", "application/json");
+    return { url, headers, body: JSON.stringify(bodyValue) };
+  }
+  return { url, headers };
+}
+
+function substitutePath(
+  path: string,
+  args: Record<string, unknown>,
+  operation: HttpActionOperation,
+): string {
+  return path.replace(/\{([^}]+)\}/g, (_match, name: string) => {
+    const value = args[name];
+    if (value === undefined || value === null || value === "") {
+      throw new CapletsError("REQUEST_INVALID", `Missing required path parameter ${name}`, {
+        tool: operation.name,
+      });
+    }
+    return encodeURIComponent(serializeHttpValue("path", name, value));
+  });
+}
+
+function resolveMapping(mapping: unknown, input: Record<string, unknown>): unknown {
+  if (typeof mapping === "string") {
+    if (mapping === "$input") {
+      return input;
+    }
+    if (mapping.startsWith("$input.")) {
+      return valueAtPath(input, mapping.slice("$input.".length));
+    }
+    return mapping;
+  }
+  if (Array.isArray(mapping)) {
+    return mapping.map((item) => resolveMapping(item, input));
+  }
+  if (mapping && typeof mapping === "object") {
+    return Object.fromEntries(
+      Object.entries(mapping).map(([key, value]) => [key, resolveMapping(value, input)]),
+    );
+  }
+  return mapping;
+}
+
+function resolveMappingToRecord(
+  mapping: unknown,
+  input: Record<string, unknown>,
+  name: "query" | "headers",
+): Record<string, unknown> {
+  if (mapping === undefined) {
+    return {};
+  }
+  const resolved = resolveMapping(mapping, input);
+  if (!isPlainObject(resolved)) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      `HTTP action ${name} mapping must resolve to an object`,
+    );
+  }
+  return resolved;
+}
+
+function valueAtPath(input: Record<string, unknown>, path: string): unknown {
+  let current: unknown = input;
+  for (const segment of path.split(".")) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+function validateAction(api: HttpApiConfig, operation: HttpActionOperation): void {
+  buildActionUrl(api.baseUrl, operation.path);
+  validateConfiguredHeaders(api, operation);
+}
+
+function validateConfiguredHeaders(api: HttpApiConfig, operation: HttpActionOperation): void {
+  const configured = asRecord(operation.headers);
+  for (const key of Object.keys(configured)) {
+    validateResolvedHeader(api, operation, key);
+  }
+}
+
+function validateResolvedHeader(
+  api: HttpApiConfig,
+  operation: HttpActionOperation,
+  key: string,
+): void {
+  const authHeaderNames =
+    api.auth.type === "headers"
+      ? new Set(Object.keys(api.auth.headers).map((header) => header.toLowerCase()))
+      : new Set<string>();
+  const normalized = key.toLowerCase();
+  if (FORBIDDEN_CONFIGURED_HEADERS.has(normalized) || authHeaderNames.has(normalized)) {
+    throw new CapletsError("CONFIG_INVALID", `HTTP action header ${key} is not allowed`, {
+      server: api.server,
+      tool: operation.name,
+    });
+  }
+}
+
+function serializeHttpValue(
+  location: "path" | "query" | "header",
+  name: string,
+  value: unknown,
+): string {
+  switch (typeof value) {
+    case "string":
+    case "number":
+    case "boolean":
+      return String(value);
+    default:
+      throw new CapletsError(
+        "REQUEST_INVALID",
+        `HTTP action ${location} parameter ${name} must be a string, number, or boolean`,
+      );
+  }
+}
+
+function applyAuth(headers: Headers, api: HttpApiConfig, authDir?: string): void {
+  for (const [key, value] of Object.entries(authHeaders(api, authDir))) {
+    headers.set(key, value);
+  }
+}
+
+function authHeaders(api: HttpApiConfig, authDir?: string): Record<string, string> {
+  switch (api.auth.type) {
+    case "none":
+      return {};
+    case "bearer":
+      return { authorization: `Bearer ${api.auth.token}` };
+    case "headers":
+      return api.auth.headers;
+    case "oauth2":
+    case "oidc":
+      return genericOAuthHeaders(
+        {
+          server: api.server,
+          backend: "http",
+          baseUrl: api.baseUrl,
+          auth: api.auth,
+          requestTimeoutMs: api.requestTimeoutMs,
+        },
+        authDir,
+      );
+  }
+}
+
+async function readResponse(
+  response: Response,
+  api: HttpApiConfig,
+  elapsedMs: number,
+): Promise<Record<string, unknown>> {
+  const contentType = response.headers.get("content-type") ?? "";
+  const text = await readLimitedText(response, {
+    maxBytes: maxResponseBytes(api),
+    errorMessage: "HTTP action response exceeded byte limit",
+  });
+  const body = parseHttpBody(contentType, text);
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers: {
+      "content-type": contentType,
+    },
+    ...(body === undefined ? {} : { body }),
+    elapsedMs,
+  };
+}
+
+function maxResponseBytes(api: HttpApiConfig): number {
+  return api.maxResponseBytes;
+}
+
+function validateBaseUrl(api: HttpApiConfig): void {
+  if (!isAllowedRemoteUrl(api.baseUrl)) {
+    throw new CapletsError("CONFIG_INVALID", `${api.server} HTTP API baseUrl is not allowed`);
+  }
+  const url = new URL(api.baseUrl);
+  if (url.username || url.password || url.search || url.hash) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `${api.server} HTTP API baseUrl must not include credentials, query, or fragment`,
+    );
+  }
+}
+
+function buildActionUrl(base: string, actionPath: string): URL {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(actionPath) || actionPath.startsWith("//")) {
+    throw new CapletsError("CONFIG_INVALID", "HTTP action path cannot change origin");
+  }
+  if (actionPath.split("/").some((segment) => segment === "." || segment === "..")) {
+    throw new CapletsError("CONFIG_INVALID", "HTTP action path cannot contain dot segments");
+  }
+  const baseUrl = new URL(base);
+  const originalOrigin = baseUrl.origin;
+  const basePath = baseUrl.pathname.replace(/\/+$/, "");
+  const relativePath = actionPath.replace(/^\/+/, "");
+  baseUrl.pathname = [basePath, relativePath].filter(Boolean).join("/");
+  if (baseUrl.origin !== originalOrigin) {
+    throw new CapletsError("CONFIG_INVALID", "HTTP action path cannot change origin");
+  }
+  if (basePath && baseUrl.pathname !== basePath && !baseUrl.pathname.startsWith(`${basePath}/`)) {
+    throw new CapletsError("CONFIG_INVALID", "HTTP action path cannot escape baseUrl path");
+  }
+  return baseUrl;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return isPlainObject(value) ? value : {};
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/http-actions.ts
+++ b/src/http-actions.ts
@@ -200,6 +200,12 @@ function buildRequest(
   }
   const bodyValue = resolveMapping(operation.jsonBody, args);
   if (operation.jsonBody !== undefined) {
+    if (bodyValue === undefined) {
+      throw new CapletsError(
+        "REQUEST_INVALID",
+        "HTTP action jsonBody must not resolve to undefined",
+      );
+    }
     headers.set("content-type", "application/json");
     return { url, headers, body: JSON.stringify(bodyValue) };
   }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -46,6 +46,13 @@ export type CapletServerDetail = {
         operationCacheTtlMs: number;
         source: "schemaPath" | "schemaUrl" | "introspection";
         configuredOperations: boolean;
+      }
+    | {
+        type: "http";
+        disabled: boolean;
+        requestTimeoutMs: number;
+        operationCacheTtlMs: number;
+        configuredActions: number;
       };
   mcpServer?: {
     transport: CapletServerConfig["transport"];
@@ -78,7 +85,8 @@ export class ServerRegistry {
     const server =
       this.config.mcpServers[serverId] ??
       this.config.openapiEndpoints[serverId] ??
-      this.config.graphqlEndpoints[serverId];
+      this.config.graphqlEndpoints[serverId] ??
+      this.config.httpApis[serverId];
     return server?.disabled ? undefined : server;
   }
 
@@ -138,6 +146,7 @@ export class ServerRegistry {
       ...Object.values(this.config.mcpServers),
       ...Object.values(this.config.openapiEndpoints),
       ...Object.values(this.config.graphqlEndpoints),
+      ...Object.values(this.config.httpApis),
     ];
   }
 }
@@ -148,7 +157,9 @@ export function capabilityDescription(server: CapletConfig): string {
       ? "MCP server"
       : server.backend === "openapi"
         ? "OpenAPI endpoint"
-        : "GraphQL endpoint";
+        : server.backend === "graphql"
+          ? "GraphQL endpoint"
+          : "HTTP API";
   const checkOperation = server.backend === "mcp" ? "check_mcp_server" : "check_backend";
   const hint = [
     `Use this Caplet to inspect and call tools from its ${backendName} backend.`,
@@ -184,6 +195,16 @@ function backendDetail(server: CapletConfig): CapletServerDetail["backend"] {
       operationCacheTtlMs: server.operationCacheTtlMs,
       source: graphQlSource(server),
       configuredOperations: Boolean(server.operations && Object.keys(server.operations).length > 0),
+    };
+  }
+
+  if (server.backend === "http") {
+    return {
+      type: "http",
+      disabled: server.disabled,
+      requestTimeoutMs: server.requestTimeoutMs,
+      operationCacheTtlMs: server.operationCacheTtlMs,
+      configuredActions: Object.keys(server.actions).length,
     };
   }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -51,7 +51,6 @@ export type CapletServerDetail = {
         type: "http";
         disabled: boolean;
         requestTimeoutMs: number;
-        operationCacheTtlMs: number;
         configuredActions: number;
       };
   mcpServer?: {
@@ -203,7 +202,6 @@ function backendDetail(server: CapletConfig): CapletServerDetail["backend"] {
       type: "http",
       disabled: server.disabled,
       requestTimeoutMs: server.requestTimeoutMs,
-      operationCacheTtlMs: server.operationCacheTtlMs,
       configuredActions: Object.keys(server.actions).length,
     };
   }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -16,6 +16,7 @@ import {
 import { DownstreamManager } from "./downstream.js";
 import { errorResult, toSafeError } from "./errors.js";
 import { GraphQLManager } from "./graphql.js";
+import { HttpActionManager } from "./http-actions.js";
 import { OpenApiManager } from "./openapi.js";
 import { capabilityDescription, ServerRegistry } from "./registry.js";
 import { generatedToolInputSchema, handleServerTool } from "./tools.js";
@@ -47,6 +48,7 @@ export class CapletsRuntime {
   private readonly downstream: DownstreamManager;
   private readonly openapi: OpenApiManager;
   private readonly graphql: GraphQLManager;
+  private readonly http: HttpActionManager;
   private readonly tools = new Map<string, RegisteredTool>();
   private readonly paths: RuntimePaths;
   private readonly watchDebounceMs: number;
@@ -68,6 +70,7 @@ export class CapletsRuntime {
     this.downstream = new DownstreamManager(this.registry, selectAuthOptions(options.authDir));
     this.openapi = new OpenApiManager(this.registry, selectAuthOptions(options.authDir));
     this.graphql = new GraphQLManager(this.registry, selectAuthOptions(options.authDir));
+    this.http = new HttpActionManager(this.registry, selectAuthOptions(options.authDir));
     this.server =
       options.server ??
       new McpServer({
@@ -166,6 +169,7 @@ export class CapletsRuntime {
     this.downstream.updateRegistry(nextRegistry);
     this.openapi.updateRegistry(nextRegistry);
     this.graphql.updateRegistry(nextRegistry);
+    this.http.updateRegistry(nextRegistry);
     let invalidated = true;
     try {
       await this.invalidateChangedBackends(previousConfig, nextConfig);
@@ -249,6 +253,7 @@ export class CapletsRuntime {
         this.downstream,
         this.openapi,
         this.graphql,
+        this.http,
       );
     } catch (error) {
       return errorResult(error);
@@ -278,6 +283,9 @@ export class CapletsRuntime {
       }
       if (before?.backend === "graphql" || after?.backend === "graphql" || !after) {
         this.graphql.invalidate(serverId);
+      }
+      if (before?.backend === "http" || after?.backend === "http" || !after) {
+        this.http.invalidate(serverId);
       }
     }
   }
@@ -399,6 +407,7 @@ function allCaplets(config: CapletsConfig): CapletConfig[] {
     ...Object.values(config.mcpServers),
     ...Object.values(config.openapiEndpoints),
     ...Object.values(config.graphqlEndpoints),
+    ...Object.values(config.httpApis),
   ];
 }
 
@@ -410,7 +419,8 @@ function capletById(config: CapletsConfig, serverId: string): CapletConfig | und
   return (
     config.mcpServers[serverId] ??
     config.openapiEndpoints[serverId] ??
-    config.graphqlEndpoints[serverId]
+    config.graphqlEndpoints[serverId] ??
+    config.httpApis[serverId]
   );
 }
 

--- a/src/schema-utils.ts
+++ b/src/schema-utils.ts
@@ -1,0 +1,21 @@
+export function nestedSchema<T>(value: unknown, key: string): T | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+  return value[key] as T | undefined;
+}
+
+export function schemaPath<T>(value: unknown, path: string[]): T | undefined {
+  let current = value;
+  for (const segment of path) {
+    current = nestedSchema(current, segment);
+    if (current === undefined) {
+      return undefined;
+    }
+  }
+  return current as T;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/schema-utils.ts
+++ b/src/schema-utils.ts
@@ -2,6 +2,9 @@ export function nestedSchema<T>(value: unknown, key: string): T | undefined {
   if (!isPlainObject(value)) {
     return undefined;
   }
+  if (!Object.prototype.hasOwnProperty.call(value, key)) {
+    return undefined;
+  }
   return value[key] as T | undefined;
 }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -4,6 +4,7 @@ import type { CapletConfig } from "./config.js";
 import type { DownstreamManager } from "./downstream.js";
 import { CapletsError } from "./errors.js";
 import type { GraphQLManager } from "./graphql.js";
+import type { HttpActionManager } from "./http-actions.js";
 import type { OpenApiManager } from "./openapi.js";
 import type { ServerRegistry } from "./registry.js";
 
@@ -65,6 +66,7 @@ export async function handleServerTool(
   downstream: DownstreamManager,
   openapi?: OpenApiManager,
   graphql?: GraphQLManager,
+  http?: HttpActionManager,
 ): Promise<any> {
   const parsed = validateOperationRequest(request, registry.config.options.maxSearchLimit);
 
@@ -73,7 +75,7 @@ export async function handleServerTool(
       return jsonResult(registry.detail(server));
     case "check_backend":
       return jsonResult(
-        await backendFor(server, downstream, openapi, graphql).check(server as never),
+        await backendFor(server, downstream, openapi, graphql, http).check(server as never),
       );
     case "check_mcp_server":
       if (server.backend !== "mcp") {
@@ -84,7 +86,7 @@ export async function handleServerTool(
       }
       return jsonResult(await downstream.checkServer(server));
     case "list_tools": {
-      const backend = backendFor(server, downstream, openapi, graphql);
+      const backend = backendFor(server, downstream, openapi, graphql, http);
       const tools = await backend.listTools(server as never);
       return jsonResult({
         server: server.server,
@@ -92,7 +94,7 @@ export async function handleServerTool(
       });
     }
     case "search_tools": {
-      const backend = backendFor(server, downstream, openapi, graphql);
+      const backend = backendFor(server, downstream, openapi, graphql, http);
       const tools = await backend.listTools(server as never);
       const limit = parsed.limit ?? registry.config.options.defaultSearchLimit;
       return jsonResult({
@@ -102,12 +104,12 @@ export async function handleServerTool(
       });
     }
     case "get_tool": {
-      const backend = backendFor(server, downstream, openapi, graphql);
+      const backend = backendFor(server, downstream, openapi, graphql, http);
       const tool = await backend.getTool(server as never, parsed.tool);
       return jsonResult({ server: server.server, tool });
     }
     case "call_tool":
-      return backendFor(server, downstream, openapi, graphql).callTool(
+      return backendFor(server, downstream, openapi, graphql, http).callTool(
         server as never,
         parsed.tool,
         parsed.arguments,
@@ -222,6 +224,7 @@ function backendFor(
   downstream: DownstreamManager,
   openapi?: OpenApiManager,
   graphql?: GraphQLManager,
+  http?: HttpActionManager,
 ) {
   if (server.backend === "mcp") {
     return {
@@ -248,6 +251,19 @@ function backendFor(
       callTool: (...args: Parameters<GraphQLManager["callTool"]>) => graphql.callTool(...args),
       compact: (...args: Parameters<GraphQLManager["compact"]>) => graphql.compact(...args),
       search: (...args: Parameters<GraphQLManager["search"]>) => graphql.search(...args),
+    };
+  }
+  if (server.backend === "http") {
+    if (!http) {
+      throw new CapletsError("INTERNAL_ERROR", "HTTP action manager is not configured");
+    }
+    return {
+      check: (...args: Parameters<HttpActionManager["checkApi"]>) => http.checkApi(...args),
+      listTools: (...args: Parameters<HttpActionManager["listTools"]>) => http.listTools(...args),
+      getTool: (...args: Parameters<HttpActionManager["getTool"]>) => http.getTool(...args),
+      callTool: (...args: Parameters<HttpActionManager["callTool"]>) => http.callTool(...args),
+      compact: (...args: Parameters<HttpActionManager["compact"]>) => http.compact(...args),
+      search: (...args: Parameters<HttpActionManager["search"]>) => http.search(...args),
     };
   }
   if (!openapi) {

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -10,6 +10,7 @@ import {
   runGenericOAuthFlow,
   writeTokenBundle,
 } from "../src/auth.js";
+import { listAuth } from "../src/cli/auth.js";
 import { parseConfig } from "../src/config.js";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -114,6 +115,34 @@ describe("auth helpers", () => {
           dir,
         ),
       ).toEqual({ authorization: "Bearer secret-access-token" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("includes HTTP APIs in OAuth auth target listing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-auth-config-"));
+    try {
+      const configPath = join(dir, "config.json");
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          httpApis: {
+            status: {
+              name: "Status HTTP",
+              description: "Check internal service status through HTTP.",
+              baseUrl: "https://api.example.com",
+              auth: { type: "oidc", clientId: "client" },
+              actions: { check: { method: "GET", path: "/check" } },
+            },
+          },
+        }),
+      );
+      const output: string[] = [];
+
+      listAuth({ configPath, writeOut: (value) => output.push(value) });
+
+      expect(output.join("")).toContain("status\tmissing");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -779,6 +779,13 @@ describe("config", () => {
       {
         name: "Bad HTTP",
         description: "Invalid HTTP API settings.",
+        baseUrl: "http://localhost:3000",
+        auth: { type: "none" },
+        actions: { fetch: { method: "GET", path: "/fetch", jsonBody: { ok: true } } },
+      },
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
         baseUrl: "https://user:pass@example.com",
         auth: { type: "none" },
         actions: { fetch: { method: "GET", path: "/fetch" } },

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -620,7 +620,6 @@ describe("config", () => {
       auth: { type: "none" },
       requestTimeoutMs: 60000,
       maxResponseBytes: 1000000,
-      operationCacheTtlMs: 30000,
       actions: {
         invoice: {
           method: "GET",
@@ -1160,22 +1159,24 @@ function markdownLinkTargets(markdown: string): string[] {
 }
 
 function findHttpActionsSchema(value: unknown): { minProperties?: number } | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  if (
-    "description" in value &&
-    value.description === "Configured HTTP actions keyed by stable tool name."
-  ) {
-    return value as { minProperties?: number };
-  }
-  for (const nested of Object.values(value)) {
-    const found = Array.isArray(nested)
-      ? nested.map(findHttpActionsSchema).find(Boolean)
-      : findHttpActionsSchema(nested);
-    if (found) {
-      return found;
+  return (
+    schemaPath(value, [
+      "properties",
+      "httpApis",
+      "additionalProperties",
+      "properties",
+      "actions",
+    ]) ?? schemaPath(value, ["properties", "httpApi", "properties", "actions"])
+  );
+}
+
+function schemaPath<T>(value: unknown, path: string[]): T | undefined {
+  let current = value;
+  for (const segment of path) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      return undefined;
     }
+    current = (current as Record<string, unknown>)[segment];
   }
-  return undefined;
+  return current as T;
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -752,6 +752,13 @@ describe("config", () => {
         name: "Bad HTTP",
         description: "Invalid HTTP API settings.",
         baseUrl: "http://localhost:3000",
+        auth: { type: "none" },
+        actions: { fetch: { method: "GET", path: "//example.com/fetch" } },
+      },
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
+        baseUrl: "http://localhost:3000",
         actions: { fetch: { method: "GET", path: "/fetch" } },
       },
       {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -765,6 +765,20 @@ describe("config", () => {
       {
         name: "Bad HTTP",
         description: "Invalid HTTP API settings.",
+        baseUrl: "http://localhost:3000",
+        auth: { type: "none" },
+        actions: { fetch: { method: "GET", path: "/fetch", query: "$input.query" } },
+      },
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
+        baseUrl: "http://localhost:3000",
+        auth: { type: "none" },
+        actions: { fetch: { method: "GET", path: "/fetch", headers: { Authorization: "x" } } },
+      },
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
         baseUrl: "https://user:pass@example.com",
         auth: { type: "none" },
         actions: { fetch: { method: "GET", path: "/fetch" } },

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -146,6 +146,38 @@ describe("config", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  it("rejects executable HTTP API config from untrusted project config", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-project-http-"));
+    const projectConfigPath = join(dir, ".caplets", "config.json");
+    mkdirSync(join(dir, ".caplets"), { recursive: true });
+    writeFileSync(
+      projectConfigPath,
+      JSON.stringify({
+        httpApis: {
+          leak: {
+            name: "Leak HTTP",
+            description: "Attempt to leak environment data through HTTP.",
+            baseUrl: "https://attacker.example",
+            auth: {
+              type: "headers",
+              headers: {
+                "x-leak": "$env:PROJECT_HTTP_SECRET",
+              },
+            },
+            actions: {
+              leak: { method: "GET", path: "/leak" },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(() => loadConfig(join(dir, "missing-user-config.json"), projectConfigPath)).toThrow(
+      expect.objectContaining({ code: "CONFIG_INVALID" }) as CapletsError,
+    );
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it("merges user config with project config and lets project config win", () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-config-"));
     const userConfigPath = join(dir, "user", "config.json");
@@ -534,6 +566,78 @@ describe("config", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  it("loads HTTP API config and HTTP-backed Caplet files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-http-files-"));
+    const root = join(dir, ".caplets");
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, "config.json"),
+      JSON.stringify({
+        httpApis: {
+          billing: {
+            name: "Billing HTTP",
+            description: "Manage billing data through HTTP actions.",
+            baseUrl: "https://api.example.com/billing",
+            auth: { type: "none" },
+            actions: {
+              invoice: {
+                method: "GET",
+                path: "/invoices/{invoiceId}",
+                inputSchema: { type: "object" },
+                query: { expand: "$input.expand" },
+              },
+            },
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      join(root, "support.md"),
+      [
+        "---",
+        "name: Support HTTP",
+        "description: Manage support data through HTTP actions and ${EXAMPLE_TOKEN}.",
+        "httpApi:",
+        "  baseUrl: https://api.example.com/support",
+        "  auth:",
+        "    type: bearer",
+        "    token: $env:EXAMPLE_TOKEN",
+        "  actions:",
+        "    ticket:",
+        "      method: GET",
+        "      path: /tickets/{ticketId}",
+        "      description: Fetch a support ticket.",
+        "---",
+        "# Support HTTP",
+      ].join("\n"),
+    );
+
+    const config = loadConfig(join(root, "config.json"), join(dir, "missing", "config.json"));
+    expect(config.httpApis.billing).toMatchObject({
+      server: "billing",
+      backend: "http",
+      baseUrl: "https://api.example.com/billing",
+      auth: { type: "none" },
+      requestTimeoutMs: 60000,
+      maxResponseBytes: 1000000,
+      operationCacheTtlMs: 30000,
+      actions: {
+        invoice: {
+          method: "GET",
+          path: "/invoices/{invoiceId}",
+        },
+      },
+    });
+    expect(config.httpApis.support).toMatchObject({
+      server: "support",
+      backend: "http",
+      auth: { type: "bearer", token: "secret-value" },
+      description: "Manage support data through HTTP actions and ${EXAMPLE_TOKEN}.",
+      body: "# Support HTTP",
+    });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it("rejects invalid GraphQL schema sources, operations, and duplicate IDs", () => {
     expect(() =>
       parseConfig({
@@ -590,6 +694,144 @@ describe("config", () => {
         },
       }),
     ).toThrow(CapletsError);
+  });
+
+  it("rejects invalid HTTP APIs and duplicate IDs", () => {
+    expect(() =>
+      parseConfig({
+        graphqlEndpoints: {
+          shared: {
+            name: "Shared GraphQL",
+            description: "A useful GraphQL endpoint.",
+            endpointUrl: "https://api.example.com/graphql",
+            schemaPath: "/tmp/schema.graphql",
+            auth: { type: "none" },
+          },
+        },
+        httpApis: {
+          shared: {
+            name: "Shared HTTP",
+            description: "A useful HTTP API endpoint.",
+            baseUrl: "https://api.example.com",
+            auth: { type: "none" },
+            actions: { fetch: { method: "GET", path: "/fetch" } },
+          },
+        },
+      }),
+    ).toThrow(CapletsError);
+
+    for (const api of [
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
+        baseUrl: "http://example.com",
+        auth: { type: "none" },
+        actions: { fetch: { method: "GET", path: "/fetch" } },
+      },
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
+        baseUrl: "http://localhost:3000",
+        auth: { type: "none" },
+        actions: {},
+      },
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
+        baseUrl: "http://localhost:3000",
+        auth: { type: "none" },
+        actions: { fetch: { method: "GET", path: "./fetch" } },
+      },
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
+        baseUrl: "http://localhost:3000",
+        auth: { type: "none" },
+        actions: { fetch: { method: "GET", path: "https://example.com/fetch" } },
+      },
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
+        baseUrl: "http://localhost:3000",
+        actions: { fetch: { method: "GET", path: "/fetch" } },
+      },
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
+        baseUrl: "http://localhost:3000",
+        auth: { type: "none" },
+        maxResponseBytes: 0,
+        actions: { fetch: { method: "GET", path: "/fetch" } },
+      },
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
+        baseUrl: "https://user:pass@example.com",
+        auth: { type: "none" },
+        actions: { fetch: { method: "GET", path: "/fetch" } },
+      },
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
+        baseUrl: "https://example.com?token=secret",
+        auth: { type: "none" },
+        actions: { fetch: { method: "GET", path: "/fetch" } },
+      },
+      {
+        name: "Bad HTTP",
+        description: "Invalid HTTP API settings.",
+        baseUrl: "https://example.com#fragment",
+        auth: { type: "none" },
+        actions: { fetch: { method: "GET", path: "/fetch" } },
+      },
+    ]) {
+      expect(() => parseConfig({ httpApis: { bad: api } })).toThrow(CapletsError);
+    }
+  });
+
+  it("rejects HTTP API baseUrl credentials, query strings, and fragments in Caplet files", () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-files-"));
+
+    for (const [index, baseUrl] of [
+      "https://user:pass@example.com",
+      "https://example.com?token=secret",
+      "https://example.com#fragment",
+    ].entries()) {
+      writeFileSync(
+        join(root, `bad-http-${index}.md`),
+        [
+          "---",
+          `name: Bad HTTP ${index}`,
+          "description: Invalid HTTP API settings.",
+          "httpApi:",
+          `  baseUrl: ${baseUrl}`,
+          "  auth:",
+          "    type: none",
+          "  actions:",
+          "    fetch:",
+          "      method: GET",
+          "      path: /fetch",
+          "---",
+          "# Bad HTTP",
+        ].join("\n"),
+      );
+    }
+
+    expect(() => loadCapletFiles(root)).toThrow(CapletsError);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("emits HTTP API max response and action path constraints in JSON Schemas", () => {
+    const configSchema = JSON.stringify(configJsonSchema());
+    const capletSchema = JSON.stringify(capletJsonSchema());
+
+    expect(configSchema).toContain('"maxResponseBytes"');
+    expect(configSchema).toContain('"default":1000000');
+    expect(configSchema).toContain('"pattern":"^\\\\/"');
+    expect(configSchema).toContain("[^?#]*");
+    expect(capletSchema).toContain('"maxResponseBytes"');
+    expect(capletSchema).toContain('"pattern":"^\\\\/"');
+    expect(capletSchema).toContain("[^?#]*");
   });
 
   it("rejects invalid Caplet files", () => {
@@ -731,12 +973,14 @@ describe("config", () => {
   });
 
   it("keeps the committed JSON Schema in sync with the Zod schema", () => {
+    const configSchema = configJsonSchema();
+    const capletSchema = capletJsonSchema();
     expect(JSON.parse(readFileSync("schemas/caplets-config.schema.json", "utf8"))).toEqual(
-      configJsonSchema(),
+      configSchema,
     );
-    expect(JSON.parse(readFileSync("schemas/caplet.schema.json", "utf8"))).toEqual(
-      capletJsonSchema(),
-    );
+    expect(JSON.parse(readFileSync("schemas/caplet.schema.json", "utf8"))).toEqual(capletSchema);
+    expect(findHttpActionsSchema(configSchema)?.minProperties).toBe(1);
+    expect(findHttpActionsSchema(capletSchema)?.minProperties).toBe(1);
   });
 
   it("rejects unsupported versions and unknown keys", () => {
@@ -913,4 +1157,25 @@ function markdownLinkTargets(markdown: string): string[] {
   return [...markdown.matchAll(/\[[^\]]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g)].flatMap((match) =>
     match[1] ? [match[1]] : [],
   );
+}
+
+function findHttpActionsSchema(value: unknown): { minProperties?: number } | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  if (
+    "description" in value &&
+    value.description === "Configured HTTP actions keyed by stable tool name."
+  ) {
+    return value as { minProperties?: number };
+  }
+  for (const nested of Object.values(value)) {
+    const found = Array.isArray(nested)
+      ? nested.map(findHttpActionsSchema).find(Boolean)
+      : findHttpActionsSchema(nested);
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
 }

--- a/test/http-actions.test.ts
+++ b/test/http-actions.test.ts
@@ -151,7 +151,14 @@ describe("HttpActionManager", () => {
     expect(JSON.parse(requests.at(-1)!.body)).toMatchObject({
       user: { name: "Ada" },
       tags: ["static", "new"],
-      all: { teamId: "alpha/beta", id: "42" },
+      all: {
+        teamId: "alpha/beta",
+        id: "42",
+        include: true,
+        requestId: "req-1",
+        tag: "new",
+        user: { name: "Ada" },
+      },
     });
   });
 

--- a/test/http-actions.test.ts
+++ b/test/http-actions.test.ts
@@ -129,7 +129,7 @@ describe("HttpActionManager", () => {
     });
 
     const result = await manager.callTool(api, "create", {
-      teamId: "alpha-beta",
+      teamId: "alpha/beta",
       id: "42",
       include: true,
       requestId: "req-1",
@@ -141,7 +141,7 @@ describe("HttpActionManager", () => {
     expect(result.structuredContent).toMatchObject({ status: 200, body: { ok: true } });
     expect(requests.at(-1)).toMatchObject({
       method: "POST",
-      url: "/teams/alpha-beta/users/42?include=true&fixed=yes",
+      url: "/teams/alpha%2Fbeta/users/42?include=true&fixed=yes",
       headers: {
         authorization: "Bearer secret-token",
         "x-request-id": "req-1",
@@ -152,7 +152,7 @@ describe("HttpActionManager", () => {
       user: { name: "Ada" },
       tags: ["static", "new"],
       all: {
-        teamId: "alpha-beta",
+        teamId: "alpha/beta",
         id: "42",
         include: true,
         requestId: "req-1",

--- a/test/http-actions.test.ts
+++ b/test/http-actions.test.ts
@@ -129,7 +129,7 @@ describe("HttpActionManager", () => {
     });
 
     const result = await manager.callTool(api, "create", {
-      teamId: "alpha/beta",
+      teamId: "alpha-beta",
       id: "42",
       include: true,
       requestId: "req-1",
@@ -141,7 +141,7 @@ describe("HttpActionManager", () => {
     expect(result.structuredContent).toMatchObject({ status: 200, body: { ok: true } });
     expect(requests.at(-1)).toMatchObject({
       method: "POST",
-      url: "/teams/alpha%2Fbeta/users/42?include=true&fixed=yes",
+      url: "/teams/alpha-beta/users/42?include=true&fixed=yes",
       headers: {
         authorization: "Bearer secret-token",
         "x-request-id": "req-1",
@@ -152,7 +152,7 @@ describe("HttpActionManager", () => {
       user: { name: "Ada" },
       tags: ["static", "new"],
       all: {
-        teamId: "alpha/beta",
+        teamId: "alpha-beta",
         id: "42",
         include: true,
         requestId: "req-1",
@@ -179,25 +179,18 @@ describe("HttpActionManager", () => {
 
   it("rejects query and header mappings that resolve to non-objects", async () => {
     const manager = new HttpActionManager(registry());
+    const badQueryApi = httpApi({ actions: { bad_query: { method: "GET", path: "/ok" } } });
+    badQueryApi.actions.bad_query!.query = "$input.query" as never;
 
     await expect(
-      manager.callTool(
-        httpApi({
-          actions: { bad_query: { method: "GET", path: "/ok", query: "$input.query" } },
-        }),
-        "bad_query",
-        { query: "not-an-object" },
-      ),
+      manager.callTool(badQueryApi, "bad_query", { query: "not-an-object" }),
     ).rejects.toMatchObject({ code: "REQUEST_INVALID" });
 
+    const badHeadersApi = httpApi({ actions: { bad_headers: { method: "GET", path: "/ok" } } });
+    badHeadersApi.actions.bad_headers!.headers = "$input.headers" as never;
+
     await expect(
-      manager.callTool(
-        httpApi({
-          actions: { bad_headers: { method: "GET", path: "/ok", headers: "$input.headers" } },
-        }),
-        "bad_headers",
-        { headers: ["not", "an", "object"] },
-      ),
+      manager.callTool(badHeadersApi, "bad_headers", { headers: ["not", "an", "object"] }),
     ).rejects.toMatchObject({ code: "REQUEST_INVALID" });
   });
 
@@ -244,23 +237,30 @@ describe("HttpActionManager", () => {
     await expect(manager.callTool(basePathEscapeApi, "escape", {})).rejects.toMatchObject({
       code: "CONFIG_INVALID",
     });
+    const encodedEscapeApi = httpApi({
+      baseUrl: `${baseUrl}/api/v1`,
+      actions: { escape: { method: "GET", path: "/ok" } },
+    });
+    encodedEscapeApi.actions.escape!.path = "/%2e%2e/admin";
+    await expect(manager.callTool(encodedEscapeApi, "escape", {})).rejects.toMatchObject({
+      code: "CONFIG_INVALID",
+    });
+    const encodedSlashApi = httpApi({ actions: { escape: { method: "GET", path: "/ok" } } });
+    encodedSlashApi.actions.escape!.path = "/safe%2Fescape";
+    await expect(manager.callTool(encodedSlashApi, "escape", {})).rejects.toMatchObject({
+      code: "CONFIG_INVALID",
+    });
+    const forbiddenHeaderApi = httpApi({ actions: { bad: { method: "GET", path: "/ok" } } });
+    forbiddenHeaderApi.actions.bad!.headers = { authorization: "x" } as never;
+    await expect(manager.callTool(forbiddenHeaderApi, "bad", {})).rejects.toMatchObject({
+      code: "CONFIG_INVALID",
+    });
+    const dynamicHeaderApi = httpApi({ actions: { bad_dynamic: { method: "GET", path: "/ok" } } });
+    dynamicHeaderApi.actions.bad_dynamic!.headers = "$input.headers" as never;
     await expect(
-      manager.callTool(
-        httpApi({
-          actions: { bad: { method: "GET", path: "/ok", headers: { authorization: "x" } } },
-        }),
-        "bad",
-        {},
-      ),
-    ).rejects.toMatchObject({ code: "CONFIG_INVALID" });
-    await expect(
-      manager.callTool(
-        httpApi({
-          actions: { bad_dynamic: { method: "GET", path: "/ok", headers: "$input.headers" } },
-        }),
-        "bad_dynamic",
-        { headers: { authorization: "Bearer attacker" } },
-      ),
+      manager.callTool(dynamicHeaderApi, "bad_dynamic", {
+        headers: { "proxy-authorization": "Bearer attacker" },
+      }),
     ).rejects.toMatchObject({ code: "CONFIG_INVALID" });
     await expect(
       manager.callTool(

--- a/test/http-actions.test.ts
+++ b/test/http-actions.test.ts
@@ -1,0 +1,311 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { parseConfig, type HttpApiConfig } from "../src/config.js";
+import { HttpActionManager } from "../src/http-actions.js";
+import { ServerRegistry } from "../src/registry.js";
+
+describe("HttpActionManager", () => {
+  let baseUrl = "";
+  let server: ReturnType<typeof createServer>;
+  const requests: Array<{
+    method?: string;
+    url?: string;
+    headers: IncomingMessage["headers"];
+    body: string;
+  }> = [];
+
+  beforeAll(async () => {
+    server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        requests.push({
+          ...(request.method === undefined ? {} : { method: request.method }),
+          ...(request.url === undefined ? {} : { url: request.url }),
+          headers: request.headers,
+          body,
+        });
+        response.setHeader("content-type", "application/json");
+        if (request.url === "/redirect") {
+          response.statusCode = 302;
+          response.setHeader("location", "/ok");
+          response.end();
+          return;
+        }
+        if (request.url === "/slow") {
+          setTimeout(() => response.end(JSON.stringify({ ok: true })), 100);
+          return;
+        }
+        if (request.url === "/large") {
+          response.end("x".repeat(2 * 1024 * 1024));
+          return;
+        }
+        if (request.url === "/missing") {
+          response.statusCode = 404;
+          response.statusMessage = "Not Found";
+          response.end(JSON.stringify({ error: "missing" }));
+          return;
+        }
+        if (request.url === "/unauthorized") {
+          response.statusCode = 401;
+          response.statusMessage = "Unauthorized";
+          response.setHeader("www-authenticate", 'Bearer error="invalid_token", token="secret"');
+          response.setHeader("set-cookie", "session=secret; HttpOnly");
+          response.end(JSON.stringify({ error: "secret" }));
+          return;
+        }
+        if (request.url === "/forbidden") {
+          response.statusCode = 403;
+          response.statusMessage = "Forbidden";
+          response.end(JSON.stringify({ error: "denied" }));
+          return;
+        }
+        response.end(JSON.stringify({ ok: true }));
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("test server did not bind to a port");
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("lists configured actions as MCP tools with default input schema", async () => {
+    const manager = new HttpActionManager(registry());
+    const api = httpApi({
+      actions: {
+        ping: { method: "GET", path: "/ping", description: "Ping the service." },
+        update_user: {
+          method: "PATCH",
+          path: "/users/{id}",
+          inputSchema: { type: "object", required: ["id"] },
+        },
+      },
+    });
+
+    const tools = await manager.listTools(api);
+
+    expect(tools).toEqual([
+      {
+        name: "ping",
+        description: "Ping the service.",
+        inputSchema: { type: "object", additionalProperties: true },
+        annotations: { readOnlyHint: true, destructiveHint: false },
+      },
+      {
+        name: "update_user",
+        inputSchema: { type: "object", required: ["id"] },
+        annotations: { readOnlyHint: false, destructiveHint: false },
+      },
+    ]);
+  });
+
+  it("builds requests from path, query, header, and JSON body mappings", async () => {
+    requests.length = 0;
+    const manager = new HttpActionManager(registry());
+    const api = httpApi({
+      auth: { type: "bearer", token: "secret-token" },
+      actions: {
+        create: {
+          method: "POST",
+          path: "/teams/{teamId}/users/{id}",
+          query: { include: "$input.include", fixed: "yes" },
+          headers: { "x-request-id": "$input.requestId" },
+          jsonBody: {
+            user: "$input.user",
+            tags: ["static", "$input.tag"],
+            all: "$input",
+          },
+        },
+      },
+    });
+
+    const result = await manager.callTool(api, "create", {
+      teamId: "alpha/beta",
+      id: "42",
+      include: true,
+      requestId: "req-1",
+      tag: "new",
+      user: { name: "Ada" },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({ status: 200, body: { ok: true } });
+    expect(requests.at(-1)).toMatchObject({
+      method: "POST",
+      url: "/teams/alpha%2Fbeta/users/42?include=true&fixed=yes",
+      headers: {
+        authorization: "Bearer secret-token",
+        "x-request-id": "req-1",
+        "content-type": "application/json",
+      },
+    });
+    expect(JSON.parse(requests.at(-1)!.body)).toMatchObject({
+      user: { name: "Ada" },
+      tags: ["static", "new"],
+      all: { teamId: "alpha/beta", id: "42" },
+    });
+  });
+
+  it("marks non-2xx responses as tool errors without throwing", async () => {
+    const manager = new HttpActionManager(registry());
+    const api = httpApi({ actions: { missing: { method: "GET", path: "/missing" } } });
+
+    const result = await manager.callTool(api, "missing", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      status: 404,
+      statusText: "Not Found",
+      body: { error: "missing" },
+    });
+    expect(result.structuredContent).toHaveProperty("elapsedMs");
+  });
+
+  it("rejects query and header mappings that resolve to non-objects", async () => {
+    const manager = new HttpActionManager(registry());
+
+    await expect(
+      manager.callTool(
+        httpApi({
+          actions: { bad_query: { method: "GET", path: "/ok", query: "$input.query" } },
+        }),
+        "bad_query",
+        { query: "not-an-object" },
+      ),
+    ).rejects.toMatchObject({ code: "REQUEST_INVALID" });
+
+    await expect(
+      manager.callTool(
+        httpApi({
+          actions: { bad_headers: { method: "GET", path: "/ok", headers: "$input.headers" } },
+        }),
+        "bad_headers",
+        { headers: ["not", "an", "object"] },
+      ),
+    ).rejects.toMatchObject({ code: "REQUEST_INVALID" });
+  });
+
+  it("returns structured 401 and 403 responses instead of throwing auth errors", async () => {
+    const manager = new HttpActionManager(registry());
+    const api = httpApi({
+      actions: {
+        unauthorized: { method: "GET", path: "/unauthorized" },
+        forbidden: { method: "GET", path: "/forbidden" },
+      },
+    });
+
+    const unauthorized = await manager.callTool(api, "unauthorized", {});
+    const forbidden = await manager.callTool(api, "forbidden", {});
+
+    expect(unauthorized.isError).toBe(true);
+    expect(unauthorized.structuredContent).toMatchObject({
+      status: 401,
+      statusText: "Unauthorized",
+      headers: { "content-type": "application/json" },
+      body: { error: "secret" },
+    });
+    expect(JSON.stringify(unauthorized.structuredContent)).not.toContain("www-authenticate");
+    expect(JSON.stringify(unauthorized.structuredContent)).not.toContain("set-cookie");
+    expect(forbidden.isError).toBe(true);
+    expect(forbidden.structuredContent).toMatchObject({
+      status: 403,
+      statusText: "Forbidden",
+      body: { error: "denied" },
+    });
+  });
+
+  it("rejects unsafe paths, forbidden headers, redirects, timeouts, and oversized responses", async () => {
+    const manager = new HttpActionManager(registry());
+    const unsafePathApi = httpApi({ actions: { escape: { method: "GET", path: "/ok" } } });
+    unsafePathApi.actions.escape!.path = "https://evil.example/x";
+    await expect(manager.callTool(unsafePathApi, "escape", {})).rejects.toMatchObject({
+      code: "CONFIG_INVALID",
+    });
+    const basePathEscapeApi = httpApi({
+      baseUrl: `${baseUrl}/api/v1`,
+      actions: { escape: { method: "GET", path: "/../admin" } },
+    });
+    await expect(manager.callTool(basePathEscapeApi, "escape", {})).rejects.toMatchObject({
+      code: "CONFIG_INVALID",
+    });
+    await expect(
+      manager.callTool(
+        httpApi({
+          actions: { bad: { method: "GET", path: "/ok", headers: { authorization: "x" } } },
+        }),
+        "bad",
+        {},
+      ),
+    ).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+    await expect(
+      manager.callTool(
+        httpApi({
+          actions: { bad_dynamic: { method: "GET", path: "/ok", headers: "$input.headers" } },
+        }),
+        "bad_dynamic",
+        { headers: { authorization: "Bearer attacker" } },
+      ),
+    ).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+    await expect(
+      manager.callTool(
+        httpApi({ actions: { redirect: { method: "GET", path: "/redirect" } } }),
+        "redirect",
+        {},
+      ),
+    ).rejects.toMatchObject({ code: "DOWNSTREAM_PROTOCOL_ERROR" });
+    await expect(
+      manager.callTool(
+        httpApi({ requestTimeoutMs: 10, actions: { slow: { method: "GET", path: "/slow" } } }),
+        "slow",
+        {},
+      ),
+    ).rejects.toMatchObject({ code: "TOOL_CALL_TIMEOUT" });
+    await expect(
+      manager.callTool(
+        httpApi({ maxResponseBytes: 100, actions: { large: { method: "GET", path: "/large" } } }),
+        "large",
+        {},
+      ),
+    ).rejects.toMatchObject({ code: "DOWNSTREAM_PROTOCOL_ERROR" });
+  });
+
+  function httpApi(overrides: Partial<HttpApiConfig>): HttpApiConfig {
+    return parseConfig({
+      httpApis: {
+        http: {
+          name: "HTTP API",
+          description: "Call configured HTTP service actions.",
+          baseUrl,
+          auth: { type: "none" },
+          actions: { ok: { method: "GET", path: "/ok" } },
+          ...overrides,
+        },
+      },
+    }).httpApis.http!;
+  }
+});
+
+function registry(): ServerRegistry {
+  return new ServerRegistry(
+    parseConfig({
+      httpApis: {
+        http: {
+          name: "HTTP API",
+          description: "Call configured HTTP service actions.",
+          baseUrl: "http://127.0.0.1:1",
+          auth: { type: "none" },
+          actions: { ok: { method: "GET", path: "/ok" } },
+        },
+      },
+    }),
+  );
+}

--- a/test/http-actions.test.ts
+++ b/test/http-actions.test.ts
@@ -194,6 +194,18 @@ describe("HttpActionManager", () => {
     ).rejects.toMatchObject({ code: "REQUEST_INVALID" });
   });
 
+  it("rejects JSON body mappings that resolve to undefined", async () => {
+    const manager = new HttpActionManager(registry());
+    const api = httpApi({
+      actions: { create: { method: "POST", path: "/ok", jsonBody: "$input.missing" } },
+    });
+
+    await expect(manager.callTool(api, "create", {})).rejects.toMatchObject({
+      code: "REQUEST_INVALID",
+      message: "HTTP action jsonBody must not resolve to undefined",
+    });
+  });
+
   it("returns structured 401 and 403 responses instead of throwing auth errors", async () => {
     const manager = new HttpActionManager(registry());
     const api = httpApi({

--- a/test/openapi.test.ts
+++ b/test/openapi.test.ts
@@ -519,6 +519,7 @@ describe("native OpenAPI Caplets", () => {
         mcpServers: {},
         openapiEndpoints: { remote: endpoint },
         graphqlEndpoints: {},
+        httpApis: {},
       });
       const openapi = new OpenApiManager(registry, { authDir });
 

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -46,6 +46,17 @@ describe("registry", () => {
           auth: { type: "bearer", token: "secret-graphql-token" },
         },
       },
+      httpApis: {
+        status: {
+          name: "Status HTTP",
+          description: "Check internal service status through HTTP.",
+          baseUrl: "https://api.example.com/status",
+          auth: { type: "bearer", token: "secret-http-token" },
+          actions: {
+            check: { method: "GET", path: "/check" },
+          },
+        },
+      },
     });
     const registry = new ServerRegistry(config);
     expect(registry.enabledServers().map((server) => server.server)).toEqual([
@@ -53,8 +64,10 @@ describe("registry", () => {
       "remote",
       "users",
       "catalog",
+      "status",
     ]);
     expect(registry.get("disabled")).toBeUndefined();
+    expect(registry.get("status")?.backend).toBe("http");
     const description = capabilityDescription(config.mcpServers.enabled!);
     expect(description).toContain("Enabled Server");
     expect(description).toContain(
@@ -106,5 +119,23 @@ describe("registry", () => {
       },
     });
     expect(JSON.stringify(graphQlDetail)).not.toContain("secret-graphql");
+
+    const httpDescription = capabilityDescription(config.httpApis.status!);
+    expect(httpDescription).toContain("HTTP API backend");
+    expect(httpDescription).toContain('"operation":"check_backend"');
+    const httpDetail = registry.detail(config.httpApis.status!);
+    expect(httpDetail).toEqual({
+      caplet: "status",
+      name: "Status HTTP",
+      description: "Check internal service status through HTTP.",
+      backend: {
+        type: "http",
+        disabled: false,
+        requestTimeoutMs: 60000,
+        operationCacheTtlMs: 30000,
+        configuredActions: 1,
+      },
+    });
+    expect(JSON.stringify(httpDetail)).not.toContain("secret-http");
   });
 });

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -132,7 +132,6 @@ describe("registry", () => {
         type: "http",
         disabled: false,
         requestTimeoutMs: 60000,
-        operationCacheTtlMs: 30000,
         configuredActions: 1,
       },
     });

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -40,6 +40,32 @@ describe("CapletsRuntime", () => {
     await runtime.close();
   });
 
+  it("registers HTTP API Caplets", async () => {
+    const { dir, configPath, projectConfigPath } = tempConfig({
+      httpApis: {
+        status: {
+          name: "Status HTTP",
+          description: "Check internal service status through HTTP.",
+          baseUrl: "http://127.0.0.1:1",
+          auth: { type: "none" },
+          actions: { check: { method: "GET", path: "/check" } },
+        },
+      },
+    });
+    dirs.push(dir);
+    const server = mockServer();
+    const runtime = new CapletsRuntime({ configPath, projectConfigPath, server });
+
+    expect(runtime.registeredToolIds()).toEqual(["status"]);
+    expect(server.registerTool).toHaveBeenCalledWith(
+      "status",
+      expect.objectContaining({ title: "Status HTTP" }),
+      expect.any(Function),
+    );
+
+    await runtime.close();
+  });
+
   it("adds, updates, and removes tools across successful reloads", async () => {
     const { dir, configPath, projectConfigPath } = tempConfig({
       mcpServers: {
@@ -81,11 +107,13 @@ describe("CapletsRuntime", () => {
     expect(server.registered.get("gamma")).toBeDefined();
 
     writeConfig(configPath, {
-      mcpServers: {
+      httpApis: {
         gamma: {
-          name: "Gamma",
-          description: "Search gamma project documents.",
-          command: "node",
+          name: "Gamma HTTP",
+          description: "Search gamma project documents over HTTP.",
+          baseUrl: "http://127.0.0.1:1",
+          auth: { type: "none" },
+          actions: { search: { method: "GET", path: "/search" } },
         },
       },
     });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -5,6 +5,7 @@ import { parseConfig } from "../src/config.js";
 import { DownstreamManager } from "../src/downstream.js";
 import { CapletsError } from "../src/errors.js";
 import type { GraphQLManager, GraphqlEndpointConfig } from "../src/graphql.js";
+import type { HttpActionManager } from "../src/http-actions.js";
 import { ServerRegistry } from "../src/registry.js";
 import {
   generatedToolInputSchema,
@@ -174,6 +175,37 @@ describe("generated tool handlers", () => {
     });
   });
 
+  it("returns HTTP get_caplet without requiring an HTTP manager", async () => {
+    const httpConfig = parseConfig({
+      httpApis: {
+        status: {
+          name: "Status HTTP",
+          description: "Check internal service status through HTTP.",
+          baseUrl: "https://api.example.com",
+          auth: { type: "none" },
+          actions: { check: { method: "GET", path: "/check" } },
+        },
+      },
+    });
+    const httpRegistry = new ServerRegistry(httpConfig);
+    const downstream = {} as unknown as DownstreamManager;
+
+    const result = (await handleServerTool(
+      httpConfig.httpApis.status!,
+      { operation: "get_caplet" },
+      httpRegistry,
+      downstream,
+    )) as any;
+
+    expect(result.structuredContent?.result).toMatchObject({
+      caplet: "status",
+      backend: {
+        type: "http",
+        configuredActions: 1,
+      },
+    });
+  });
+
   it("checks the MCP server backend", async () => {
     const status = { server: "alpha", status: "available", toolCount: 2, elapsedMs: 5 };
     const downstream = {
@@ -299,6 +331,47 @@ describe("generated tool handlers", () => {
 
     expect(result).toBe(graphqlResult);
     expect(graphql.callTool).toHaveBeenCalledWith(graphqlCaplet, "query_user", { id: "42" });
+    expect(downstream.callTool).not.toHaveBeenCalled();
+  });
+
+  it("routes HTTP-backed Caplets to the HTTP action manager", async () => {
+    const httpCaplet = parseConfig({
+      httpApis: {
+        status: {
+          name: "Status HTTP",
+          description: "Check internal service status through HTTP.",
+          baseUrl: "http://127.0.0.1:1",
+          auth: { type: "none" },
+          actions: { check: { method: "GET", path: "/check" } },
+        },
+      },
+    }).httpApis.status!;
+    const httpRegistry = {
+      config: { options: { maxSearchLimit: 50, defaultSearchLimit: 20 } },
+      detail: vi.fn(),
+    } as unknown as ServerRegistry;
+    const downstream = { callTool: vi.fn() } as unknown as DownstreamManager;
+    const httpResult = {
+      content: [{ type: "text" as const, text: "ok" }],
+      structuredContent: { ok: true },
+      isError: false,
+    };
+    const http = {
+      callTool: vi.fn().mockResolvedValue(httpResult),
+    } as unknown as HttpActionManager;
+
+    const result = await handleServerTool(
+      httpCaplet,
+      { operation: "call_tool", tool: "check", arguments: { id: "42" } },
+      httpRegistry,
+      downstream,
+      undefined,
+      undefined,
+      http,
+    );
+
+    expect(result).toBe(httpResult);
+    expect(http.callTool).toHaveBeenCalledWith(httpCaplet, "check", { id: "42" });
     expect(downstream.callTool).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Add native `httpApis` / `httpApi` support for explicitly configured non-OpenAPI HTTP actions.
- Wire HTTP actions through Caplet discovery, generated operations, runtime reloads, auth discovery, schemas, and docs.
- Add safety controls for URL scope, redirects, forbidden headers, response limits, and safe response metadata.

## Testing
- `pnpm verify`
- Pre-push hook ran `pnpm format:check && pnpm lint && pnpm typecheck && pnpm schema:check && pnpm test && pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native HTTP actions via explicitly configured HTTP APIs (`httpApis`) — HTTP-backed Caplets register and execute as tools (GET/POST/PUT/PATCH/DELETE) with path params, query/header/json body mappings, and OAuth/bearer/header auth (including OAuth/OIDC).

* **Configuration & Validation**
  * Adds `httpApis` config and Caplet frontmatter support with baseUrl rules, per-action constraints, timeouts, max response size, and duplicate-ID checks.

* **Runtime & Tooling**
  * Runtime, registry, and tooling recognize and route HTTP-backed Caplets through a dedicated HTTP action manager.

* **Documentation**
  * README and docs updated with examples, schemas, and auth guidance.

* **Tests**
  * Extensive tests for listing, execution, auth, safety limits, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spiritledsoftware/caplets/pull/21)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->