### PR TITLE
fix: add native package publishing metadata

### DIFF
--- a/.changeset/fix-native-package-publishing.md
+++ b/.changeset/fix-native-package-publishing.md
@@ -1,0 +1,6 @@
+---
+"@caplets/opencode": patch
+"@caplets/pi": patch
+---
+
+Add repository metadata required for npm trusted publishing.

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -2,6 +2,17 @@
   "name": "@caplets/opencode",
   "version": "0.1.1",
   "description": "Native OpenCode plugin for Caplets.",
+  "homepage": "https://github.com/spiritledsoftware/caplets#readme",
+  "bugs": {
+    "url": "https://github.com/spiritledsoftware/caplets/issues"
+  },
+  "license": "MIT",
+  "author": "Spirit-Led Software LLC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spiritledsoftware/caplets.git",
+    "directory": "packages/opencode"
+  },
   "files": [
     "dist",
     "README.md"

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -2,6 +2,17 @@
   "name": "@caplets/pi",
   "version": "0.1.1",
   "description": "Native Pi extension for Caplets.",
+  "homepage": "https://github.com/spiritledsoftware/caplets#readme",
+  "bugs": {
+    "url": "https://github.com/spiritledsoftware/caplets/issues"
+  },
+  "license": "MIT",
+  "author": "Spirit-Led Software LLC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spiritledsoftware/caplets.git",
+    "directory": "packages/pi"
+  },
   "files": [
     "dist",
     "README.md"


### PR DESCRIPTION
## Summary
- Add npm repository, homepage, bugs, license, and author metadata to `@caplets/opencode` and `@caplets/pi`.
- Add a patch changeset so the native integration packages get republished with metadata required by npm trusted publishing.

## Verification
- `pnpm verify`
- `pnpm --filter @caplets/opencode pack --dry-run`
- `pnpm --filter @caplets/pi pack --dry-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata for `@caplets/opencode` and `@caplets/pi` to enable npm trusted publishing support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spiritledsoftware/caplets/pull/35)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->