### PR TITLE
fix(landing): scrollbars hide when inactive

### DIFF
--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -408,6 +408,25 @@ const installSteps = [
       document.documentElement.classList.add("js-enabled");
 
       const canAnimate = !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      let scrollbarIdleTimer = 0;
+
+      function showScrollbarsBriefly() {
+        document.documentElement.classList.add("scrollbars-active");
+        window.clearTimeout(scrollbarIdleTimer);
+        scrollbarIdleTimer = window.setTimeout(() => {
+          document.documentElement.classList.remove("scrollbars-active");
+        }, 900);
+      }
+
+      window.addEventListener("scroll", showScrollbarsBriefly, { passive: true });
+      window.addEventListener("wheel", showScrollbarsBriefly, { passive: true });
+      window.addEventListener("touchmove", showScrollbarsBriefly, { passive: true });
+      window.addEventListener("pointerdown", showScrollbarsBriefly);
+      window.addEventListener("keydown", (event: KeyboardEvent) => {
+        if (["ArrowDown", "ArrowUp", "End", "Home", "PageDown", "PageUp", "Space"].includes(event.code)) {
+          showScrollbarsBriefly();
+        }
+      });
 
       const agentTabsRoot = document.querySelector<HTMLElement>("[data-agent-tabs]");
       const agentTablist = document.querySelector<HTMLElement>("[data-agent-tablist]");

--- a/apps/landing/src/styles/global.css
+++ b/apps/landing/src/styles/global.css
@@ -39,10 +39,43 @@
   --ease-out: cubic-bezier(0.25, 1, 0.5, 1);
   --ease-expo: cubic-bezier(0.16, 1, 0.3, 1);
   --content: min(1180px, calc(100vw - 32px));
+  --scrollbar-thumb: transparent;
+  --scrollbar-thumb-active: oklch(51% 0.045 100 / 0.42);
+  --scrollbar-thumb-hover: oklch(43% 0.05 100 / 0.56);
+  --scrollbar-track: transparent;
 }
 
 * {
   box-sizing: border-box;
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+}
+
+html.scrollbars-active,
+:where(.agent-setup-panel, .agent-setup-panel pre):hover,
+:where(.agent-setup-panel, .agent-setup-panel pre):focus-within {
+  --scrollbar-thumb: var(--scrollbar-thumb-active);
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+
+::-webkit-scrollbar-thumb {
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background: var(--scrollbar-thumb);
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover);
+  background-clip: padding-box;
 }
 
 html {


### PR DESCRIPTION
This pull request enhances the visual behavior and accessibility of scrollbars on the landing page by introducing dynamic styling and interaction feedback. The main improvements include showing custom-styled scrollbars briefly during user interaction and updating the global CSS to support these visual changes.

**Scrollbar interaction and behavior improvements:**

* Added a script to temporarily show custom-styled scrollbars when the user interacts with the page via scroll, wheel, touch, pointer, or specific keyboard events. The scrollbars become visible for a short period after interaction and then fade out. (`apps/landing/src/pages/index.astro`)

**Styling and theming updates:**

* Introduced new CSS variables for scrollbar colors and states (default, active, hover) to support the dynamic scrollbar appearance. (`apps/landing/src/styles/global.css`)
* Applied custom scrollbar styles using both standard and WebKit-specific selectors, including thin width, rounded corners, and color transitions based on interaction state. (`apps/landing/src/styles/global.css`)
* Enabled the `scrollbars-active` class on the `html` element and certain panels to trigger the active scrollbar style, improving visibility during user interaction. (`apps/landing/src/styles/global.css`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Scrollbars now briefly appear when users interact with the page through scrolling, mouse wheel, touch input, or keyboard navigation
  * Enhanced scrollbar visual styling with improved colors and appearance throughout the interface
  * Scrollbars become more prominent when hovering over them or when interactive panels are in focus

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spiritledsoftware/caplets/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->