### PR TITLE
fix: publish scoped integration packages publicly

### DIFF
--- a/.changeset/public-integrations-publish.md
+++ b/.changeset/public-integrations-publish.md
@@ -1,0 +1,6 @@
+---
+"@caplets/opencode": patch
+"@caplets/pi": patch
+---
+
+Fix npm publishing for public scoped integration packages.

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -11,6 +11,9 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rm -rf dist && rolldown -c",
     "prepack": "pnpm build",

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -11,6 +11,9 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rm -rf dist && rolldown -c",
     "prepack": "pnpm build",


### PR DESCRIPTION
## Summary
- Mark `@caplets/opencode` and `@caplets/pi` as public scoped packages for npm publishing.
- Add a patch changeset so the release workflow can version the publish metadata fix.

## Verification
- `pnpm exec oxfmt --check packages/opencode/package.json packages/pi/package.json .changeset/public-integrations-publish.md`
- `pnpm changeset status`
- Pre-push hook ran `pnpm verify` successfully from clean worktree `/tmp/opencode/caplets-release-pr`

## Notes
- Original release failure: npm rejected first publish of `@caplets/opencode` and `@caplets/pi`; public scoped packages need explicit public access metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed npm publishing configuration for public scoped integration packages (`@caplets/opencode` and `@caplets/pi`), enabling proper public distribution on npm.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spiritledsoftware/caplets/pull/33)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->