### PR TITLE
feat: add caplet sets backend

### DIFF
--- a/.changeset/quiet-caplets-nest.md
+++ b/.changeset/quiet-caplets-nest.md
@@ -1,0 +1,5 @@
+---
+"@caplets/core": minor
+---
+
+Add the `capletSets` backend for nested Caplets collections.

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ the committed schema stays in sync with the Zod config validator.
 
 For richer skill-like cards, add Markdown Caplet files beside `config.json`. Every Caplet
 file must include exactly one executable backend: `mcpServer`, `openapiEndpoint`,
-`graphqlEndpoint`, `httpApi`, or `cliTools`;
+`graphqlEndpoint`, `httpApi`, `cliTools`, or `capletSet`;
 serverless Caplets are intentionally out of scope.
 
 Top-level files derive the Caplet ID from the filename:
@@ -454,7 +454,7 @@ caplets init --force
 
 ### Caplet IDs
 
-Each key under `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, `httpApis`, or `cliTools` is the
+Each key under `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, `httpApis`, `cliTools`, or `capletSets` is the
 stable Caplet ID. It becomes the generated MCP tool name exactly, so keep it short and specific:
 
 ```json
@@ -471,7 +471,7 @@ stable Caplet ID. It becomes the generated MCP tool name exactly, so keep it sho
 ```
 
 Caplet IDs must match `^[a-zA-Z0-9_-]{1,64}$` and must be unique across `mcpServers`,
-`openapiEndpoints`, `graphqlEndpoints`, `httpApis`, and `cliTools`. Spaces, dots, slashes, colons, and Unicode IDs are rejected.
+`openapiEndpoints`, `graphqlEndpoints`, `httpApis`, `cliTools`, and `capletSets`. Spaces, dots, slashes, colons, and Unicode IDs are rejected.
 
 ### Stdio Servers
 
@@ -689,6 +689,42 @@ Pass `-g` or `--global` to write to the user Caplets root, `--print` to review t
 manifest without writing, `--output <path>` for an explicit destination, or `--force` to overwrite
 an existing destination file.
 
+### Caplet Sets
+
+Use `capletSets` to expose another Caplets collection as nested Caplets. Each child Caplet appears
+as one downstream tool, and that child tool accepts the same Caplets operation schema:
+`get_caplet`, `list_tools`, `search_tools`, `get_tool`, and `call_tool`.
+
+```json
+{
+  "capletSets": {
+    "team": {
+      "name": "Team Caplets",
+      "description": "Use the team's shared Caplets collection.",
+      "configPath": "./team-caplets/config.json",
+      "capletsRoot": "./team-caplets/caplets"
+    }
+  }
+}
+```
+
+`configPath` and `capletsRoot` are independently optional, but at least one is required. Child
+collections are isolated from the parent collection; they use their own config and Caplet files,
+with their own `defaultSearchLimit` and `maxSearchLimit` when set on the `capletSets` entry.
+Recursive nesting is supported, and repeated source paths are rejected as cycles.
+
+Markdown Caplet files use `capletSet` frontmatter:
+
+```yaml
+---
+name: Team Caplets
+description: Use the team's shared Caplets collection.
+capletSet:
+  configPath: ./team-caplets/config.json
+  capletsRoot: ./team-caplets/caplets
+---
+```
+
 Add MCP, OpenAPI, GraphQL, and HTTP API Caplets with the same destination options:
 
 ```sh
@@ -854,7 +890,7 @@ Call one exact downstream tool:
 Available operations:
 
 - `get_caplet`: return the configured capability card without starting the downstream server.
-- `check_backend`: verify the selected backend, whether MCP, OpenAPI, or GraphQL.
+- `check_backend`: verify the selected backend, whether MCP, OpenAPI, GraphQL, HTTP, CLI, or nested Caplets.
 - `check_mcp_server`: start or connect to an MCP server and verify its tool list.
 - `list_tools`: return compact downstream tool metadata.
 - `search_tools`: search downstream tool names and descriptions within this Caplet.

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ exposed two ways: direct flat MCP aggregation versus Caplets progressive disclos
 | Initial Agent Surface     |   Direct Flat MCP |      Caplets |     Reduction |
 | ------------------------- | ----------------: | -----------: | ------------: |
 | Visible tools             |               106 |            3 |   97.2% fewer |
-| Serialized MCP payload    |      32,090 bytes |  8,400 bytes | 73.8% smaller |
-| Approx. context surface   |      8,023 tokens | 2,100 tokens |   5,923 fewer |
+| Serialized MCP payload    |      32,090 bytes |  8,442 bytes | 73.7% smaller |
+| Approx. context surface   |      8,023 tokens | 2,111 tokens |   5,912 fewer |
 | Top-level name collisions | 3 duplicate names |            0 |    eliminated |
 
 Caplets does not remove access to downstream tools. It places them behind scoped
@@ -692,8 +692,8 @@ an existing destination file.
 ### Caplet Sets
 
 Use `capletSets` to expose another Caplets collection as nested Caplets. Each child Caplet appears
-as one downstream tool, and that child tool accepts the same Caplets operation schema:
-`get_caplet`, `list_tools`, `search_tools`, `get_tool`, and `call_tool`.
+as one downstream tool and supports the full Caplets operation set: `get_caplet`, `check_backend`,
+`check_mcp_server`, `list_tools`, `search_tools`, `get_tool`, and `call_tool`.
 
 ```json
 {

--- a/docs/benchmarks/coding-agent.md
+++ b/docs/benchmarks/coding-agent.md
@@ -14,13 +14,13 @@ The fixture uses local mock MCP metadata only. It does not call external APIs, d
 ## Summary
 
 - Initial tools visible: direct flat MCP 106, Caplets top-level 3, 97.2% fewer.
-- Serialized payload bytes: direct flat MCP 32090, Caplets top-level 8400, 73.8% fewer.
-- Approx. tokens: direct flat MCP 8023, Caplets top-level 2100, 5923 fewer.
+- Serialized payload bytes: direct flat MCP 32090, Caplets top-level 8442, 73.7% fewer.
+- Approx. tokens: direct flat MCP 8023, Caplets top-level 2111, 5912 fewer.
 - Candidate set before discovery: direct flat MCP 106, Caplets top-level 3, 103 fewer.
 
 ## Deterministic Results
 
-Caplets reduces the initial serialized MCP tool payload by 73.8%, from 32090 bytes to 8400 bytes. It reduces initially visible tools by 97.2%, from 106 direct flat tools to 3 Caplets capability tools, while preserving access to downstream tools through scoped discovery and `call_tool`.
+Caplets reduces the initial serialized MCP tool payload by 73.7%, from 32090 bytes to 8442 bytes. It reduces initially visible tools by 97.2%, from 106 direct flat tools to 3 Caplets capability tools, while preserving access to downstream tools through scoped discovery and `call_tool`.
 
 ## Collision Check
 
@@ -38,7 +38,7 @@ Caplets starts from 3 capability tools. Expected task-specific discovery is 4 ca
 
 ## Validation
 
-- Initial payload reduction threshold: 73.8% >= 70.0%
+- Initial payload reduction threshold: 73.7% >= 70.0%
 - Top-level Caplets collisions: 0
 
 Payload implementation: `source`

--- a/docs/product/caplets-progressive-mcp-disclosure-prd.md
+++ b/docs/product/caplets-progressive-mcp-disclosure-prd.md
@@ -211,7 +211,7 @@ Requirements:
 - `mcpServers` is optional when one or more valid Markdown Caplet files are present.
 - `$schema` is optional and exists only for JSON Schema-aware editor validation.
 - `version` is optional for MVP and defaults to 1 when omitted. If present, MVP accepts only `1` and rejects unsupported versions with `CONFIG_INVALID`.
-- Allowed top-level keys in MVP are `$schema`, `version`, `defaultSearchLimit`, `maxSearchLimit`, `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, `httpApis`, and `cliTools`; unknown top-level keys are rejected with `CONFIG_INVALID`.
+- Allowed top-level keys in MVP are `$schema`, `version`, `defaultSearchLimit`, `maxSearchLimit`, `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, `httpApis`, `cliTools`, and `capletSets`; unknown top-level keys are rejected with `CONFIG_INVALID`.
 - The committed JSON Schema lives at `schemas/caplets-config.schema.json`, is generated from the Zod runtime config schema, and CI must fail when the committed schema drifts from the generated output.
 - Unknown keys inside each server config are rejected with `CONFIG_INVALID`, except fields that belong to the tracked standard MCP server schema plus Caplets-owned additions documented here.
 - `mcpServers` is the only accepted top-level server configuration key for plain JSON downstream MCP servers in MVP.
@@ -226,7 +226,7 @@ Requirements:
 - `description` must be at most 1500 characters and is returned exactly as configured.
 - `description` may contain Markdown syntax because the primary reader is an LLM, but MVP treats it as opaque text: Caplets does not render, sanitize, transform, or interpret Markdown.
 - Caplets should reuse or closely track existing MCP server config validation semantics where practical rather than inventing a new dialect.
-- Markdown Caplet files are executable configuration because they require exactly one backend among `mcpServer`, `openapiEndpoint`, `graphqlEndpoint`, `httpApi`, or `cliTools`, and some backends can start downstream processes. User Caplet files are trusted by location, and project Caplet files load by default from the current project's `./.caplets` directory. When a project Caplet shadows a global/user Caplet, CLI inspection must make the winning project source and shadowed source visible.
+- Markdown Caplet files are executable configuration because they require exactly one backend among `mcpServer`, `openapiEndpoint`, `graphqlEndpoint`, `httpApi`, `cliTools`, or `capletSet`, and some backends can start downstream processes. User Caplet files are trusted by location, and project Caplet files load by default from the current project's `./.caplets` directory. When a project Caplet shadows a global/user Caplet, CLI inspection must make the winning project source and shadowed source visible.
 - Each server config must define exactly one connection shape:
   - Stdio: `command` is required; optional `args`, `env`, and `cwd` are allowed.
   - Remote: `url` is required and `transport` must be `http` or `sse`.
@@ -268,6 +268,7 @@ Requirements:
 - GraphQL backends support local `schemaPath`, remote `schemaUrl`, or endpoint introspection, configured operations, auto-generated query/mutation tools, explicit `auth`, and native GraphQL HTTP execution.
 - HTTP action backends support explicit `httpApis` config or Markdown `httpApi` frontmatter with `baseUrl`, `auth`, and one or more named actions. Each action defines `method`, `path`, optional `description`, optional `inputSchema`, and optional `query`, `headers`, and `jsonBody` mappings.
 - CLI backends support explicit `cliTools` config or Markdown `cliTools` frontmatter with one or more named actions. Each action defines a command, optional fixed args, optional description, optional inputSchema, optional argument/environment/stdin mappings, optional cwd, timeout, and output byte limits; execution must avoid shell evaluation unless explicitly modeled as a command executable.
+- Caplet set backends support explicit `capletSets` config or Markdown `capletSet` frontmatter with `configPath`, `capletsRoot`, or both. Each child Caplet is exposed as one downstream tool that accepts the normal Caplets operation schema; child collections are isolated from the parent, and recursive nesting must reject repeated source paths as cycles.
 - HTTP action `query` and `headers` mappings must resolve to object maps whose values are strings, numbers, or booleans. HTTP action `jsonBody` mappings support literal values, nested arrays/objects, `$input.field` references, and `$input` for the complete argument object. HTTP action paths may contain `{field}` placeholders resolved from top-level arguments.
 - HTTP action requests require HTTPS except loopback URLs, reject origin-changing paths and redirects, reject managed configured headers, enforce timeouts and response byte limits, and return structured `{ status, statusText, headers, body, elapsedMs }` content with `isError` set for non-2xx status.
 - OpenCode's `mcp` config shape is a compatibility reference, not Caplets' native MVP shape: OpenCode uses local/remote entries under `mcp`, local `command` as an array, `environment` instead of `env`, and `{env:NAME}`-style interpolation in its broader config system. Automatic OpenCode config import/normalization is deferred.
@@ -380,6 +381,7 @@ Core modules:
 - `graphqlEndpoints: Record<string, GraphQlEndpointConfig>`
 - `httpApis: Record<string, HttpApiConfig>`
 - `cliTools: Record<string, CliToolConfig>`
+- `capletSets: Record<string, CapletSetConfig>`
 
 `CapletServerConfig`:
 
@@ -626,7 +628,7 @@ If no test runner exists yet, implementation must add one before claiming MVP co
 **MVP: Local progressive MCP gateway**
 
 - Read `${XDG_CONFIG_HOME:-~/.config}/caplets/config.json` on Unix-like platforms or `%APPDATA%\caplets\config.json` on Windows.
-- Validate all supported backend config maps with required descriptions: `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, `httpApis`, and `cliTools`.
+- Validate all supported backend config maps with required descriptions: `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, `httpApis`, `cliTools`, and `capletSets`.
 - Require restart after config changes while keeping config loading, registry construction, and downstream client lifecycle modular enough for later hot reload.
 - Expose one generated top-level MCP tool per enabled downstream server.
 - Support server-scoped diagnostics, tool listing, lexical search, tool metadata lookup, and explicit tool invocation through each generated Caplet tool.
@@ -656,7 +658,7 @@ If no test runner exists yet, implementation must add one before claiming MVP co
 
 ### Technical Risks
 
-- **Config fragmentation**: MCP clients differ on config shape. MVP mitigates this by documenting and supporting exactly the configured backend keys, including `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, `httpApis`, and `cliTools`.
+- **Config fragmentation**: MCP clients differ on config shape. MVP mitigates this by documenting and supporting exactly the configured backend keys, including `mcpServers`, `openapiEndpoints`, `graphqlEndpoints`, `httpApis`, `cliTools`, and `capletSets`.
 - **Client expectations**: Some clients may expect every downstream tool in `tools/list`. MVP intentionally exposes one generated server/caplet tool per downstream server instead.
 - **Lifecycle cost**: Keeping downstream stdio servers running improves freshness but consumes local resources and may surface startup failures earlier. MVP mitigates this with bounded startup, process reuse, status reporting, and partial failures.
 - **Unsafe downstream behavior**: Downstream tools may be destructive. MVP mitigates this by avoiding safety claims and preserving MCP client confirmation flows.

--- a/packages/core/src/capability-description.mjs
+++ b/packages/core/src/capability-description.mjs
@@ -10,7 +10,9 @@ export function capabilityDescription(server) {
             ? "HTTP API"
             : server.backend === "cli"
               ? "CLI tools"
-              : "nested Caplets";
+              : server.backend === "caplets"
+                ? "nested Caplets"
+                : "backend";
   const checkOperation = server.backend === "mcp" ? "check_mcp_server" : "check_backend";
   const hint = [
     `Use this Caplet to inspect and call tools from its ${backendName} backend.`,

--- a/packages/core/src/capability-description.mjs
+++ b/packages/core/src/capability-description.mjs
@@ -8,7 +8,9 @@ export function capabilityDescription(server) {
           ? "GraphQL endpoint"
           : server.backend === "http"
             ? "HTTP API"
-            : "CLI tools";
+            : server.backend === "cli"
+              ? "CLI tools"
+              : "nested Caplets";
   const checkOperation = server.backend === "mcp" ? "check_mcp_server" : "check_backend";
   const hint = [
     `Use this Caplet to inspect and call tools from its ${backendName} backend.`,

--- a/packages/core/src/caplet-files.ts
+++ b/packages/core/src/caplet-files.ts
@@ -505,6 +505,36 @@ const capletCliToolsSchema = z
   })
   .strict();
 
+const capletSetSchema = z
+  .object({
+    configPath: z.string().min(1).optional().describe("Child Caplets config.json path."),
+    capletsRoot: z.string().min(1).optional().describe("Child Markdown Caplets root directory."),
+    defaultSearchLimit: z.number().int().positive().optional(),
+    maxSearchLimit: z.number().int().positive().max(50).optional(),
+    toolCacheTtlMs: z.number().int().nonnegative().optional(),
+    disabled: z.boolean().optional().describe("When true, omit this Caplet from discovery."),
+  })
+  .strict()
+  .superRefine((set, ctx) => {
+    if (!set.configPath && !set.capletsRoot) {
+      ctx.addIssue({
+        code: "custom",
+        message: "capletSet must define at least one source: configPath or capletsRoot",
+      });
+    }
+    if (
+      set.defaultSearchLimit !== undefined &&
+      set.maxSearchLimit !== undefined &&
+      set.defaultSearchLimit > set.maxSearchLimit
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["defaultSearchLimit"],
+        message: "defaultSearchLimit must be <= maxSearchLimit",
+      });
+    }
+  });
+
 export const capletFileSchema = z
   .object({
     $schema: z
@@ -540,6 +570,9 @@ export const capletFileSchema = z
     cliTools: capletCliToolsSchema
       .describe("CLI tools backend configuration for this Caplet.")
       .optional(),
+    capletSet: capletSetSchema
+      .describe("Nested Caplet collection backend configuration for this Caplet.")
+      .optional(),
   })
   .strict()
   .superRefine((frontmatter, ctx) => {
@@ -548,12 +581,13 @@ export const capletFileSchema = z
       Number(Boolean(frontmatter.openapiEndpoint)) +
       Number(Boolean(frontmatter.graphqlEndpoint)) +
       Number(Boolean(frontmatter.httpApi)) +
-      Number(Boolean(frontmatter.cliTools));
+      Number(Boolean(frontmatter.cliTools)) +
+      Number(Boolean(frontmatter.capletSet));
     if (backendCount !== 1) {
       ctx.addIssue({
         code: "custom",
         message:
-          "Caplet file must define exactly one backend: mcpServer, openapiEndpoint, graphqlEndpoint, httpApi, or cliTools",
+          "Caplet file must define exactly one backend: mcpServer, openapiEndpoint, graphqlEndpoint, httpApi, cliTools, or capletSet",
       });
     }
   });
@@ -576,6 +610,7 @@ export type CapletFileConfig = {
   graphqlEndpoints?: Record<string, unknown>;
   httpApis?: Record<string, unknown>;
   cliTools?: Record<string, unknown>;
+  capletSets?: Record<string, unknown>;
 };
 
 export type CapletFileLoadResult = {
@@ -597,6 +632,7 @@ export function loadCapletFilesWithPaths(root: string): CapletFileLoadResult | u
   const graphqlEndpoints: Record<string, unknown> = {};
   const httpApis: Record<string, unknown> = {};
   const cliTools: Record<string, unknown> = {};
+  const capletSets: Record<string, unknown> = {};
   const paths: Record<string, string> = {};
   for (const candidate of discoverCapletFiles(root)) {
     if (
@@ -604,7 +640,8 @@ export function loadCapletFilesWithPaths(root: string): CapletFileLoadResult | u
       openapiEndpoints[candidate.id] ||
       graphqlEndpoints[candidate.id] ||
       httpApis[candidate.id] ||
-      cliTools[candidate.id]
+      cliTools[candidate.id] ||
+      capletSets[candidate.id]
     ) {
       throw new CapletsError("CONFIG_INVALID", `Duplicate Caplet ID ${candidate.id} under ${root}`);
     }
@@ -622,6 +659,9 @@ export function loadCapletFilesWithPaths(root: string): CapletFileLoadResult | u
     } else if (isPlainObject(config) && config.backend === "cli") {
       const { backend: _backend, ...endpoint } = config;
       cliTools[candidate.id] = endpoint;
+    } else if (isPlainObject(config) && config.backend === "caplets") {
+      const { backend: _backend, ...endpoint } = config;
+      capletSets[candidate.id] = endpoint;
     } else {
       servers[candidate.id] = config;
     }
@@ -632,7 +672,8 @@ export function loadCapletFilesWithPaths(root: string): CapletFileLoadResult | u
   const hasGraphQl = Object.keys(graphqlEndpoints).length > 0;
   const hasHttpApis = Object.keys(httpApis).length > 0;
   const hasCliTools = Object.keys(cliTools).length > 0;
-  return hasServers || hasOpenApi || hasGraphQl || hasHttpApis || hasCliTools
+  const hasCapletSets = Object.keys(capletSets).length > 0;
+  return hasServers || hasOpenApi || hasGraphQl || hasHttpApis || hasCliTools || hasCapletSets
     ? {
         config: {
           ...(hasServers ? { mcpServers: servers } : {}),
@@ -640,6 +681,7 @@ export function loadCapletFilesWithPaths(root: string): CapletFileLoadResult | u
           ...(hasGraphQl ? { graphqlEndpoints } : {}),
           ...(hasHttpApis ? { httpApis } : {}),
           ...(hasCliTools ? { cliTools } : {}),
+          ...(hasCapletSets ? { capletSets } : {}),
         },
         paths,
       }
@@ -757,6 +799,19 @@ function capletToServerConfig(
       cwd: normalizeLocalPath(frontmatter.cliTools.cwd, baseDir),
       actions: normalizeCliToolActions(frontmatter.cliTools.actions, baseDir),
       backend: "cli",
+      name: frontmatter.name,
+      description: frontmatter.description,
+      ...(frontmatter.tags ? { tags: frontmatter.tags } : {}),
+      body,
+    };
+  }
+
+  if (frontmatter.capletSet) {
+    return {
+      ...frontmatter.capletSet,
+      configPath: normalizeLocalPath(frontmatter.capletSet.configPath, baseDir),
+      capletsRoot: normalizeLocalPath(frontmatter.capletSet.capletsRoot, baseDir),
+      backend: "caplets",
       name: frontmatter.name,
       description: frontmatter.description,
       ...(frontmatter.tags ? { tags: frontmatter.tags } : {}),

--- a/packages/core/src/caplet-sets.ts
+++ b/packages/core/src/caplet-sets.ts
@@ -38,6 +38,14 @@ export class CapletSetManager {
   }
 
   invalidate(serverId: string): void {
+    const pending = this.childRefreshLocks.get(serverId);
+    if (pending) {
+      void pending.then(
+        () => this.closeChild(serverId),
+        () => this.closeChild(serverId),
+      );
+      return;
+    }
     void this.closeChild(serverId);
   }
 
@@ -183,10 +191,6 @@ export class CapletSetManager {
     if (existing && !force && isFresh) {
       return existing;
     }
-    if (existing) {
-      await this.closeChild(config.server);
-    }
-
     const ancestry = this.options.ancestry ?? new Set<string>();
     if (ancestry.has(cacheKey)) {
       throw new CapletsError("CONFIG_INVALID", "Nested Caplet set cycle detected", {
@@ -196,30 +200,42 @@ export class CapletSetManager {
       });
     }
 
-    const childConfig = loadIsolatedConfig({
-      ...(config.configPath ? { configPath: config.configPath } : {}),
-      ...(config.capletsRoot ? { capletsRoot: config.capletsRoot } : {}),
-      defaultSearchLimit: config.defaultSearchLimit,
-      maxSearchLimit: config.maxSearchLimit,
-    });
-    const registry = new ServerRegistry(childConfig);
-    const authOptions = this.options.authDir ? { authDir: this.options.authDir } : {};
-    const childAncestry = new Set([...ancestry, cacheKey]);
-    const child: ChildRuntime = {
-      registry,
-      downstream: new DownstreamManager(registry, authOptions),
-      openapi: new OpenApiManager(registry, authOptions),
-      graphql: new GraphQLManager(registry, authOptions),
-      http: new HttpActionManager(registry, authOptions),
-      cli: new CliToolsManager(registry),
-      capletSets: new CapletSetManager(registry, {
-        ...authOptions,
-        ancestry: childAncestry,
-      }),
-      cacheKey,
-      configFingerprint: JSON.stringify(config),
-      loadedAt: now,
-    };
+    let child: ChildRuntime;
+    try {
+      const childConfig = loadIsolatedConfig({
+        ...(config.configPath ? { configPath: config.configPath } : {}),
+        ...(config.capletsRoot ? { capletsRoot: config.capletsRoot } : {}),
+        defaultSearchLimit: config.defaultSearchLimit,
+        maxSearchLimit: config.maxSearchLimit,
+      });
+      const registry = new ServerRegistry(childConfig);
+      const authOptions = this.options.authDir ? { authDir: this.options.authDir } : {};
+      const childAncestry = new Set([...ancestry, cacheKey]);
+      child = {
+        registry,
+        downstream: new DownstreamManager(registry, authOptions),
+        openapi: new OpenApiManager(registry, authOptions),
+        graphql: new GraphQLManager(registry, authOptions),
+        http: new HttpActionManager(registry, authOptions),
+        cli: new CliToolsManager(registry),
+        capletSets: new CapletSetManager(registry, {
+          ...authOptions,
+          ancestry: childAncestry,
+        }),
+        cacheKey,
+        configFingerprint: JSON.stringify(config),
+        loadedAt: now,
+      };
+    } catch (error) {
+      if (existing) {
+        return existing;
+      }
+      throw error;
+    }
+
+    if (existing) {
+      await this.closeChild(config.server);
+    }
     this.children.set(config.server, child);
     this.registry.setStatus(config.server, "available");
     return child;

--- a/packages/core/src/caplet-sets.ts
+++ b/packages/core/src/caplet-sets.ts
@@ -1,0 +1,245 @@
+import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import { resolve } from "node:path";
+import { CliToolsManager } from "./cli-tools.js";
+import { type CapletConfig, type CapletSetConfig, loadIsolatedConfig } from "./config.js";
+import { DownstreamManager, type CompactTool } from "./downstream.js";
+import { CapletsError, errorResult, toSafeError } from "./errors.js";
+import { GraphQLManager } from "./graphql.js";
+import { HttpActionManager } from "./http-actions.js";
+import { OpenApiManager } from "./openapi.js";
+import { capabilityDescription, ServerRegistry } from "./registry.js";
+import { generatedToolInputJsonSchema } from "./generated-tool-input-schema.mjs";
+import { handleServerTool } from "./tools.js";
+
+type ChildRuntime = {
+  registry: ServerRegistry;
+  downstream: DownstreamManager;
+  openapi: OpenApiManager;
+  graphql: GraphQLManager;
+  http: HttpActionManager;
+  cli: CliToolsManager;
+  capletSets: CapletSetManager;
+  cacheKey: string;
+  configFingerprint: string;
+  loadedAt: number;
+};
+
+export class CapletSetManager {
+  private readonly children = new Map<string, ChildRuntime>();
+
+  constructor(
+    private registry: ServerRegistry,
+    private readonly options: { authDir?: string; ancestry?: Set<string> } = {},
+  ) {}
+
+  updateRegistry(registry: ServerRegistry): void {
+    this.registry = registry;
+  }
+
+  invalidate(serverId: string): void {
+    void this.closeChild(serverId);
+  }
+
+  async close(): Promise<void> {
+    await Promise.allSettled(
+      [...this.children.keys()].map((serverId) => this.closeChild(serverId)),
+    );
+  }
+
+  async checkSet(config: CapletSetConfig): Promise<{
+    server: string;
+    status: string;
+    toolCount?: number;
+    elapsedMs: number;
+    error?: unknown;
+  }> {
+    const startedAt = Date.now();
+    try {
+      const child = await this.childRuntime(config, true);
+      const childCaplets = child.registry.enabledServers();
+      this.registry.setStatus(config.server, "available");
+      return {
+        server: config.server,
+        status: "available",
+        toolCount: childCaplets.length,
+        elapsedMs: Date.now() - startedAt,
+      };
+    } catch (error) {
+      const safe = toSafeError(error, "SERVER_UNAVAILABLE");
+      this.registry.setStatus(config.server, "unavailable", safe);
+      return {
+        server: config.server,
+        status: "unavailable",
+        elapsedMs: Date.now() - startedAt,
+        error: safe,
+      };
+    }
+  }
+
+  async listTools(config: CapletSetConfig): Promise<Tool[]> {
+    const child = await this.childRuntime(config, false);
+    return child.registry.enabledServers().map((caplet) => this.toTool(caplet));
+  }
+
+  async getTool(config: CapletSetConfig, toolName: string): Promise<Tool> {
+    const child = await this.childRuntime(config, false);
+    const caplet = child.registry.get(toolName);
+    if (!caplet) {
+      throw new CapletsError(
+        "TOOL_NOT_FOUND",
+        `Tool ${toolName} was not found on ${config.server}`,
+        {
+          server: config.server,
+          tool: toolName,
+          suggestions: nearbyCapletNames(child.registry.enabledServers(), toolName),
+        },
+      );
+    }
+    return this.toTool(caplet);
+  }
+
+  async callTool(
+    config: CapletSetConfig,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<CompatibilityCallToolResult> {
+    const child = await this.childRuntime(config, false);
+    const caplet = child.registry.get(toolName);
+    if (!caplet) {
+      throw new CapletsError(
+        "TOOL_NOT_FOUND",
+        `Tool ${toolName} was not found on ${config.server}`,
+        {
+          server: config.server,
+          tool: toolName,
+          suggestions: nearbyCapletNames(child.registry.enabledServers(), toolName),
+        },
+      );
+    }
+    try {
+      return (await handleServerTool(
+        caplet,
+        args,
+        child.registry,
+        child.downstream,
+        child.openapi,
+        child.graphql,
+        child.http,
+        child.cli,
+        child.capletSets,
+      )) as CompatibilityCallToolResult;
+    } catch (error) {
+      return errorResult(error) as CompatibilityCallToolResult;
+    }
+  }
+
+  compact(config: CapletSetConfig, tool: Tool): CompactTool {
+    return {
+      server: config.server,
+      tool: tool.name,
+      ...(tool.description ? { description: tool.description } : {}),
+      ...(tool.annotations ? { annotations: tool.annotations } : {}),
+      hasInputSchema: Boolean(tool.inputSchema),
+      hasOutputSchema: Boolean(tool.outputSchema),
+    };
+  }
+
+  search(config: CapletSetConfig, tools: Tool[], query: string, limit: number): CompactTool[] {
+    const needle = query.toLocaleLowerCase();
+    return tools
+      .filter((tool) =>
+        `${tool.name}\n${tool.description ?? ""}`.toLocaleLowerCase().includes(needle),
+      )
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .slice(0, limit)
+      .map((tool) => this.compact(config, tool));
+  }
+
+  private async childRuntime(config: CapletSetConfig, force: boolean): Promise<ChildRuntime> {
+    const cacheKey = sourceKey(config);
+    const existing = this.children.get(config.server);
+    const now = Date.now();
+    const isFresh =
+      existing &&
+      existing.cacheKey === cacheKey &&
+      existing.configFingerprint === JSON.stringify(config) &&
+      config.toolCacheTtlMs > 0 &&
+      now - existing.loadedAt <= config.toolCacheTtlMs;
+    if (existing && !force && isFresh) {
+      return existing;
+    }
+    if (existing) {
+      await this.closeChild(config.server);
+    }
+
+    const ancestry = this.options.ancestry ?? new Set<string>();
+    if (ancestry.has(cacheKey)) {
+      throw new CapletsError("CONFIG_INVALID", "Nested Caplet set cycle detected", {
+        server: config.server,
+        source: cacheKey,
+        ancestry: [...ancestry],
+      });
+    }
+
+    const childConfig = loadIsolatedConfig({
+      ...(config.configPath ? { configPath: config.configPath } : {}),
+      ...(config.capletsRoot ? { capletsRoot: config.capletsRoot } : {}),
+      defaultSearchLimit: config.defaultSearchLimit,
+      maxSearchLimit: config.maxSearchLimit,
+    });
+    const registry = new ServerRegistry(childConfig);
+    const authOptions = this.options.authDir ? { authDir: this.options.authDir } : {};
+    const childAncestry = new Set([...ancestry, cacheKey]);
+    const child: ChildRuntime = {
+      registry,
+      downstream: new DownstreamManager(registry, authOptions),
+      openapi: new OpenApiManager(registry, authOptions),
+      graphql: new GraphQLManager(registry, authOptions),
+      http: new HttpActionManager(registry, authOptions),
+      cli: new CliToolsManager(registry),
+      capletSets: new CapletSetManager(registry, {
+        ...authOptions,
+        ancestry: childAncestry,
+      }),
+      cacheKey,
+      configFingerprint: JSON.stringify(config),
+      loadedAt: now,
+    };
+    this.children.set(config.server, child);
+    this.registry.setStatus(config.server, "available");
+    return child;
+  }
+
+  private async closeChild(serverId: string): Promise<void> {
+    const child = this.children.get(serverId);
+    this.children.delete(serverId);
+    if (!child) {
+      return;
+    }
+    await Promise.allSettled([child.downstream.close(), child.capletSets.close()]);
+  }
+
+  private toTool(caplet: CapletConfig): Tool {
+    return {
+      name: caplet.server,
+      description: capabilityDescription(caplet),
+      inputSchema: generatedToolInputJsonSchema() as Tool["inputSchema"],
+    };
+  }
+}
+
+function sourceKey(config: CapletSetConfig): string {
+  return JSON.stringify({
+    configPath: config.configPath ? resolve(config.configPath) : undefined,
+    capletsRoot: config.capletsRoot ? resolve(config.capletsRoot) : undefined,
+  });
+}
+
+function nearbyCapletNames(caplets: CapletConfig[], needle: string): string[] {
+  const lower = needle.toLocaleLowerCase();
+  return caplets
+    .map((caplet) => caplet.server)
+    .filter((name) => name.toLocaleLowerCase().includes(lower[0] ?? ""))
+    .sort()
+    .slice(0, 5);
+}

--- a/packages/core/src/caplet-sets.ts
+++ b/packages/core/src/caplet-sets.ts
@@ -26,6 +26,7 @@ type ChildRuntime = {
 
 export class CapletSetManager {
   private readonly children = new Map<string, ChildRuntime>();
+  private readonly childRefreshLocks = new Map<string, Promise<ChildRuntime>>();
 
   constructor(
     private registry: ServerRegistry,
@@ -156,6 +157,19 @@ export class CapletSetManager {
   }
 
   private async childRuntime(config: CapletSetConfig, force: boolean): Promise<ChildRuntime> {
+    const pending = this.childRefreshLocks.get(config.server);
+    if (pending) {
+      return pending;
+    }
+
+    const refresh = this.loadChildRuntime(config, force).finally(() => {
+      this.childRefreshLocks.delete(config.server);
+    });
+    this.childRefreshLocks.set(config.server, refresh);
+    return await refresh;
+  }
+
+  private async loadChildRuntime(config: CapletSetConfig, force: boolean): Promise<ChildRuntime> {
     const cacheKey = sourceKey(config);
     const existing = this.children.get(config.server);
     const now = Date.now();

--- a/packages/core/src/caplet-sets.ts
+++ b/packages/core/src/caplet-sets.ts
@@ -42,6 +42,7 @@ export class CapletSetManager {
   }
 
   async close(): Promise<void> {
+    await Promise.allSettled(this.childRefreshLocks.values());
     await Promise.allSettled(
       [...this.children.keys()].map((serverId) => this.closeChild(serverId)),
     );

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, join } from "node:path";
 import { z } from "zod";
-import { loadCapletFilesWithPaths } from "./caplet-files.js";
+import { loadCapletFiles, loadCapletFilesWithPaths } from "./caplet-files.js";
 import { resolveCapletsRoot, resolveConfigPath, resolveProjectConfigPath } from "./config/paths.js";
 import {
   FORBIDDEN_HEADERS,
@@ -193,12 +193,28 @@ export type CliToolsConfig = {
   disabled: boolean;
 };
 
+export type CapletSetConfig = {
+  server: string;
+  backend: "caplets";
+  name: string;
+  description: string;
+  tags?: string[] | undefined;
+  body?: string | undefined;
+  configPath?: string | undefined;
+  capletsRoot?: string | undefined;
+  defaultSearchLimit: number;
+  maxSearchLimit: number;
+  toolCacheTtlMs: number;
+  disabled: boolean;
+};
+
 export type CapletConfig =
   | CapletServerConfig
   | OpenApiEndpointConfig
   | GraphQlEndpointConfig
   | HttpApiConfig
-  | CliToolsConfig;
+  | CliToolsConfig
+  | CapletSetConfig;
 
 export type CapletsOptions = {
   defaultSearchLimit: number;
@@ -213,6 +229,7 @@ export type CapletsConfig = {
   graphqlEndpoints: Record<string, GraphQlEndpointConfig>;
   httpApis: Record<string, HttpApiConfig>;
   cliTools: Record<string, CliToolsConfig>;
+  capletSets: Record<string, CapletSetConfig>;
 };
 
 export type ConfigSourceKind = "global-config" | "global-file" | "project-config" | "project-file";
@@ -684,17 +701,75 @@ const normalizedCliToolsSchema = publicCliToolsSchema.extend({
   body: z.string().optional(),
 });
 
+const publicCapletSetSchema = z
+  .object({
+    name: z.string().trim().min(1).max(80).describe("Human-readable Caplet set display name."),
+    description: z
+      .string()
+      .describe("Capability description shown before child Caplets are disclosed.")
+      .refine(
+        (value) => value.trim().length >= 10,
+        "description must contain at least 10 non-whitespace characters",
+      )
+      .refine((value) => value.length <= 1500, "description must be at most 1500 characters"),
+    configPath: z.string().min(1).optional().describe("Child Caplets config.json path."),
+    capletsRoot: z.string().min(1).optional().describe("Child Markdown Caplets root directory."),
+    defaultSearchLimit: z
+      .number()
+      .int()
+      .positive()
+      .default(20)
+      .describe("Default maximum number of child Caplet search results."),
+    maxSearchLimit: z
+      .number()
+      .int()
+      .positive()
+      .max(50)
+      .default(50)
+      .describe("Maximum accepted child Caplet search result limit."),
+    toolCacheTtlMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(30_000)
+      .describe("Milliseconds child Caplet metadata stays fresh. Set 0 to refresh every time."),
+    tags: z.array(z.string().trim().min(1).max(80)).optional(),
+    disabled: z.boolean().default(false).describe("When true, omit this Caplet set."),
+  })
+  .strict()
+  .superRefine((set, ctx) => {
+    if (!set.configPath && !set.capletsRoot) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Caplet set must define at least one source: configPath or capletsRoot",
+      });
+    }
+    if (set.defaultSearchLimit > set.maxSearchLimit) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["defaultSearchLimit"],
+        message: "defaultSearchLimit must be <= maxSearchLimit",
+      });
+    }
+  });
+
+const normalizedCapletSetSchema = publicCapletSetSchema.extend({
+  body: z.string().optional(),
+});
+
 type ConfigSchemaServerValue = z.infer<typeof normalizedServerSchema>;
 type ConfigSchemaOpenApiEndpointValue = z.infer<typeof normalizedOpenApiEndpointSchema>;
 type ConfigSchemaGraphQlEndpointValue = z.infer<typeof normalizedGraphQlEndpointSchema>;
 type ConfigSchemaHttpApiValue = z.infer<typeof normalizedHttpApiSchema>;
 type ConfigSchemaCliToolsValue = z.infer<typeof normalizedCliToolsSchema>;
+type ConfigSchemaCapletSetValue = z.infer<typeof normalizedCapletSetSchema>;
 type ConfigInput = {
   mcpServers?: Record<string, unknown>;
   openapiEndpoints?: Record<string, unknown>;
   graphqlEndpoints?: Record<string, unknown>;
   httpApis?: Record<string, unknown>;
   cliTools?: Record<string, unknown>;
+  capletSets?: Record<string, unknown>;
   [key: string]: unknown;
 };
 
@@ -704,6 +779,7 @@ function configSchemaFor(
   graphQlEndpointValueSchema: z.ZodTypeAny,
   httpApiValueSchema: z.ZodTypeAny,
   cliToolsValueSchema: z.ZodTypeAny,
+  capletSetValueSchema: z.ZodTypeAny,
 ) {
   return z
     .object({
@@ -746,6 +822,10 @@ function configSchemaFor(
         .record(z.string().regex(SERVER_ID_PATTERN), cliToolsValueSchema)
         .default({})
         .describe("CLI tools keyed by stable Caplet ID."),
+      capletSets: z
+        .record(z.string().regex(SERVER_ID_PATTERN), capletSetValueSchema)
+        .default({})
+        .describe("Nested Caplet collections keyed by stable Caplet ID."),
     })
     .strict()
     .superRefine((config, ctx) => {
@@ -997,6 +1077,42 @@ function configSchemaFor(
           }
         }
       }
+
+      for (const [server, rawValue] of Object.entries(config.capletSets)) {
+        const raw = rawValue as ConfigSchemaCapletSetValue;
+        const duplicateBackend = config.mcpServers[server]
+          ? "mcpServers"
+          : config.openapiEndpoints[server]
+            ? "openapiEndpoints"
+            : config.graphqlEndpoints[server]
+              ? "graphqlEndpoints"
+              : config.httpApis[server]
+                ? "httpApis"
+                : config.cliTools[server]
+                  ? "cliTools"
+                  : undefined;
+        if (duplicateBackend) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["capletSets", server],
+            message: `Caplet ID ${server} is already used by ${duplicateBackend}`,
+          });
+        }
+        if (!SERVER_ID_PATTERN.test(server)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["capletSets", server],
+            message: "Caplet set ID must match ^[a-zA-Z0-9_-]{1,64}$",
+          });
+        }
+        if (!raw.configPath && !raw.capletsRoot) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["capletSets", server],
+            message: "Caplet set must define at least one source: configPath or capletsRoot",
+          });
+        }
+      }
     });
 }
 
@@ -1006,6 +1122,7 @@ export const configFileSchema = configSchemaFor(
   publicGraphQlEndpointSchema,
   publicHttpApiSchema,
   publicCliToolsSchema,
+  publicCapletSetSchema,
 );
 const normalizedConfigFileSchema = configSchemaFor(
   normalizedServerSchema,
@@ -1013,6 +1130,7 @@ const normalizedConfigFileSchema = configSchemaFor(
   normalizedGraphQlEndpointSchema,
   normalizedHttpApiSchema,
   normalizedCliToolsSchema,
+  normalizedCapletSetSchema,
 );
 
 export function configJsonSchema(): unknown {
@@ -1075,11 +1193,12 @@ export function loadConfigWithSources(
       Object.keys(config.openapiEndpoints).length === 0 &&
       Object.keys(config.graphqlEndpoints).length === 0 &&
       Object.keys(config.httpApis).length === 0 &&
-      Object.keys(config.cliTools).length === 0
+      Object.keys(config.cliTools).length === 0 &&
+      Object.keys(config.capletSets).length === 0
     ) {
       throw new CapletsError(
         "CONFIG_INVALID",
-        "Caplets config must define at least one MCP server, OpenAPI endpoint, GraphQL endpoint, HTTP API, or CLI tools backend",
+        "Caplets config must define at least one MCP server, OpenAPI endpoint, GraphQL endpoint, HTTP API, CLI tools backend, or Caplet set",
       );
     }
     return { config, sources, shadows };
@@ -1103,6 +1222,48 @@ type ConfigInputWithSource = {
   input: ConfigInput | undefined;
   source: ConfigSourceInput;
 };
+
+export function loadIsolatedConfig(options: {
+  configPath?: string;
+  capletsRoot?: string;
+  defaultSearchLimit: number;
+  maxSearchLimit: number;
+}): CapletsConfig {
+  if (!options.configPath && !options.capletsRoot) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      "Nested Caplet set must define at least one source: configPath or capletsRoot",
+    );
+  }
+
+  const configInput = options.configPath ? readPublicConfigInput(options.configPath) : undefined;
+  const capletInput = options.capletsRoot ? loadCapletFiles(options.capletsRoot) : undefined;
+  if (!configInput && !capletInput) {
+    throw new CapletsError(
+      "CONFIG_NOT_FOUND",
+      `Nested Caplet set sources not found: ${[options.configPath, options.capletsRoot].filter(Boolean).join(", ")}`,
+    );
+  }
+
+  const config = parseConfig(
+    mergeConfigInputs(configInput, capletInput, {
+      version: 1,
+      defaultSearchLimit: options.defaultSearchLimit,
+      maxSearchLimit: options.maxSearchLimit,
+    }),
+  );
+  if (
+    Object.keys(config.mcpServers).length === 0 &&
+    Object.keys(config.openapiEndpoints).length === 0 &&
+    Object.keys(config.graphqlEndpoints).length === 0 &&
+    Object.keys(config.httpApis).length === 0 &&
+    Object.keys(config.cliTools).length === 0 &&
+    Object.keys(config.capletSets).length === 0
+  ) {
+    throw new CapletsError("CONFIG_INVALID", "Nested Caplet set must define at least one Caplet");
+  }
+  return config;
+}
 
 function resolveProjectCapletsRootForConfigPath(projectPath: string): string | undefined {
   const root = dirname(projectPath);
@@ -1142,6 +1303,7 @@ function normalizeLocalPaths(input: ConfigInput, baseDir: string): ConfigInput {
     openapiEndpoints: normalizeEndpointPaths(input.openapiEndpoints, baseDir, normalizeOpenApiPath),
     graphqlEndpoints: normalizeEndpointPaths(input.graphqlEndpoints, baseDir, normalizeGraphQlPath),
     cliTools: normalizeEndpointPaths(input.cliTools, baseDir, normalizeCliToolsPaths),
+    capletSets: normalizeEndpointPaths(input.capletSets, baseDir, normalizeCapletSetPaths),
   }) as ConfigInput;
 }
 
@@ -1219,6 +1381,17 @@ function normalizeCliToolsPaths(
   };
 }
 
+function normalizeCapletSetPaths(
+  endpoint: Record<string, unknown>,
+  baseDir: string,
+): Record<string, unknown> {
+  return {
+    ...endpoint,
+    configPath: normalizeLocalPath(endpoint.configPath, baseDir),
+    capletsRoot: normalizeLocalPath(endpoint.capletsRoot, baseDir),
+  };
+}
+
 function normalizeLocalPath(value: unknown, baseDir: string): unknown {
   if (typeof value !== "string" || !value || isAbsolute(value) || hasEnvReference(value)) {
     return value;
@@ -1249,6 +1422,12 @@ function rejectProjectConfigExecutableBackendMaps(input: ConfigInput, path: stri
     throw new CapletsError(
       "CONFIG_INVALID",
       `Project config at ${path} cannot define executable backend map cliTools; use project Markdown Caplet files or user config instead`,
+    );
+  }
+  if (input.capletSets && Object.keys(input.capletSets).length > 0) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Project config at ${path} cannot define executable backend map capletSets; use project Markdown Caplet files or user config instead`,
     );
   }
   return input;
@@ -1282,6 +1461,10 @@ function mergeConfigInputs(...inputs: Array<ConfigInput | undefined>): ConfigInp
       cliTools: {
         ...merged?.cliTools,
         ...input.cliTools,
+      },
+      capletSets: {
+        ...merged?.capletSets,
+        ...input.capletSets,
       },
     };
   }
@@ -1321,6 +1504,7 @@ function removeCapletId(input: ConfigInput, id: string): ConfigInput {
   const { [id]: _graphqlEndpoint, ...graphqlEndpoints } = input.graphqlEndpoints ?? {};
   const { [id]: _httpApi, ...httpApis } = input.httpApis ?? {};
   const { [id]: _cliTools, ...cliTools } = input.cliTools ?? {};
+  const { [id]: _capletSet, ...capletSets } = input.capletSets ?? {};
 
   return {
     ...input,
@@ -1329,6 +1513,7 @@ function removeCapletId(input: ConfigInput, id: string): ConfigInput {
     graphqlEndpoints,
     httpApis,
     cliTools,
+    capletSets,
   };
 }
 
@@ -1339,6 +1524,7 @@ function capletIds(input: ConfigInput): string[] {
     ...Object.keys(input.graphqlEndpoints ?? {}),
     ...Object.keys(input.httpApis ?? {}),
     ...Object.keys(input.cliTools ?? {}),
+    ...Object.keys(input.capletSets ?? {}),
   ];
 }
 
@@ -1406,6 +1592,16 @@ export function parseConfig(input: unknown): CapletsConfig {
     }) as CliToolsConfig;
   }
 
+  const capletSets: Record<string, CapletSetConfig> = {};
+  for (const [server, raw] of Object.entries(parsed.data.capletSets)) {
+    const interpolated = raw as ConfigSchemaCapletSetValue;
+    capletSets[server] = stripUndefined({
+      ...interpolated,
+      server,
+      backend: "caplets",
+    }) as CapletSetConfig;
+  }
+
   return {
     version: parsed.data.version,
     options: {
@@ -1417,6 +1613,7 @@ export function parseConfig(input: unknown): CapletsConfig {
     graphqlEndpoints,
     httpApis,
     cliTools,
+    capletSets,
   };
 }
 
@@ -1474,7 +1671,8 @@ function isPublicMetadataPath(path: string[]): boolean {
       path[0] !== "openapiEndpoints" &&
       path[0] !== "graphqlEndpoints" &&
       path[0] !== "httpApis" &&
-      path[0] !== "cliTools")
+      path[0] !== "cliTools" &&
+      path[0] !== "capletSets")
   ) {
     return false;
   }

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, statSync, watch, type FSWatcher } from "node:fs";
 import { dirname, join, parse } from "node:path";
+import { CapletSetManager } from "./caplet-sets.js";
 import { CliToolsManager } from "./cli-tools.js";
 import {
   type CapletConfig,
@@ -49,6 +50,7 @@ export class CapletsEngine {
   private readonly graphql: GraphQLManager;
   private readonly http: HttpActionManager;
   private readonly cli: CliToolsManager;
+  private readonly capletSets: CapletSetManager;
   private readonly paths: RuntimePaths;
   private readonly watchDebounceMs: number;
   private readonly watchEnabled: boolean;
@@ -73,6 +75,7 @@ export class CapletsEngine {
     this.graphql = new GraphQLManager(this.registry, selectAuthOptions(options.authDir));
     this.http = new HttpActionManager(this.registry, selectAuthOptions(options.authDir));
     this.cli = new CliToolsManager(this.registry);
+    this.capletSets = new CapletSetManager(this.registry, selectAuthOptions(options.authDir));
     this.watchDebounceMs = options.watchDebounceMs ?? 250;
     this.watchEnabled = options.watch ?? true;
     this.writeErr = options.writeErr ?? ((value: string) => process.stderr.write(value));
@@ -139,6 +142,7 @@ export class CapletsEngine {
         this.graphql,
         this.http,
         this.cli,
+        this.capletSets,
       );
     } catch (error) {
       return errorResult(error);
@@ -162,6 +166,7 @@ export class CapletsEngine {
     } finally {
       this.closeWatchers();
       await this.downstream.close();
+      await this.capletSets.close();
       this.reloadListeners.clear();
     }
   }
@@ -190,6 +195,7 @@ export class CapletsEngine {
     this.graphql.updateRegistry(nextRegistry);
     this.http.updateRegistry(nextRegistry);
     this.cli.updateRegistry(nextRegistry);
+    this.capletSets.updateRegistry(nextRegistry);
 
     let invalidated = true;
     try {
@@ -264,6 +270,9 @@ export class CapletsEngine {
       }
       if (before?.backend === "cli" || after?.backend === "cli" || !after) {
         this.cli.invalidate(serverId);
+      }
+      if (before?.backend === "caplets" || after?.backend === "caplets" || !after) {
+        this.capletSets.invalidate(serverId);
       }
     }
   }
@@ -381,6 +390,7 @@ function allCaplets(config: CapletsConfig): CapletConfig[] {
     ...Object.values(config.graphqlEndpoints),
     ...Object.values(config.httpApis),
     ...Object.values(config.cliTools),
+    ...Object.values(config.capletSets),
   ];
 }
 

--- a/packages/core/src/generated-tool-input-schema.mjs
+++ b/packages/core/src/generated-tool-input-schema.mjs
@@ -11,7 +11,7 @@ export const operations = [
 export const generatedToolInputDescriptions = {
   operation: [
     "Caplets wrapper operation to perform for this configured Caplet backend.",
-    "Use get_caplet to read the full Caplet card, check_backend to check any backend, check_mcp_server to check an MCP backend, list_tools or search_tools to discover downstream tools, get_tool to read a downstream input schema, and call_tool to run one downstream tool, operation, action, or CLI command.",
+    "Use get_caplet to read the full Caplet card, check_backend to check any backend, check_mcp_server to check an MCP backend, list_tools or search_tools to discover downstream tools, get_tool to read a downstream input schema, and call_tool to run one downstream tool, operation, action, CLI command, or child Caplet.",
     'For call_tool, pass downstream inputs only inside the top-level "arguments" object.',
   ].join(" "),
   query:

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -60,6 +60,12 @@ export type CapletServerDetail = {
         timeoutMs: number;
         maxOutputBytes: number;
         configuredActions: number;
+      }
+    | {
+        type: "caplets";
+        disabled: boolean;
+        source: "configPath" | "capletsRoot" | "both";
+        toolCacheTtlMs: number;
       };
   mcpServer?: {
     transport: CapletServerConfig["transport"];
@@ -94,7 +100,8 @@ export class ServerRegistry {
       this.config.openapiEndpoints[serverId] ??
       this.config.graphqlEndpoints[serverId] ??
       this.config.httpApis[serverId] ??
-      this.config.cliTools[serverId];
+      this.config.cliTools[serverId] ??
+      this.config.capletSets[serverId];
     return server?.disabled ? undefined : server;
   }
 
@@ -156,6 +163,7 @@ export class ServerRegistry {
       ...Object.values(this.config.graphqlEndpoints),
       ...Object.values(this.config.httpApis),
       ...Object.values(this.config.cliTools),
+      ...Object.values(this.config.capletSets),
     ];
   }
 }
@@ -200,6 +208,14 @@ function backendDetail(server: CapletConfig): CapletServerDetail["backend"] {
       configuredActions: Object.keys(server.actions).length,
     };
   }
+  if (server.backend === "caplets") {
+    return {
+      type: "caplets",
+      disabled: server.disabled,
+      source: capletSetSource(server),
+      toolCacheTtlMs: server.toolCacheTtlMs,
+    };
+  }
 
   return {
     type: "mcp",
@@ -209,6 +225,16 @@ function backendDetail(server: CapletConfig): CapletServerDetail["backend"] {
     callTimeoutMs: server.callTimeoutMs,
     toolCacheTtlMs: server.toolCacheTtlMs,
   };
+}
+
+function capletSetSource(
+  server: Extract<CapletConfig, { backend: "caplets" }>,
+): "configPath" | "capletsRoot" | "both" {
+  return server.configPath && server.capletsRoot
+    ? "both"
+    : server.configPath
+      ? "configPath"
+      : "capletsRoot";
 }
 
 function graphQlSource(

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -124,6 +124,7 @@ function nextEnabledServers(config: CapletsConfig): CapletConfig[] {
     ...Object.values(config.graphqlEndpoints),
     ...Object.values(config.httpApis),
     ...Object.values(config.cliTools),
+    ...Object.values(config.capletSets),
   ].filter((server) => !server.disabled);
 }
 
@@ -133,7 +134,8 @@ function capletById(config: CapletsConfig, serverId: string): CapletConfig | und
     config.openapiEndpoints[serverId] ??
     config.graphqlEndpoints[serverId] ??
     config.httpApis[serverId] ??
-    config.cliTools[serverId]
+    config.cliTools[serverId] ??
+    config.capletSets[serverId]
   );
 }
 

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CapletSetManager } from "./caplet-sets.js";
 import type { CapletConfig } from "./config.js";
 import { CliToolsManager } from "./cli-tools.js";
 import type { DownstreamManager } from "./downstream.js";
@@ -42,6 +43,7 @@ export async function handleServerTool(
   graphql?: GraphQLManager,
   http?: HttpActionManager,
   cli?: CliToolsManager,
+  caplets?: CapletSetManager,
 ): Promise<any> {
   const parsed = validateOperationRequest(request, registry.config.options.maxSearchLimit);
 
@@ -50,7 +52,9 @@ export async function handleServerTool(
       return jsonResult(registry.detail(server));
     case "check_backend":
       return jsonResult(
-        await backendFor(server, downstream, openapi, graphql, http, cli).check(server as never),
+        await backendFor(server, downstream, openapi, graphql, http, cli, caplets).check(
+          server as never,
+        ),
       );
     case "check_mcp_server":
       if (server.backend !== "mcp") {
@@ -61,7 +65,7 @@ export async function handleServerTool(
       }
       return jsonResult(await downstream.checkServer(server));
     case "list_tools": {
-      const backend = backendFor(server, downstream, openapi, graphql, http, cli);
+      const backend = backendFor(server, downstream, openapi, graphql, http, cli, caplets);
       const tools = await backend.listTools(server as never);
       return jsonResult({
         server: server.server,
@@ -69,7 +73,7 @@ export async function handleServerTool(
       });
     }
     case "search_tools": {
-      const backend = backendFor(server, downstream, openapi, graphql, http, cli);
+      const backend = backendFor(server, downstream, openapi, graphql, http, cli, caplets);
       const tools = await backend.listTools(server as never);
       const limit = parsed.limit ?? registry.config.options.defaultSearchLimit;
       return jsonResult({
@@ -79,12 +83,12 @@ export async function handleServerTool(
       });
     }
     case "get_tool": {
-      const backend = backendFor(server, downstream, openapi, graphql, http, cli);
+      const backend = backendFor(server, downstream, openapi, graphql, http, cli, caplets);
       const tool = await backend.getTool(server as never, parsed.tool);
       return jsonResult({ server: server.server, tool });
     }
     case "call_tool": {
-      const backend = backendFor(server, downstream, openapi, graphql, http, cli);
+      const backend = backendFor(server, downstream, openapi, graphql, http, cli, caplets);
       if (parsed.fields === undefined) {
         return backend.callTool(server as never, parsed.tool, parsed.arguments);
       }
@@ -256,6 +260,7 @@ function backendFor(
   graphql?: GraphQLManager,
   http?: HttpActionManager,
   cli?: CliToolsManager,
+  caplets?: CapletSetManager,
 ) {
   if (server.backend === "mcp") {
     return {
@@ -308,6 +313,19 @@ function backendFor(
       callTool: (...args: Parameters<CliToolsManager["callTool"]>) => cli.callTool(...args),
       compact: (...args: Parameters<CliToolsManager["compact"]>) => cli.compact(...args),
       search: (...args: Parameters<CliToolsManager["search"]>) => cli.search(...args),
+    };
+  }
+  if (server.backend === "caplets") {
+    if (!caplets) {
+      throw new CapletsError("INTERNAL_ERROR", "Caplet set manager is not configured");
+    }
+    return {
+      check: (...args: Parameters<CapletSetManager["checkSet"]>) => caplets.checkSet(...args),
+      listTools: (...args: Parameters<CapletSetManager["listTools"]>) => caplets.listTools(...args),
+      getTool: (...args: Parameters<CapletSetManager["getTool"]>) => caplets.getTool(...args),
+      callTool: (...args: Parameters<CapletSetManager["callTool"]>) => caplets.callTool(...args),
+      compact: (...args: Parameters<CapletSetManager["compact"]>) => caplets.compact(...args),
+      search: (...args: Parameters<CapletSetManager["search"]>) => caplets.search(...args),
     };
   }
   if (!openapi) {

--- a/packages/core/test/caplet-sets.test.ts
+++ b/packages/core/test/caplet-sets.test.ts
@@ -187,6 +187,62 @@ describe("CapletSetManager", () => {
     expect(closeCalls).toBe(1);
   });
 
+  it("does not let in-flight refreshes repopulate invalidated child runtimes", async () => {
+    const { dir, childConfigPath } = childCliConfig();
+    dirs.push(dir);
+    const config = parseConfig({
+      capletSets: {
+        nested: {
+          name: "Nested Caplets",
+          description: "Expose child Caplets through a nested collection.",
+          configPath: childConfigPath,
+          toolCacheTtlMs: 0,
+        },
+      },
+    });
+    const caplet = config.capletSets.nested!;
+    const manager = new CapletSetManager(new ServerRegistry(config));
+
+    const target = manager as unknown as {
+      loadChildRuntime: (nextConfig: typeof caplet, force: boolean) => Promise<unknown>;
+      children: Map<string, unknown>;
+    };
+    const originalLoadChildRuntime = target.loadChildRuntime.bind(manager);
+    target.loadChildRuntime = async (nextConfig, force) => {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      return await originalLoadChildRuntime(nextConfig, force);
+    };
+
+    const refresh = manager.listTools(caplet);
+    manager.invalidate(caplet.server);
+    await refresh;
+    await Promise.resolve();
+
+    expect(target.children.has(caplet.server)).toBe(false);
+  });
+
+  it("keeps serving the last known-good child runtime when reload config is invalid", async () => {
+    const { dir, childConfigPath } = childCliConfig();
+    dirs.push(dir);
+    const config = parseConfig({
+      capletSets: {
+        nested: {
+          name: "Nested Caplets",
+          description: "Expose child Caplets through a nested collection.",
+          configPath: childConfigPath,
+          toolCacheTtlMs: 0,
+        },
+      },
+    });
+    const caplet = config.capletSets.nested!;
+    const manager = new CapletSetManager(new ServerRegistry(config));
+    await expect(manager.listTools(caplet)).resolves.toMatchObject([{ name: "echoes" }]);
+
+    writeFileSync(childConfigPath, "{");
+
+    await expect(manager.listTools(caplet)).resolves.toMatchObject([{ name: "echoes" }]);
+  });
+
   it("reports recursive source cycles through nested Caplet sets", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-set-cycle-"));
     dirs.push(dir);

--- a/packages/core/test/caplet-sets.test.ts
+++ b/packages/core/test/caplet-sets.test.ts
@@ -116,6 +116,37 @@ describe("CapletSetManager", () => {
     ]);
   });
 
+  it("serializes concurrent refreshes for one parent Caplet set", async () => {
+    const { dir, childConfigPath } = childCliConfig();
+    dirs.push(dir);
+    const config = parseConfig({
+      capletSets: {
+        nested: {
+          name: "Nested Caplets",
+          description: "Expose child Caplets through a nested collection.",
+          configPath: childConfigPath,
+          toolCacheTtlMs: 0,
+        },
+      },
+    });
+    const caplet = config.capletSets.nested!;
+    const manager = new CapletSetManager(new ServerRegistry(config));
+    await manager.listTools(caplet);
+
+    let closeCalls = 0;
+    const target = manager as unknown as { closeChild: (serverId: string) => Promise<void> };
+    const originalCloseChild = target.closeChild.bind(manager);
+    target.closeChild = async (serverId: string) => {
+      closeCalls += 1;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await originalCloseChild(serverId);
+    };
+
+    await Promise.all([manager.listTools(caplet), manager.listTools(caplet)]);
+
+    expect(closeCalls).toBe(1);
+  });
+
   it("reports recursive source cycles through nested Caplet sets", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-set-cycle-"));
     dirs.push(dir);

--- a/packages/core/test/caplet-sets.test.ts
+++ b/packages/core/test/caplet-sets.test.ts
@@ -1,0 +1,195 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CapletSetManager } from "../src/caplet-sets.js";
+import { parseConfig } from "../src/config.js";
+import { ServerRegistry } from "../src/registry.js";
+
+describe("CapletSetManager", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("lists, searches, reads, and calls child Caplets as nested tools", async () => {
+    const { dir, childConfigPath } = childCliConfig();
+    dirs.push(dir);
+    const config = parseConfig({
+      capletSets: {
+        nested: {
+          name: "Nested Caplets",
+          description: "Expose child Caplets through a nested collection.",
+          configPath: childConfigPath,
+          toolCacheTtlMs: 0,
+        },
+      },
+    });
+    const caplet = config.capletSets.nested!;
+    const registry = new ServerRegistry(config);
+    const manager = new CapletSetManager(registry);
+
+    await expect(manager.checkSet(caplet)).resolves.toMatchObject({
+      server: "nested",
+      status: "available",
+      toolCount: 1,
+    });
+    const tools = await manager.listTools(caplet);
+    expect(tools.map((tool) => tool.name)).toEqual(["echoes"]);
+    expect(manager.search(caplet, tools, "echo", 5)).toMatchObject([{ tool: "echoes" }]);
+    await expect(manager.getTool(caplet, "echoes")).resolves.toMatchObject({
+      name: "echoes",
+      inputSchema: expect.objectContaining({
+        properties: expect.objectContaining({ operation: expect.any(Object) }),
+      }),
+    });
+
+    const listed = await manager.callTool(caplet, "echoes", { operation: "list_tools" });
+    expect(listed.structuredContent).toMatchObject({
+      result: {
+        server: "echoes",
+        tools: [{ tool: "echo_json" }],
+      },
+    });
+
+    const called = await manager.callTool(caplet, "echoes", {
+      operation: "call_tool",
+      tool: "echo_json",
+      arguments: { message: "hello" },
+    });
+    expect(called.isError).toBe(false);
+    expect(called.structuredContent).toMatchObject({
+      exitCode: 0,
+      json: { message: "hello" },
+    });
+  });
+
+  it("loads child config and child Caplet files from independently configured sources", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-set-files-"));
+    dirs.push(dir);
+    const configPath = join(dir, "config.json");
+    const capletsRoot = join(dir, "caplets");
+    mkdirSync(capletsRoot, { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          configured: {
+            name: "Configured",
+            description: "Configured child Caplet.",
+            command: process.execPath,
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      join(capletsRoot, "file.md"),
+      [
+        "---",
+        "name: File Child",
+        "description: Child Caplet loaded from a Markdown file.",
+        "mcpServer:",
+        `  command: ${JSON.stringify(process.execPath)}`,
+        "---",
+        "# File Child",
+      ].join("\n"),
+    );
+    const config = parseConfig({
+      capletSets: {
+        nested: {
+          name: "Nested Caplets",
+          description: "Expose child Caplets through a nested collection.",
+          configPath,
+          capletsRoot,
+        },
+      },
+    });
+    const caplet = config.capletSets.nested!;
+    const manager = new CapletSetManager(new ServerRegistry(config));
+
+    await expect(manager.listTools(caplet)).resolves.toMatchObject([
+      { name: "configured" },
+      { name: "file" },
+    ]);
+  });
+
+  it("reports recursive source cycles through nested Caplet sets", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-set-cycle-"));
+    dirs.push(dir);
+    const childConfigPath = join(dir, "child.json");
+    writeFileSync(
+      childConfigPath,
+      JSON.stringify({
+        capletSets: {
+          self: {
+            name: "Self",
+            description: "Points back to the same child Caplets source.",
+            configPath: childConfigPath,
+          },
+        },
+      }),
+    );
+    const config = parseConfig({
+      capletSets: {
+        nested: {
+          name: "Nested Caplets",
+          description: "Expose child Caplets through a nested collection.",
+          configPath: childConfigPath,
+          toolCacheTtlMs: 0,
+        },
+      },
+    });
+    const caplet = config.capletSets.nested!;
+    const manager = new CapletSetManager(new ServerRegistry(config));
+
+    const result = await manager.callTool(caplet, "self", { operation: "check_backend" });
+
+    expect(result.structuredContent).toMatchObject({
+      result: {
+        status: "unavailable",
+        error: {
+          code: "CONFIG_INVALID",
+          message: "Nested Caplet set cycle detected",
+        },
+      },
+    });
+  });
+
+  function childCliConfig(): { dir: string; childConfigPath: string } {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-set-"));
+    const script = join(dir, "echo.mjs");
+    const childConfigPath = join(dir, "child.json");
+    writeFileSync(
+      script,
+      ["const message = process.argv[2];", "console.log(JSON.stringify({ message }));"].join("\n"),
+    );
+    writeFileSync(
+      childConfigPath,
+      JSON.stringify({
+        cliTools: {
+          echoes: {
+            name: "Echoes",
+            description: "Echo JSON messages from a child Caplet.",
+            actions: {
+              echo_json: {
+                description: "Echo one JSON message.",
+                command: process.execPath,
+                args: [script, "$input.message"],
+                inputSchema: {
+                  type: "object",
+                  properties: { message: { type: "string" } },
+                  required: ["message"],
+                },
+                output: { type: "json" },
+              },
+            },
+          },
+        },
+      }),
+    );
+    return { dir, childConfigPath };
+  }
+});

--- a/packages/core/test/caplet-sets.test.ts
+++ b/packages/core/test/caplet-sets.test.ts
@@ -147,6 +147,46 @@ describe("CapletSetManager", () => {
     expect(closeCalls).toBe(1);
   });
 
+  it("waits for in-flight refreshes before closing child runtimes", async () => {
+    const { dir, childConfigPath } = childCliConfig();
+    dirs.push(dir);
+    const config = parseConfig({
+      capletSets: {
+        nested: {
+          name: "Nested Caplets",
+          description: "Expose child Caplets through a nested collection.",
+          configPath: childConfigPath,
+          toolCacheTtlMs: 0,
+        },
+      },
+    });
+    const caplet = config.capletSets.nested!;
+    const manager = new CapletSetManager(new ServerRegistry(config));
+
+    const target = manager as unknown as {
+      loadChildRuntime: (nextConfig: typeof caplet, force: boolean) => Promise<unknown>;
+      closeChild: (serverId: string) => Promise<void>;
+    };
+    const originalLoadChildRuntime = target.loadChildRuntime.bind(manager);
+    target.loadChildRuntime = async (nextConfig, force) => {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      return await originalLoadChildRuntime(nextConfig, force);
+    };
+
+    let closeCalls = 0;
+    const originalCloseChild = target.closeChild.bind(manager);
+    target.closeChild = async (serverId: string) => {
+      closeCalls += 1;
+      await originalCloseChild(serverId);
+    };
+
+    const refresh = manager.listTools(caplet);
+    await manager.close();
+    await refresh;
+
+    expect(closeCalls).toBe(1);
+  });
+
   it("reports recursive source cycles through nested Caplet sets", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-set-cycle-"));
     dirs.push(dir);

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -114,6 +114,34 @@ describe("config", () => {
     delete process.env.PROJECT_OPENAPI_SECRET;
   });
 
+  it("rejects Caplet set executable backend maps from project config", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-project-capletsets-"));
+    const projectConfigPath = join(dir, ".caplets", "config.json");
+    mkdirSync(join(dir, ".caplets"), { recursive: true });
+    writeFileSync(
+      projectConfigPath,
+      JSON.stringify({
+        capletSets: {
+          nested: {
+            name: "Nested",
+            description: "Attempt to load a nested project Caplet set.",
+            capletsRoot: "./child",
+          },
+        },
+      }),
+    );
+
+    expect(() => loadConfig(join(dir, "missing-user-config.json"), projectConfigPath)).toThrow(
+      expect.objectContaining({
+        code: "CONFIG_INVALID",
+        message: expect.stringContaining(
+          "cannot define executable backend map capletSets; use project Markdown Caplet files or user config instead",
+        ) as string,
+      }) as CapletsError,
+    );
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it("rejects GraphQL executable backend maps from project config", () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-project-graphql-"));
     const projectConfigPath = join(dir, ".caplets", "config.json");
@@ -1370,6 +1398,84 @@ describe("config", () => {
             transport: "http",
             url: "https://example.com/mcp",
             auth: { type: "headers", headers: { Connection: "close" } },
+          },
+        },
+      }),
+    ).toThrow(CapletsError);
+  });
+
+  it("loads Caplet set config and Caplet files with normalized child source paths", () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-set-config-"));
+    const root = join(dir, ".caplets");
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, "nested.md"),
+      [
+        "---",
+        "name: Nested",
+        "description: Expose a nested child Caplet collection.",
+        "capletSet:",
+        "  configPath: ./child/config.json",
+        "  capletsRoot: ./child/caplets",
+        "  toolCacheTtlMs: 0",
+        "---",
+        "# Nested",
+      ].join("\n"),
+    );
+
+    const fileConfig = loadCapletFiles(root);
+    const parsedFileConfig = parseConfig(fileConfig);
+    expect(parsedFileConfig.capletSets.nested).toMatchObject({
+      backend: "caplets",
+      configPath: join(root, "child", "config.json"),
+      capletsRoot: join(root, "child", "caplets"),
+      toolCacheTtlMs: 0,
+    });
+
+    const parsedJsonConfig = parseConfig({
+      capletSets: {
+        nested: {
+          name: "Nested",
+          description: "Expose a nested child Caplet collection.",
+          configPath: join(dir, "child-config.json"),
+        },
+      },
+    });
+    expect(parsedJsonConfig.capletSets.nested).toMatchObject({
+      backend: "caplets",
+      defaultSearchLimit: 20,
+      maxSearchLimit: 50,
+      toolCacheTtlMs: 30000,
+    });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("rejects invalid Caplet set sources and duplicate IDs", () => {
+    expect(() =>
+      parseConfig({
+        capletSets: {
+          nested: {
+            name: "Nested",
+            description: "Expose a nested child Caplet collection.",
+          },
+        },
+      }),
+    ).toThrow(CapletsError);
+
+    expect(() =>
+      parseConfig({
+        cliTools: {
+          nested: {
+            name: "Nested CLI",
+            description: "Run nested CLI tools.",
+            actions: { status: { command: process.execPath } },
+          },
+        },
+        capletSets: {
+          nested: {
+            name: "Nested",
+            description: "Expose a nested child Caplet collection.",
+            capletsRoot: "/tmp/caplets",
           },
         },
       }),

--- a/packages/core/test/openapi.test.ts
+++ b/packages/core/test/openapi.test.ts
@@ -648,6 +648,7 @@ describe("native OpenAPI Caplets", () => {
         graphqlEndpoints: {},
         httpApis: {},
         cliTools: {},
+        capletSets: {},
       });
       const openapi = new OpenApiManager(registry, { authDir });
 

--- a/packages/core/test/registry.test.ts
+++ b/packages/core/test/registry.test.ts
@@ -66,6 +66,13 @@ describe("registry", () => {
           },
         },
       },
+      capletSets: {
+        nested: {
+          name: "Nested Caplets",
+          description: "Expose child Caplets through a nested collection.",
+          capletsRoot: "/tmp/caplets",
+        },
+      },
     });
     const registry = new ServerRegistry(config);
     expect(registry.enabledServers().map((server) => server.server)).toEqual([
@@ -75,6 +82,7 @@ describe("registry", () => {
       "catalog",
       "status",
       "repo",
+      "nested",
     ]);
     expect(registry.get("disabled")).toBeUndefined();
     expect(registry.get("status")?.backend).toBe("http");
@@ -164,6 +172,22 @@ describe("registry", () => {
         timeoutMs: 60000,
         maxOutputBytes: 1000000,
         configuredActions: 1,
+      },
+    });
+
+    const capletSetDescription = capabilityDescription(config.capletSets.nested!);
+    expect(capletSetDescription).toContain("nested Caplets backend");
+    expect(capletSetDescription).toContain('"operation":"check_backend"');
+    const capletSetDetail = registry.detail(config.capletSets.nested!);
+    expect(capletSetDetail).toEqual({
+      caplet: "nested",
+      name: "Nested Caplets",
+      description: "Expose child Caplets through a nested collection.",
+      backend: {
+        type: "caplets",
+        disabled: false,
+        source: "capletsRoot",
+        toolCacheTtlMs: 30000,
       },
     });
   });

--- a/packages/core/test/runtime.test.ts
+++ b/packages/core/test/runtime.test.ts
@@ -118,6 +118,30 @@ describe("CapletsRuntime", () => {
     await runtime.close();
   });
 
+  it("registers Caplet set Caplets", async () => {
+    const { dir, configPath, projectConfigPath } = tempConfig({
+      capletSets: {
+        nested: {
+          name: "Nested Caplets",
+          description: "Expose child Caplets through a nested collection.",
+          capletsRoot: join(tmpdir(), "caplets-child"),
+        },
+      },
+    });
+    dirs.push(dir);
+    const server = mockServer();
+    const runtime = new CapletsRuntime({ configPath, projectConfigPath, server });
+
+    expect(runtime.registeredToolIds()).toEqual(["nested"]);
+    expect(server.registerTool).toHaveBeenCalledWith(
+      "nested",
+      expect.objectContaining({ title: "Nested Caplets" }),
+      expect.any(Function),
+    );
+
+    await runtime.close();
+  });
+
   it("adds, updates, and removes tools across successful reloads", async () => {
     const { dir, configPath, projectConfigPath } = tempConfig({
       mcpServers: {

--- a/schemas/caplet.schema.json
+++ b/schemas/caplet.schema.json
@@ -1142,6 +1142,42 @@
       "required": ["actions"],
       "additionalProperties": false,
       "description": "CLI tools backend configuration for this Caplet."
+    },
+    "capletSet": {
+      "type": "object",
+      "properties": {
+        "configPath": {
+          "description": "Child Caplets config.json path.",
+          "type": "string",
+          "minLength": 1
+        },
+        "capletsRoot": {
+          "description": "Child Markdown Caplets root directory.",
+          "type": "string",
+          "minLength": 1
+        },
+        "defaultSearchLimit": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "maxSearchLimit": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 50
+        },
+        "toolCacheTtlMs": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "disabled": {
+          "description": "When true, omit this Caplet from discovery.",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Nested Caplet collection backend configuration for this Caplet."
     }
   },
   "required": ["name", "description"],

--- a/schemas/caplets-config.schema.json
+++ b/schemas/caplets-config.schema.json
@@ -1304,6 +1304,76 @@
         "required": ["name", "description", "actions"],
         "additionalProperties": false
       }
+    },
+    "capletSets": {
+      "default": {},
+      "description": "Nested Caplet collections keyed by stable Caplet ID.",
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[a-zA-Z0-9_-]{1,64}$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "description": "Human-readable Caplet set display name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Capability description shown before child Caplets are disclosed."
+          },
+          "configPath": {
+            "description": "Child Caplets config.json path.",
+            "type": "string",
+            "minLength": 1
+          },
+          "capletsRoot": {
+            "description": "Child Markdown Caplets root directory.",
+            "type": "string",
+            "minLength": 1
+          },
+          "defaultSearchLimit": {
+            "default": 20,
+            "description": "Default maximum number of child Caplet search results.",
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "maxSearchLimit": {
+            "default": 50,
+            "description": "Maximum accepted child Caplet search result limit.",
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 50
+          },
+          "toolCacheTtlMs": {
+            "default": 30000,
+            "description": "Milliseconds child Caplet metadata stays fresh. Set 0 to refresh every time.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          "disabled": {
+            "default": false,
+            "description": "When true, omit this Caplet set.",
+            "type": "boolean"
+          }
+        },
+        "required": ["name", "description"],
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary

Adds `capletSets`, a new Caplets backend for nested Caplet collections. A parent Caplet can now point at a child `configPath`, `capletsRoot`, or both, and exposes each child Caplet as one downstream tool that accepts the normal Caplets operation schema.

## What changed

- Added `capletSets` config support and `capletSet` Markdown frontmatter.
- Added `CapletSetManager` for isolated child collection loading, nested `list_tools`/`search_tools`/`get_tool`/`call_tool`, caching, cleanup, and recursive cycle detection.
- Wired the backend through runtime registration, engine execution, registry details, capability descriptions, generated schemas, docs, and benchmarks.
- Added focused tests for nested calls, mixed child sources, recursive cycle detection, config/frontmatter validation, registry output, and runtime registration.
- Added a changeset for `@caplets/core`.

## Validation

- `npm exec --package=pnpm@11.0.9 -- pnpm verify`
- `git diff --check`

Note: `pnpm` was not directly available on `PATH` in this shell, so hooks were run with a temporary shim to pinned `pnpm@11.0.9`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Caplet Sets: nested Caplet collections with isolated discovery, searchable tool listings, execution routing to child Caplets, configurable search limits and cache TTLs, recursion with cycle detection, and runtime refresh/invalidation.

* **Documentation**
  * README, PRD, schemas, and benchmarks updated with Caplet Sets config, examples, validation rules, and revised benchmark figures.

* **Tests**
  * New tests covering nested Caplet Sets discovery, listing, search, execution, concurrency, refresh/shutdown, and cycle rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spiritledsoftware/caplets/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->