### PR TITLE
chore: local dev plugins setup

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -4,7 +4,7 @@
     [
       "@caplets/opencode@file:./packages/opencode",
       {
-        "mode": "remote",
+        "mode": "local",
         "remote": {
           "url": "http://localhost:5387/mcp"
         }

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,7 +1,7 @@
 {
   "packages": ["npm:@caplets/pi@file:../../packages/pi"],
   "caplets": {
-    "mode": "remote",
+    "mode": "local",
     "remote": {
       "url": "http://localhost:5387/mcp"
     }


### PR DESCRIPTION
This pull request updates configuration files to switch the operating mode of both the OpenCode and Pi packages from "remote" to "local". This change is likely intended to support local development or testing by ensuring the packages run locally instead of connecting to a remote service.

Configuration updates for local development:

* Changed the `mode` from `"remote"` to `"local"` in `.opencode/opencode.json` for the `@caplets/opencode` package.
* Changed the `mode` from `"remote"` to `"local"` in `.pi/settings.json` for the `@caplets/pi` package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to switch the opencode and caplets modules from remote to local execution mode, affecting how the system processes operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spiritledsoftware/caplets/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->