### PR TITLE
feat: use platform config and state paths

### DIFF
--- a/.changeset/oauth-client-metadata-url.md
+++ b/.changeset/oauth-client-metadata-url.md
@@ -1,0 +1,5 @@
+---
+"caplets": patch
+---
+
+Support configured OAuth/OIDC client metadata URLs for MCP, OpenAPI, GraphQL, and HTTP auth configs.

--- a/.changeset/oauth-client-metadata-url.md
+++ b/.changeset/oauth-client-metadata-url.md
@@ -1,5 +1,5 @@
 ---
-"caplets": patch
+"caplets": minor
 ---
 
 Support configured OAuth/OIDC client metadata URLs for MCP, OpenAPI, GraphQL, and HTTP auth configs.

--- a/.changeset/xdg-windows-default-paths.md
+++ b/.changeset/xdg-windows-default-paths.md
@@ -1,0 +1,5 @@
+---
+"caplets": minor
+---
+
+Default user config and OAuth token state locations now follow XDG conventions on Unix-like platforms and Windows platform conventions on Windows.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the agent chooses that server and asks to search, list, inspect, or call them.
 
 ## What It Does
 
-- Reads downstream MCP server definitions, native OpenAPI endpoint definitions, native GraphQL endpoint definitions, and explicit HTTP API action definitions from `~/.caplets/config.json`.
+- Reads downstream MCP server definitions, native OpenAPI endpoint definitions, native GraphQL endpoint definitions, and explicit HTTP API action definitions from the user config file.
 - Registers one generated MCP tool for each enabled MCP server, OpenAPI endpoint, GraphQL endpoint, or HTTP API.
 - Uses the configured server ID as the generated tool name.
 - Uses the configured `name` and `description` as the capability card shown to agents.
@@ -59,7 +59,7 @@ pnpm build
 
 ## Configure
 
-Create a starter `~/.caplets/config.json`:
+Create a starter user config at `${XDG_CONFIG_HOME:-~/.config}/caplets/config.json` on Unix-like platforms or `%APPDATA%\caplets\config.json` on Windows:
 
 ```sh
 caplets init
@@ -143,7 +143,7 @@ you want Caplets to expose:
 }
 ```
 
-The default config path can be overridden with `CAPLETS_CONFIG`:
+The default config path is `${XDG_CONFIG_HOME:-~/.config}/caplets/config.json` on Unix-like platforms and `%APPDATA%\caplets\config.json` on Windows. It can be overridden with `CAPLETS_CONFIG`:
 
 ```sh
 CAPLETS_CONFIG=/path/to/config.json caplets init
@@ -279,11 +279,13 @@ caplets install spiritledsoftware/caplets github linear
 ```
 
 `caplets install` accepts a GitHub `owner/repo` shorthand, a Git URL, or a local repository path.
-It installs into your user Caplets root, which is `~/.caplets` by default or the parent directory
-of `CAPLETS_CONFIG` when that environment variable is set. Existing Caplets are not overwritten
-unless `--force` is passed.
+It installs into your user Caplets root, which is `${XDG_CONFIG_HOME:-~/.config}/caplets` on Unix-like platforms,
+`%APPDATA%\caplets` on Windows, or the parent directory of `CAPLETS_CONFIG` when that environment variable is set.
+Existing Caplets are not overwritten unless `--force` is passed.
 
-Caplets always loads user Caplet files from `~/.caplets`. Project `./.caplets/config.json`
+On Unix-like platforms, relative `XDG_CONFIG_HOME` and `XDG_STATE_HOME` values are ignored.
+
+Caplets always loads user Caplet files from the user Caplets root. Project `./.caplets/config.json`
 is still loaded as project config, but project Markdown Caplet files are executable
 configuration and are ignored unless explicitly trusted:
 
@@ -511,10 +513,11 @@ For headless terminals:
 caplets auth login <server> --no-open
 ```
 
-OAuth/OIDC tokens are stored under `~/.caplets/auth/<server>.json` with owner-only file
-permissions where the platform supports them. Caplets supports well-known OAuth/OIDC
-discovery and dynamic client registration when advertised. When a token expires, run
-`caplets auth login <server>` again.
+OAuth/OIDC tokens are stored under `${XDG_STATE_HOME:-~/.local/state}/caplets/auth/<server>.json`
+on Unix-like platforms and `%LOCALAPPDATA%\caplets\auth\<server>.json` on Windows.
+Token files use owner-only file permissions where the platform supports them. Caplets supports
+well-known OAuth/OIDC discovery and dynamic client registration when advertised. When a token expires,
+run `caplets auth login <server>` again.
 
 To inspect or remove stored OAuth credentials:
 

--- a/docs/plans/2026-05-13-xdg-cross-platform-paths.md
+++ b/docs/plans/2026-05-13-xdg-cross-platform-paths.md
@@ -1,0 +1,202 @@
+# XDG and Cross-Platform Paths Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move Caplets user config to XDG/standard platform config locations and OAuth state to XDG/standard platform state locations.
+
+**Architecture:** Centralize all default user paths in `src/config/paths.ts`, then consume those shared defaults from config loading, CLI inspection, installation, runtime, and auth storage. Project-local `./.caplets` behavior stays unchanged because it is project state, not user state. `CAPLETS_CONFIG` remains the explicit config override, and internal/test `authDir` overrides remain supported.
+
+**Tech Stack:** Node.js 22, TypeScript, Vitest, Commander, Caplets existing config/auth modules.
+
+---
+
+## Target Paths
+
+| Platform         | Config                                              | State/Auth                                                     |
+| ---------------- | --------------------------------------------------- | -------------------------------------------------------------- |
+| Linux/macOS/Unix | `${XDG_CONFIG_HOME:-~/.config}/caplets/config.json` | `${XDG_STATE_HOME:-~/.local/state}/caplets/auth/<server>.json` |
+| Windows          | `%APPDATA%\\caplets\\config.json`                   | `%LOCALAPPDATA%\\caplets\\auth\\<server>.json`                 |
+| Override         | `CAPLETS_CONFIG=/custom/config.json` wins           | Existing `authDir` option wins                                 |
+
+XDG environment variables must be absolute. Relative `XDG_CONFIG_HOME` and `XDG_STATE_HOME` values are ignored.
+
+## File Structure
+
+- Modify: `src/config/paths.ts` - own all platform-specific default path resolution.
+- Modify: `src/auth/store.ts` - use the shared default auth directory instead of hard-coding `~/.caplets/auth`.
+- Modify: `src/cli/inspection.ts` - expose the split config and state roots in `caplets config paths`.
+- Modify: `test/config.test.ts` or create `test/config-paths.test.ts` - cover path helper behavior.
+- Modify: `test/cli.test.ts` - update path inspection expectations.
+- Modify: `README.md` - document XDG and Windows paths.
+- Modify: `docs/product/caplets-progressive-mcp-disclosure-prd.md` - update product/default path references.
+- Create: `.changeset/<name>.md` - note the pre-1.0 default location change.
+
+### Task 1: Platform-Aware Path Helpers
+
+**Files:**
+
+- Modify: `src/config/paths.ts`
+- Test: `test/config-paths.test.ts`
+
+- [ ] **Step 1: Write path helper tests**
+
+Add tests that call injectable helper functions with explicit environment, home, and platform inputs. Cover Unix defaults, Unix XDG overrides, ignored relative XDG overrides, Windows environment defaults, and Windows homedir fallbacks.
+
+- [ ] **Step 2: Run path helper tests to verify they fail**
+
+Run: `pnpm vitest run test/config-paths.test.ts`
+
+Expected: FAIL because the injectable helpers do not exist yet.
+
+- [ ] **Step 3: Implement path helpers**
+
+In `src/config/paths.ts`, add exported helpers equivalent to:
+
+```ts
+type Platform = NodeJS.Platform;
+type PathEnv = NodeJS.ProcessEnv;
+
+export function defaultConfigBaseDir(
+  env: PathEnv = process.env,
+  home = homedir(),
+  platform: Platform = process.platform,
+): string {
+  if (platform === "win32") {
+    return env.APPDATA && isAbsolute(env.APPDATA) ? env.APPDATA : join(home, "AppData", "Roaming");
+  }
+  return env.XDG_CONFIG_HOME && isAbsolute(env.XDG_CONFIG_HOME)
+    ? env.XDG_CONFIG_HOME
+    : join(home, ".config");
+}
+
+export function defaultStateBaseDir(
+  env: PathEnv = process.env,
+  home = homedir(),
+  platform: Platform = process.platform,
+): string {
+  if (platform === "win32") {
+    return env.LOCALAPPDATA && isAbsolute(env.LOCALAPPDATA)
+      ? env.LOCALAPPDATA
+      : join(home, "AppData", "Local");
+  }
+  return env.XDG_STATE_HOME && isAbsolute(env.XDG_STATE_HOME)
+    ? env.XDG_STATE_HOME
+    : join(home, ".local", "state");
+}
+
+export function defaultConfigPath(...): string {
+  return join(defaultConfigBaseDir(...), "caplets", "config.json");
+}
+
+export function defaultAuthDir(...): string {
+  return join(defaultStateBaseDir(...), "caplets", "auth");
+}
+```
+
+Keep exported `DEFAULT_CONFIG_PATH` and `DEFAULT_AUTH_DIR`, but define them from the new functions.
+
+- [ ] **Step 4: Run path helper tests to verify they pass**
+
+Run: `pnpm vitest run test/config-paths.test.ts`
+
+Expected: PASS.
+
+### Task 2: Auth Store Uses State Directory
+
+**Files:**
+
+- Modify: `src/auth/store.ts`
+- Test: `test/auth.test.ts`
+
+- [ ] **Step 1: Write or update auth default tests**
+
+Add coverage proving `authStorePath("remote")` resolves under the shared default auth dir. Keep traversal rejection coverage intact.
+
+- [ ] **Step 2: Run auth tests to verify they fail before implementation**
+
+Run: `pnpm vitest run test/auth.test.ts`
+
+Expected: FAIL if the test expects the new default while the auth store still hard-codes `~/.caplets/auth`.
+
+- [ ] **Step 3: Update auth store default**
+
+Import `DEFAULT_AUTH_DIR` from `../config/paths.js`, remove direct `homedir()` usage, and use `DEFAULT_AUTH_DIR` in `authStorePath` and `listTokenBundles` defaults.
+
+- [ ] **Step 4: Run auth tests to verify they pass**
+
+Run: `pnpm vitest run test/auth.test.ts`
+
+Expected: PASS.
+
+### Task 3: CLI Path Inspection
+
+**Files:**
+
+- Modify: `src/cli/inspection.ts`
+- Modify: `test/cli.test.ts`
+
+- [ ] **Step 1: Update CLI path inspection tests**
+
+Update `caplets config paths --json` expectations to include `stateRoot`, and verify `authDir` can still be overridden by the internal test `authDir` option.
+
+- [ ] **Step 2: Run CLI tests to verify they fail before implementation**
+
+Run: `pnpm vitest run test/cli.test.ts`
+
+Expected: FAIL because `stateRoot` is not present yet.
+
+- [ ] **Step 3: Update inspection output**
+
+Import `defaultStateBaseDir` if needed, add `stateRoot: dirname(authDir ?? DEFAULT_AUTH_DIR)` or equivalent root reporting, and update human `formatConfigPaths` output.
+
+- [ ] **Step 4: Run CLI tests to verify they pass**
+
+Run: `pnpm vitest run test/cli.test.ts`
+
+Expected: PASS.
+
+### Task 4: Documentation and Changeset
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/product/caplets-progressive-mcp-disclosure-prd.md`
+- Create: `.changeset/<name>.md`
+
+- [ ] **Step 1: Update README paths**
+
+Replace default user config references with `~/.config/caplets/config.json`, auth state references with `~/.local/state/caplets/auth/<server>.json`, and include Windows `%APPDATA%\\caplets\\config.json` and `%LOCALAPPDATA%\\caplets\\auth` equivalents.
+
+- [ ] **Step 2: Update PRD path references**
+
+Update all user-level path references from `~/.caplets` to the new split config/state locations. Keep project `./.caplets` references unchanged.
+
+- [ ] **Step 3: Add changeset**
+
+Create a minor changeset explaining that default config and OAuth token state locations now follow XDG and Windows platform conventions.
+
+- [ ] **Step 4: Check docs for stale user path references**
+
+Run a content search for `~/.caplets` and `.caplets/auth` and update stale default-user references only. Existing historical plans may remain unchanged if they describe already-completed old work.
+
+### Task 5: Full Verification and Review
+
+**Files:**
+
+- Verify all modified files.
+
+- [ ] **Step 1: Run targeted tests**
+
+Run: `pnpm vitest run test/config-paths.test.ts test/config.test.ts test/cli.test.ts test/auth.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full verification**
+
+Run: `pnpm verify`
+
+Expected: PASS.
+
+- [ ] **Step 3: Review changed diff**
+
+Inspect the final diff for accidental compatibility fallback to `~/.caplets`, stale docs, or unrelated changes.

--- a/docs/product/caplets-progressive-mcp-disclosure-prd.md
+++ b/docs/product/caplets-progressive-mcp-disclosure-prd.md
@@ -4,7 +4,7 @@
 
 **Problem Statement**: MCP clients that connect directly to many servers receive a large, flat tool surface up front. This creates context bloat, weak tool selection, name-collision risk, and poor discoverability when an agent only needs to know which capability domain to inspect next.
 
-**Proposed Solution**: Caplets is a local MCP server that reads downstream MCP server definitions, native OpenAPI endpoint definitions, native GraphQL endpoint definitions, and explicit HTTP API action definitions from `~/.caplets/config.json`, user-owned Markdown Caplet files from `~/.caplets`, project config from `./.caplets/config.json`, and explicitly trusted project Markdown Caplet files from `./.caplets`. It exposes each enabled Caplet as one top-level, skill-like MCP tool. Each generated Caplet tool uses the Caplet ID as the tool name and the configured `name`/`description` as its compact capability card, then progressively discloses the full Caplet card and the backing MCP tools, OpenAPI operations, GraphQL operations, or HTTP actions through operations such as `get_caplet`, `search_tools`, `list_tools`, `get_tool`, and `call_tool`.
+**Proposed Solution**: Caplets is a local MCP server that reads downstream MCP server definitions, native OpenAPI endpoint definitions, native GraphQL endpoint definitions, and explicit HTTP API action definitions from `${XDG_CONFIG_HOME:-~/.config}/caplets/config.json` on Unix-like platforms or `%APPDATA%\caplets\config.json` on Windows, user-owned Markdown Caplet files from the user Caplets root, project config from `./.caplets/config.json`, and explicitly trusted project Markdown Caplet files from `./.caplets`. It exposes each enabled Caplet as one top-level, skill-like MCP tool. Each generated Caplet tool uses the Caplet ID as the tool name and the configured `name`/`description` as its compact capability card, then progressively discloses the full Caplet card and the backing MCP tools, OpenAPI operations, GraphQL operations, or HTTP actions through operations such as `get_caplet`, `search_tools`, `list_tools`, `get_tool`, and `call_tool`.
 
 **Success Criteria**:
 
@@ -25,7 +25,7 @@
 ### Primary User Flow
 
 1. User installs and configures Caplets as an MCP server in their MCP client.
-2. User creates either `~/.caplets/config.json` with downstream server, OpenAPI endpoint, GraphQL endpoint, or HTTP API action definitions and Caplets options, or Markdown Caplet files with exactly one executable backend.
+2. User creates either `${XDG_CONFIG_HOME:-~/.config}/caplets/config.json` on Unix-like platforms or `%APPDATA%\caplets\config.json` on Windows with downstream server, OpenAPI endpoint, GraphQL endpoint, or HTTP API action definitions and Caplets options, or Markdown Caplet files with exactly one executable backend.
 3. Each downstream MCP server, OpenAPI endpoint, GraphQL endpoint, HTTP API, or Caplet file uses the supported backend configuration shape plus a required `description`.
 4. Client calls Caplets `tools/list` and sees one top-level tool per enabled downstream server, for example `linear`, `chrome-devtools`, and `context7`.
 5. Agent chooses the relevant Caplet tool based on its skill-like tool name and description.
@@ -39,8 +39,8 @@
 
 Acceptance Criteria:
 
-- Caplets reads `~/.caplets/config.json` from the current user's home directory by default.
-- Caplets reads user-owned Markdown Caplet files from `~/.caplets` by default.
+- Caplets reads `${XDG_CONFIG_HOME:-~/.config}/caplets/config.json` on Unix-like platforms or `%APPDATA%\caplets\config.json` on Windows by default.
+- Caplets reads user-owned Markdown Caplet files from `${XDG_CONFIG_HOME:-~/.config}/caplets` on Unix-like platforms or `%APPDATA%\caplets` on Windows by default.
 - Caplets reads project Markdown Caplet files from `./.caplets` only when `CAPLETS_TRUST_PROJECT_CAPLETS` is set to `1`, `true`, or `yes`.
 - Caplets supports `mcpServers` for MCP backends, `openapiEndpoints` for native OpenAPI backends, `graphqlEndpoints` for native GraphQL backends, and `httpApis` for explicitly configured HTTP actions.
 - Generated top-level tool names are unique across `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, `httpApis`, and Markdown Caplet files; duplicate IDs reject with `CONFIG_INVALID`.
@@ -112,7 +112,7 @@ Acceptance Criteria:
 - `caplets auth login <server>` performs OAuth setup for configured remote servers with `auth.type: "oauth2"`.
 - The command opens a browser-based authorization code flow with PKCE and receives the callback on a loopback URL.
 - `caplets auth login <server> --no-open` supports headless terminals and remote shells by printing the authorization URL and accepting manual completion input.
-- Successful auth writes a token bundle to `~/.caplets/auth/<server>.json` using owner-only file permissions where supported.
+- Successful auth writes a token bundle to `${XDG_STATE_HOME:-~/.local/state}/caplets/auth/<server>.json` on Unix-like platforms or `%LOCALAPPDATA%\caplets\auth\<server>.json` on Windows using owner-only file permissions where supported.
 - The Caplets MCP server uses stored OAuth tokens for subsequent HTTP/SSE requests without exposing tokens through MCP tools, generated descriptions, logs, or errors.
 - Auth failures are reported with structured, redacted errors.
 - Re-running `caplets auth login <server>` replaces the stored token bundle for that server atomically.
@@ -161,7 +161,7 @@ Generated Caplet tool input schema:
 
 ### Configuration
 
-MVP supports one documented config file at `~/.caplets/config.json`:
+MVP supports one documented user config file at `${XDG_CONFIG_HOME:-~/.config}/caplets/config.json` on Unix-like platforms or `%APPDATA%\caplets\config.json` on Windows:
 
 ```json
 {
@@ -244,7 +244,8 @@ Requirements:
 - Manual OAuth completion must validate `state`, apply the stored PKCE verifier, reject mismatched callback URLs or codes, and redact pasted secrets from logs and errors.
 - OAuth authorization requests must include a state parameter and PKCE challenge. OAuth token requests must verify state and include the PKCE verifier.
 - For MCP-compliant OAuth servers, Caplets must include the target server resource indicator in authorization and token requests when required by the MCP authorization specification.
-- The default OAuth token store is `~/.caplets/auth/<server>.json`; files must be created with owner-only permissions when the platform supports it.
+- The default OAuth token store is `${XDG_STATE_HOME:-~/.local/state}/caplets/auth/<server>.json` on Unix-like platforms or `%LOCALAPPDATA%\caplets\auth\<server>.json` on Windows; files must be created with owner-only permissions when the platform supports it.
+- Relative `XDG_CONFIG_HOME` and `XDG_STATE_HOME` values are ignored.
 - Token bundles are runtime auth state, not server description state. They must not be embedded in generated MCP tool descriptions, `get_caplet`, logs, or structured errors.
 - The Caplets MCP server reads OAuth tokens from the auth store lazily before remote operations. Updating tokens with `caplets auth login <server>` should not require editing config and should be designed to work without restarting Caplets when practical.
 - `caplets auth list` reports configured OAuth remote servers as missing, authenticated, or expired and must not enumerate arbitrary orphan token files outside the configured server set.
@@ -342,7 +343,7 @@ Caplets runs as a local stdio MCP server.
 ```mermaid
 flowchart LR
   Client["MCP client / agent"] --> Caplets["Caplets MCP server"]
-  Caplets --> Config["~/.caplets/config.json"]
+  Caplets --> Config["user config"]
   Caplets --> Registry["Server registry"]
   Registry --> ClientManager["Lazy downstream client manager"]
   ClientManager --> ServerA["Downstream MCP server A"]
@@ -500,7 +501,7 @@ Requirements:
 
 ### Integration Points
 
-- File system: reads `~/.caplets/config.json`.
+- File system: reads `${XDG_CONFIG_HOME:-~/.config}/caplets/config.json` on Unix-like platforms or `%APPDATA%\caplets\config.json` on Windows.
 - MCP SDK server: exposes Caplets over stdio.
 - MCP SDK client: connects to downstream stdio, Streamable HTTP, and legacy HTTP+SSE servers.
 - Node child process runtime: launches configured downstream commands.
@@ -509,7 +510,7 @@ Requirements:
 - Native fetch: executes configured HTTP actions with explicit Caplets auth.
 - Caplets CLI: runs `caplets auth login <server>` for OAuth-backed remote servers.
 - Browser/loopback OAuth: opens the authorization URL and receives the OAuth callback on localhost for configured OAuth servers.
-- Local auth store: reads and writes OAuth token bundles under `~/.caplets/auth`.
+- Local auth store: reads and writes OAuth token bundles under `${XDG_STATE_HOME:-~/.local/state}/caplets/auth` on Unix-like platforms or `%LOCALAPPDATA%\caplets\auth` on Windows.
 - Remote transport headers: preserves required MCP protocol-version and session headers for Streamable HTTP servers.
 
 ### Error Codes
@@ -555,7 +556,7 @@ Caplets errors should be structured and stable:
 
 Add automated tests for:
 
-- File system reads `~/.caplets/config.json`.
+- File system reads `${XDG_CONFIG_HOME:-~/.config}/caplets/config.json` on Unix-like platforms or `%APPDATA%\caplets\config.json` on Windows.
 - Valid config loading from a temp home directory.
 - Optional config version defaulting to 1 and unsupported version rejection.
 - Unknown top-level and server config key rejection.
@@ -618,7 +619,7 @@ If no test runner exists yet, implementation must add one before claiming MVP co
 
 **MVP: Local progressive MCP gateway**
 
-- Read `~/.caplets/config.json`.
+- Read `${XDG_CONFIG_HOME:-~/.config}/caplets/config.json` on Unix-like platforms or `%APPDATA%\caplets\config.json` on Windows.
 - Validate `mcpServers` config with required descriptions.
 - Require restart after config changes while keeping config loading, registry construction, and downstream client lifecycle modular enough for later hot reload.
 - Expose one generated top-level MCP tool per enabled downstream server.

--- a/schemas/caplet.schema.json
+++ b/schemas/caplet.schema.json
@@ -149,6 +149,10 @@
                   "type": "string",
                   "minLength": 1
                 },
+                "clientMetadataUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "clientId": {
                   "type": "string",
                   "minLength": 1
@@ -200,6 +204,10 @@
                   "minLength": 1
                 },
                 "openidConfigurationUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "clientMetadataUrl": {
                   "type": "string",
                   "minLength": 1
                 },
@@ -353,6 +361,10 @@
                   "type": "string",
                   "minLength": 1
                 },
+                "clientMetadataUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "clientId": {
                   "type": "string",
                   "minLength": 1
@@ -404,6 +416,10 @@
                   "minLength": 1
                 },
                 "openidConfigurationUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "clientMetadataUrl": {
                   "type": "string",
                   "minLength": 1
                 },
@@ -591,6 +607,10 @@
                   "type": "string",
                   "minLength": 1
                 },
+                "clientMetadataUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "clientId": {
                   "type": "string",
                   "minLength": 1
@@ -642,6 +662,10 @@
                   "minLength": 1
                 },
                 "openidConfigurationUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "clientMetadataUrl": {
                   "type": "string",
                   "minLength": 1
                 },
@@ -788,6 +812,10 @@
                   "type": "string",
                   "minLength": 1
                 },
+                "clientMetadataUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "clientId": {
                   "type": "string",
                   "minLength": 1
@@ -839,6 +867,10 @@
                   "minLength": 1
                 },
                 "openidConfigurationUrl": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "clientMetadataUrl": {
                   "type": "string",
                   "minLength": 1
                 },

--- a/schemas/caplets-config.schema.json
+++ b/schemas/caplets-config.schema.json
@@ -168,6 +168,10 @@
                     "type": "string",
                     "format": "uri"
                   },
+                  "clientMetadataUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
                   "clientId": {
                     "type": "string",
                     "minLength": 1
@@ -219,6 +223,10 @@
                     "format": "uri"
                   },
                   "openidConfigurationUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "clientMetadataUrl": {
                     "type": "string",
                     "format": "uri"
                   },
@@ -403,6 +411,10 @@
                     "type": "string",
                     "format": "uri"
                   },
+                  "clientMetadataUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
                   "clientId": {
                     "type": "string",
                     "minLength": 1
@@ -454,6 +466,10 @@
                     "format": "uri"
                   },
                   "openidConfigurationUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "clientMetadataUrl": {
                     "type": "string",
                     "format": "uri"
                   },
@@ -670,6 +686,10 @@
                     "type": "string",
                     "format": "uri"
                   },
+                  "clientMetadataUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
                   "clientId": {
                     "type": "string",
                     "minLength": 1
@@ -721,6 +741,10 @@
                     "format": "uri"
                   },
                   "openidConfigurationUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "clientMetadataUrl": {
                     "type": "string",
                     "format": "uri"
                   },
@@ -896,6 +920,10 @@
                     "type": "string",
                     "format": "uri"
                   },
+                  "clientMetadataUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
                   "clientId": {
                     "type": "string",
                     "minLength": 1
@@ -947,6 +975,10 @@
                     "format": "uri"
                   },
                   "openidConfigurationUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "clientMetadataUrl": {
                     "type": "string",
                     "format": "uri"
                   },

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -335,6 +335,7 @@ function normalizeMcpOAuthError(server: CapletServerConfig, error: unknown): unk
   if (
     (server.auth?.type === "oauth2" || server.auth?.type === "oidc") &&
     !server.auth.clientId &&
+    !server.auth.clientMetadataUrl &&
     error instanceof Error &&
     // Matched from the MCP SDK dynamic-registration error text; update if the SDK changes it.
     error.message.includes("does not support dynamic client registration")

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -38,6 +38,7 @@ type OAuthLikeAuthConfig = {
   resourceMetadataUrl?: string | undefined;
   authorizationServerMetadataUrl?: string | undefined;
   openidConfigurationUrl?: string | undefined;
+  clientMetadataUrl?: string | undefined;
   clientId?: string | undefined;
   clientSecret?: string | undefined;
   scopes?: string[] | undefined;
@@ -119,13 +120,21 @@ export class FileOAuthProvider implements OAuthClientProvider {
   private verifier = base64url(randomBytes(32));
   private readonly stateValue = base64url(randomBytes(24));
   private clientInfo?: OAuthClientInformationMixed;
+  readonly clientMetadataUrl?: string;
 
   constructor(
     readonly server: CapletServerConfig,
     readonly redirectUrl: string,
     private readonly onRedirect: (url: URL) => void,
     private readonly authDir?: string,
-  ) {}
+  ) {
+    if (
+      (this.server.auth?.type === "oauth2" || this.server.auth?.type === "oidc") &&
+      this.server.auth.clientMetadataUrl
+    ) {
+      this.clientMetadataUrl = this.server.auth.clientMetadataUrl;
+    }
+  }
 
   get clientMetadata(): OAuthClientMetadata {
     return {
@@ -315,9 +324,30 @@ export async function runOAuthFlow(
       authorizationCode: completion.code,
       ...(scope ? { scope } : {}),
     });
+  } catch (error) {
+    throw normalizeMcpOAuthError(server, error);
   } finally {
     await callback.close();
   }
+}
+
+function normalizeMcpOAuthError(server: CapletServerConfig, error: unknown): unknown {
+  if (
+    (server.auth?.type === "oauth2" || server.auth?.type === "oidc") &&
+    !server.auth.clientId &&
+    error instanceof Error &&
+    error.message.includes("does not support dynamic client registration")
+  ) {
+    return new CapletsError(
+      "AUTH_FAILED",
+      "OAuth is not available for this server without a host-specific OAuth app or PAT auth",
+      {
+        server: server.server,
+        nextAction: "configure_bearer_auth_or_host_oauth_app",
+      },
+    );
+  }
+  return error;
 }
 
 type AuthorizationServerMetadata = {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -336,6 +336,7 @@ function normalizeMcpOAuthError(server: CapletServerConfig, error: unknown): unk
     (server.auth?.type === "oauth2" || server.auth?.type === "oidc") &&
     !server.auth.clientId &&
     error instanceof Error &&
+    // Matched from the MCP SDK dynamic-registration error text; update if the SDK changes it.
     error.message.includes("does not support dynamic client registration")
   ) {
     return new CapletsError(
@@ -658,6 +659,12 @@ async function resolveGenericClient(
     return {
       clientId: authConfig.clientId,
       ...(authConfig.clientSecret ? { clientSecret: authConfig.clientSecret } : {}),
+      dynamic: false,
+    };
+  }
+  if (authConfig.clientMetadataUrl) {
+    return {
+      clientId: authConfig.clientMetadataUrl,
       dynamic: false,
     };
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -665,6 +665,7 @@ async function resolveGenericClient(
   if (authConfig.clientMetadataUrl) {
     return {
       clientId: authConfig.clientMetadataUrl,
+      ...(authConfig.clientSecret ? { clientSecret: authConfig.clientSecret } : {}),
       dynamic: false,
     };
   }
@@ -776,11 +777,12 @@ function assertTokenBundleMatchesTarget(
   target: GenericAuthTarget,
   authConfig: OAuthLikeAuthConfig,
 ): void {
+  const configuredClientId = authConfig.clientId ?? authConfig.clientMetadataUrl;
   const expectedOrigin = protectedResourceOrigin(target, authConfig);
   const mismatch =
     bundle.authType !== authConfig.type ||
     (expectedOrigin && bundle.protectedResourceOrigin !== expectedOrigin) ||
-    (authConfig.clientId && bundle.clientId !== authConfig.clientId) ||
+    (configuredClientId && bundle.clientId !== configuredClientId) ||
     (authConfig.issuer && bundle.issuer !== authConfig.issuer);
   if (mismatch) {
     throw new CapletsError(

--- a/src/auth/store.ts
+++ b/src/auth/store.ts
@@ -8,8 +8,8 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join, resolve, sep } from "node:path";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { DEFAULT_AUTH_DIR } from "../config/paths.js";
 import { CapletsError } from "../errors.js";
 
 export type StoredOAuthTokenBundle = {
@@ -29,16 +29,14 @@ export type StoredOAuthTokenBundle = {
   metadata?: Record<string, unknown>;
 };
 
-export function authStorePath(
-  server: string,
-  authDir = join(homedir(), ".caplets", "auth"),
-): string {
+export function authStorePath(server: string, authDir = DEFAULT_AUTH_DIR): string {
   if (!server || server.includes("/") || server.includes("\\") || server.includes("..")) {
     throw new CapletsError("REQUEST_INVALID", `Invalid auth store server name ${server}`);
   }
   const authRoot = resolve(authDir);
   const candidate = resolve(authRoot, `${server}.json`);
-  if (candidate !== authRoot && candidate.startsWith(`${authRoot}${sep}`)) {
+  const relativePath = relative(authRoot, candidate);
+  if (relativePath && !relativePath.startsWith("..") && !isAbsolute(relativePath)) {
     return candidate;
   }
   throw new CapletsError("REQUEST_INVALID", `Invalid auth store server name ${server}`);
@@ -60,7 +58,7 @@ export function readTokenBundle(
 }
 
 export function listTokenBundles(authDir?: string): StoredOAuthTokenBundle[] {
-  const dir = authDir ?? join(homedir(), ".caplets", "auth");
+  const dir = authDir ?? DEFAULT_AUTH_DIR;
   if (!existsSync(dir)) {
     return [];
   }

--- a/src/caplet-files.ts
+++ b/src/caplet-files.ts
@@ -177,7 +177,7 @@ const capletMcpServerSchema = z
       });
     }
 
-    if (server.auth?.type === "oauth2") {
+    if (server.auth?.type === "oauth2" || server.auth?.type === "oidc") {
       for (const field of [
         "authorizationUrl",
         "tokenUrl",

--- a/src/caplet-files.ts
+++ b/src/caplet-files.ts
@@ -35,6 +35,7 @@ const capletRemoteAuthSchema = z
         resourceMetadataUrl: z.string().min(1).optional(),
         authorizationServerMetadataUrl: z.string().min(1).optional(),
         openidConfigurationUrl: z.string().min(1).optional(),
+        clientMetadataUrl: z.string().min(1).optional(),
         clientId: z.string().min(1).optional(),
         clientSecret: z.string().min(1).optional(),
         scopes: z.array(z.string().min(1)).optional(),
@@ -50,6 +51,7 @@ const capletRemoteAuthSchema = z
         resourceMetadataUrl: z.string().min(1).optional(),
         authorizationServerMetadataUrl: z.string().min(1).optional(),
         openidConfigurationUrl: z.string().min(1).optional(),
+        clientMetadataUrl: z.string().min(1).optional(),
         clientId: z.string().min(1).optional(),
         clientSecret: z.string().min(1).optional(),
         scopes: z.array(z.string().min(1)).optional(),
@@ -75,6 +77,7 @@ const capletEndpointAuthSchema = z
         resourceMetadataUrl: z.string().min(1).optional(),
         authorizationServerMetadataUrl: z.string().min(1).optional(),
         openidConfigurationUrl: z.string().min(1).optional(),
+        clientMetadataUrl: z.string().min(1).optional(),
         clientId: z.string().min(1).optional(),
         clientSecret: z.string().min(1).optional(),
         scopes: z.array(z.string().min(1)).optional(),
@@ -90,6 +93,7 @@ const capletEndpointAuthSchema = z
         resourceMetadataUrl: z.string().min(1).optional(),
         authorizationServerMetadataUrl: z.string().min(1).optional(),
         openidConfigurationUrl: z.string().min(1).optional(),
+        clientMetadataUrl: z.string().min(1).optional(),
         clientId: z.string().min(1).optional(),
         clientSecret: z.string().min(1).optional(),
         scopes: z.array(z.string().min(1)).optional(),
@@ -174,7 +178,13 @@ const capletMcpServerSchema = z
     }
 
     if (server.auth?.type === "oauth2") {
-      for (const field of ["authorizationUrl", "tokenUrl", "issuer", "redirectUri"] as const) {
+      for (const field of [
+        "authorizationUrl",
+        "tokenUrl",
+        "issuer",
+        "clientMetadataUrl",
+        "redirectUri",
+      ] as const) {
         const value = server.auth[field];
         if (value && !hasEnvReference(value) && !isUrl(value)) {
           ctx.addIssue({

--- a/src/cli/inspection.ts
+++ b/src/cli/inspection.ts
@@ -1,3 +1,4 @@
+import { dirname } from "node:path";
 import {
   DEFAULT_AUTH_DIR,
   resolveCapletsRoot,
@@ -24,6 +25,7 @@ type ConfigPaths = {
   userConfig: string;
   projectConfig: string;
   userRoot: string;
+  stateRoot: string;
   projectRoot: string;
   authDir: string;
   envConfig: string | null;
@@ -75,12 +77,14 @@ export function resolveCliConfigPaths(
   authDir?: string,
 ): ConfigPaths {
   const configPath = resolveConfigPath(envConfigPath);
+  const effectiveAuthDir = authDir ?? DEFAULT_AUTH_DIR;
   return {
     userConfig: configPath,
     projectConfig: resolveProjectConfigPath(),
     userRoot: resolveCapletsRoot(configPath),
+    stateRoot: dirname(effectiveAuthDir),
     projectRoot: resolveProjectCapletsRoot(),
-    authDir: authDir ?? DEFAULT_AUTH_DIR,
+    authDir: effectiveAuthDir,
     envConfig: envConfigPath ?? null,
     projectCapletsTrusted: isTrustedProjectCapletsEnabled(),
   };
@@ -92,6 +96,7 @@ export function formatConfigPaths(paths: ConfigPaths): string {
       `userConfig: ${paths.userConfig}`,
       `projectConfig: ${paths.projectConfig}`,
       `userRoot: ${paths.userRoot}`,
+      `stateRoot: ${paths.stateRoot}`,
       `projectRoot: ${paths.projectRoot}`,
       `authDir: ${paths.authDir}`,
       `envConfig: ${paths.envConfig ?? "unset"}`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,7 @@ export type RemoteAuthConfig =
       resourceMetadataUrl?: string | undefined;
       authorizationServerMetadataUrl?: string | undefined;
       openidConfigurationUrl?: string | undefined;
+      clientMetadataUrl?: string | undefined;
       clientId?: string | undefined;
       clientSecret?: string | undefined;
       scopes?: string[] | undefined;
@@ -59,6 +60,7 @@ export type RemoteAuthConfig =
       resourceMetadataUrl?: string | undefined;
       authorizationServerMetadataUrl?: string | undefined;
       openidConfigurationUrl?: string | undefined;
+      clientMetadataUrl?: string | undefined;
       clientId?: string | undefined;
       clientSecret?: string | undefined;
       scopes?: string[] | undefined;
@@ -196,6 +198,7 @@ const remoteAuthSchema = z
         resourceMetadataUrl: z.string().url().optional(),
         authorizationServerMetadataUrl: z.string().url().optional(),
         openidConfigurationUrl: z.string().url().optional(),
+        clientMetadataUrl: z.string().url().optional(),
         clientId: z.string().min(1).optional(),
         clientSecret: z.string().min(1).optional(),
         scopes: z.array(z.string().min(1)).optional(),
@@ -211,6 +214,7 @@ const remoteAuthSchema = z
         resourceMetadataUrl: z.string().url().optional(),
         authorizationServerMetadataUrl: z.string().url().optional(),
         openidConfigurationUrl: z.string().url().optional(),
+        clientMetadataUrl: z.string().url().optional(),
         clientId: z.string().min(1).optional(),
         clientSecret: z.string().min(1).optional(),
         scopes: z.array(z.string().min(1)).optional(),
@@ -230,6 +234,7 @@ const oauthLikeAuthSchema = z.union([
       resourceMetadataUrl: z.string().url().optional(),
       authorizationServerMetadataUrl: z.string().url().optional(),
       openidConfigurationUrl: z.string().url().optional(),
+      clientMetadataUrl: z.string().url().optional(),
       clientId: z.string().min(1).optional(),
       clientSecret: z.string().min(1).optional(),
       scopes: z.array(z.string().min(1)).optional(),
@@ -245,6 +250,7 @@ const oauthLikeAuthSchema = z.union([
       resourceMetadataUrl: z.string().url().optional(),
       authorizationServerMetadataUrl: z.string().url().optional(),
       openidConfigurationUrl: z.string().url().optional(),
+      clientMetadataUrl: z.string().url().optional(),
       clientId: z.string().min(1).optional(),
       clientSecret: z.string().min(1).optional(),
       scopes: z.array(z.string().min(1)).optional(),

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,8 +1,61 @@
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, posix, win32 } from "node:path";
 
-export const DEFAULT_CONFIG_PATH = join(homedir(), ".caplets", "config.json");
-export const DEFAULT_AUTH_DIR = join(homedir(), ".caplets", "auth");
+type Platform = NodeJS.Platform;
+type PathEnv = NodeJS.ProcessEnv;
+
+export function defaultConfigBaseDir(
+  env: PathEnv = process.env,
+  home = homedir(),
+  platform: Platform = process.platform,
+): string {
+  if (platform === "win32") {
+    return env.APPDATA && win32.isAbsolute(env.APPDATA)
+      ? env.APPDATA
+      : win32.join(home, "AppData", "Roaming");
+  }
+
+  return env.XDG_CONFIG_HOME && posix.isAbsolute(env.XDG_CONFIG_HOME)
+    ? env.XDG_CONFIG_HOME
+    : posix.join(home, ".config");
+}
+
+export function defaultStateBaseDir(
+  env: PathEnv = process.env,
+  home = homedir(),
+  platform: Platform = process.platform,
+): string {
+  if (platform === "win32") {
+    return env.LOCALAPPDATA && win32.isAbsolute(env.LOCALAPPDATA)
+      ? env.LOCALAPPDATA
+      : win32.join(home, "AppData", "Local");
+  }
+
+  return env.XDG_STATE_HOME && posix.isAbsolute(env.XDG_STATE_HOME)
+    ? env.XDG_STATE_HOME
+    : posix.join(home, ".local", "state");
+}
+
+export function defaultConfigPath(
+  env: PathEnv = process.env,
+  home = homedir(),
+  platform: Platform = process.platform,
+): string {
+  const pathJoin = platform === "win32" ? win32.join : posix.join;
+  return pathJoin(defaultConfigBaseDir(env, home, platform), "caplets", "config.json");
+}
+
+export function defaultAuthDir(
+  env: PathEnv = process.env,
+  home = homedir(),
+  platform: Platform = process.platform,
+): string {
+  const pathJoin = platform === "win32" ? win32.join : posix.join;
+  return pathJoin(defaultStateBaseDir(env, home, platform), "caplets", "auth");
+}
+
+export const DEFAULT_CONFIG_PATH = defaultConfigPath();
+export const DEFAULT_AUTH_DIR = defaultAuthDir();
 export const PROJECT_CONFIG_FILE = join(".caplets", "config.json");
 export const TRUST_PROJECT_CAPLETS_ENV = "CAPLETS_TRUST_PROJECT_CAPLETS";
 

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -496,6 +496,7 @@ describe("auth helpers", () => {
               authorizationUrl: `${baseUrl}/authorize`,
               tokenUrl: `${baseUrl}/token`,
               clientMetadataUrl,
+              clientSecret: "metadata-url-secret",
             },
           },
           {
@@ -514,8 +515,59 @@ describe("auth helpers", () => {
 
       expect(new URL(authorizationUrl).searchParams.get("client_id")).toBe(clientMetadataUrl);
       expect(new URLSearchParams(tokenRequestBody).get("client_id")).toBe(clientMetadataUrl);
+      expect(new URLSearchParams(tokenRequestBody).get("client_secret")).toBe(
+        "metadata-url-secret",
+      );
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("matches generic OAuth token bundles against configured client metadata URLs", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
+    try {
+      writeTokenBundle(
+        {
+          server: "users",
+          authType: "oauth2",
+          accessToken: "metadata-url-token",
+          clientId: "https://client.example.com/caplets/oauth-client-metadata.json",
+          protectedResourceOrigin: "https://api.example.com",
+        },
+        dir,
+      );
+
+      expect(
+        genericOAuthHeaders(
+          {
+            server: "users",
+            backend: "openapi",
+            url: "https://api.example.com/openapi.json",
+            auth: {
+              type: "oauth2",
+              clientMetadataUrl: "https://client.example.com/caplets/oauth-client-metadata.json",
+            },
+          },
+          dir,
+        ),
+      ).toEqual({ authorization: "Bearer metadata-url-token" });
+
+      expect(() =>
+        genericOAuthHeaders(
+          {
+            server: "users",
+            backend: "openapi",
+            url: "https://api.example.com/openapi.json",
+            auth: {
+              type: "oauth2",
+              clientMetadataUrl: "https://client.example.com/other-client.json",
+            },
+          },
+          dir,
+        ),
+      ).toThrow(expect.objectContaining({ code: "AUTH_REQUIRED" }));
+    } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -243,6 +243,29 @@ describe("auth helpers", () => {
     expect(headers.get("content-type")).toBe("application/x-www-form-urlencoded");
   });
 
+  it("exposes configured OAuth client metadata URL for URL-based client IDs", () => {
+    const server = parseConfig({
+      mcpServers: {
+        remote: {
+          name: "Remote",
+          description: "A useful remote server.",
+          transport: "http",
+          url: "https://example.com/mcp",
+          auth: {
+            type: "oauth2",
+            clientMetadataUrl: "https://example.com/caplets/oauth-client-metadata.json",
+          },
+        },
+      },
+    }).mcpServers.remote!;
+    const provider = new FileOAuthProvider(server, "http://127.0.0.1/callback", () => {});
+
+    expect(provider.clientMetadataUrl).toBe(
+      "https://example.com/caplets/oauth-client-metadata.json",
+    );
+    expect(provider.clientInformation()).toBeUndefined();
+  });
+
   it.each(["oauth2", "oidc"] as const)(
     "adds dynamically registered %s client information during SDK token exchange",
     async (authType) => {

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const mockMcpAuth = vi.hoisted(() => vi.fn());
+
+vi.mock("@modelcontextprotocol/sdk/client/auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@modelcontextprotocol/sdk/client/auth")>()),
+  auth: mockMcpAuth,
+}));
+
 import {
   classifyRemoteAuthError,
   genericOAuthHeaders,
@@ -7,6 +15,7 @@ import {
   authStorePath,
   oauthHeaders,
   readTokenBundle,
+  runOAuthFlow,
   runGenericOAuthFlow,
   writeTokenBundle,
 } from "../src/auth.js";
@@ -264,6 +273,27 @@ describe("auth helpers", () => {
       "https://example.com/caplets/oauth-client-metadata.json",
     );
     expect(provider.clientInformation()).toBeUndefined();
+  });
+
+  it("does not rewrite SDK dynamic-registration errors when MCP OAuth uses a client metadata URL", async () => {
+    const sdkError = new Error("server does not support dynamic client registration");
+    mockMcpAuth.mockRejectedValueOnce(sdkError);
+    const server = parseConfig({
+      mcpServers: {
+        remote: {
+          name: "Remote",
+          description: "A useful remote server.",
+          transport: "http",
+          url: "https://example.com/mcp",
+          auth: {
+            type: "oauth2",
+            clientMetadataUrl: "https://example.com/caplets/oauth-client-metadata.json",
+          },
+        },
+      },
+    }).mcpServers.remote!;
+
+    await expect(runOAuthFlow(server, { noOpen: true })).rejects.toBe(sdkError);
   });
 
   it.each(["oauth2", "oidc"] as const)(

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -455,6 +455,71 @@ describe("auth helpers", () => {
     ).rejects.toMatchObject({ code: "AUTH_FAILED" });
   });
 
+  it("uses configured client metadata URLs as URL-based client IDs for generic OAuth", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
+    let baseUrl = "";
+    let authorizationUrl = "";
+    let tokenRequestBody = "";
+    const clientMetadataUrl = "https://client.example.com/caplets/oauth-client-metadata.json";
+    const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        response.setHeader("content-type", "application/json");
+        if (request.url === "/token") {
+          tokenRequestBody = body;
+          response.end(JSON.stringify({ access_token: "metadata-url-token" }));
+          return;
+        }
+        response.end("{}");
+      });
+    });
+    try {
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("test server did not bind");
+      }
+      baseUrl = `http://127.0.0.1:${address.port}`;
+
+      await expect(
+        runGenericOAuthFlow(
+          {
+            server: "users",
+            backend: "openapi",
+            url: baseUrl,
+            auth: {
+              type: "oauth2",
+              authorizationUrl: `${baseUrl}/authorize`,
+              tokenUrl: `${baseUrl}/token`,
+              clientMetadataUrl,
+            },
+          },
+          {
+            authDir: dir,
+            noOpen: true,
+            print: (line) => {
+              authorizationUrl = line.match(/https?:\/\/\S+/)?.[0] ?? "";
+            },
+            readManualInput: async () => {
+              const url = new URL(authorizationUrl);
+              return `http://127.0.0.1/callback?code=auth-code&state=${url.searchParams.get("state")}`;
+            },
+          },
+        ),
+      ).resolves.toMatchObject({ accessToken: "metadata-url-token", clientId: clientMetadataUrl });
+
+      expect(new URL(authorizationUrl).searchParams.get("client_id")).toBe(clientMetadataUrl);
+      expect(new URLSearchParams(tokenRequestBody).get("client_id")).toBe(clientMetadataUrl);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects insecure explicit OAuth discovery URLs instead of falling back", async () => {
     await expect(
       runGenericOAuthFlow(

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -12,10 +12,11 @@ import {
 } from "../src/auth.js";
 import { listAuth } from "../src/cli/auth.js";
 import { parseConfig } from "../src/config.js";
+import { DEFAULT_AUTH_DIR } from "../src/config/paths.js";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, parse } from "node:path";
 
 describe("auth helpers", () => {
   it("extracts callback code and state together", () => {
@@ -86,6 +87,25 @@ describe("auth helpers", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("stores remote auth under the shared default auth directory", () => {
+    expect(authStorePath("remote")).toBe(join(DEFAULT_AUTH_DIR, "remote.json"));
+  });
+
+  it("honors explicit auth directory overrides", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
+    try {
+      expect(authStorePath("remote", dir)).toBe(join(dir, "remote.json"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("honors filesystem root as an explicit auth directory", () => {
+    const root = parse(process.cwd()).root;
+
+    expect(authStorePath("remote", root)).toBe(join(root, "remote.json"));
   });
 
   it("builds generic OAuth headers for OpenAPI and GraphQL auth targets", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { version as packageJsonVersion } from "../package.json";
 import { initConfig, installCaplets, normalizeGitRepo, runCli, starterConfig } from "../src/cli.js";
 import { parseConfig, TRUST_PROJECT_CAPLETS_ENV } from "../src/config.js";
@@ -229,11 +229,43 @@ describe("cli init", () => {
         userConfig: configPath,
         projectConfig: join(process.cwd(), ".caplets", "config.json"),
         userRoot: dir,
+        stateRoot: dirname(authDir),
         projectRoot: join(process.cwd(), ".caplets"),
         authDir,
         envConfig: configPath,
         projectCapletsTrusted: true,
       });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prints resolved config paths for humans", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-config-paths-"));
+    const configPath = join(dir, "custom.json");
+    const authDir = join(dir, "state", "auth");
+    const out: string[] = [];
+    try {
+      process.env.CAPLETS_CONFIG = configPath;
+
+      await runCli(["config", "paths"], {
+        writeOut: (value) => out.push(value),
+        authDir,
+      });
+
+      expect(out.join("")).toBe(
+        [
+          `userConfig: ${configPath}`,
+          `projectConfig: ${join(process.cwd(), ".caplets", "config.json")}`,
+          `userRoot: ${dir}`,
+          `stateRoot: ${dirname(authDir)}`,
+          `projectRoot: ${join(process.cwd(), ".caplets")}`,
+          `authDir: ${authDir}`,
+          `envConfig: ${configPath}`,
+          "projectCapletsTrusted: false",
+          "",
+        ].join("\n"),
+      );
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/config-paths.test.ts
+++ b/test/config-paths.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { posix, win32 } from "node:path";
+import {
+  defaultAuthDir,
+  defaultConfigBaseDir,
+  defaultConfigPath,
+  defaultStateBaseDir,
+} from "../src/config/paths.js";
+
+describe("config paths", () => {
+  it("uses XDG-compatible Unix defaults", () => {
+    const env = {};
+    const home = "/home/alex";
+
+    expect(defaultConfigBaseDir(env, home, "linux")).toBe(posix.join(home, ".config"));
+    expect(defaultStateBaseDir(env, home, "linux")).toBe(posix.join(home, ".local", "state"));
+    expect(defaultConfigPath(env, home, "linux")).toBe(
+      posix.join(home, ".config", "caplets", "config.json"),
+    );
+    expect(defaultAuthDir(env, home, "linux")).toBe(
+      posix.join(home, ".local", "state", "caplets", "auth"),
+    );
+  });
+
+  it("uses absolute Unix XDG overrides", () => {
+    const env = {
+      XDG_CONFIG_HOME: "/xdg/config",
+      XDG_STATE_HOME: "/xdg/state",
+    };
+
+    expect(defaultConfigPath(env, "/home/alex", "darwin")).toBe(
+      posix.join("/xdg/config", "caplets", "config.json"),
+    );
+    expect(defaultAuthDir(env, "/home/alex", "darwin")).toBe(
+      posix.join("/xdg/state", "caplets", "auth"),
+    );
+  });
+
+  it("ignores relative Unix XDG overrides", () => {
+    const env = {
+      XDG_CONFIG_HOME: "relative/config",
+      XDG_STATE_HOME: "relative/state",
+    };
+    const home = "/Users/alex";
+
+    expect(defaultConfigPath(env, home, "darwin")).toBe(
+      posix.join(home, ".config", "caplets", "config.json"),
+    );
+    expect(defaultAuthDir(env, home, "darwin")).toBe(
+      posix.join(home, ".local", "state", "caplets", "auth"),
+    );
+  });
+
+  it("uses absolute Windows app data environment directories", () => {
+    const env = {
+      APPDATA: "C:\\Users\\Alex\\AppData\\Roaming",
+      LOCALAPPDATA: "C:\\Users\\Alex\\AppData\\Local",
+    };
+
+    expect(defaultConfigPath(env, "C:\\Users\\Alex", "win32")).toBe(
+      win32.join(env.APPDATA, "caplets", "config.json"),
+    );
+    expect(defaultAuthDir(env, "C:\\Users\\Alex", "win32")).toBe(
+      win32.join(env.LOCALAPPDATA, "caplets", "auth"),
+    );
+  });
+
+  it("falls back to Windows home app data directories when env vars are missing or relative", () => {
+    const env = {
+      APPDATA: "AppData\\Roaming",
+      LOCALAPPDATA: "AppData\\Local",
+    };
+    const home = "C:\\Users\\Alex";
+
+    expect(defaultConfigPath(env, home, "win32")).toBe(
+      win32.join(home, "AppData", "Roaming", "caplets", "config.json"),
+    );
+    expect(defaultAuthDir({}, home, "win32")).toBe(
+      win32.join(home, "AppData", "Local", "caplets", "auth"),
+    );
+    expect(defaultAuthDir(env, home, "win32")).toBe(
+      win32.join(home, "AppData", "Local", "caplets", "auth"),
+    );
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -36,7 +36,7 @@ describe("config", () => {
     }
   });
 
-  it("loads ~/.caplets-compatible config from a path with defaults and interpolation", () => {
+  it("loads user config from a path with defaults and interpolation", () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-config-"));
     const path = join(dir, "config.json");
     writeFileSync(
@@ -511,6 +511,7 @@ describe("config", () => {
             auth: {
               type: "oidc",
               issuer: "https://login.example.com",
+              clientMetadataUrl: "https://client.example.com/caplets/oauth-client-metadata.json",
               clientId: "catalog-client",
             },
             operations: {
@@ -549,7 +550,11 @@ describe("config", () => {
       backend: "graphql",
       endpointUrl: "https://api.example.com/graphql",
       schemaPath: join(root, "catalog.graphql"),
-      auth: { type: "oidc", issuer: "https://login.example.com" },
+      auth: {
+        type: "oidc",
+        issuer: "https://login.example.com",
+        clientMetadataUrl: "https://client.example.com/caplets/oauth-client-metadata.json",
+      },
       operations: {
         product: {
           documentPath: join(root, "product.graphql"),

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -912,6 +912,29 @@ describe("config", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  it("rejects invalid OIDC URL fields in Caplet files", () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-files-"));
+    writeFileSync(
+      join(root, "bad-oidc.md"),
+      [
+        "---",
+        "name: Bad OIDC",
+        "description: Invalid OIDC settings.",
+        "mcpServer:",
+        "  transport: http",
+        "  url: https://example.com/mcp",
+        "  auth:",
+        "    type: oidc",
+        "    clientMetadataUrl: not-a-url",
+        "---",
+        "# Bad OIDC",
+      ].join("\n"),
+    );
+
+    expect(() => loadCapletFiles(root)).toThrow(CapletsError);
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it("rejects oversized Caplet files and bodies", () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-files-"));
     const root = join(dir, ".caplets");


### PR DESCRIPTION
## Summary
- Move default user config and Caplet file roots to XDG config locations on Unix-like platforms and AppData Roaming on Windows.
- Move OAuth token storage to XDG state locations on Unix-like platforms and LocalAppData on Windows.
- Add path helper coverage, CLI `stateRoot` reporting, docs updates, implementation plan, and a minor changeset.

## Testing
- `pnpm vitest run test/config-paths.test.ts test/config.test.ts test/cli.test.ts test/auth.test.ts`
- `pnpm verify`
- Pre-push hook ran `pnpm format:check && pnpm lint && pnpm typecheck && pnpm schema:check && pnpm test && pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config and OAuth token defaults now follow platform conventions (XDG on Unix, AppData/LocalAppData on Windows); starter config is created in the platform config dir and can be overridden via env var. OAuth token storage moved to platform state dirs.
  * Optional OAuth/OIDC clientMetadataUrl accepted for downstream servers/endpoints; token matching honors it.

* **CLI**
  * CLI shows a resolved stateRoot alongside config paths.

* **Documentation**
  * README/PRD/docs updated for new default paths and behavior.

* **Tests**
  * Added/updated tests for path logic, auth storage, and client-metadata behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spiritledsoftware/caplets/pull/23)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->