### PR TITLE
fix: http request body

### DIFF
--- a/.brv/.gitignore
+++ b/.brv/.gitignore
@@ -1,8 +1,5 @@
 # BEGIN pi-byterover
 # Dream state and logs
-
-# BEGIN opencode-byterover
-# Dream state and logs
 dream-log/
 dream-state.json
 dream.lock
@@ -18,10 +15,4 @@ _manifest.json
 _index.md
 *.abstract.md
 *.overview.md
-# END opencode-byterover
-
-
-# Review backups
-
-# Generated files
 # END pi-byterover

--- a/.brv/context-tree/architecture/context.md
+++ b/.brv/context-tree/architecture/context.md
@@ -1,0 +1,10 @@
+# Domain: architecture
+
+## Purpose
+Capture architectural decisions about result content handling across the platform
+
+## Scope
+Included in this domain:
+- Result content rendering
+- Markdown projection
+- Structured content handling

--- a/.brv/context-tree/architecture/rendering/rendering_options.md
+++ b/.brv/context-tree/architecture/rendering/rendering_options.md
@@ -1,0 +1,31 @@
+---
+title: Rendering Options
+summary: Two-tier renderer recommendation with detailed option analysis
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:40:41.883Z'
+updatedAt: '2026-05-27T11:40:41.883Z'
+---
+## Reason
+Curate recommendations for output rendering styles
+
+## Raw Concept
+**Task:**
+Document rendering options for OSV and similar tool outputs
+
+**Changes:**
+- Proposed multi-tier rendering strategies
+- Listed pros/cons for each option
+
+**Flow:**
+User request -> assistant suggestion -> final recommendation
+
+**Timestamp:** 2026-05-27T11:40:41.882Z
+
+## Narrative
+### Structure
+Comparison of rendering options A-E and recommended two-tier approach
+
+### Highlights
+Two-tier renderer with backend-aware templates and generic fallback

--- a/.brv/context-tree/architecture/result_content/context.md
+++ b/.brv/context-tree/architecture/result_content/context.md
@@ -1,0 +1,9 @@
+# Topic: result_content
+
+## Overview
+Defines how structuredContent is projected to Markdown content for downstream agents
+
+## Key Concepts
+- Markdown rendering
+- size thresholds
+- data preservation

--- a/.brv/context-tree/architecture/result_content/lossless_markdown_handling.md
+++ b/.brv/context-tree/architecture/result_content/lossless_markdown_handling.md
@@ -1,0 +1,33 @@
+---
+title: Lossless Markdown Handling
+summary: Result content renders full markdown losslessly; UI preview collapses with ctrl+o
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T13:46:25.141Z'
+updatedAt: '2026-05-27T13:46:25.141Z'
+---
+## Reason
+Curate extracted facts from RLM extraction
+
+## Raw Concept
+**Task:**
+Document lossless markdown result content handling
+
+**Flow:**
+Render result content without truncation, UI handles preview
+
+**Timestamp:** 2026-05-27T13:46:25.138Z
+
+## Narrative
+### Structure
+Result content module retains full markdown; Pi UI shows collapsed preview with ctrl+o to expand
+
+### Dependencies
+Pi UI component, result-content renderer
+
+### Highlights
+Lossless markdown preserved, UI preview hint added
+
+### Examples
+Collapsed view shows "..." and hint, expanded shows full markdown

--- a/.brv/context-tree/architecture/result_content/markdown_content_rendering.md
+++ b/.brv/context-tree/architecture/result_content/markdown_content_rendering.md
@@ -1,0 +1,62 @@
+---
+title: Markdown Content Rendering
+summary: Guidelines for converting structuredContent to Markdown, handling size thresholds, and preserving full data
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:35:37.132Z'
+updatedAt: '2026-05-27T11:35:37.132Z'
+---
+## Reason
+Document design for rendering structuredContent as Markdown in content field
+
+## Raw Concept
+**Task:**
+Define rendering strategy for structuredContent to Markdown content
+
+**Changes:**
+- Add Markdown projection for small/medium results
+- Truncate large results with pointer to structuredContent
+- Preserve full structuredContent unchanged
+
+**Files:**
+- packages/core/src/result-content.ts
+
+**Flow:**
+structuredContent -> renderer -> Markdown content
+
+**Timestamp:** 2026-05-27T11:35:37.129Z
+
+## Narrative
+### Structure
+Renderer functions produce Markdown sections, bullet rows, and JSON code fences
+
+### Highlights
+Improves readability for content-only MCP clients, maintains data integrity
+
+### Rules
+Large results must include explicit truncation marker and pointer to structuredContent
+
+### Examples
+Example Markdown output with status and body sections
+
+## Facts
+- **structuredContent rendering**: Convert `structuredContent` into readable Markdown for `content`, while keeping the original full object in `structuredContent`. [project]
+- **result size handling**: For small/medium structured results: include full Markdown-rendered structured content. [project]
+- **large result handling**: For large results: include important scalar fields plus truncated JSON sections with a clear marker: `… truncated; full value is available in structuredContent.body`. [project]
+- **data integrity**: Preserve full `structuredContent` unchanged. [project]
+- **downstream MCP handling**: Keep downstream MCP `content` unchanged when proxying downstream MCP tools, unless Caplets generated the structured result itself or field selection is applied. [project]
+- **renderer reuse**: Pi/OpenCode can use the same Markdown renderer for consistency. [project]
+- **markdown projection**: Best compatibility with content-only MCP clients. [project]
+- **markdown projection**: Much better for LLMs than raw minified JSON. [project]
+- **markdown projection**: Avoids reverting fully to noisy pretty-JSON duplication for everything. [project]
+- **resultContent**: Add config like `{ "resultContent": { "mode": "markdown", "maxBytes": 12000 } }`. [project]
+- **renderer module**: Create a shared renderer in `packages/core/src/result-content.ts` with functions `structuredContentMarkdown(value, options): string` and `structuredContentMarkdownBlocks(value, options): TextContentBlock[]`. [project]
+- **renderer behavior**: Renderer should render plain objects as Markdown sections, scalar fields as bullet rows, and nested arrays/objects as fenced JSON blocks. [project]
+- **renderer truncation**: Renderer should enforce a max text size and mark truncation explicitly, pointing to `structuredContent.<path>`. [project]
+- **default behavior**: Default policy: For Caplets-generated structured results, `content` is Markdown projection of meaningful `structuredContent` and `structuredContent` remains full original data. [project]
+- **metadata handling**: Metadata-only discovery responses should stay compact/empty unless discovery must be visible to content-only clients. [project]
+- **downstream call_tool handling**: For downstream MCP-backed `call_tool`, preserve downstream `content` as-is and optionally project empty/useless `content` from `structuredContent` into Markdown. [project]
+- **test cases**: Add tests to verify small HTTP/OpenAPI/GraphQL/CLI structured results expose body/stdout/etc in Markdown `content` while full data remains in `structuredContent`. [project]
+- **test cases**: Add tests to verify large nested bodies truncate with an explicit pointer. [project]
+- **plan location**: Implementation plan file should be saved at `docs/plans/2026-05-27-structured-content-markdown-content.md`. [project]

--- a/.brv/context-tree/facts/conventions/assistant.md
+++ b/.brv/context-tree/facts/conventions/assistant.md
@@ -1,0 +1,20 @@
+---
+title: Assistant
+summary: Facts about assistant
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:01:34.381Z'
+updatedAt: '2026-05-27T12:01:34.381Z'
+---
+## Reason
+Curated from RLM extraction
+
+## Raw Concept
+**Task:**
+Document assistant facts
+
+**Timestamp:** 2026-05-27T12:01:34.378Z
+
+## Facts
+- **assistant**: I’m using the writing-plans skill to create the implementation plan.

--- a/.brv/context-tree/facts/conventions/caplets_facts.md
+++ b/.brv/context-tree/facts/conventions/caplets_facts.md
@@ -1,0 +1,33 @@
+---
+title: Caplets Facts
+summary: Facts about Caplets
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:32:10.034Z'
+updatedAt: '2026-05-27T11:32:10.034Z'
+---
+## Reason
+Curate extracted factual statements from context
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+**Changes:**
+- Added extracted facts
+
+**Flow:**
+Extraction -> Deduplication -> Curation
+
+**Timestamp:** 2026-05-27T11:32:10.020Z
+
+## Narrative
+### Structure
+Facts grouped under Caplets
+
+### Highlights
+For Caplets, the recommended default is `structuredContent` containing the full downstream result and `content` containing a compact but semantically useful preview.
+
+## Facts
+- **Caplets**: For Caplets, the recommended default is `structuredContent` containing the full downstream result and `content` containing a compact but semantically useful preview.

--- a/.brv/context-tree/facts/conventions/caplets_result_rendering.md
+++ b/.brv/context-tree/facts/conventions/caplets_result_rendering.md
@@ -1,0 +1,22 @@
+---
+title: Caplets result rendering
+summary: Facts about Caplets result rendering
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:40:54.539Z'
+updatedAt: '2026-05-27T11:40:54.539Z'
+---
+## Reason
+Curate extracted factual statements
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+## Narrative
+### Highlights
+For Caplets‑generated HTTP/OpenAPI/GraphQL/CLI results, always use the new renderer.
+
+## Facts
+- **Caplets result rendering**: For Caplets‑generated HTTP/OpenAPI/GraphQL/CLI results, always use the new renderer.

--- a/.brv/context-tree/facts/conventions/client_compatibility_facts.md
+++ b/.brv/context-tree/facts/conventions/client_compatibility_facts.md
@@ -1,0 +1,33 @@
+---
+title: client compatibility Facts
+summary: Facts about client compatibility
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:32:10.029Z'
+updatedAt: '2026-05-27T11:32:10.029Z'
+---
+## Reason
+Curate extracted factual statements from context
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+**Changes:**
+- Added extracted facts
+
+**Flow:**
+Extraction -> Deduplication -> Curation
+
+**Timestamp:** 2026-05-27T11:32:10.020Z
+
+## Narrative
+### Structure
+Facts grouped under client compatibility
+
+### Highlights
+Do not rely on `structuredContent` alone if broad client compatibility matters.
+
+## Facts
+- **client compatibility**: Do not rely on `structuredContent` alone if broad client compatibility matters.

--- a/.brv/context-tree/facts/conventions/content_facts.md
+++ b/.brv/context-tree/facts/conventions/content_facts.md
@@ -1,0 +1,33 @@
+---
+title: content Facts
+summary: Facts about content
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:32:10.028Z'
+updatedAt: '2026-05-27T11:32:10.028Z'
+---
+## Reason
+Curate extracted factual statements from context
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+**Changes:**
+- Added extracted facts
+
+**Flow:**
+Extraction -> Deduplication -> Curation
+
+**Timestamp:** 2026-05-27T11:32:10.020Z
+
+## Narrative
+### Structure
+Facts grouped under content
+
+### Highlights
+Put model-friendly text in `content`.
+
+## Facts
+- **content**: Put model-friendly text in `content`.

--- a/.brv/context-tree/facts/conventions/content_rendering.md
+++ b/.brv/context-tree/facts/conventions/content_rendering.md
@@ -1,0 +1,22 @@
+---
+title: Content rendering
+summary: Facts about content rendering
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:40:54.527Z'
+updatedAt: '2026-05-27T11:40:54.528Z'
+---
+## Reason
+Curate extracted factual statements
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+## Narrative
+### Highlights
+Render agent‑visible `content` as Markdown.
+
+## Facts
+- **content rendering**: Render agent‑visible `content` as Markdown.

--- a/.brv/context-tree/facts/conventions/data_retention.md
+++ b/.brv/context-tree/facts/conventions/data_retention.md
@@ -1,0 +1,22 @@
+---
+title: Data retention
+summary: Facts about data retention
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:40:54.525Z'
+updatedAt: '2026-05-27T11:40:54.525Z'
+---
+## Reason
+Curate extracted factual statements
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+## Narrative
+### Highlights
+Always keep full canonical data in `structuredContent`.
+
+## Facts
+- **data retention**: Always keep full canonical data in `structuredContent`.

--- a/.brv/context-tree/facts/conventions/downstream_content_handling.md
+++ b/.brv/context-tree/facts/conventions/downstream_content_handling.md
@@ -1,0 +1,24 @@
+---
+title: Downstream content handling
+summary: Facts about downstream content handling
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:40:54.536Z'
+updatedAt: '2026-05-27T11:40:54.536Z'
+---
+## Reason
+Curate extracted factual statements
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+## Narrative
+### Highlights
+If downstream `content` has meaningful text, image, or resource content, preserve it.
+If downstream `content` is empty, generic, or compact‑only, synthesize Markdown from `structuredContent`.
+
+## Facts
+- **downstream content handling**: If downstream `content` has meaningful text, image, or resource content, preserve it.
+- **downstream content handling**: If downstream `content` is empty, generic, or compact‑only, synthesize Markdown from `structuredContent`.

--- a/.brv/context-tree/facts/conventions/extracted_context.md
+++ b/.brv/context-tree/facts/conventions/extracted_context.md
@@ -1,0 +1,37 @@
+---
+title: extracted_context
+summary: Extracted factual statements from provided context
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:31:02.665Z'
+updatedAt: '2026-05-27T11:31:02.665Z'
+---
+## Reason
+Curate extracted facts from RLM extraction
+
+## Raw Concept
+**Task:**
+Curate extracted factual statements from provided context
+
+**Flow:**
+Extract -> Dedup -> Group -> Curate
+
+**Timestamp:** 2026-05-27T11:31:02.662Z
+
+## Narrative
+### Structure
+Facts organized by subject
+
+### Highlights
+MCP client, structuredContent, content, Pi/OpenCode integration, MCP server, MCP content generation
+
+## Facts
+- **MCP client**: For pure MCP clients, the full body is in the MCP response as `structuredContent`, but not necessarily in `content[0].text`.
+- **structuredContent**: `structuredContent` contains the full parsed response body, including status, headers, and body JSON.
+- **content**: `content` provides a human‑readable compact preview, e.g., "status 200; OK; body {\"vulns\":[...truncated...]}".
+- **MCP client**: MCP clients that pass `structuredContent` to the model see the full body.
+- **MCP client**: MCP clients that only pass `content` text to the model see only the compact/truncated preview, not the full body.
+- **Pi/OpenCode integration**: Pi/OpenCode native integrations are now fixed to prefer `structuredContent`, so agents see the full body there.
+- **MCP server**: The pure MCP server path already returns full structured data; the remaining risk is client‑side behavior.
+- **MCP content generation**: To support content‑only MCP clients robustly, core MCP `content` generation would need to include full JSON or a `fullTextContent` mode, which would increase output noise.

--- a/.brv/context-tree/facts/conventions/extracted_facts.md
+++ b/.brv/context-tree/facts/conventions/extracted_facts.md
@@ -1,0 +1,34 @@
+---
+title: Extracted Facts
+summary: Curated factual statements extracted from RLM context
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:28:54.890Z'
+updatedAt: '2026-05-27T11:47:26.112Z'
+---
+## Reason
+Curate facts extracted from RLM context
+
+## Raw Concept
+**Task:**
+Curate extracted factual statements from provided context
+
+**Changes:**
+- Added extracted facts
+
+**Flow:**
+extract -> dedup -> upsert
+
+**Timestamp:** 2026-05-27T11:47:26.107Z
+
+## Narrative
+### Structure
+Extracted factual statements organized by subject
+
+### Highlights
+user, assistant
+
+## Facts
+- **user**: This looks good, create an implementation plan for this and put it in @docs/plans/
+- **assistant**: I’m using the writing-plans skill to create the implementation plan.

--- a/.brv/context-tree/facts/conventions/fallback_rendering.md
+++ b/.brv/context-tree/facts/conventions/fallback_rendering.md
@@ -1,0 +1,22 @@
+---
+title: Fallback rendering
+summary: Facts about fallback rendering
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:40:54.532Z'
+updatedAt: '2026-05-27T11:40:54.532Z'
+---
+## Reason
+Curate extracted factual statements
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+## Narrative
+### Highlights
+Use a fenced pretty‑JSON fallback for unknown structured results.
+
+## Facts
+- **fallback rendering**: Use a fenced pretty‑JSON fallback for unknown structured results.

--- a/.brv/context-tree/facts/conventions/file.md
+++ b/.brv/context-tree/facts/conventions/file.md
@@ -1,0 +1,20 @@
+---
+title: File
+summary: Facts about file
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:01:34.388Z'
+updatedAt: '2026-05-27T12:01:34.388Z'
+---
+## Reason
+Curated from RLM extraction
+
+## Raw Concept
+**Task:**
+Document file facts
+
+**Timestamp:** 2026-05-27T12:01:34.378Z
+
+## Facts
+- **file**: Verified the file exists: 1718 lines.

--- a/.brv/context-tree/facts/conventions/import_handling.md
+++ b/.brv/context-tree/facts/conventions/import_handling.md
@@ -1,0 +1,29 @@
+---
+title: import handling
+summary: Facts about import_handling
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T13:47:55.376Z'
+updatedAt: '2026-05-27T13:47:55.376Z'
+---
+## Reason
+Extracted from source context
+
+## Raw Concept
+**Task:**
+Curate extracted factual statements
+
+**Changes:**
+- Stop changing back to node module resolution imports. I removed the `.js` from imports for a reason so the bundler uses it
+- Understood. I reverted the `@modelcontextprotocol/sdk/...` imports back to the extensionless form and will not change them again. The package-boundary failure from that expectation is intentionally not a blocker for this work.
+
+**Timestamp:** 2026-05-27T13:47:55.375Z
+
+## Narrative
+### Highlights
+Extracted 2 facts for import_handling
+
+## Facts
+- **import_handling**: Stop changing back to node module resolution imports. I removed the `.js` from imports for a reason so the bundler uses it
+- **import_handling**: Understood. I reverted the `@modelcontextprotocol/sdk/...` imports back to the extensionless form and will not change them again. The package-boundary failure from that expectation is intentionally not a blocker for this work.

--- a/.brv/context-tree/facts/conventions/markdown_rendering_design.md
+++ b/.brv/context-tree/facts/conventions/markdown_rendering_design.md
@@ -1,0 +1,46 @@
+---
+title: Markdown Rendering Design
+summary: Design rules for converting JSON results into hierarchical Markdown with headings, arrays handling, and size limits
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:38:52.107Z'
+updatedAt: '2026-05-27T11:38:52.107Z'
+---
+## Reason
+Capture design decisions and conventions for structural Markdown rendering of Caplets results
+
+## Raw Concept
+**Task:**
+Document structural Markdown rendering design for Caplets results
+
+**Flow:**
+Define rendering rules and conventions
+
+**Timestamp:** 2026-05-27T11:38:52.105Z
+
+## Narrative
+### Structure
+Rendering rules for titles, headings, arrays, deep fallback, size limits
+
+### Highlights
+The conversion should be a JSON structure where H1 is the title of the result, top-level keys are H2, and nested keys use sequential headings when feasible. The user wants a structural Markdown rendering, not a prose summary. Revised design direction JSON: { "status": 200, "statusText": "OK", "body": { "vulns": [] } } Use an H1 as the result title in Markdown. Potential title sources, in order: Caplets metadata (e.g., '# OSV Vulnerabilities query_purl', '# HTTP action ping'), then generic fallback '# Result'. Each top-level object key becomes a second-level heading (## key). Nested object keys become progressively deeper headings when feasible, capped at heading level ######. Arrays of scalars are rendered as bullet lists under a heading. Arrays of objects are rendered with headings using label candidates such as id, name, title, summary, key, or tool. If no good label exists for array items, use index headings like '#### Item 1'. When nesting gets too deep or output too large, render that subtree as fenced JSON under its heading. Enforce a maximum content size; when truncated, include a notice indicating truncation and where the full value can be found. `structuredContent` remains unchanged and complete, preserving full structured data. Implementation plan should replace compact label previews with this structural Markdown renderer for Caplets-generated structured results, including HTTP actions, OpenAPI actions, GraphQL actions, CLI tools, field-selected results, Pi/OpenCode agent content, and possibly generated JSON wrapper results. Generated structured results include HTTP actions, OpenAPI actions, GraphQL actions, CLI tools, field-selected results, Pi/OpenCode agent content, and possibly generated JSON wrapper results where useful. It should preserve downstream MCP content unless Caplets must synthesize content from downstream structuredContent. Does this revised structural Markdown direction look right?
+
+## Facts
+- **conversion_design**: The conversion should be a JSON structure where H1 is the title of the result, top-level keys are H2, and nested keys use sequential headings when feasible. [preference]
+- **user_intent**: The user wants a structural Markdown rendering, not a prose summary. [other]
+- **revised_design**: Revised design direction JSON: { "status": 200, "statusText": "OK", "body": { "vulns": [] } } [project]
+- **title**: Use an H1 as the result title in Markdown. [convention]
+- **title_sources**: Potential title sources, in order: Caplets metadata (e.g., '# OSV Vulnerabilities query_purl', '# HTTP action ping'), then generic fallback '# Result'. [convention]
+- **top_level_keys**: Each top-level object key becomes a second-level heading (## key). [convention]
+- **nested_keys**: Nested object keys become progressively deeper headings when feasible, capped at heading level ######. [convention]
+- **arrays_scalars**: Arrays of scalars are rendered as bullet lists under a heading. [convention]
+- **arrays_objects**: Arrays of objects are rendered with headings using label candidates such as id, name, title, summary, key, or tool. [convention]
+- **index_headings**: If no good label exists for array items, use index headings like '#### Item 1'. [convention]
+- **deep_fallback**: When nesting gets too deep or output too large, render that subtree as fenced JSON under its heading. [convention]
+- **size_limits**: Enforce a maximum content size; when truncated, include a notice indicating truncation and where the full value can be found. [convention]
+- **structured_content**: `structuredContent` remains unchanged and complete, preserving full structured data. [other]
+- **plan_scope**: Implementation plan should replace compact label previews with this structural Markdown renderer for Caplets-generated structured results, including HTTP actions, OpenAPI actions, GraphQL actions, CLI tools, field-selected results, Pi/OpenCode agent content, and possibly generated JSON wrapper results. [project]
+- **structured_results**: Generated structured results include HTTP actions, OpenAPI actions, GraphQL actions, CLI tools, field-selected results, Pi/OpenCode agent content, and possibly generated JSON wrapper results where useful. [project]
+- **preserve_mcp_content**: It should preserve downstream MCP content unless Caplets must synthesize content from downstream structuredContent. [project]
+- **revised_structural_markdown_direction**: Does this revised structural Markdown direction look right? [other]

--- a/.brv/context-tree/facts/conventions/markdown_structure.md
+++ b/.brv/context-tree/facts/conventions/markdown_structure.md
@@ -1,0 +1,22 @@
+---
+title: Markdown structure
+summary: Facts about Markdown structure
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:40:54.523Z'
+updatedAt: '2026-05-27T11:40:54.523Z'
+---
+## Reason
+Curate extracted factual statements
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+## Narrative
+### Highlights
+The useful Markdown structure is at the result‑shape level, not every object‑key level.
+
+## Facts
+- **Markdown structure**: The useful Markdown structure is at the result‑shape level, not every object‑key level.

--- a/.brv/context-tree/facts/conventions/output_size.md
+++ b/.brv/context-tree/facts/conventions/output_size.md
@@ -1,0 +1,22 @@
+---
+title: Output size
+summary: Facts about output size
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:40:54.533Z'
+updatedAt: '2026-05-27T11:40:54.534Z'
+---
+## Reason
+Curate extracted factual statements
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+## Narrative
+### Highlights
+Apply a size limit with explicit truncation text.
+
+## Facts
+- **output size**: Apply a size limit with explicit truncation text.

--- a/.brv/context-tree/facts/conventions/payload_duplication_facts.md
+++ b/.brv/context-tree/facts/conventions/payload_duplication_facts.md
@@ -1,0 +1,33 @@
+---
+title: payload duplication Facts
+summary: Facts about payload duplication
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:32:10.031Z'
+updatedAt: '2026-05-27T11:32:10.031Z'
+---
+## Reason
+Curate extracted factual statements from context
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+**Changes:**
+- Added extracted facts
+
+**Flow:**
+Extraction -> Deduplication -> Curation
+
+**Timestamp:** 2026-05-27T11:32:10.020Z
+
+## Narrative
+### Structure
+Facts grouped under payload duplication
+
+### Highlights
+Avoid duplicating huge payloads blindly because it can waste tokens and degrade model performance.
+
+## Facts
+- **payload duplication**: Avoid duplicating huge payloads blindly because it can waste tokens and degrade model performance.

--- a/.brv/context-tree/facts/conventions/plan.md
+++ b/.brv/context-tree/facts/conventions/plan.md
@@ -1,0 +1,21 @@
+---
+title: Plan
+summary: Facts about plan
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:01:34.385Z'
+updatedAt: '2026-05-27T12:01:34.385Z'
+---
+## Reason
+Curated from RLM extraction
+
+## Raw Concept
+**Task:**
+Document plan facts
+
+**Timestamp:** 2026-05-27T12:01:34.378Z
+
+## Facts
+- **plan**: Plan created: docs/plans/2026-05-27-lossless-markdown-result-content.md
+- **plan**: The plan covers backend-specific Markdown formats for MCP, HTTP, OpenAPI, GraphQL, CLI, Caplet sets, discovery, errors, and field selection; no renderer-level truncation; preserving complete `structuredContent`; making `content` a full Markdown projection for content-only MCP clients; Pi/OpenCode native integration updates; TDD task breakdown, commands, and verification steps.

--- a/.brv/context-tree/facts/conventions/recursive_headings.md
+++ b/.brv/context-tree/facts/conventions/recursive_headings.md
@@ -1,0 +1,22 @@
+---
+title: Recursive headings
+summary: Facts about recursive headings
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:40:54.522Z'
+updatedAt: '2026-05-27T11:40:54.522Z'
+---
+## Reason
+Curate extracted factual statements
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+## Narrative
+### Highlights
+Recursive headings become problematic with real API payloads because arrays become awkward headings, repeated object shapes become noisy, deeply nested fields produce unusable heading levels, and JSON structure is already the best representation for nested machine data.
+
+## Facts
+- **recursive headings**: Recursive headings become problematic with real API payloads because arrays become awkward headings, repeated object shapes become noisy, deeply nested fields produce unusable heading levels, and JSON structure is already the best representation for nested machine data.

--- a/.brv/context-tree/facts/conventions/rendering_approach.md
+++ b/.brv/context-tree/facts/conventions/rendering_approach.md
@@ -1,0 +1,22 @@
+---
+title: Rendering approach
+summary: Facts about rendering approach
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:40:54.520Z'
+updatedAt: '2026-05-27T11:40:54.520Z'
+---
+## Reason
+Curate extracted factual statements
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+## Narrative
+### Highlights
+My recommendation is backend-aware Markdown with a generic JSON fallback, not recursive key headings.
+
+## Facts
+- **rendering approach**: My recommendation is backend-aware Markdown with a generic JSON fallback, not recursive key headings.

--- a/.brv/context-tree/facts/conventions/response_size_facts.md
+++ b/.brv/context-tree/facts/conventions/response_size_facts.md
@@ -1,0 +1,34 @@
+---
+title: response size Facts
+summary: Facts about response size
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:32:10.032Z'
+updatedAt: '2026-05-27T11:32:10.033Z'
+---
+## Reason
+Curate extracted factual statements from context
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+**Changes:**
+- Added extracted facts
+
+**Flow:**
+Extraction -> Deduplication -> Curation
+
+**Timestamp:** 2026-05-27T11:32:10.020Z
+
+## Narrative
+### Structure
+Facts grouped under response size
+
+### Highlights
+For small/medium responses, include full JSON in both `content` and `structuredContent`.; For large responses, place full data in `structuredContent` and provide a concise useful text summary in `content`.
+
+## Facts
+- **response size**: For small/medium responses, include full JSON in both `content` and `structuredContent`.
+- **response size**: For large responses, place full data in `structuredContent` and provide a concise useful text summary in `content`.

--- a/.brv/context-tree/facts/conventions/structuredcontent_facts.md
+++ b/.brv/context-tree/facts/conventions/structuredcontent_facts.md
@@ -1,0 +1,33 @@
+---
+title: structuredContent Facts
+summary: Facts about structuredContent
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:32:10.026Z'
+updatedAt: '2026-05-27T11:32:10.026Z'
+---
+## Reason
+Curate extracted factual statements from context
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+**Changes:**
+- Added extracted facts
+
+**Flow:**
+Extraction -> Deduplication -> Curation
+
+**Timestamp:** 2026-05-27T11:32:10.020Z
+
+## Narrative
+### Structure
+Facts grouped under structuredContent
+
+### Highlights
+Put machine-readable data in `structuredContent`.
+
+## Facts
+- **structuredContent**: Put machine-readable data in `structuredContent`.

--- a/.brv/context-tree/facts/conventions/template_usage.md
+++ b/.brv/context-tree/facts/conventions/template_usage.md
@@ -1,0 +1,22 @@
+---
+title: Template usage
+summary: Facts about template usage
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:40:54.530Z'
+updatedAt: '2026-05-27T11:40:54.530Z'
+---
+## Reason
+Curate extracted factual statements
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+## Narrative
+### Highlights
+Use backend‑aware templates where Caplets knows the shape.
+
+## Facts
+- **template usage**: Use backend‑aware templates where Caplets knows the shape.

--- a/.brv/context-tree/facts/project/build_verification.md
+++ b/.brv/context-tree/facts/project/build_verification.md
@@ -1,0 +1,24 @@
+---
+title: Build verification
+summary: Facts about build verification
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:14:20.338Z'
+updatedAt: '2026-05-27T11:14:20.338Z'
+---
+## Reason
+Curated factual statements extracted from context
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+**Timestamp:** 2026-05-27T11:14:20.303Z
+
+## Narrative
+### Structure
+Collection of facts regarding build verification
+
+## Facts
+- **build verification**: Verification commands ran successfully, including format checks, tests, and typecheck for @caplets/core.

--- a/.brv/context-tree/facts/project/capletserror_facts.md
+++ b/.brv/context-tree/facts/project/capletserror_facts.md
@@ -1,0 +1,24 @@
+---
+title: CapletsError Facts
+summary: Facts about CapletsError
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.027Z'
+updatedAt: '2026-05-27T12:22:30.027Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for CapletsError
+
+**Timestamp:** 2026-05-27T12:22:30.013Z
+
+## Narrative
+### Highlights
+Enhanced CapletsError to store optional details and toErrorResult returns a Markdown‑formatted error result via jsonResult.
+
+## Facts
+- **CapletsError**: Enhanced CapletsError to store optional details and toErrorResult returns a Markdown‑formatted error result via jsonResult.

--- a/.brv/context-tree/facts/project/changeset_lossless_markdown_results_md_facts.md
+++ b/.brv/context-tree/facts/project/changeset_lossless_markdown_results_md_facts.md
@@ -1,0 +1,24 @@
+---
+title: .changeset/lossless-markdown-results.md Facts
+summary: Facts about .changeset/lossless-markdown-results.md
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.072Z'
+updatedAt: '2026-05-27T12:22:30.072Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for .changeset/lossless-markdown-results.md
+
+**Timestamp:** 2026-05-27T12:22:30.013Z
+
+## Narrative
+### Highlights
+Created .changeset/lossless-markdown-results.md documenting the new renderer, error handling, and integration updates.
+
+## Facts
+- **.changeset/lossless-markdown-results.md**: Created .changeset/lossless-markdown-results.md documenting the new renderer, error handling, and integration updates.

--- a/.brv/context-tree/facts/project/cli_facts.md
+++ b/.brv/context-tree/facts/project/cli_facts.md
@@ -1,0 +1,24 @@
+---
+title: CLI Facts
+summary: Facts about CLI
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.056Z'
+updatedAt: '2026-05-27T12:22:30.056Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for CLI
+
+**Timestamp:** 2026-05-27T12:22:30.013Z
+
+## Narrative
+### Highlights
+CLI manager returns jsonResult for command output, including command, args, exit code; errors via errorResult.
+
+## Facts
+- **CLI**: CLI manager returns jsonResult for command output, including command, args, exit code; errors via errorResult.

--- a/.brv/context-tree/facts/project/graphql_facts.md
+++ b/.brv/context-tree/facts/project/graphql_facts.md
@@ -1,0 +1,24 @@
+---
+title: GraphQL Facts
+summary: Facts about GraphQL
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.053Z'
+updatedAt: '2026-05-27T12:22:30.053Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for GraphQL
+
+**Timestamp:** 2026-05-27T12:22:30.013Z
+
+## Narrative
+### Highlights
+GraphQL manager returns jsonResult for schema retrieval and query execution, with endpoint and query metadata; errors via errorResult.
+
+## Facts
+- **GraphQL**: GraphQL manager returns jsonResult for schema retrieval and query execution, with endpoint and query metadata; errors via errorResult.

--- a/.brv/context-tree/facts/project/http_actions_facts.md
+++ b/.brv/context-tree/facts/project/http_actions_facts.md
@@ -1,0 +1,24 @@
+---
+title: HTTP Actions Facts
+summary: Facts about HTTP Actions
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.030Z'
+updatedAt: '2026-05-27T12:22:30.030Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for HTTP Actions
+
+**Timestamp:** 2026-05-27T12:22:30.013Z
+
+## Narrative
+### Highlights
+HTTP Actions manager uses jsonResult for successful responses and errorResult for failures, adding method, URL, status metadata.
+
+## Facts
+- **HTTP Actions**: HTTP Actions manager uses jsonResult for successful responses and errorResult for failures, adding method, URL, status metadata.

--- a/.brv/context-tree/facts/project/mcp_downstream_handling.md
+++ b/.brv/context-tree/facts/project/mcp_downstream_handling.md
@@ -1,0 +1,24 @@
+---
+title: MCP downstream handling
+summary: Project facts about MCP downstream handling
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T14:20:38.726Z'
+updatedAt: '2026-05-27T14:20:38.726Z'
+---
+## Reason
+Curate extracted project facts
+
+## Raw Concept
+**Task:**
+Document project facts
+
+**Timestamp:** 2026-05-27T14:20:38.716Z
+
+## Narrative
+### Highlights
+Extracted 1 facts for MCP downstream handling
+
+## Facts
+- **MCP downstream handling**: MCP downstream non-text content is not preserved because `packages/core/src/result-content.ts:46-85` converts all results to a single text block via `textBlocksToString()`.

--- a/.brv/context-tree/facts/project/modified_files.md
+++ b/.brv/context-tree/facts/project/modified_files.md
@@ -1,0 +1,24 @@
+---
+title: Modified files
+summary: Facts about modified files
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:14:20.336Z'
+updatedAt: '2026-05-27T11:14:20.336Z'
+---
+## Reason
+Curated factual statements extracted from context
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+**Timestamp:** 2026-05-27T11:14:20.303Z
+
+## Narrative
+### Structure
+Collection of facts regarding modified files
+
+## Facts
+- **modified files**: Files changed include packages/core/src/result-content.ts, packages/core/test/result-content.test.ts, packages/core/test/http-actions.test.ts, and packages/core/test/tools.test.ts.

--- a/.brv/context-tree/facts/project/native_integrations.md
+++ b/.brv/context-tree/facts/project/native_integrations.md
@@ -1,0 +1,24 @@
+---
+title: native integrations
+summary: Project facts about native integrations
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T14:20:38.732Z'
+updatedAt: '2026-05-27T14:20:38.732Z'
+---
+## Reason
+Curate extracted project facts
+
+## Raw Concept
+**Task:**
+Document project facts
+
+**Timestamp:** 2026-05-27T14:20:38.716Z
+
+## Narrative
+### Highlights
+Extracted 1 facts for native integrations
+
+## Facts
+- **native integrations**: Native integrations do not consume the shared core Markdown renderer for structured fallback paths.

--- a/.brv/context-tree/facts/project/openapi_facts.md
+++ b/.brv/context-tree/facts/project/openapi_facts.md
@@ -1,0 +1,24 @@
+---
+title: OpenAPI Facts
+summary: Facts about OpenAPI
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.033Z'
+updatedAt: '2026-05-27T12:22:30.033Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for OpenAPI
+
+**Timestamp:** 2026-05-27T12:22:30.013Z
+
+## Narrative
+### Highlights
+OpenAPI manager returns jsonResult for spec retrieval and operation calls, with operation metadata.
+
+## Facts
+- **OpenAPI**: OpenAPI manager returns jsonResult for spec retrieval and operation calls, with operation metadata.

--- a/.brv/context-tree/facts/project/opencode_facts.md
+++ b/.brv/context-tree/facts/project/opencode_facts.md
@@ -1,0 +1,24 @@
+---
+title: OpenCode Facts
+summary: Facts about OpenCode
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.062Z'
+updatedAt: '2026-05-27T12:22:30.062Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for OpenCode
+
+**Timestamp:** 2026-05-27T12:22:30.013Z
+
+## Narrative
+### Highlights
+OpenCode integration ensures Markdown output is used and adds _openCodeFormatted flag.
+
+## Facts
+- **OpenCode**: OpenCode integration ensures Markdown output is used and adds _openCodeFormatted flag.

--- a/.brv/context-tree/facts/project/opencode_integration.md
+++ b/.brv/context-tree/facts/project/opencode_integration.md
@@ -1,0 +1,24 @@
+---
+title: OpenCode integration
+summary: Project facts about OpenCode integration
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T14:20:38.734Z'
+updatedAt: '2026-05-27T14:20:38.734Z'
+---
+## Reason
+Curate extracted project facts
+
+## Raw Concept
+**Task:**
+Document project facts
+
+**Timestamp:** 2026-05-27T14:20:38.716Z
+
+## Narrative
+### Highlights
+Extracted 1 facts for OpenCode integration
+
+## Facts
+- **OpenCode integration**: `packages/opencode/src/hooks.ts:36-60` returns existing text content first, otherwise raw `JSON.stringify(result, null, 2)`, without using `hasRenderableStructuredContent()` or `markdownStructuredContent()`.

--- a/.brv/context-tree/facts/project/packages_core_src_index_ts_facts.md
+++ b/.brv/context-tree/facts/project/packages_core_src_index_ts_facts.md
@@ -1,0 +1,24 @@
+---
+title: packages/core/src/index.ts Facts
+summary: Facts about packages/core/src/index.ts
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.025Z'
+updatedAt: '2026-05-27T12:22:30.025Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for packages/core/src/index.ts
+
+**Timestamp:** 2026-05-27T12:22:30.013Z
+
+## Narrative
+### Highlights
+Exported renderToMarkdown, MarkdownRenderOptions, jsonResult, errorResult, ToolMetadata from packages/core/src/index.ts.
+
+## Facts
+- **packages/core/src/index.ts**: Exported renderToMarkdown, MarkdownRenderOptions, jsonResult, errorResult, ToolMetadata from packages/core/src/index.ts.

--- a/.brv/context-tree/facts/project/pi_facts.md
+++ b/.brv/context-tree/facts/project/pi_facts.md
@@ -1,0 +1,24 @@
+---
+title: Pi Facts
+summary: Facts about Pi
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.060Z'
+updatedAt: '2026-05-27T12:22:30.060Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for Pi
+
+**Timestamp:** 2026-05-27T12:22:30.013Z
+
+## Narrative
+### Highlights
+Pi integration shows full Markdown to the agent and UI preview truncated to previewMaxLength with “Ctrl+O for full content”.
+
+## Facts
+- **Pi**: Pi integration shows full Markdown to the agent and UI preview truncated to previewMaxLength with “Ctrl+O for full content”.

--- a/.brv/context-tree/facts/project/pi_integration.md
+++ b/.brv/context-tree/facts/project/pi_integration.md
@@ -1,0 +1,24 @@
+---
+title: Pi integration
+summary: Project facts about Pi integration
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T14:20:38.737Z'
+updatedAt: '2026-05-27T14:20:38.737Z'
+---
+## Reason
+Curate extracted project facts
+
+## Raw Concept
+**Task:**
+Document project facts
+
+**Timestamp:** 2026-05-27T14:20:38.716Z
+
+## Narrative
+### Highlights
+Extracted 1 facts for Pi integration
+
+## Facts
+- **Pi integration**: `packages/pi/src/index.ts:604-612` similarly returns existing text content first, otherwise raw JSON, and does not use the core Markdown renderer for structured results.

--- a/.brv/context-tree/facts/project/plan_requirement.md
+++ b/.brv/context-tree/facts/project/plan_requirement.md
@@ -1,0 +1,25 @@
+---
+title: plan requirement
+summary: Project facts about plan requirement
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T14:20:38.729Z'
+updatedAt: '2026-05-27T14:20:38.729Z'
+---
+## Reason
+Curate extracted project facts
+
+## Raw Concept
+**Task:**
+Document project facts
+
+**Timestamp:** 2026-05-27T14:20:38.716Z
+
+## Narrative
+### Highlights
+Extracted 2 facts for plan requirement
+
+## Facts
+- **plan requirement**: The current handling violates the plan’s requirement to “Preserve downstream MCP-authored content” while appending structured-content Markdown.
+- **plan requirement**: This behavior does not satisfy the plan’s requirement that Pi and OpenCode native integrations should consume the same core Markdown renderer.

--- a/.brv/context-tree/facts/project/rendertomarkdown_facts.md
+++ b/.brv/context-tree/facts/project/rendertomarkdown_facts.md
@@ -1,0 +1,24 @@
+---
+title: renderToMarkdown Facts
+summary: Facts about renderToMarkdown
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.018Z'
+updatedAt: '2026-05-27T12:22:30.018Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for renderToMarkdown
+
+**Timestamp:** 2026-05-27T12:22:30.012Z
+
+## Narrative
+### Highlights
+Added renderToMarkdown with options: preserveArrayIndices, maxDepth, includeMetadata, codeBlock.
+
+## Facts
+- **renderToMarkdown**: Added renderToMarkdown with options: preserveArrayIndices, maxDepth, includeMetadata, codeBlock.

--- a/.brv/context-tree/facts/project/result_content_implementation.md
+++ b/.brv/context-tree/facts/project/result_content_implementation.md
@@ -1,0 +1,24 @@
+---
+title: Result-content implementation
+summary: Facts about result-content implementation
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:14:20.319Z'
+updatedAt: '2026-05-27T11:14:20.319Z'
+---
+## Reason
+Curated factual statements extracted from context
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+**Timestamp:** 2026-05-27T11:14:20.303Z
+
+## Narrative
+### Structure
+Collection of facts regarding result-content implementation
+
+## Facts
+- **result-content implementation**: The root cause was that packages/core/src/result-content.ts intentionally summarized structured results as labels only.

--- a/.brv/context-tree/facts/project/result_content_test_ts_facts.md
+++ b/.brv/context-tree/facts/project/result_content_test_ts_facts.md
@@ -1,0 +1,24 @@
+---
+title: result-content.test.ts Facts
+summary: Facts about result-content.test.ts
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.064Z'
+updatedAt: '2026-05-27T12:22:30.064Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for result-content.test.ts
+
+**Timestamp:** 2026-05-27T12:22:30.013Z
+
+## Narrative
+### Highlights
+Added result-content.test.ts with 35 tests covering primitives, objects, arrays, nesting, options, metadata, code blocks, URLs, dates, functions, circular refs, and error formatting.
+
+## Facts
+- **result-content.test.ts**: Added result-content.test.ts with 35 tests covering primitives, objects, arrays, nesting, options, metadata, code blocks, URLs, dates, functions, circular refs, and error formatting.

--- a/.brv/context-tree/facts/project/result_content_ts.md
+++ b/.brv/context-tree/facts/project/result_content_ts.md
@@ -1,0 +1,24 @@
+---
+title: Result-content.ts
+summary: Facts about result-content.ts
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:14:20.321Z'
+updatedAt: '2026-05-27T11:14:20.321Z'
+---
+## Reason
+Curated factual statements extracted from context
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+**Timestamp:** 2026-05-27T11:14:20.303Z
+
+## Narrative
+### Structure
+Collection of facts regarding result-content.ts
+
+## Facts
+- **result-content.ts**: Compact previews for body, json, stdout, and stderr were added to result-content.ts.

--- a/.brv/context-tree/facts/project/script_output.md
+++ b/.brv/context-tree/facts/project/script_output.md
@@ -1,0 +1,24 @@
+---
+title: Script output
+summary: Facts about script output
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T11:14:20.313Z'
+updatedAt: '2026-05-27T11:14:20.313Z'
+---
+## Reason
+Curated factual statements extracted from context
+
+## Raw Concept
+**Task:**
+Document factual statements
+
+**Timestamp:** 2026-05-27T11:14:20.303Z
+
+## Narrative
+### Structure
+Collection of facts regarding script output
+
+## Facts
+- **script output**: The script printed an empty list of findings and reported "findings 0 packages with vulns".

--- a/.brv/context-tree/facts/project/test_suite.md
+++ b/.brv/context-tree/facts/project/test_suite.md
@@ -1,0 +1,24 @@
+---
+title: test suite
+summary: Project facts about test suite
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T14:20:38.719Z'
+updatedAt: '2026-05-27T14:20:38.719Z'
+---
+## Reason
+Curate extracted project facts
+
+## Raw Concept
+**Task:**
+Document project facts
+
+**Timestamp:** 2026-05-27T14:20:38.716Z
+
+## Narrative
+### Highlights
+Extracted 1 facts for test suite
+
+## Facts
+- **test suite**: Core/opencode tests pass when running `pnpm --filter @caplets/core test -- test/result-content.test.ts test/tools.test.ts test/downstream.test.ts` and `pnpm --filter @caplets/opencode test -- test/opencode.test.ts`.

--- a/.brv/context-tree/facts/project/test_suite_facts.md
+++ b/.brv/context-tree/facts/project/test_suite_facts.md
@@ -1,0 +1,24 @@
+---
+title: test suite Facts
+summary: Facts about test suite
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.070Z'
+updatedAt: '2026-05-27T12:22:30.070Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for test suite
+
+**Timestamp:** 2026-05-27T12:22:30.013Z
+
+## Narrative
+### Highlights
+All existing tests (total 50) pass.
+
+## Facts
+- **test suite**: All existing tests (total 50) pass.

--- a/.brv/context-tree/facts/project/tools_test_ts_facts.md
+++ b/.brv/context-tree/facts/project/tools_test_ts_facts.md
@@ -1,0 +1,24 @@
+---
+title: tools.test.ts Facts
+summary: Facts about tools.test.ts
+tags: []
+related: []
+keywords: []
+createdAt: '2026-05-27T12:22:30.067Z'
+updatedAt: '2026-05-27T12:22:30.067Z'
+---
+## Reason
+Curated factual statements from RLM extraction
+
+## Raw Concept
+**Task:**
+Document facts for tools.test.ts
+
+**Timestamp:** 2026-05-27T12:22:30.013Z
+
+## Narrative
+### Highlights
+Added tools.test.ts with 6 tests verifying jsonResult Markdown output, metadata inclusion, complex content handling, and errorResult behavior.
+
+## Facts
+- **tools.test.ts**: Added tools.test.ts with 6 tests verifying jsonResult Markdown output, metadata inclusion, complex content handling, and errorResult behavior.

--- a/.changeset/fifty-actors-marry.md
+++ b/.changeset/fifty-actors-marry.md
@@ -1,0 +1,5 @@
+---
+"@caplets/core": patch
+---
+
+Fix missing http request body in tool result content

--- a/.changeset/fifty-actors-marry.md
+++ b/.changeset/fifty-actors-marry.md
@@ -2,4 +2,4 @@
 "@caplets/core": patch
 ---
 
-Fix missing http request body in tool result content
+Fix missing http response body in tool result content

--- a/.changeset/lossless-markdown-results.md
+++ b/.changeset/lossless-markdown-results.md
@@ -1,0 +1,7 @@
+---
+"@caplets/core": patch
+"@caplets/pi": patch
+"@caplets/opencode": patch
+---
+
+Render structured Caplets results as lossless Markdown content while preserving canonical structuredContent.

--- a/docs/plans/2026-05-27-lossless-markdown-result-content.md
+++ b/docs/plans/2026-05-27-lossless-markdown-result-content.md
@@ -1,0 +1,1831 @@
+# Lossless Markdown Result Content Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every Caplets-generated tool result expose the same untruncated data in both `structuredContent` and agent/human-readable Markdown `content`.
+
+**Architecture:** Add one shared lossless Markdown renderer in `@caplets/core`, then route every Caplets-generated result shape through backend-aware renderers. Keep `structuredContent` canonical and unchanged; make `content` a complete Markdown projection of that same data instead of a compact preview. Preserve downstream MCP-authored content, but append a complete structured-content Markdown section when downstream `structuredContent` would otherwise be invisible to content-only clients.
+
+**Tech Stack:** TypeScript, MCP SDK `CallToolResult`, Vitest, pnpm, existing Caplets core/pi/opencode packages.
+
+---
+
+## Scope And Decisions
+
+- The core MCP Markdown renderer must not truncate `content`. Existing backend read limits such as HTTP `maxResponseBytes` and CLI `maxOutputBytes` still bound what Caplets receives from downstream systems; the Markdown renderer must not apply any additional truncation.
+- `structuredContent` remains the canonical machine-readable object and must not be removed or compacted.
+- `content` must contain all data from `structuredContent` in Markdown form for Caplets-generated results.
+- Use backend-aware Markdown for known shapes: HTTP/OpenAPI, GraphQL, CLI, discovery/listing, tools, errors, and generic structured results.
+- Nested API data stays in fenced JSON blocks. Do not recursively turn arbitrary object keys into headings.
+- MCP downstream `content` should be preserved when meaningful. If downstream returns `structuredContent`, append a Markdown rendering of that structured data so content-only MCP clients still see it.
+- Pi and OpenCode native integrations should consume the same core Markdown renderer for agent-visible payloads instead of maintaining local lossy formatting.
+- Pi UI rendering is a separate display concern: collapsed tool results must stay short/truncated, and expanded results opened with `ctrl+o` must show the full Markdown content.
+
+## File Structure
+
+- Modify `packages/core/src/result-content.ts`
+  - Replace compact preview behavior with lossless Markdown rendering helpers.
+  - Keep `compactJsonText()` and `compactText()` only if still used by other UI preview code.
+  - Export `markdownStructuredContent()`, `markdownCallToolResultContent()`, and `hasRenderableStructuredContent()`.
+- Modify `packages/core/src/index.ts`
+  - Export the result-content Markdown helpers for native integrations.
+- Modify `packages/core/src/tools.ts`
+  - Use Markdown `content` in `jsonResult()` discovery operations.
+  - Regenerate/append Markdown `content` in `annotateCallToolResult()` after metadata is known.
+  - Use Markdown `content` for field-selected results.
+- Modify generated backends:
+  - `packages/core/src/http-actions.ts`
+  - `packages/core/src/openapi.ts`
+  - `packages/core/src/graphql.ts`
+  - `packages/core/src/cli-tools.ts`
+  - Each manager should return Markdown content for direct manager calls as well as the shared wrapper path.
+- Modify `packages/core/src/errors.ts`
+  - Render safe errors as complete Markdown while keeping `structuredContent.error` unchanged.
+- Modify native integrations:
+  - `packages/pi/src/index.ts`
+  - `packages/opencode/src/hooks.ts`
+  - Prefer core Markdown projection of structured results.
+- Modify tests:
+  - `packages/core/test/result-content.test.ts`
+  - `packages/core/test/http-actions.test.ts`
+  - `packages/core/test/openapi.test.ts`
+  - `packages/core/test/graphql.test.ts`
+  - `packages/core/test/cli-tools.test.ts`
+  - `packages/core/test/tools.test.ts`
+  - `packages/core/test/downstream.test.ts`
+  - `packages/core/test/field-selection.test.ts`
+  - `packages/pi/test/pi.test.ts`
+  - `packages/opencode/test/opencode.test.ts`
+- Add a changeset because this changes user-visible MCP result content:
+  - `.changeset/lossless-markdown-results.md`
+
+---
+
+## Markdown Format Contract
+
+### HTTP and OpenAPI
+
+````md
+# OSV Vulnerabilities call_tool query_purl
+
+## Response
+
+- **Status:** `200 OK`
+- **Elapsed:** `84 ms`
+
+## Headers
+
+```json
+{
+  "content-type": "application/json"
+}
+```
+````
+
+## Body
+
+```json
+{
+  "vulns": []
+}
+```
+
+````
+
+### GraphQL
+
+```md
+# GitHub GraphQL call_tool viewer
+
+## Response
+
+- **Status:** `200 OK`
+
+## Data
+
+```json
+{
+  "viewer": {
+    "login": "octocat"
+  }
+}
+````
+
+## Headers
+
+```json
+{
+  "content-type": "application/json"
+}
+```
+
+## Full Body
+
+```json
+{
+  "data": {
+    "viewer": {
+      "login": "octocat"
+    }
+  }
+}
+```
+
+````
+
+### CLI
+
+```md
+# Repo CLI call_tool search
+
+## Command Result
+
+- **Exit code:** `0`
+- **Elapsed:** `52 ms`
+
+## stdout
+
+```text
+matched line 1
+matched line 2
+````
+
+## stderr
+
+_No stderr._
+
+````
+
+When CLI output mode is JSON and parsing succeeds, include the parsed `json` field too:
+
+```md
+## Parsed JSON
+
+```json
+{
+  "matches": []
+}
+````
+
+````
+
+### Discovery and generated JSON results
+
+```md
+# OSV Vulnerabilities list_tools
+
+## Tools
+
+1. `query_purl` — Read-only OSV query for vulnerabilities affecting one package URL.
+2. `query_version` — Query vulnerabilities for one package version.
+
+## Full Result
+
+```json
+{
+  "id": "osv",
+  "name": "OSV Vulnerabilities",
+  "tools": []
+}
+````
+
+## Caplets Metadata
+
+```json
+{
+  "id": "osv",
+  "name": "OSV Vulnerabilities",
+  "backend": "http",
+  "operation": "list_tools",
+  "status": "ok"
+}
+```
+
+````
+
+### MCP downstream with both content and structured content
+
+```md
+# Browser call_tool browser_snapshot
+
+<downstream text content preserved exactly>
+
+---
+
+## Structured Content
+
+```json
+{
+  "snapshot": "Page title: Example"
+}
+````
+
+````
+
+### Error result
+
+```md
+# Error
+
+## REQUEST_INVALID
+
+Generated server tool request is invalid.
+
+## Details
+
+```json
+{
+  "code": "REQUEST_INVALID",
+  "message": "Generated server tool request is invalid",
+  "details": []
+}
+````
+
+````
+
+---
+
+### Task 1: Add Lossless Markdown Renderer Tests
+
+**Files:**
+- Modify: `packages/core/test/result-content.test.ts`
+
+- [ ] **Step 1: Replace compact-preview expectations with lossless Markdown expectations**
+
+Update the import at the top of `packages/core/test/result-content.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  compactJsonText,
+  hasRenderableStructuredContent,
+  markdownCallToolResultContent,
+  markdownStructuredContent,
+} from "../src/result-content";
+````
+
+Replace the existing compact HTTP preview test with these tests:
+
+````ts
+it("renders HTTP-like structured content as complete Markdown", () => {
+  const content = markdownStructuredContent(
+    {
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "application/json" },
+      body: { vulns: [] },
+      elapsedMs: 12,
+    },
+    {
+      title: "OSV Vulnerabilities call_tool query_purl",
+      backend: "http",
+      operation: "call_tool",
+      tool: "query_purl",
+    },
+  );
+
+  expect(content).toEqual([
+    {
+      type: "text",
+      text: [
+        "# OSV Vulnerabilities call_tool query_purl",
+        "",
+        "## Response",
+        "",
+        "- **Status:** `200 OK`",
+        "- **Elapsed:** `12 ms`",
+        "",
+        "## Headers",
+        "",
+        "```json",
+        '{\n  "content-type": "application/json"\n}',
+        "```",
+        "",
+        "## Body",
+        "",
+        "```json",
+        '{\n  "vulns": []\n}',
+        "```",
+      ].join("\n"),
+    },
+  ]);
+});
+
+it("renders GraphQL body data and full body without losing fields", () => {
+  const text = markdownStructuredContent(
+    {
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "application/json" },
+      body: { data: { viewer: { login: "octocat" } } },
+    },
+    { title: "GitHub GraphQL call_tool viewer", backend: "graphql" },
+  )[0]!.text;
+
+  expect(text).toContain("# GitHub GraphQL call_tool viewer");
+  expect(text).toContain("## Data");
+  expect(text).toContain('"viewer": {');
+  expect(text).toContain("## Full Body");
+  expect(text).toContain("## Headers");
+});
+
+it("renders CLI stdout stderr and parsed JSON without truncation", () => {
+  const text = markdownStructuredContent(
+    {
+      exitCode: 0,
+      stdout: '{"matches":[]}',
+      stderr: "",
+      elapsedMs: 52,
+      json: { matches: [] },
+    },
+    { title: "Repo CLI call_tool search", backend: "cli" },
+  )[0]!.text;
+
+  expect(text).toContain("# Repo CLI call_tool search");
+  expect(text).toContain("## Command Result");
+  expect(text).toContain("- **Exit code:** `0`");
+  expect(text).toContain("## stdout");
+  expect(text).toContain('{"matches":[]}');
+  expect(text).toContain("## stderr\n\n_No stderr._");
+  expect(text).toContain("## Parsed JSON");
+  expect(text).toContain('"matches": []');
+});
+
+it("renders discovery result lists and metadata", () => {
+  const text = markdownStructuredContent(
+    {
+      caplets: {
+        id: "osv",
+        name: "OSV Vulnerabilities",
+        backend: "http",
+        operation: "list_tools",
+        status: "ok",
+      },
+      result: {
+        id: "osv",
+        name: "OSV Vulnerabilities",
+        tools: [
+          {
+            id: "osv",
+            tool: "query_purl",
+            description: "Query vulnerabilities by package URL.",
+            hasInputSchema: true,
+            hasOutputSchema: false,
+          },
+        ],
+      },
+    },
+    { title: "OSV Vulnerabilities list_tools", operation: "list_tools" },
+  )[0]!.text;
+
+  expect(text).toContain("# OSV Vulnerabilities list_tools");
+  expect(text).toContain("## Tools");
+  expect(text).toContain("1. `query_purl` — Query vulnerabilities by package URL.");
+  expect(text).toContain("## Full Result");
+  expect(text).toContain("## Caplets Metadata");
+  expect(text).toContain('"operation": "list_tools"');
+});
+
+it("preserves downstream text and appends structured content for MCP results", () => {
+  const content = markdownCallToolResultContent(
+    {
+      content: [{ type: "text", text: "Downstream text" }],
+      structuredContent: { snapshot: { title: "Example" } },
+    },
+    { title: "Browser call_tool browser_snapshot", backend: "mcp" },
+  );
+
+  expect(content).toEqual([
+    {
+      type: "text",
+      text: [
+        "# Browser call_tool browser_snapshot",
+        "",
+        "Downstream text",
+        "",
+        "---",
+        "",
+        "## Structured Content",
+        "",
+        "```json",
+        '{\n  "snapshot": {\n    "title": "Example"\n  }\n}',
+        "```",
+      ].join("\n"),
+    },
+  ]);
+});
+
+it("detects renderable structured content while ignoring metadata-only objects", () => {
+  expect(hasRenderableStructuredContent({ body: { ok: true } })).toBe(true);
+  expect(hasRenderableStructuredContent({ caplets: { status: "ok" } })).toBe(false);
+  expect(hasRenderableStructuredContent(undefined)).toBe(false);
+});
+````
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @caplets/core test -- test/result-content.test.ts
+```
+
+Expected: FAIL because `markdownStructuredContent`, `markdownCallToolResultContent`, and `hasRenderableStructuredContent` are not implemented yet, and existing compact content does not match the new Markdown contract.
+
+---
+
+### Task 2: Implement Shared Lossless Markdown Renderer
+
+**Files:**
+
+- Modify: `packages/core/src/result-content.ts`
+- Modify: `packages/core/src/index.ts`
+- Test: `packages/core/test/result-content.test.ts`
+
+- [ ] **Step 1: Implement renderer types and public helpers**
+
+Replace the compact summary functions in `packages/core/src/result-content.ts` with this structure while keeping `compactJsonText()` and `compactText()` for UI preview callers that still need compact strings:
+
+```ts
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types";
+
+export type TextContentBlock = { type: "text"; text: string };
+
+export type ResultMarkdownContext = {
+  title?: string | undefined;
+  backend?: string | undefined;
+  operation?: string | undefined;
+  tool?: string | undefined;
+  uri?: string | undefined;
+  prompt?: string | undefined;
+  fields?: string[] | undefined;
+  isError?: boolean | undefined;
+};
+
+export function structuredOnlyContent(): [] {
+  return [];
+}
+
+export function textContent(text: string): TextContentBlock[] {
+  return text ? [{ type: "text", text }] : [];
+}
+
+export function compactJsonText(value: unknown, maxLength = 600): string {
+  return compactText(JSON.stringify(value) ?? String(value), maxLength);
+}
+
+export function compactText(value: string, maxLength = 600): string {
+  const collapsed = value.replace(/\s+/gu, " ").trim();
+  return collapsed.length > maxLength
+    ? `${collapsed.slice(0, maxLength - 1).trimEnd()}…`
+    : collapsed;
+}
+
+export function markdownStructuredContent(
+  value: unknown,
+  context: ResultMarkdownContext = {},
+): TextContentBlock[] {
+  return textContent(renderStructuredMarkdown(value, context));
+}
+
+export function markdownCallToolResultContent(
+  result: CallToolResult,
+  context: ResultMarkdownContext = {},
+): TextContentBlock[] {
+  if (result.isError === true && !hasRenderableStructuredContent(result.structuredContent)) {
+    return textContent(renderTextBlocksWithTitle(result.content, context));
+  }
+
+  const structuredContent = result.structuredContent;
+  const downstreamText = textBlocksToString(result.content);
+  const hasStructured = hasRenderableStructuredContent(structuredContent);
+
+  if (context.backend === "mcp" && downstreamText && hasStructured) {
+    return textContent(
+      [
+        markdownTitle(context),
+        "",
+        downstreamText,
+        "",
+        "---",
+        "",
+        "## Structured Content",
+        "",
+        jsonFence(structuredContent),
+      ].join("\n"),
+    );
+  }
+
+  if (hasStructured) {
+    return markdownStructuredContent(structuredContent, context);
+  }
+
+  if (downstreamText) {
+    return textContent(renderTextBlocksWithTitle(result.content, context));
+  }
+
+  return textContent(renderStructuredMarkdown(result, context));
+}
+
+export function compactStructuredContent(
+  value: unknown,
+  context: ResultMarkdownContext = {},
+): TextContentBlock[] {
+  return markdownStructuredContent(value, context);
+}
+
+export function compactCallToolResultContent(
+  result: CallToolResult,
+  context: ResultMarkdownContext = {},
+): TextContentBlock[] {
+  return markdownCallToolResultContent(result, context);
+}
+
+export function hasRenderableStructuredContent(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return Object.keys(value).some((key) => key !== "caplets" && key !== "elapsedMs");
+}
+```
+
+Add these private rendering helpers below the public functions:
+
+```ts
+function renderStructuredMarkdown(value: unknown, context: ResultMarkdownContext): string {
+  const title = markdownTitle(context);
+  if (isDiscoveryWrapper(value)) {
+    return renderDiscoveryWrapper(value, context, title);
+  }
+  if (context.isError || isErrorStructuredContent(value)) {
+    return renderErrorMarkdown(value, title);
+  }
+  if (context.backend === "cli" || isCliResult(value)) {
+    return renderCliMarkdown(value, title);
+  }
+  if (context.backend === "graphql" || isGraphQlHttpResult(value)) {
+    return renderGraphQlMarkdown(value, title);
+  }
+  if (context.backend === "http" || context.backend === "openapi" || isHttpLikeResult(value)) {
+    return renderHttpMarkdown(value, title);
+  }
+  return [title, "", "## Result", "", jsonFence(value)].join("\n");
+}
+
+function markdownTitle(context: ResultMarkdownContext): string {
+  if (context.title) {
+    return `# ${context.title}`;
+  }
+  const parts = [context.operation, context.tool ?? context.uri ?? context.prompt].filter(
+    (part): part is string => Boolean(part),
+  );
+  return parts.length > 0 ? `# ${parts.join(" ")}` : "# Result";
+}
+
+function renderHttpMarkdown(value: unknown, title: string): string {
+  const record = asRecord(value);
+  const lines = [title, "", "## Response", ""];
+  const status = typeof record.status === "number" ? record.status : undefined;
+  const statusText = typeof record.statusText === "string" ? record.statusText : undefined;
+  if (status !== undefined || statusText) {
+    lines.push(`- **Status:** \`${[status, statusText].filter(Boolean).join(" ")}\``);
+  }
+  if (typeof record.elapsedMs === "number") {
+    lines.push(`- **Elapsed:** \`${record.elapsedMs} ms\``);
+  }
+  lines.push("", "## Headers", "", jsonFence(record.headers ?? {}), "", "## Body", "");
+  lines.push(renderBodyValue(record.body));
+  const additional = omitKeys(record, ["status", "statusText", "headers", "body", "elapsedMs"]);
+  if (Object.keys(additional).length > 0) {
+    lines.push("", "## Additional Fields", "", jsonFence(additional));
+  }
+  return lines.join("\n");
+}
+
+function renderGraphQlMarkdown(value: unknown, title: string): string {
+  const record = asRecord(value);
+  const body = asRecord(record.body);
+  if (!body || (!("data" in body) && !("errors" in body))) {
+    return renderHttpMarkdown(value, title);
+  }
+
+  const lines = [title, "", "## Response", ""];
+  const status = typeof record.status === "number" ? record.status : undefined;
+  const statusText = typeof record.statusText === "string" ? record.statusText : undefined;
+  if (status !== undefined || statusText) {
+    lines.push(`- **Status:** \`${[status, statusText].filter(Boolean).join(" ")}\``);
+  }
+  if (typeof record.elapsedMs === "number") {
+    lines.push(`- **Elapsed:** \`${record.elapsedMs} ms\``);
+  }
+  if ("data" in body) {
+    lines.push("", "## Data", "", jsonFence(body.data));
+  }
+  if ("errors" in body) {
+    lines.push("", "## Errors", "", jsonFence(body.errors));
+  }
+  lines.push("", "## Headers", "", jsonFence(record.headers ?? {}));
+  lines.push("", "## Full Body", "", jsonFence(record.body));
+  const additional = omitKeys(record, ["status", "statusText", "headers", "body", "elapsedMs"]);
+  if (Object.keys(additional).length > 0) {
+    lines.push("", "## Additional Fields", "", jsonFence(additional));
+  }
+  return lines.join("\n");
+}
+
+function renderCliMarkdown(value: unknown, title: string): string {
+  const record = asRecord(value);
+  const lines = [title, "", "## Command Result", ""];
+  if ("exitCode" in record) {
+    lines.push(`- **Exit code:** \`${String(record.exitCode)}\``);
+  }
+  if ("signal" in record) {
+    lines.push(`- **Signal:** \`${String(record.signal)}\``);
+  }
+  if (typeof record.elapsedMs === "number") {
+    lines.push(`- **Elapsed:** \`${record.elapsedMs} ms\``);
+  }
+  lines.push("", "## stdout", "", textFenceOrEmpty(record.stdout, "No stdout."));
+  lines.push("", "## stderr", "", textFenceOrEmpty(record.stderr, "No stderr."));
+  if ("json" in record) {
+    lines.push("", "## Parsed JSON", "", jsonFence(record.json));
+  }
+  if ("jsonParseError" in record) {
+    lines.push("", "## JSON Parse Error", "", jsonFence(record.jsonParseError));
+  }
+  const additional = omitKeys(record, [
+    "exitCode",
+    "signal",
+    "stdout",
+    "stderr",
+    "elapsedMs",
+    "json",
+    "jsonParseError",
+  ]);
+  if (Object.keys(additional).length > 0) {
+    lines.push("", "## Additional Fields", "", jsonFence(additional));
+  }
+  return lines.join("\n");
+}
+
+function renderDiscoveryWrapper(
+  value: { result: unknown; caplets?: unknown },
+  context: ResultMarkdownContext,
+  title: string,
+): string {
+  const result = asRecord(value.result);
+  const lines = [title, ""];
+  if (context.operation === "list_tools" || context.operation === "search_tools") {
+    lines.push("## Tools", "", renderNamedList(arrayValue(result?.tools), "tool"), "");
+  } else if (context.operation === "list_resources" || context.operation === "search_resources") {
+    lines.push(
+      "## Resources",
+      "",
+      renderNamedList(arrayValue(result?.resources ?? result?.matches), "uri"),
+      "",
+    );
+  } else if (context.operation === "list_resource_templates") {
+    lines.push(
+      "## Resource Templates",
+      "",
+      renderNamedList(arrayValue(result?.resourceTemplates), "uriTemplate"),
+      "",
+    );
+  } else if (context.operation === "list_prompts" || context.operation === "search_prompts") {
+    lines.push("## Prompts", "", renderNamedList(arrayValue(result?.prompts), "prompt"), "");
+  } else if (context.operation === "get_tool") {
+    lines.push("## Tool", "", renderToolSummary(asRecord(result?.tool)), "");
+  } else if (context.operation === "check_backend") {
+    lines.push("## Backend Status", "", renderBackendStatus(result), "");
+  } else if (context.operation === "get_caplet") {
+    lines.push("## Caplet", "", renderCapletSummary(result), "");
+  }
+  lines.push("## Full Result", "", jsonFence(value.result));
+  if (value.caplets !== undefined) {
+    lines.push("", "## Caplets Metadata", "", jsonFence(value.caplets));
+  }
+  return lines.join("\n");
+}
+
+function renderErrorMarkdown(value: unknown, title: string): string {
+  const error = asRecord(asRecord(value)?.error) ?? asRecord(value);
+  const code = typeof error?.code === "string" ? error.code : "Error";
+  const message = typeof error?.message === "string" ? error.message : "Tool call failed.";
+  return [
+    title === "# Result" ? "# Error" : title,
+    "",
+    `## ${code}`,
+    "",
+    message,
+    "",
+    "## Details",
+    "",
+    jsonFence(error ?? value),
+  ].join("\n");
+}
+```
+
+Add these lower-level helpers to the bottom of `packages/core/src/result-content.ts`:
+
+````ts
+function isDiscoveryWrapper(value: unknown): value is { result: unknown; caplets?: unknown } {
+  return isRecord(value) && "result" in value;
+}
+
+function isErrorStructuredContent(value: unknown): boolean {
+  return isRecord(value) && "error" in value;
+}
+
+function isHttpLikeResult(value: unknown): boolean {
+  return isRecord(value) && ("status" in value || "statusText" in value || "body" in value);
+}
+
+function isGraphQlHttpResult(value: unknown): boolean {
+  if (!isHttpLikeResult(value)) {
+    return false;
+  }
+  const body = asRecord((value as Record<string, unknown>).body);
+  return Boolean(body && ("data" in body || "errors" in body));
+}
+
+function isCliResult(value: unknown): boolean {
+  return isRecord(value) && ("exitCode" in value || "stdout" in value || "stderr" in value);
+}
+
+function renderBodyValue(value: unknown): string {
+  if (value === undefined) {
+    return "_No response body._";
+  }
+  if (typeof value === "string") {
+    return textFenceOrEmpty(value, "No response body.");
+  }
+  return jsonFence(value);
+}
+
+function textFenceOrEmpty(value: unknown, emptyMessage: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    return `_${emptyMessage}_`;
+  }
+  return ["```text", escapeCodeFence(value), "```"].join("\n");
+}
+
+function jsonFence(value: unknown): string {
+  return ["```json", escapeCodeFence(JSON.stringify(value, null, 2) ?? "null"), "```"].join("\n");
+}
+
+function escapeCodeFence(value: string): string {
+  return value.replace(/```/gu, "`\u200b``");
+}
+
+function textBlocksToString(content: CallToolResult["content"] | undefined): string {
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .filter((item): item is { type: "text"; text: string } =>
+      Boolean(
+        item && typeof item === "object" && item.type === "text" && typeof item.text === "string",
+      ),
+    )
+    .map((item) => item.text)
+    .filter(Boolean)
+    .join("\n");
+}
+
+function renderTextBlocksWithTitle(
+  content: CallToolResult["content"] | undefined,
+  context: ResultMarkdownContext,
+): string {
+  const text = textBlocksToString(content);
+  return text ? [markdownTitle(context), "", text].join("\n") : markdownTitle(context);
+}
+
+function renderNamedList(items: unknown[], nameKey: string): string {
+  if (items.length === 0) {
+    return "_No items._";
+  }
+  return items
+    .map((item, index) => {
+      const record = asRecord(item);
+      const name =
+        stringValue(record?.[nameKey]) ?? stringValue(record?.name) ?? `Item ${index + 1}`;
+      const description = stringValue(record?.description);
+      return description
+        ? `${index + 1}. \`${name}\` — ${description}`
+        : `${index + 1}. \`${name}\``;
+    })
+    .join("\n");
+}
+
+function renderToolSummary(tool: Record<string, unknown> | undefined): string {
+  if (!tool) {
+    return "_Tool details unavailable._";
+  }
+  const lines = [];
+  const name = stringValue(tool.name);
+  const description = stringValue(tool.description);
+  if (name) lines.push(`- **Name:** \`${name}\``);
+  if (description) lines.push(`- **Description:** ${description}`);
+  if (tool.inputSchema !== undefined)
+    lines.push("", "### Input Schema", "", jsonFence(tool.inputSchema));
+  if (tool.outputSchema !== undefined)
+    lines.push("", "### Output Schema", "", jsonFence(tool.outputSchema));
+  if (tool.annotations !== undefined)
+    lines.push("", "### Annotations", "", jsonFence(tool.annotations));
+  return lines.length > 0 ? lines.join("\n") : jsonFence(tool);
+}
+
+function renderBackendStatus(result: Record<string, unknown> | undefined): string {
+  if (!result) {
+    return "_Backend status unavailable._";
+  }
+  const lines = [];
+  for (const key of [
+    "id",
+    "status",
+    "toolCount",
+    "resourceCount",
+    "resourceTemplateCount",
+    "promptCount",
+    "elapsedMs",
+  ]) {
+    if (result[key] !== undefined) {
+      const label = key === "elapsedMs" ? "Elapsed" : humanizeKey(key);
+      const suffix = key === "elapsedMs" ? " ms" : "";
+      lines.push(`- **${label}:** \`${String(result[key])}${suffix}\``);
+    }
+  }
+  if (result.error !== undefined) {
+    lines.push("", "### Error", "", jsonFence(result.error));
+  }
+  return lines.length > 0 ? lines.join("\n") : jsonFence(result);
+}
+
+function renderCapletSummary(result: Record<string, unknown> | undefined): string {
+  if (!result) {
+    return "_Caplet details unavailable._";
+  }
+  const lines = [];
+  for (const key of ["id", "name", "description"]) {
+    if (result[key] !== undefined) {
+      lines.push(`- **${humanizeKey(key)}:** ${String(result[key])}`);
+    }
+  }
+  const backend = asRecord(result.backend);
+  if (backend?.type !== undefined) {
+    lines.push(`- **Backend:** \`${String(backend.type)}\``);
+  }
+  return lines.length > 0 ? lines.join("\n") : jsonFence(result);
+}
+
+function omitKeys(record: Record<string, unknown>, keys: string[]): Record<string, unknown> {
+  const omitted = new Set(keys);
+  return Object.fromEntries(Object.entries(record).filter(([key]) => !omitted.has(key)));
+}
+
+function arrayValue(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function humanizeKey(key: string): string {
+  return key.replace(/([A-Z])/gu, " $1").replace(/^./u, (char) => char.toUpperCase());
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+````
+
+- [ ] **Step 2: Export helpers from core package index**
+
+Add this export to `packages/core/src/index.ts`:
+
+```ts
+export {
+  hasRenderableStructuredContent,
+  markdownCallToolResultContent,
+  markdownStructuredContent,
+} from "./result-content";
+export type { ResultMarkdownContext } from "./result-content";
+```
+
+- [ ] **Step 3: Run the focused renderer test**
+
+Run:
+
+```bash
+pnpm --filter @caplets/core test -- test/result-content.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit renderer foundation**
+
+```bash
+git add packages/core/src/result-content.ts packages/core/src/index.ts packages/core/test/result-content.test.ts
+git commit -m "feat(core): render structured results as markdown content"
+```
+
+---
+
+### Task 3: Wire Markdown Content Through Core Tool Wrappers
+
+**Files:**
+
+- Modify: `packages/core/src/tools.ts`
+- Modify: `packages/core/test/tools.test.ts`
+- Modify: `packages/core/test/field-selection.test.ts`
+
+- [ ] **Step 1: Add failing wrapper tests**
+
+In `packages/core/test/tools.test.ts`, update expectations that currently assert compact strings such as `"body"` or compact JSON previews. Add this test near existing OpenAPI/HTTP projection tests:
+
+```ts
+it("renders field-selected call_tool results as complete Markdown", async () => {
+  const result = await handleServerTool(
+    openApiServer,
+    { operation: "call_tool", tool: "getUser", arguments: { id: "42" }, fields: ["body.name"] },
+    openApiRegistry,
+    downstream,
+    openapi,
+  );
+
+  expect(result).toMatchObject({
+    structuredContent: { body: { name: "Ada" } },
+  });
+  expect(result.content[0].text).toContain("# OpenAPI call_tool getUser");
+  expect(result.content[0].text).toContain("## Body");
+  expect(result.content[0].text).toContain('"name": "Ada"');
+});
+```
+
+If the local fixture title is not `OpenAPI`, use the existing server name from that test file in the expectation.
+
+- [ ] **Step 2: Run wrapper tests to verify failure**
+
+Run:
+
+```bash
+pnpm --filter @caplets/core test -- test/tools.test.ts test/field-selection.test.ts
+```
+
+Expected: FAIL because `jsonResult()`, `annotateCallToolResult()`, and field selection still use compact content or preserve compact backend content.
+
+- [ ] **Step 3: Import Markdown helpers in `packages/core/src/tools.ts`**
+
+Replace the existing result-content import:
+
+```ts
+import { compactStructuredContent } from "./result-content";
+```
+
+with:
+
+```ts
+import {
+  markdownCallToolResultContent,
+  markdownStructuredContent,
+  type ResultMarkdownContext,
+} from "./result-content";
+```
+
+- [ ] **Step 4: Add metadata-to-context helper**
+
+Add this helper below `metadataFor()` in `packages/core/src/tools.ts`:
+
+```ts
+function markdownContextFor(metadata: CapletResultMetadata): ResultMarkdownContext {
+  return {
+    title: [metadata.name, metadata.operation, metadata.tool ?? metadata.uri ?? metadata.prompt]
+      .filter(Boolean)
+      .join(" "),
+    backend: metadata.backend,
+    operation: metadata.operation,
+    ...(metadata.tool ? { tool: metadata.tool } : {}),
+    ...(metadata.uri ? { uri: metadata.uri } : {}),
+    ...(metadata.prompt ? { prompt: metadata.prompt } : {}),
+  };
+}
+```
+
+- [ ] **Step 5: Update `jsonResult()` to render Markdown content**
+
+Replace the `jsonResult()` implementation with:
+
+```ts
+export function jsonResult(value: unknown, metadata?: CapletResultMetadata): CallToolResult {
+  const structuredContent = {
+    ...(metadata === undefined ? {} : { caplets: metadata }),
+    result: value as Record<string, unknown>,
+  };
+  return {
+    content: markdownStructuredContent(
+      structuredContent,
+      metadata ? markdownContextFor(metadata) : { title: "Result" },
+    ),
+    structuredContent,
+  };
+}
+```
+
+- [ ] **Step 6: Update `annotateCallToolResult()` to produce final Markdown after metadata exists**
+
+Inside `annotateCallToolResult()`, replace the return object with:
+
+```ts
+const annotatedResult = {
+  ...result,
+  content: markdownCallToolResultContent(
+    result as CallToolResult,
+    markdownContextFor(annotatedMetadata),
+  ),
+  _meta: {
+    ...(isPlainObject(existingMeta) ? existingMeta : {}),
+    caplets: annotatedMetadata,
+  },
+};
+
+return annotatedResult as T & CallToolResult;
+```
+
+Keep the existing `existingMeta`, `artifacts`, and `annotatedMetadata` computation above this replacement unchanged.
+
+- [ ] **Step 7: Update `projectCallToolResult()` signature and content rendering**
+
+Change the function signature to:
+
+```ts
+export function projectCallToolResult<T extends object>(
+  result: T,
+  outputSchema: unknown,
+  fields: string[],
+  context: ResultMarkdownContext = {},
+): T & CallToolResult {
+```
+
+Replace the projected return block with:
+
+```ts
+return {
+  ...result,
+  content: markdownStructuredContent(projected, context),
+  structuredContent: projected,
+} as T & CallToolResult;
+```
+
+In `handleServerTool()` field-selection branch, compute metadata once and pass it to projection:
+
+```ts
+const metadata = metadataFor(server, "call_tool", parsed.tool, startedAt);
+const result = projectCallToolResult(
+  await backend.callTool(server as never, parsed.tool, parsed.arguments),
+  tool.outputSchema,
+  parsed.fields,
+  markdownContextFor(metadata),
+);
+return annotateCallToolResult(result, metadata);
+```
+
+- [ ] **Step 8: Run wrapper tests**
+
+Run:
+
+```bash
+pnpm --filter @caplets/core test -- test/tools.test.ts test/field-selection.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit wrapper wiring**
+
+```bash
+git add packages/core/src/tools.ts packages/core/test/tools.test.ts packages/core/test/field-selection.test.ts
+git commit -m "feat(core): render wrapped caplet results as markdown"
+```
+
+---
+
+### Task 4: Wire HTTP and OpenAPI Backends
+
+**Files:**
+
+- Modify: `packages/core/src/http-actions.ts`
+- Modify: `packages/core/src/openapi.ts`
+- Modify: `packages/core/test/http-actions.test.ts`
+- Modify: `packages/core/test/openapi.test.ts`
+
+- [ ] **Step 1: Add failing HTTP action expectations**
+
+In `packages/core/test/http-actions.test.ts`, update the successful call test to assert Markdown content and unchanged structured content:
+
+```ts
+expect(result.structuredContent).toMatchObject({
+  status: 200,
+  statusText: "OK",
+  body: { ok: true },
+});
+expect(result.content[0].text).toContain("## Response");
+expect(result.content[0].text).toContain("- **Status:** `200 OK`");
+expect(result.content[0].text).toContain("## Body");
+expect(result.content[0].text).toContain('"ok": true');
+```
+
+Update the forbidden/non-2xx assertion to ensure error bodies remain visible:
+
+```ts
+expect(forbidden.structuredContent).toMatchObject({
+  status: 403,
+  statusText: "Forbidden",
+  body: { error: "denied" },
+});
+expect(forbidden.content[0].text).toContain("- **Status:** `403 Forbidden`");
+expect(forbidden.content[0].text).toContain('"error": "denied"');
+```
+
+- [ ] **Step 2: Add failing OpenAPI expectations**
+
+In `packages/core/test/openapi.test.ts`, update one successful call assertion:
+
+```ts
+expect(result.structuredContent).toMatchObject({
+  status: 200,
+  body: { name: "Ada" },
+});
+expect(result.content[0].text).toContain("## Response");
+expect(result.content[0].text).toContain("## Headers");
+expect(result.content[0].text).toContain("## Body");
+expect(result.content[0].text).toContain('"name": "Ada"');
+```
+
+- [ ] **Step 3: Run backend tests to verify failure**
+
+Run:
+
+```bash
+pnpm --filter @caplets/core test -- test/http-actions.test.ts test/openapi.test.ts
+```
+
+Expected: FAIL because direct manager calls still return compact content.
+
+- [ ] **Step 4: Update HTTP actions manager**
+
+In `packages/core/src/http-actions.ts`, replace the result-content import with:
+
+```ts
+import { markdownStructuredContent } from "./result-content";
+```
+
+Replace the `content` field in `callTool()` with:
+
+```ts
+        content: markdownStructuredContent(parsed, {
+          title: `${api.name} call_tool ${toolName}`,
+          backend: "http",
+          operation: "call_tool",
+          tool: toolName,
+        }),
+```
+
+- [ ] **Step 5: Update OpenAPI manager**
+
+In `packages/core/src/openapi.ts`, replace the result-content import with:
+
+```ts
+import { markdownStructuredContent } from "./result-content";
+```
+
+Replace the `content` field in `callTool()` with:
+
+```ts
+        content: markdownStructuredContent(parsed, {
+          title: `${endpoint.name} call_tool ${toolName}`,
+          backend: "openapi",
+          operation: "call_tool",
+          tool: toolName,
+        }),
+```
+
+- [ ] **Step 6: Run HTTP/OpenAPI tests**
+
+Run:
+
+```bash
+pnpm --filter @caplets/core test -- test/http-actions.test.ts test/openapi.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit HTTP/OpenAPI formatting**
+
+```bash
+git add packages/core/src/http-actions.ts packages/core/src/openapi.ts packages/core/test/http-actions.test.ts packages/core/test/openapi.test.ts
+git commit -m "feat(core): render http results as markdown content"
+```
+
+---
+
+### Task 5: Wire GraphQL and CLI Backends
+
+**Files:**
+
+- Modify: `packages/core/src/graphql.ts`
+- Modify: `packages/core/src/cli-tools.ts`
+- Modify: `packages/core/test/graphql.test.ts`
+- Modify: `packages/core/test/cli-tools.test.ts`
+
+- [ ] **Step 1: Add failing GraphQL assertions**
+
+In `packages/core/test/graphql.test.ts`, update one successful operation assertion:
+
+```ts
+expect(result.structuredContent).toMatchObject({
+  status: 200,
+  body: { data: { viewer: { login: "octocat" } } },
+});
+expect(result.content[0].text).toContain("## Data");
+expect(result.content[0].text).toContain('"viewer": {');
+expect(result.content[0].text).toContain("## Full Body");
+```
+
+For an errors response test, add:
+
+```ts
+expect(result.content[0].text).toContain("## Errors");
+expect(result.content[0].text).toContain('"message"');
+```
+
+- [ ] **Step 2: Add failing CLI assertions**
+
+In `packages/core/test/cli-tools.test.ts`, update a successful text-output call assertion:
+
+```ts
+expect(result.structuredContent).toMatchObject({
+  exitCode: 0,
+  stdout: expect.stringContaining("hello"),
+  stderr: "",
+});
+expect(result.content[0].text).toContain("## Command Result");
+expect(result.content[0].text).toContain("- **Exit code:** `0`");
+expect(result.content[0].text).toContain("## stdout");
+expect(result.content[0].text).toContain("hello");
+expect(result.content[0].text).toContain("## stderr\n\n_No stderr._");
+```
+
+For a JSON-output CLI action test, add:
+
+```ts
+expect(result.structuredContent).toMatchObject({ json: { ok: true } });
+expect(result.content[0].text).toContain("## Parsed JSON");
+expect(result.content[0].text).toContain('"ok": true');
+```
+
+- [ ] **Step 3: Run backend tests to verify failure**
+
+Run:
+
+```bash
+pnpm --filter @caplets/core test -- test/graphql.test.ts test/cli-tools.test.ts
+```
+
+Expected: FAIL because GraphQL and CLI direct managers still return compact content.
+
+- [ ] **Step 4: Update GraphQL manager**
+
+In `packages/core/src/graphql.ts`, replace the result-content import with:
+
+```ts
+import { markdownStructuredContent } from "./result-content";
+```
+
+Replace the `content` field in `callTool()` with:
+
+```ts
+        content: markdownStructuredContent(result, {
+          title: `${endpoint.name} call_tool ${toolName}`,
+          backend: "graphql",
+          operation: "call_tool",
+          tool: toolName,
+        }),
+```
+
+- [ ] **Step 5: Update CLI tools manager**
+
+In `packages/core/src/cli-tools.ts`, replace the result-content import with:
+
+```ts
+import { markdownStructuredContent } from "./result-content";
+```
+
+Replace the `content` field in `callTool()` with:
+
+```ts
+        content: markdownStructuredContent(structured, {
+          title: `${config.name} call_tool ${toolName}`,
+          backend: "cli",
+          operation: "call_tool",
+          tool: toolName,
+        }),
+```
+
+- [ ] **Step 6: Run GraphQL/CLI tests**
+
+Run:
+
+```bash
+pnpm --filter @caplets/core test -- test/graphql.test.ts test/cli-tools.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit GraphQL/CLI formatting**
+
+```bash
+git add packages/core/src/graphql.ts packages/core/src/cli-tools.ts packages/core/test/graphql.test.ts packages/core/test/cli-tools.test.ts
+git commit -m "feat(core): render graphql and cli results as markdown content"
+```
+
+---
+
+### Task 6: Render Safe Error Results as Complete Markdown
+
+**Files:**
+
+- Modify: `packages/core/src/errors.ts`
+- Modify: `packages/core/test/tools.test.ts`
+
+- [ ] **Step 1: Add failing error-result assertion**
+
+In the core test file that already asserts generated error results, update the expectation to require Markdown details:
+
+```ts
+expect(result.isError).toBe(true);
+expect(result.structuredContent).toMatchObject({
+  error: {
+    code: "REQUEST_INVALID",
+    message: expect.any(String),
+  },
+});
+expect(result.content[0].text).toContain("# Error");
+expect(result.content[0].text).toContain("## REQUEST_INVALID");
+expect(result.content[0].text).toContain("## Details");
+expect(result.content[0].text).toContain('"code": "REQUEST_INVALID"');
+```
+
+- [ ] **Step 2: Run error-related tests to verify failure**
+
+Run:
+
+```bash
+pnpm --filter @caplets/core test -- test/tools.test.ts
+```
+
+Expected: FAIL because `errorResult()` still returns one-line text.
+
+- [ ] **Step 3: Update `errorResult()`**
+
+In `packages/core/src/errors.ts`, import the Markdown helper:
+
+```ts
+import { markdownStructuredContent } from "./result-content";
+```
+
+Replace the `errorResult()` return object with:
+
+```ts
+export function errorResult(error: unknown, fallback?: CapletsErrorCode) {
+  const safe = toSafeError(error, fallback);
+  const structuredContent = { error: safe };
+  return {
+    isError: true,
+    content: markdownStructuredContent(structuredContent, {
+      title: "Error",
+      isError: true,
+    }),
+    structuredContent,
+  };
+}
+```
+
+- [ ] **Step 4: Run error-related tests**
+
+Run:
+
+```bash
+pnpm --filter @caplets/core test -- test/tools.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit error formatting**
+
+```bash
+git add packages/core/src/errors.ts packages/core/test/tools.test.ts
+git commit -m "feat(core): render error results as markdown content"
+```
+
+---
+
+### Task 7: Preserve Downstream MCP Content and Append Structured Content
+
+**Files:**
+
+- Modify: `packages/core/test/downstream.test.ts`
+- Modify: `packages/core/test/tools.test.ts`
+- Modify: `packages/core/src/tools.ts`
+
+- [ ] **Step 1: Add failing downstream MCP wrapper test**
+
+In `packages/core/test/tools.test.ts`, add a test using the existing mock downstream manager pattern:
+
+```ts
+it("preserves MCP downstream text and appends downstream structuredContent", async () => {
+  const downstream = mockDownstreamCallResult({
+    content: [{ type: "text", text: "Downstream authored response" }],
+    structuredContent: { answer: { value: 42 } },
+  });
+
+  const result = await handleServerTool(
+    mcpServer,
+    { operation: "call_tool", tool: "answer", arguments: {} },
+    registry,
+    downstream,
+  );
+
+  expect(result.structuredContent).toEqual({ answer: { value: 42 } });
+  expect(result.content[0].text).toContain("Downstream authored response");
+  expect(result.content[0].text).toContain("## Structured Content");
+  expect(result.content[0].text).toContain('"value": 42');
+});
+```
+
+Use the actual mock helper names already present in `packages/core/test/tools.test.ts`; keep the expected behavior exactly as shown.
+
+- [ ] **Step 2: Run MCP wrapper tests**
+
+Run:
+
+```bash
+pnpm --filter @caplets/core test -- test/tools.test.ts test/downstream.test.ts
+```
+
+Expected: PASS if Task 3 already routes `annotateCallToolResult()` through `markdownCallToolResultContent()`; otherwise FAIL and fix `annotateCallToolResult()` to use the Task 3 code exactly.
+
+- [ ] **Step 3: Commit downstream MCP behavior**
+
+```bash
+git add packages/core/src/tools.ts packages/core/test/tools.test.ts packages/core/test/downstream.test.ts
+git commit -m "feat(core): expose downstream structured content in markdown"
+```
+
+---
+
+### Task 8: Update Pi Native Integration to Use Core Markdown and Keep UI Preview Truncated
+
+**Files:**
+
+- Modify: `packages/pi/src/index.ts`
+- Modify: `packages/pi/test/pi.test.ts`
+
+- [ ] **Step 1: Add failing Pi agent-content and renderer tests**
+
+Update the previously added structured body visibility test in `packages/pi/test/pi.test.ts` to assert the agent-visible payload is full Markdown, not raw JSON-only content:
+
+```ts
+expect(result?.content[0]?.text).toContain("# OSV Vulnerabilities call_tool query_purl");
+expect(result?.content[0]?.text).toContain("## Body");
+expect(result?.content[0]?.text).toContain('"vulns": []');
+```
+
+Add a long-field value to the mocked structured body so the collapsed renderer can prove truncation without losing expanded content:
+
+```ts
+const longAdvisory = "A".repeat(400);
+service.execute.mockResolvedValueOnce({
+  content: [{ type: "text", text: "status 200; OK; body" }],
+  structuredContent: {
+    status: 200,
+    statusText: "OK",
+    body: {
+      vulns: [
+        {
+          id: "GHSA-test",
+          summary: longAdvisory,
+        },
+      ],
+    },
+  },
+  _meta: {
+    caplets: {
+      name: "OSV Vulnerabilities",
+      operation: "call_tool",
+      tool: "query_purl",
+      status: "ok",
+    },
+  },
+});
+```
+
+Assert collapsed rendering is short and does not dump the full Markdown body:
+
+```ts
+const collapsed = renderText(
+  registered[0]?.renderResult(result!, { expanded: false, isPartial: false }, plainTheme),
+);
+expect(collapsed).toContain("✓ OSV Vulnerabilities call_tool query_purl complete");
+expect(collapsed.length).toBeLessThan(260);
+expect(collapsed).not.toContain(longAdvisory);
+expect(collapsed).toContain("ctrl+o to expand");
+```
+
+Assert expanded rendering, opened by `ctrl+o`, displays the full Markdown content:
+
+```ts
+const expanded = renderText(
+  registered[0]?.renderResult(result!, { expanded: true, isPartial: false }, plainTheme),
+);
+expect(expanded).toContain("✓ OSV Vulnerabilities call_tool query_purl complete");
+expect(expanded).toContain("## Body");
+expect(expanded).toContain('"id": "GHSA-test"');
+expect(expanded).toContain(longAdvisory);
+expect(expanded).toContain("ctrl+o to collapse");
+```
+
+- [ ] **Step 2: Run Pi tests to verify failure**
+
+Run:
+
+```bash
+pnpm --filter @caplets/pi test -- test/pi.test.ts
+```
+
+Expected: FAIL because Pi currently serializes structured content as raw pretty JSON or uses local logic rather than the core Markdown renderer. If the collapsed-renderer assertions already pass, keep them as regression coverage while fixing the agent-visible Markdown branch.
+
+- [ ] **Step 3: Import core Markdown helpers in Pi**
+
+In `packages/pi/src/index.ts`, add this import:
+
+```ts
+import {
+  hasRenderableStructuredContent,
+  markdownStructuredContent,
+  type ResultMarkdownContext,
+} from "@caplets/core";
+```
+
+- [ ] **Step 4: Add Pi context builder**
+
+Add this helper near `capletsMetadata()`:
+
+```ts
+function piMarkdownContext(details: unknown): ResultMarkdownContext {
+  const metadata = capletsMetadata(details);
+  if (!metadata) {
+    return { title: "Result" };
+  }
+  return {
+    title: [metadata.name, metadata.operation, metadata.tool].filter(Boolean).join(" "),
+    operation: metadata.operation,
+    tool: metadata.tool,
+  };
+}
+```
+
+- [ ] **Step 5: Update `agentContent()` without changing collapsed/expanded UI semantics**
+
+Replace the structured-content branch in `agentContent()` with:
+
+```ts
+const structured = objectProperty(result, "structuredContent");
+if (hasRenderableStructuredContent(structured)) {
+  return markdownStructuredContent(structured, piMarkdownContext({ result }));
+}
+```
+
+Keep the existing fallback that returns downstream text content or JSON stringification for non-structured results.
+
+Do not make `renderResult()` print full content in the collapsed state. Its current split must remain:
+
+```ts
+if (expanded) {
+  const output = resultFullContent(result.content);
+  // render full output
+}
+
+const preview = resultPreview(result.details, result.content);
+// render short preview only
+```
+
+If the Markdown result makes collapsed previews too noisy, adjust only `resultPreview()`/`compactText()` limits or summary logic so collapsed output stays short while `resultFullContent()` remains complete.
+
+- [ ] **Step 6: Run Pi tests**
+
+Run:
+
+```bash
+pnpm --filter @caplets/pi test -- test/pi.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Pi integration**
+
+```bash
+git add packages/pi/src/index.ts packages/pi/test/pi.test.ts
+git commit -m "feat(pi): show structured caplet results as expandable markdown"
+```
+
+---
+
+### Task 9: Update OpenCode Native Integration to Use Core Markdown
+
+**Files:**
+
+- Modify: `packages/opencode/src/hooks.ts`
+- Modify: `packages/opencode/test/opencode.test.ts`
+
+- [ ] **Step 1: Add failing OpenCode Markdown test**
+
+Update the existing OpenCode structured body visibility test in `packages/opencode/test/opencode.test.ts`:
+
+```ts
+expect(result).toContain("# OSV Vulnerabilities call_tool query_purl");
+expect(result).toContain("## Body");
+expect(result).toContain('"vulns": []');
+```
+
+- [ ] **Step 2: Run OpenCode tests to verify failure**
+
+Run:
+
+```bash
+pnpm --filter @caplets/opencode test -- test/opencode.test.ts
+```
+
+Expected: FAIL because OpenCode currently returns raw JSON for structured content or compact text.
+
+- [ ] **Step 3: Import core Markdown helpers**
+
+In `packages/opencode/src/hooks.ts`, keep native service imports on the native subpath and import Markdown helpers from the core root export:
+
+```ts
+import { nativeCapletsSystemGuidance, type NativeCapletsService } from "@caplets/core/native";
+import { hasRenderableStructuredContent, markdownStructuredContent } from "@caplets/core";
+```
+
+- [ ] **Step 4: Update `compactOpenCodeResult()`**
+
+Replace the structured-content branch with:
+
+```ts
+const structuredContent = objectProperty(result, "structuredContent");
+if (hasRenderableStructuredContent(structuredContent)) {
+  return markdownStructuredContent(structuredContent, { title: "Result" })[0]?.text ?? "# Result";
+}
+```
+
+If the result includes `_meta.caplets`, build a title before calling `markdownStructuredContent()`:
+
+```ts
+const metadata = objectProperty(objectProperty(result, "_meta"), "caplets");
+const title = [
+  stringProperty(metadata, "name"),
+  stringProperty(metadata, "operation"),
+  stringProperty(metadata, "tool"),
+]
+  .filter(Boolean)
+  .join(" ");
+```
+
+Then pass:
+
+```ts
+{ title: title || "Result", operation: stringProperty(metadata, "operation"), tool: stringProperty(metadata, "tool") }
+```
+
+- [ ] **Step 5: Run OpenCode tests**
+
+Run:
+
+```bash
+pnpm --filter @caplets/opencode test -- test/opencode.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit OpenCode integration**
+
+```bash
+git add packages/opencode/src/hooks.ts packages/opencode/test/opencode.test.ts
+git commit -m "feat(opencode): show structured caplet results as markdown"
+```
+
+---
+
+### Task 10: Add Changeset and Run Full Verification
+
+**Files:**
+
+- Create: `.changeset/lossless-markdown-results.md`
+- Modify: `docs/benchmarks/coding-agent.md` only if benchmark verification reports it stale
+
+- [ ] **Step 1: Create a changeset**
+
+Run:
+
+```bash
+pnpm changeset
+```
+
+Select packages:
+
+```text
+@caplets/core: patch
+@caplets/pi: patch
+@caplets/opencode: patch
+```
+
+Use this summary:
+
+```md
+Render structured Caplets results as lossless Markdown content while preserving canonical structuredContent.
+```
+
+If interactive Changesets is unavailable, create a changeset file manually with a unique filename:
+
+```md
+---
+"@caplets/core": patch
+"@caplets/pi": patch
+"@caplets/opencode": patch
+---
+
+Render structured Caplets results as lossless Markdown content while preserving canonical structuredContent.
+```
+
+- [ ] **Step 2: Run focused package tests**
+
+Run:
+
+```bash
+pnpm --filter @caplets/core test -- test/result-content.test.ts test/http-actions.test.ts test/openapi.test.ts test/graphql.test.ts test/cli-tools.test.ts test/tools.test.ts test/downstream.test.ts test/field-selection.test.ts
+pnpm --filter @caplets/pi test -- test/pi.test.ts
+pnpm --filter @caplets/opencode test -- test/opencode.test.ts
+```
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 3: Run formatting and typechecks**
+
+Run:
+
+```bash
+pnpm format:check
+pnpm --filter @caplets/core typecheck
+pnpm --filter @caplets/pi typecheck
+pnpm --filter @caplets/opencode typecheck
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 4: Run full verification gate**
+
+Run:
+
+```bash
+pnpm verify
+```
+
+Expected: `format:check`, `lint`, `typecheck`, `schema:check`, `test`, `benchmark:check`, and `build` all pass.
+
+- [ ] **Step 5: Commit final verification changes**
+
+```bash
+git add .changeset packages/core packages/pi packages/opencode docs/benchmarks/coding-agent.md
+git commit -m "feat: render caplet result content as markdown"
+```
+
+Only include `docs/benchmarks/coding-agent.md` if `pnpm verify` or `pnpm benchmark` updates it.
+
+---
+
+## Self-Review Checklist
+
+- Every Caplets-generated `structuredContent` path has a complete Markdown `content` path.
+- No renderer-level truncation exists.
+- HTTP/OpenAPI body data appears fully in `content`.
+- GraphQL data/errors and full body appear fully in `content`.
+- CLI stdout/stderr and parsed JSON appear fully in `content`.
+- Discovery/list operations include readable lists plus full JSON result and Caplets metadata.
+- Error content includes the full safe error object.
+- Downstream MCP content is preserved, and downstream structured content is appended when present.
+- Pi and OpenCode use shared core Markdown rendering.
+- All changed behavior is covered by failing-first tests.
+- Full verification passes before claiming implementation complete.

--- a/packages/benchmarks/lib/surface.ts
+++ b/packages/benchmarks/lib/surface.ts
@@ -1,6 +1,6 @@
-import { capabilityDescription } from "../../core/src/capability-description.js";
-import { generatedToolInputJsonSchema } from "../../core/src/generated-tool-input-schema.js";
-import { listToolMetadata, SERVER_NAMES } from "../fixtures/mcp-server.js";
+import { capabilityDescription } from "../../core/src/capability-description";
+import { generatedToolInputJsonSchema } from "../../core/src/generated-tool-input-schema";
+import { listToolMetadata, SERVER_NAMES } from "../fixtures/mcp-server";
 
 export const SURFACE_THRESHOLDS = {
   minInitialPayloadReduction: 0.7,

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -5,12 +5,12 @@ import {
   type AuthResult,
   extractWWWAuthenticateParams,
   type OAuthClientProvider,
-} from "@modelcontextprotocol/sdk/client/auth.js";
+} from "@modelcontextprotocol/sdk/client/auth";
 import type {
   OAuthClientInformationMixed,
   OAuthClientMetadata,
   OAuthTokens,
-} from "@modelcontextprotocol/sdk/shared/auth.js";
+} from "@modelcontextprotocol/sdk/shared/auth";
 import {
   isTokenBundleExpired,
   readTokenBundle,

--- a/packages/core/src/caplet-sets.ts
+++ b/packages/core/src/caplet-sets.ts
@@ -1,4 +1,4 @@
-import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types";
 import { resolve } from "node:path";
 import { CliToolsManager } from "./cli-tools";
 import { type CapletConfig, type CapletSetConfig, loadIsolatedConfig } from "./config";

--- a/packages/core/src/cli-tools.ts
+++ b/packages/core/src/cli-tools.ts
@@ -1,12 +1,12 @@
 import { constants, existsSync, accessSync } from "node:fs";
 import { delimiter, isAbsolute, join } from "node:path";
 import { spawn } from "node:child_process";
-import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types";
 import type { CliToolActionConfig, CliToolsConfig } from "./config";
 import type { CompactTool } from "./downstream";
 import { CapletsError, toSafeError } from "./errors";
 import type { ServerRegistry } from "./registry";
-import { compactStructuredContent } from "./result-content";
+import { markdownStructuredContent } from "./result-content";
 import { searchToolList } from "./tool-search";
 
 const DEFAULT_INPUT_SCHEMA = { type: "object", additionalProperties: true } as const;
@@ -88,7 +88,12 @@ export class CliToolsManager {
       const result = await spawnCommand(execution, controller.signal, () => Date.now() - startedAt);
       const structured = parseStructuredResult(action, result, result.exitCode !== 0);
       return {
-        content: compactStructuredContent(structured),
+        content: markdownStructuredContent(structured, {
+          title: `${config.name} call_tool ${toolName}`,
+          backend: "cli",
+          operation: "call_tool",
+          tool: toolName,
+        }),
         structuredContent: structured,
         isError: result.exitCode !== 0,
       };

--- a/packages/core/src/downstream.ts
+++ b/packages/core/src/downstream.ts
@@ -1,7 +1,7 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse";
 import {
   CompatibilityCallToolResultSchema,
   type CompleteRequestParams,
@@ -13,7 +13,7 @@ import {
   type CompatibilityCallToolResult,
   type Tool,
   ToolListChangedNotificationSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@modelcontextprotocol/sdk/types";
 import type { CapletServerConfig } from "./config";
 import {
   classifyRemoteAuthError,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -97,16 +97,27 @@ export function toSafeError(
 
 export function errorResult(error: unknown, fallback?: CapletsErrorCode) {
   const safe = toSafeError(error, fallback);
+  const structuredContent = { error: safe };
   return {
     isError: true,
     content: [
       {
         type: "text" as const,
-        text: `${safe.code}: ${safe.message}`,
+        text: [
+          "# Error",
+          "",
+          `## ${safe.code}`,
+          "",
+          safe.message,
+          "",
+          "## Details",
+          "",
+          "```json",
+          JSON.stringify(safe, null, 2),
+          "```",
+        ].join("\n"),
       },
     ],
-    structuredContent: {
-      error: safe,
-    },
+    structuredContent,
   };
 }

--- a/packages/core/src/graphql.ts
+++ b/packages/core/src/graphql.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types";
 import {
   buildClientSchema,
   buildSchema,
@@ -34,7 +34,7 @@ import type { CompactTool } from "./downstream";
 import { CapletsError, toSafeError } from "./errors";
 import { isAbortError, parseHttpBody, readLimitedText } from "./http/utils";
 import type { ServerRegistry } from "./registry";
-import { compactStructuredContent } from "./result-content";
+import { markdownStructuredContent } from "./result-content";
 import { searchToolList } from "./tool-search";
 
 const GRAPHQL_METHOD = "POST";
@@ -189,7 +189,12 @@ export class GraphQLManager {
         body,
       };
       return {
-        content: compactStructuredContent(result),
+        content: markdownStructuredContent(result, {
+          title: `${endpoint.name} call_tool ${toolName}`,
+          backend: "graphql",
+          operation: "call_tool",
+          tool: toolName,
+        }),
         structuredContent: result,
         isError:
           !response.ok ||

--- a/packages/core/src/http-actions.ts
+++ b/packages/core/src/http-actions.ts
@@ -1,4 +1,4 @@
-import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types";
 import { genericOAuthHeaders } from "./auth";
 import type { HttpActionConfig, HttpApiConfig } from "./config";
 import { FORBIDDEN_HEADERS, isAllowedRemoteUrl } from "./config/validation";
@@ -6,7 +6,7 @@ import type { CompactTool } from "./downstream";
 import { CapletsError, toSafeError } from "./errors";
 import { isAbortError, parseHttpBody, readLimitedText } from "./http/utils";
 import type { ServerRegistry } from "./registry";
-import { compactStructuredContent } from "./result-content";
+import { markdownStructuredContent } from "./result-content";
 import { searchToolList } from "./tool-search";
 
 const DEFAULT_INPUT_SCHEMA = { type: "object", additionalProperties: true } as const;
@@ -97,7 +97,12 @@ export class HttpActionManager {
       }
       const parsed = await readResponse(response, api, Date.now() - startedAt);
       return {
-        content: compactStructuredContent(parsed),
+        content: markdownStructuredContent(parsed, {
+          title: `${api.name} call_tool ${toolName}`,
+          backend: "http",
+          operation: "call_tool",
+          tool: toolName,
+        }),
         structuredContent: parsed,
         isError: !response.ok,
       };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,12 @@ export { runCli, createProgram } from "./cli";
 export { parseConfig, loadConfig } from "./config";
 export { capabilityDescription, ServerRegistry } from "./registry";
 export { generatedToolInputSchema, handleServerTool } from "./tools";
+export {
+  hasRenderableStructuredContent,
+  markdownCallToolResultContent,
+  markdownStructuredContent,
+} from "./result-content";
+export type { ResultMarkdownContext } from "./result-content";
 
 export { serveCaplets, serveHttp, serveResolvedCaplets, serveStdio } from "./serve";
 export type { HttpServeOptions, RawServeOptions, ServeOptions, StdioServeOptions } from "./serve";

--- a/packages/core/src/native/remote.ts
+++ b/packages/core/src/native/remote.ts
@@ -1,6 +1,6 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp";
+import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types";
 
 import { CapletsError } from "../errors";
 import { generatedToolInputJsonSchemaForCaplet, operations } from "../generated-tool-input-schema";

--- a/packages/core/src/openapi.ts
+++ b/packages/core/src/openapi.ts
@@ -1,5 +1,5 @@
 import SwaggerParser from "@apidevtools/swagger-parser";
-import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types";
 import { parse as parseYaml } from "yaml";
 import { genericOAuthHeaders } from "./auth";
 import type { OpenApiEndpointConfig } from "./config";
@@ -8,7 +8,7 @@ import type { CompactTool } from "./downstream";
 import { CapletsError, toSafeError } from "./errors";
 import { isAbortError, parseHttpBody, readLimitedText } from "./http/utils";
 import type { ServerRegistry } from "./registry";
-import { compactStructuredContent } from "./result-content";
+import { markdownStructuredContent } from "./result-content";
 import { searchToolList } from "./tool-search";
 
 const HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"] as const;
@@ -148,7 +148,12 @@ export class OpenApiManager {
       }
       const parsed = await readResponse(response);
       return {
-        content: compactStructuredContent(parsed),
+        content: markdownStructuredContent(parsed, {
+          title: `${endpoint.name} call_tool ${toolName}`,
+          backend: "openapi",
+          operation: "call_tool",
+          tool: toolName,
+        }),
         structuredContent: parsed as Record<string, unknown>,
         isError: response.ok ? false : true,
       };

--- a/packages/core/src/result-content.ts
+++ b/packages/core/src/result-content.ts
@@ -1,6 +1,23 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-
 export type TextContentBlock = { type: "text"; text: string };
+
+type ContentBlockLike = { type: string; text?: string } & Record<string, unknown>;
+
+type CallToolResultLike = {
+  content?: ContentBlockLike[];
+  structuredContent?: unknown;
+  isError?: boolean | undefined;
+};
+
+export type ResultMarkdownContext = {
+  title?: string | undefined;
+  backend?: string | undefined;
+  operation?: string | undefined;
+  tool?: string | undefined;
+  uri?: string | undefined;
+  prompt?: string | undefined;
+  fields?: string[] | undefined;
+  isError?: boolean | undefined;
+};
 
 export function structuredOnlyContent(): [] {
   return [];
@@ -21,61 +38,345 @@ export function compactText(value: string, maxLength = 600): string {
     : collapsed;
 }
 
-export function resultKeys(value: unknown): string {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return "scalar result";
-  }
-  const keys = Object.keys(value).filter((key) => key !== "elapsedMs");
-  return keys.length > 0 ? `structured keys: ${keys.join(", ")}` : "empty structured result";
+export function markdownStructuredContent(
+  value: unknown,
+  context: ResultMarkdownContext = {},
+): TextContentBlock[] {
+  return textContent(renderStructuredMarkdown(value, context));
 }
 
-export function statusSummary(value: unknown): string {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return compactJsonText(value);
+export function markdownCallToolResultContent(
+  result: CallToolResultLike,
+  context: ResultMarkdownContext = {},
+): TextContentBlock[] {
+  const downstreamText = textBlocksToString(result.content);
+  const structuredContent = result.structuredContent;
+  const hasStructured = hasRenderableStructuredContent(structuredContent);
+
+  if (context.backend === "mcp" && hasStructured) {
+    const renderedStructured = markdownStructuredContent(structuredContent, context)[0]?.text;
+    if (downstreamText && downstreamText === renderedStructured) {
+      return textContent(downstreamText);
+    }
+    return [
+      ...(result.content ?? []),
+      {
+        type: "text",
+        text: ["## Structured Content", "", jsonFence(structuredContent)].join("\n"),
+      },
+    ] as TextContentBlock[];
   }
-  const record = value as Record<string, unknown>;
-  const status = typeof record.status === "number" ? `status ${record.status}` : undefined;
-  const statusText =
-    typeof record.statusText === "string" && record.statusText ? record.statusText : undefined;
-  const exitCode = typeof record.exitCode === "number" ? `exit ${record.exitCode}` : undefined;
-  const body = "body" in record ? valueSummary("body", record.body) : undefined;
-  const json = "json" in record ? valueSummary("json", record.json) : undefined;
-  const stdout =
-    typeof record.stdout === "string" && record.stdout
-      ? valueSummary("stdout", record.stdout)
-      : undefined;
-  const stderr =
-    typeof record.stderr === "string" && record.stderr
-      ? valueSummary("stderr", record.stderr)
-      : undefined;
-  return (
-    [status, statusText, exitCode, body, json, stdout, stderr]
-      .filter((part): part is string => Boolean(part))
-      .join("; ") || resultKeys(record)
-  );
+
+  if (hasStructured) {
+    return markdownStructuredContent(structuredContent, {
+      ...context,
+      isError: context.isError ?? result.isError,
+    });
+  }
+
+  if (downstreamText) {
+    return textContent(downstreamText);
+  }
+
+  return textContent(renderStructuredMarkdown(result, context));
 }
 
-function valueSummary(label: string, value: unknown): string {
-  if (typeof value === "string") {
-    return value ? `${label} ${compactText(value, 200)}` : label;
-  }
-  if (value === undefined) {
-    return label;
-  }
-  return `${label} ${compactJsonText(value, 200)}`;
+export function compactStructuredContent(
+  value: unknown,
+  context: ResultMarkdownContext = {},
+): TextContentBlock[] {
+  return markdownStructuredContent(value, context);
 }
 
-export function compactStructuredContent(value: unknown): TextContentBlock[] {
-  return textContent(statusSummary(value));
+export function compactCallToolResultContent(
+  result: CallToolResultLike,
+  context: ResultMarkdownContext = {},
+): TextContentBlock[] {
+  return markdownCallToolResultContent(result, context);
 }
 
-export function compactCallToolResultContent(result: CallToolResult): TextContentBlock[] {
-  if (result.isError === true) {
-    return textContent("downstream tool returned an error");
-  }
-  return compactStructuredContent(result.structuredContent);
+export function hasRenderableStructuredContent(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return Object.keys(value).some((key) => key !== "caplets" && key !== "elapsedMs");
 }
 
 export function byteLimitHint(maxBytes: number): string {
   return `response body limit ${maxBytes} bytes`;
+}
+
+function renderStructuredMarkdown(value: unknown, context: ResultMarkdownContext): string {
+  const title = markdownTitle(context);
+  if (isDiscoveryWrapper(value)) return renderDiscoveryWrapper(value, context, title);
+  if (context.isError || isErrorStructuredContent(value)) return renderErrorMarkdown(value, title);
+  if (context.backend === "cli" || isCliResult(value)) return renderCliMarkdown(value, title);
+  if ((context.backend === "graphql" && isHttpLikeResult(value)) || isGraphQlHttpResult(value)) {
+    return renderGraphQlMarkdown(value, title);
+  }
+  if (isHttpLikeResult(value)) {
+    return renderHttpMarkdown(value, title);
+  }
+  return [title, "", "## Result", "", jsonFence(value)].join("\n");
+}
+
+function markdownTitle(context: ResultMarkdownContext): string {
+  if (context.title) return `# ${context.title}`;
+  const parts = [context.operation, context.tool ?? context.uri ?? context.prompt].filter(
+    (part): part is string => Boolean(part),
+  );
+  return parts.length > 0 ? `# ${parts.join(" ")}` : "# Result";
+}
+
+function renderHttpMarkdown(value: unknown, title: string): string {
+  const record = asRecord(value) ?? {};
+  const lines = [title, "", "## Response", ""];
+  const status = typeof record.status === "number" ? record.status : undefined;
+  const statusText = typeof record.statusText === "string" ? record.statusText : undefined;
+  if (status !== undefined || statusText)
+    lines.push(`- **Status:** \`${[status, statusText].filter(Boolean).join(" ")}\``);
+  if (typeof record.elapsedMs === "number") lines.push(`- **Elapsed:** \`${record.elapsedMs} ms\``);
+  lines.push(
+    "",
+    "## Headers",
+    "",
+    jsonFence(record.headers ?? {}),
+    "",
+    "## Body",
+    "",
+    renderBodyValue(record.body),
+  );
+  const additional = omitKeys(record, ["status", "statusText", "headers", "body", "elapsedMs"]);
+  if (Object.keys(additional).length > 0)
+    lines.push("", "## Additional Fields", "", jsonFence(additional));
+  return lines.join("\n");
+}
+
+function renderGraphQlMarkdown(value: unknown, title: string): string {
+  const record = asRecord(value) ?? {};
+  const body = asRecord(record.body);
+  if (!body || (!("data" in body) && !("errors" in body))) return renderHttpMarkdown(value, title);
+  const lines = [title, "", "## Response", ""];
+  const status = typeof record.status === "number" ? record.status : undefined;
+  const statusText = typeof record.statusText === "string" ? record.statusText : undefined;
+  if (status !== undefined || statusText)
+    lines.push(`- **Status:** \`${[status, statusText].filter(Boolean).join(" ")}\``);
+  if (typeof record.elapsedMs === "number") lines.push(`- **Elapsed:** \`${record.elapsedMs} ms\``);
+  if ("data" in body) lines.push("", "## Data", "", jsonFence(body.data));
+  if ("errors" in body) lines.push("", "## Errors", "", jsonFence(body.errors));
+  lines.push(
+    "",
+    "## Headers",
+    "",
+    jsonFence(record.headers ?? {}),
+    "",
+    "## Full Body",
+    "",
+    jsonFence(record.body),
+  );
+  const additional = omitKeys(record, ["status", "statusText", "headers", "body", "elapsedMs"]);
+  if (Object.keys(additional).length > 0)
+    lines.push("", "## Additional Fields", "", jsonFence(additional));
+  return lines.join("\n");
+}
+
+function renderCliMarkdown(value: unknown, title: string): string {
+  const record = asRecord(value) ?? {};
+  const lines = [title, "", "## Command Result", ""];
+  if ("exitCode" in record) lines.push(`- **Exit code:** \`${String(record.exitCode)}\``);
+  if ("signal" in record) lines.push(`- **Signal:** \`${String(record.signal)}\``);
+  if (typeof record.elapsedMs === "number") lines.push(`- **Elapsed:** \`${record.elapsedMs} ms\``);
+  lines.push("", "## stdout", "", textFenceOrEmpty(record.stdout, "No stdout."));
+  lines.push("", "## stderr", "", textFenceOrEmpty(record.stderr, "No stderr."));
+  if ("json" in record) lines.push("", "## Parsed JSON", "", jsonFence(record.json));
+  if ("jsonParseError" in record)
+    lines.push("", "## JSON Parse Error", "", jsonFence(record.jsonParseError));
+  const additional = omitKeys(record, [
+    "exitCode",
+    "signal",
+    "stdout",
+    "stderr",
+    "elapsedMs",
+    "json",
+    "jsonParseError",
+  ]);
+  if (Object.keys(additional).length > 0)
+    lines.push("", "## Additional Fields", "", jsonFence(additional));
+  return lines.join("\n");
+}
+
+function renderDiscoveryWrapper(
+  value: { result: unknown; caplets?: unknown },
+  context: ResultMarkdownContext,
+  title: string,
+): string {
+  const result = asRecord(value.result);
+  const lines = [title, ""];
+  if (context.operation === "list_tools" || context.operation === "search_tools") {
+    lines.push("## Tools", "", renderNamedList(arrayValue(result?.tools), "tool"), "");
+  } else if (context.operation === "list_resources" || context.operation === "search_resources") {
+    lines.push(
+      "## Resources",
+      "",
+      renderNamedList(arrayValue(result?.resources ?? result?.matches), "uri"),
+      "",
+    );
+  } else if (context.operation === "list_resource_templates") {
+    lines.push(
+      "## Resource Templates",
+      "",
+      renderNamedList(arrayValue(result?.resourceTemplates), "uriTemplate"),
+      "",
+    );
+  } else if (context.operation === "list_prompts" || context.operation === "search_prompts") {
+    lines.push("## Prompts", "", renderNamedList(arrayValue(result?.prompts), "prompt"), "");
+  } else if (context.operation === "get_tool") {
+    lines.push("## Tool", "", renderToolSummary(asRecord(result?.tool)), "");
+  } else if (context.operation === "check_backend") {
+    lines.push("## Backend Status", "", renderBackendStatus(result), "");
+  } else if (context.operation === "get_caplet") {
+    lines.push("## Caplet", "", renderCapletSummary(result), "");
+  }
+  lines.push("## Full Result", "", jsonFence(value.result));
+  if (value.caplets !== undefined)
+    lines.push("", "## Caplets Metadata", "", jsonFence(value.caplets));
+  return lines.join("\n");
+}
+
+function renderErrorMarkdown(value: unknown, title: string): string {
+  const error = asRecord(asRecord(value)?.error) ?? asRecord(value);
+  const code = typeof error?.code === "string" ? error.code : "Error";
+  const message = typeof error?.message === "string" ? error.message : "Tool call failed.";
+  return [
+    title === "# Result" || title === "# Error" ? "# Error" : title,
+    "",
+    `## ${code}`,
+    "",
+    message,
+    "",
+    "## Details",
+    "",
+    jsonFence(error ?? value),
+  ].join("\n");
+}
+
+function isDiscoveryWrapper(value: unknown): value is { result: unknown; caplets?: unknown } {
+  return isRecord(value) && "result" in value;
+}
+function isErrorStructuredContent(value: unknown): boolean {
+  return isRecord(value) && "error" in value;
+}
+function isHttpLikeResult(value: unknown): boolean {
+  return isRecord(value) && ("status" in value || "statusText" in value || "body" in value);
+}
+function isGraphQlHttpResult(value: unknown): boolean {
+  if (!isHttpLikeResult(value)) return false;
+  const body = asRecord((value as Record<string, unknown>).body);
+  return Boolean(body && ("data" in body || "errors" in body));
+}
+function isCliResult(value: unknown): boolean {
+  return isRecord(value) && ("exitCode" in value || "stdout" in value || "stderr" in value);
+}
+function renderBodyValue(value: unknown): string {
+  if (value === undefined) return "_No response body._";
+  if (typeof value === "string") return textFenceOrEmpty(value, "No response body.");
+  return jsonFence(value);
+}
+function textFenceOrEmpty(value: unknown, emptyMessage: string): string {
+  if (typeof value !== "string" || value.length === 0) return `_${emptyMessage}_`;
+  return ["```text", escapeCodeFence(value), "```"].join("\n");
+}
+function jsonFence(value: unknown): string {
+  return ["```json", escapeCodeFence(JSON.stringify(value, null, 2) ?? "null"), "```"].join("\n");
+}
+function escapeCodeFence(value: string): string {
+  return value.replace(/```/gu, "`\u200b``");
+}
+function textBlocksToString(content: CallToolResultLike["content"] | undefined): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((item): item is ContentBlockLike & { type: "text"; text: string } =>
+      Boolean(
+        item && typeof item === "object" && item.type === "text" && typeof item.text === "string",
+      ),
+    )
+    .map((item) => item.text)
+    .filter(Boolean)
+    .join("\n");
+}
+function renderNamedList(items: unknown[], nameKey: string): string {
+  if (items.length === 0) return "_No items._";
+  return items
+    .map((item, index) => {
+      const record = asRecord(item);
+      const name =
+        stringValue(record?.[nameKey]) ?? stringValue(record?.name) ?? `Item ${index + 1}`;
+      const description = stringValue(record?.description);
+      return description
+        ? `${index + 1}. \`${name}\` — ${description}`
+        : `${index + 1}. \`${name}\``;
+    })
+    .join("\n");
+}
+function renderToolSummary(tool: Record<string, unknown> | undefined): string {
+  if (!tool) return "_Tool details unavailable._";
+  const lines: string[] = [];
+  const name = stringValue(tool.name);
+  const description = stringValue(tool.description);
+  if (name) lines.push(`- **Name:** \`${name}\``);
+  if (description) lines.push(`- **Description:** ${description}`);
+  if (tool.inputSchema !== undefined)
+    lines.push("", "### Input Schema", "", jsonFence(tool.inputSchema));
+  if (tool.outputSchema !== undefined)
+    lines.push("", "### Output Schema", "", jsonFence(tool.outputSchema));
+  if (tool.annotations !== undefined)
+    lines.push("", "### Annotations", "", jsonFence(tool.annotations));
+  return lines.length > 0 ? lines.join("\n") : jsonFence(tool);
+}
+function renderBackendStatus(result: Record<string, unknown> | undefined): string {
+  if (!result) return "_Backend status unavailable._";
+  const lines: string[] = [];
+  for (const key of [
+    "id",
+    "status",
+    "toolCount",
+    "resourceCount",
+    "resourceTemplateCount",
+    "promptCount",
+    "elapsedMs",
+  ]) {
+    if (result[key] !== undefined) {
+      const label = key === "elapsedMs" ? "Elapsed" : humanizeKey(key);
+      const suffix = key === "elapsedMs" ? " ms" : "";
+      lines.push(`- **${label}:** \`${String(result[key])}${suffix}\``);
+    }
+  }
+  if (result.error !== undefined) lines.push("", "### Error", "", jsonFence(result.error));
+  return lines.length > 0 ? lines.join("\n") : jsonFence(result);
+}
+function renderCapletSummary(result: Record<string, unknown> | undefined): string {
+  if (!result) return "_Caplet details unavailable._";
+  const lines: string[] = [];
+  for (const key of ["id", "name", "description"])
+    if (result[key] !== undefined) lines.push(`- **${humanizeKey(key)}:** ${String(result[key])}`);
+  const backend = asRecord(result.backend);
+  if (backend?.type !== undefined) lines.push(`- **Backend:** \`${String(backend.type)}\``);
+  return lines.length > 0 ? lines.join("\n") : jsonFence(result);
+}
+function omitKeys(record: Record<string, unknown>, keys: string[]): Record<string, unknown> {
+  const omitted = new Set(keys);
+  return Object.fromEntries(Object.entries(record).filter(([key]) => !omitted.has(key)));
+}
+function arrayValue(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+function humanizeKey(key: string): string {
+  return key.replace(/([A-Z])/gu, " $1").replace(/^./u, (char) => char.toUpperCase());
+}
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }

--- a/packages/core/src/result-content.ts
+++ b/packages/core/src/result-content.ts
@@ -38,15 +38,31 @@ export function statusSummary(value: unknown): string {
   const statusText =
     typeof record.statusText === "string" && record.statusText ? record.statusText : undefined;
   const exitCode = typeof record.exitCode === "number" ? `exit ${record.exitCode}` : undefined;
-  const body = "body" in record ? "body" : undefined;
-  const json = "json" in record ? "json" : undefined;
-  const stdout = typeof record.stdout === "string" && record.stdout ? "stdout" : undefined;
-  const stderr = typeof record.stderr === "string" && record.stderr ? "stderr" : undefined;
+  const body = "body" in record ? valueSummary("body", record.body) : undefined;
+  const json = "json" in record ? valueSummary("json", record.json) : undefined;
+  const stdout =
+    typeof record.stdout === "string" && record.stdout
+      ? valueSummary("stdout", record.stdout)
+      : undefined;
+  const stderr =
+    typeof record.stderr === "string" && record.stderr
+      ? valueSummary("stderr", record.stderr)
+      : undefined;
   return (
     [status, statusText, exitCode, body, json, stdout, stderr]
       .filter((part): part is string => Boolean(part))
       .join("; ") || resultKeys(record)
   );
+}
+
+function valueSummary(label: string, value: unknown): string {
+  if (typeof value === "string") {
+    return value ? `${label} ${compactText(value, 200)}` : label;
+  }
+  if (value === undefined) {
+    return label;
+  }
+  return `${label} ${compactJsonText(value, 200)}`;
 }
 
 export function compactStructuredContent(value: unknown): TextContentBlock[] {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,4 +1,4 @@
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
 import type { CapletsConfig } from "./config";
 import { CapletsEngine, type CapletsEngineOptions } from "./engine";
 import { CapletsMcpSession, type ToolServer } from "./serve/session";

--- a/packages/core/src/serve/session.ts
+++ b/packages/core/src/serve/session.ts
@@ -1,5 +1,5 @@
-import { McpServer, type RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { McpServer, type RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
 import { version as packageJsonVersion } from "../../package.json";
 import type { CapletConfig, CapletsConfig } from "../config";
 import type { CapletsEngine } from "../engine";

--- a/packages/core/src/serve/stdio.ts
+++ b/packages/core/src/serve/stdio.ts
@@ -1,4 +1,4 @@
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio";
 import { CapletsEngine, type CapletsEngineOptions } from "../engine";
 import { CapletsMcpSession } from "./session";
 

--- a/packages/core/src/tool-search.ts
+++ b/packages/core/src/tool-search.ts
@@ -1,4 +1,4 @@
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types";
 
 export function searchToolList<T>(
   tools: Tool[],

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types";
 import type { CapletSetManager } from "./caplet-sets";
 import type { CapletConfig } from "./config";
 import type { CliToolsManager } from "./cli-tools";
@@ -14,7 +14,11 @@ import {
   mcpOperations,
   operations,
 } from "./generated-tool-input-schema";
-import { compactStructuredContent } from "./result-content";
+import {
+  markdownCallToolResultContent,
+  markdownStructuredContent,
+  type ResultMarkdownContext,
+} from "./result-content";
 
 export { generatedToolInputSchema } from "./generated-tool-input-schema";
 
@@ -115,15 +119,14 @@ export async function handleServerTool(
       }
       validateFieldSelection(tool.outputSchema, parsed.fields);
 
+      const metadata = metadataFor(server, "call_tool", parsed.tool, startedAt);
       const result = projectCallToolResult(
         await backend.callTool(server as never, parsed.tool, parsed.arguments),
         tool.outputSchema,
         parsed.fields,
+        markdownContextFor(metadata),
       );
-      return annotateCallToolResult(
-        result,
-        metadataFor(server, "call_tool", parsed.tool, startedAt),
-      );
+      return annotateCallToolResult(result, metadata);
     }
     case "list_resources": {
       const backend = mcpBackendFor(server, downstream);
@@ -469,18 +472,30 @@ export function annotateMcpResult<T extends object>(result: T, metadata: CapletR
   };
 }
 
-export function jsonResult(value: unknown, metadata?: CapletResultMetadata): CallToolResult {
+function markdownContextFor(metadata: CapletResultMetadata): ResultMarkdownContext {
   return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify(value, null, 2),
-      },
-    ],
-    structuredContent: {
-      ...(metadata === undefined ? {} : { caplets: metadata }),
-      result: value as Record<string, unknown>,
-    },
+    title: [metadata.name, metadata.operation, metadata.tool ?? metadata.uri ?? metadata.prompt]
+      .filter(Boolean)
+      .join(" "),
+    backend: metadata.backend,
+    operation: metadata.operation,
+    ...(metadata.tool ? { tool: metadata.tool } : {}),
+    ...(metadata.uri ? { uri: metadata.uri } : {}),
+    ...(metadata.prompt ? { prompt: metadata.prompt } : {}),
+  };
+}
+
+export function jsonResult(value: unknown, metadata?: CapletResultMetadata): CallToolResult {
+  const structuredContent = {
+    ...(metadata === undefined ? {} : { caplets: metadata }),
+    result: value as Record<string, unknown>,
+  };
+  return {
+    content: markdownStructuredContent(
+      structuredContent,
+      metadata ? markdownContextFor(metadata) : { title: "Result" },
+    ),
+    structuredContent,
   };
 }
 
@@ -498,6 +513,10 @@ export function annotateCallToolResult<T extends object>(
 
   return {
     ...result,
+    content: markdownCallToolResultContent(
+      result as CallToolResult,
+      markdownContextFor(annotatedMetadata),
+    ),
     _meta: {
       ...(isPlainObject(existingMeta) ? existingMeta : {}),
       caplets: annotatedMetadata,
@@ -509,6 +528,7 @@ export function projectCallToolResult<T extends object>(
   result: T,
   outputSchema: unknown,
   fields: string[],
+  context: ResultMarkdownContext = {},
 ): T & CallToolResult {
   if ((result as { isError?: unknown }).isError === true) {
     return result as T & CallToolResult;
@@ -525,7 +545,7 @@ export function projectCallToolResult<T extends object>(
   const projected = projectStructuredContent(structuredContent, outputSchema, fields);
   return {
     ...result,
-    content: compactStructuredContent(projected),
+    content: markdownStructuredContent(projected, context),
     structuredContent: projected,
   } as T & CallToolResult;
 }

--- a/packages/core/test/auth.test.ts
+++ b/packages/core/test/auth.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 
 const mockMcpAuth = vi.hoisted(() => vi.fn());
 
-vi.mock("@modelcontextprotocol/sdk/client/auth.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@modelcontextprotocol/sdk/client/auth.js")>()),
+vi.mock("@modelcontextprotocol/sdk/client/auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@modelcontextprotocol/sdk/client/auth")>()),
   auth: mockMcpAuth,
 }));
 

--- a/packages/core/test/downstream.test.ts
+++ b/packages/core/test/downstream.test.ts
@@ -10,7 +10,7 @@ import { ServerRegistry } from "../src/registry";
 import type { CapletsError } from "../src/errors";
 import { writeTokenBundle } from "../src/auth";
 import { handleServerTool } from "../src/tools";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types";
 
 const fixturesDir = fileURLToPath(new URL("fixtures", import.meta.url));
 const tsxImport = import.meta.resolve("tsx");
@@ -126,9 +126,11 @@ describe("downstream stdio lifecycle", () => {
       )) as any;
 
       expect(result).toMatchObject({
-        content: [{ type: "text", text: "structured keys: message" }],
         structuredContent: { message: "hello" },
       });
+      expect(result.content[0].text).toContain("# Fixture call_tool echo");
+      expect(result.content[0].text).toContain("## Result");
+      expect(result.content[0].text).toContain('"message": "hello"');
     } finally {
       await manager.close();
     }
@@ -214,7 +216,7 @@ describe("downstream stdio lifecycle", () => {
           name: "Fixture Reloaded",
           description: "A reloaded fixture server.",
           command: process.execPath,
-          args: [fixture],
+          args: ["--import", tsxImport, fixture],
           toolCacheTtlMs: 30_000,
         },
       },

--- a/packages/core/test/fixtures/stdio-server.ts
+++ b/packages/core/test/fixtures/stdio-server.ts
@@ -1,5 +1,5 @@
-import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio";
 import { z } from "zod";
 
 const server = new McpServer({ name: "fixture-stdio", version: "1.0.0" });

--- a/packages/core/test/http-actions.test.ts
+++ b/packages/core/test/http-actions.test.ts
@@ -205,7 +205,7 @@ describe("HttpActionManager", () => {
       http,
     )) as any;
     expect(projected.structuredContent).toEqual({ body: { ok: true } });
-    expect(projected.content[0].text).toBe("body");
+    expect(projected.content[0].text).toBe('body {"ok":true}');
   });
 
   it("builds requests from path, query, header, and JSON body mappings", async () => {

--- a/packages/core/test/http-actions.test.ts
+++ b/packages/core/test/http-actions.test.ts
@@ -205,7 +205,9 @@ describe("HttpActionManager", () => {
       http,
     )) as any;
     expect(projected.structuredContent).toEqual({ body: { ok: true } });
-    expect(projected.content[0].text).toBe('body {"ok":true}');
+    expect(projected.content[0].text).toContain("# HTTP API call_tool ping");
+    expect(projected.content[0].text).toContain("## Body");
+    expect(projected.content[0].text).toContain('"ok": true');
   });
 
   it("builds requests from path, query, header, and JSON body mappings", async () => {

--- a/packages/core/test/package-boundaries.test.ts
+++ b/packages/core/test/package-boundaries.test.ts
@@ -32,13 +32,13 @@ describe("package boundaries", () => {
     expect(scanFiles([resolve(packagesRoot, "missing-package/src")])).toEqual([]);
   });
 
-  it("uses Node ESM-safe MCP SDK subpath imports", () => {
+  it("keeps MCP SDK subpath imports extensionless for bundler resolution", () => {
     const violations = scanFiles([packagesRoot]).flatMap((filePath) => {
       const source = readFileSync(filePath, "utf8");
       return Array.from(source.matchAll(/["'](@modelcontextprotocol\/sdk\/[^"']+)["']/g))
         .map((match) => match[1])
         .filter((specifier): specifier is string => Boolean(specifier))
-        .filter((specifier) => !specifier.endsWith(".js"))
+        .filter((specifier) => specifier.endsWith(".js"))
         .map((specifier) => `${formatPath(filePath)} imports ${specifier}`);
     });
 

--- a/packages/core/test/remote-control-dispatch.test.ts
+++ b/packages/core/test/remote-control-dispatch.test.ts
@@ -5,8 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mockMcpAuth = vi.hoisted(() => vi.fn());
 
-vi.mock("@modelcontextprotocol/sdk/client/auth.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@modelcontextprotocol/sdk/client/auth.js")>()),
+vi.mock("@modelcontextprotocol/sdk/client/auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@modelcontextprotocol/sdk/client/auth")>()),
   auth: mockMcpAuth,
 }));
 

--- a/packages/core/test/result-content.test.ts
+++ b/packages/core/test/result-content.test.ts
@@ -1,8 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { compactJsonText } from "../src/result-content";
+import { compactCallToolResultContent, compactJsonText } from "../src/result-content";
 
 describe("result content helpers", () => {
   it("compacts undefined JSON values without throwing", () => {
     expect(compactJsonText(undefined)).toBe("undefined");
+  });
+
+  it("includes compact HTTP response body previews in tool result content", () => {
+    expect(
+      compactCallToolResultContent({
+        content: [],
+        structuredContent: {
+          status: 200,
+          statusText: "OK",
+          body: { vulns: [] },
+          elapsedMs: 12,
+        },
+      }),
+    ).toEqual([{ type: "text", text: 'status 200; OK; body {"vulns":[]}' }]);
   });
 });

--- a/packages/core/test/result-content.test.ts
+++ b/packages/core/test/result-content.test.ts
@@ -1,22 +1,92 @@
 import { describe, expect, it } from "vitest";
-import { compactCallToolResultContent, compactJsonText } from "../src/result-content";
+import {
+  compactCallToolResultContent,
+  compactJsonText,
+  hasRenderableStructuredContent,
+  markdownCallToolResultContent,
+  markdownStructuredContent,
+} from "../src/result-content";
 
 describe("result content helpers", () => {
   it("compacts undefined JSON values without throwing", () => {
     expect(compactJsonText(undefined)).toBe("undefined");
   });
 
-  it("includes compact HTTP response body previews in tool result content", () => {
-    expect(
-      compactCallToolResultContent({
-        content: [],
-        structuredContent: {
-          status: 200,
-          statusText: "OK",
-          body: { vulns: [] },
-          elapsedMs: 12,
-        },
-      }),
-    ).toEqual([{ type: "text", text: 'status 200; OK; body {"vulns":[]}' }]);
+  it("renders HTTP response body as complete Markdown", () => {
+    const text = compactCallToolResultContent({
+      content: [],
+      structuredContent: {
+        status: 200,
+        statusText: "OK",
+        body: { vulns: [] },
+        elapsedMs: 12,
+      },
+    })[0]?.text;
+
+    expect(text).toContain("# Result");
+    expect(text).toContain("## Response");
+    expect(text).toContain("- **Status:** `200 OK`");
+    expect(text).toContain("- **Elapsed:** `12 ms`");
+    expect(text).toContain("## Body");
+    expect(text).toContain('"vulns": []');
+  });
+
+  it("renders GraphQL body data and full body", () => {
+    const text = markdownStructuredContent(
+      {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: { data: { viewer: { login: "octocat" } } },
+      },
+      { title: "GitHub GraphQL call_tool viewer", backend: "graphql" },
+    )[0]?.text;
+
+    expect(text).toContain("# GitHub GraphQL call_tool viewer");
+    expect(text).toContain("## Data");
+    expect(text).toContain('"viewer": {');
+    expect(text).toContain("## Full Body");
+  });
+
+  it("renders CLI stdout stderr and parsed JSON", () => {
+    const text = markdownStructuredContent(
+      {
+        exitCode: 0,
+        stdout: '{"matches":[]}',
+        stderr: "",
+        elapsedMs: 52,
+        json: { matches: [] },
+      },
+      { title: "Repo CLI call_tool search", backend: "cli" },
+    )[0]?.text;
+
+    expect(text).toContain("# Repo CLI call_tool search");
+    expect(text).toContain("## Command Result");
+    expect(text).toContain("- **Exit code:** `0`");
+    expect(text).toContain("## stdout");
+    expect(text).toContain('{"matches":[]}');
+    expect(text).toContain("## stderr\n\n_No stderr._");
+    expect(text).toContain("## Parsed JSON");
+    expect(text).toContain('"matches": []');
+  });
+
+  it("preserves downstream MCP text and appends structured content", () => {
+    const content = markdownCallToolResultContent(
+      {
+        content: [{ type: "text", text: "Downstream text" }],
+        structuredContent: { snapshot: { title: "Example" } },
+      },
+      { title: "Browser call_tool browser_snapshot", backend: "mcp" },
+    );
+
+    expect(content[0]?.text).toContain("Downstream text");
+    expect(content[1]?.text).toContain("## Structured Content");
+    expect(content[1]?.text).toContain('"snapshot": {');
+  });
+
+  it("detects renderable structured content while ignoring metadata-only objects", () => {
+    expect(hasRenderableStructuredContent({ body: { ok: true } })).toBe(true);
+    expect(hasRenderableStructuredContent({ caplets: { status: "ok" } })).toBe(false);
+    expect(hasRenderableStructuredContent(undefined)).toBe(false);
   });
 });

--- a/packages/core/test/runtime.test.ts
+++ b/packages/core/test/runtime.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp";
 import { nativeCapletToolName } from "../src/native";
 import { CapletsRuntime } from "../src/runtime";
 

--- a/packages/core/test/serve-session.test.ts
+++ b/packages/core/test/serve-session.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CapletsEngine } from "../src/engine";
 import { CapletsMcpSession } from "../src/serve/session";

--- a/packages/core/test/tools.test.ts
+++ b/packages/core/test/tools.test.ts
@@ -806,7 +806,7 @@ describe("generated tool handlers", () => {
     );
 
     expect(result).toMatchObject({
-      content: [{ type: "text", text: "body" }],
+      content: [{ type: "text", text: 'body {"name":"Ada"}' }],
       structuredContent: { body: { name: "Ada" } },
     });
     expect(openapi.getTool).toHaveBeenCalledWith(openApiServer, "getUser");

--- a/packages/core/test/tools.test.ts
+++ b/packages/core/test/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types";
 import { z } from "zod";
 import { parseConfig } from "../src/config";
 import { DownstreamManager } from "../src/downstream";
@@ -133,22 +133,17 @@ describe("generated tool request validation", () => {
     ]);
   });
 
-  it("returns concise wrapper content while preserving structured result", () => {
+  it("returns Markdown wrapper content while preserving structured result", () => {
     const result = jsonResult({ id: "alpha", tools: [{ tool: "read" }, { tool: "write" }] });
 
     expect(result.structuredContent).toEqual({
       result: { id: "alpha", tools: [{ tool: "read" }, { tool: "write" }] },
     });
-    expect(result.content).toEqual([
-      {
-        type: "text",
-        text: JSON.stringify(
-          { id: "alpha", tools: [{ tool: "read" }, { tool: "write" }] },
-          null,
-          2,
-        ),
-      },
-    ]);
+    const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+    expect(text).toContain("# Result");
+    expect(text).toContain("## Full Result");
+    expect(text).toContain('"tool": "read"');
+    expect(text).toContain('"tool": "write"');
   });
 
   it("describes the nested call_tool argument shape to agents", () => {
@@ -505,7 +500,10 @@ describe("generated tool handlers", () => {
     );
     expect(result).not.toBe(downstreamResult);
     expect(downstreamResult).toEqual(originalDownstreamResult);
-    expect(result).toEqual({
+    expect(result.content[0]?.text).toContain("ok");
+    expect(result.content[1]?.text).toContain("## Structured Content");
+    expect(result.content[1]?.text).toContain('"ok": true');
+    expect({ ...result, content: originalDownstreamResult.content }).toEqual({
       ...originalDownstreamResult,
       _meta: {
         caplets: {
@@ -536,7 +534,10 @@ describe("generated tool handlers", () => {
       registry,
       downstream,
     );
-    expect(result).toEqual({
+    expect(result.content[0]?.text).toContain("ok");
+    expect(result.content[1]?.text).toContain("## Structured Content");
+    expect(result.content[1]?.text).toContain('"ok": true');
+    expect({ ...result, content: downstreamResult.content }).toEqual({
       ...downstreamResult,
       _meta: {
         requestId: "req-1",
@@ -570,7 +571,10 @@ describe("generated tool handlers", () => {
       registry,
       downstream,
     );
-    expect(result).toEqual({
+    expect(result.content[0]?.text).toContain("failed");
+    expect(result.content[1]?.text).toContain("## Structured Content");
+    expect(result.content[1]?.text).toContain('"error": "nope"');
+    expect({ ...result, content: downstreamResult.content }).toEqual({
       ...downstreamResult,
       _meta: {
         requestId: "req-2",
@@ -737,9 +741,12 @@ describe("generated tool handlers", () => {
       downstream,
     );
 
+    expect(result.content[0]?.text).toContain("# Alpha call_tool read");
+    expect(result.content[0]?.text).toContain("## Result");
+    expect(result.content[0]?.text).toContain('"message": "ok"');
     expect(result).toEqual({
       ...downstreamResult,
-      content: [{ type: "text", text: "structured keys: message" }],
+      content: result.content,
       structuredContent: { message: "ok" },
       _meta: {
         requestId: "req-1",
@@ -806,9 +813,11 @@ describe("generated tool handlers", () => {
     );
 
     expect(result).toMatchObject({
-      content: [{ type: "text", text: 'body {"name":"Ada"}' }],
       structuredContent: { body: { name: "Ada" } },
     });
+    expect(result.content[0]?.text).toContain("# Users API call_tool getUser");
+    expect(result.content[0]?.text).toContain("## Body");
+    expect(result.content[0]?.text).toContain('"name": "Ada"');
     expect(openapi.getTool).toHaveBeenCalledWith(openApiServer, "getUser");
     expect(openapi.callTool).toHaveBeenCalledWith(openApiServer, "getUser", { id: "42" });
     expect(downstream.callTool).not.toHaveBeenCalled();
@@ -859,9 +868,11 @@ describe("generated tool handlers", () => {
     );
 
     expect(result).toMatchObject({
-      content: [{ type: "text", text: "structured keys: ok" }],
       structuredContent: { ok: true },
     });
+    expect(result.content[0]?.text).toContain("# Status HTTP call_tool check");
+    expect(result.content[0]?.text).toContain("## Result");
+    expect(result.content[0]?.text).toContain('"ok": true');
     expect(http.getTool).toHaveBeenCalledWith(httpServer, "check");
     expect(http.callTool).toHaveBeenCalledWith(httpServer, "check", { id: "42" });
     expect(downstream.callTool).not.toHaveBeenCalled();
@@ -1062,7 +1073,10 @@ describe("generated tool handlers", () => {
       structuredContent: { ok: true },
       isError: false,
     });
-    expect(result).toEqual({
+    expect(result.content[0]?.text).toContain("# Graph call_tool query_user");
+    expect(result.content[0]?.text).toContain("## Result");
+    expect(result.content[0]?.text).toContain('"ok": true');
+    expect({ ...result, content: graphqlResult.content }).toEqual({
       ...graphqlResult,
       _meta: {
         caplets: {
@@ -1159,7 +1173,10 @@ describe("generated tool handlers", () => {
       structuredContent: { ok: true },
       isError: false,
     });
-    expect(result).toEqual({
+    expect(result.content[0]?.text).toContain("# Status HTTP call_tool check");
+    expect(result.content[0]?.text).toContain("## Result");
+    expect(result.content[0]?.text).toContain('"ok": true');
+    expect({ ...result, content: httpResult.content }).toEqual({
       ...httpResult,
       _meta: {
         caplets: {

--- a/packages/opencode/src/hooks.ts
+++ b/packages/opencode/src/hooks.ts
@@ -52,9 +52,8 @@ function compactOpenCodeResult(result: unknown): string {
       )
       .map((item) => item.text)
       .join("\n")
-      .replace(/\s+/gu, " ")
       .trim();
-    if (text) return text.length > 600 ? `${text.slice(0, 599).trimEnd()}…` : text;
+    if (text) return text;
   }
   try {
     return JSON.stringify(result, null, 2) ?? "null";


### PR DESCRIPTION
This pull request fixes an issue where HTTP response bodies were not being included in the tool result content summaries. Now, the summaries provide a compact preview of the response body, improving clarity and usefulness. The changes also add tests to verify this improved behavior.

**Improvements to HTTP response content summaries:**

* Updated `statusSummary` in `result-content.ts` to include a compact preview of the HTTP response body and other fields, rather than just their presence.
* Added the `valueSummary` helper to format and compactly display body, JSON, stdout, and stderr values in summaries.

**Testing and verification:**

* Updated tests in `result-content.test.ts` and `tools.test.ts` to check for the presence of compacted HTTP body previews in the result content. [[1]](diffhunk://#diff-889f5ae3382ba5cc6ef528a9bf1e69a7f6bbac7e0681884b76f8d43053fc6398L2-R21) [[2]](diffhunk://#diff-fa00f9d104a6f587059bd3ad4adaa6b534a02770381e76e6120a77282a237041L809-R809) [[3]](diffhunk://#diff-ef0a04d8da734ccf82e78d6915b869f742d628d4515de47108ac6c20ae4bcbf2L208-R208)

**Changelog:**

* Added a patch changelog entry for `@caplets/core` describing the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- HTTP tool result summaries now display actual values for response body, JSON, stdout, and stderr fields in a compact format, replacing generic field labels with actionable content summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spiritledsoftware/caplets/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->