### PR TITLE
ci: disable release workflow husky hooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ permissions:
   pull-requests: write
   id-token: write
 
+env:
+  # CI runs explicit quality gates; do not let Changesets' git pushes invoke
+  # Husky pre-push and start another pnpm verify in the release workspace.
+  HUSKY: 0
+
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary\n- Disable Husky in the release workflow with `HUSKY=0`\n- Prevent Changesets git pushes/tags from invoking the pre-push `pnpm verify` hook inside the release job\n- Avoid duplicate concurrent verify runs that can race on git index locks\n\n## Verification\n- `pnpm format:check`\n- pre-push `pnpm verify` passed