### PR TITLE
feat(core): add unified remote login profiles

### DIFF
--- a/.changeset/native-remote-background-auth.md
+++ b/.changeset/native-remote-background-auth.md
@@ -1,0 +1,5 @@
+---
+"@caplets/core": patch
+---
+
+Refresh native remote credentials before background polling, attach event reconnects, tool invokes, and stale-manifest retries so long-lived Remote Profile integrations do not reuse expired authorization headers.

--- a/.changeset/unified-remote-login.md
+++ b/.changeset/unified-remote-login.md
@@ -1,0 +1,8 @@
+---
+"@caplets/core": minor
+"caplets": minor
+"@caplets/opencode": minor
+"@caplets/pi": minor
+---
+
+Replace self-hosted remote env-token and Basic Auth setup with unified Remote Login profiles. Remote attach, hosted Cloud, OpenCode, and Pi now resolve Caplets-owned credentials from `caplets remote login <url>` and use `CAPLETS_REMOTE_URL` only as a non-secret selector.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -53,3 +53,21 @@ Recovery References are separate from session handles. Possessing a session hand
 ### Progressive Exposure
 
 The Caplets exposure mode where agents discover and call backend operations through a small set of wrapper tools instead of receiving every downstream operation as a separate top-level tool.
+
+## Remote Attach
+
+### Remote Login
+
+The provider-neutral flow that trusts a local Caplets client to a Caplets host, whether the host is self-hosted or Caplets Cloud.
+
+Remote Login stores host credentials in Caplets-owned credential storage so agent configs can launch `caplets attach --remote-url ...` without carrying remote secrets.
+
+### Pairing Code
+
+A short-lived, one-time code minted by a self-hosted Caplets host and exchanged by a client during Remote Login.
+
+Pairing Codes are bootstrap material only. They are not reusable client credentials.
+
+### Remote Profile
+
+The stored local record for a trusted Caplets host, including the normalized host URL, host kind, selected workspace when applicable, and redacted credential status.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -56,6 +56,12 @@ The Caplets exposure mode where agents discover and call backend operations thro
 
 ## Remote Attach
 
+### Remote Attach
+
+The process where a local agent-facing Caplets runtime connects to a trusted Caplets host and exposes that host's capabilities through local or native agent integrations.
+
+Remote Attach uses Remote Profiles for trust and credentials. Long-lived attach traffic treats credentials as refreshable runtime state rather than fixed startup state.
+
 ### Remote Login
 
 The provider-neutral flow that trusts a local Caplets client to a Caplets host, whether the host is self-hosted or Caplets Cloud.
@@ -71,3 +77,5 @@ Pairing Codes are bootstrap material only. They are not reusable client credenti
 ### Remote Profile
 
 The stored local record for a trusted Caplets host, including the normalized host URL, host kind, selected workspace when applicable, and redacted credential status.
+
+Remote Profiles are the source of truth for request credentials. Long-lived clients resolve current profile state when sending remote traffic instead of copying credentials into agent config or one-time startup state.

--- a/README.md
+++ b/README.md
@@ -145,15 +145,14 @@ Native integrations expose `caplets__code_mode` for multi-step TypeScript workfl
 generated `caplets.<id>` handles. Progressive exposure adds `caplets__<id>` tools; direct
 exposure adds operation-level tools such as `caplets__<id>__<operation>`.
 
-Remote mode is available with `caplets attach`, self-hosted HTTP service settings, or
-Caplets Cloud auth:
+Remote mode uses Remote Login for both self-hosted Caplets and Caplets Cloud. Trust the
+host once, then launch attach or a native integration with only non-secret selectors:
 
 ```sh
-export CAPLETS_MODE=remote
-export CAPLETS_REMOTE_URL=https://caplets.example.com/caplets
-export CAPLETS_REMOTE_TOKEN=...
+caplets remote login https://caplets.example.com/caplets
+caplets attach --remote-url https://caplets.example.com/caplets
 
-caplets cloud auth login
+caplets remote login https://cloud.caplets.dev
 CAPLETS_MODE=cloud CAPLETS_REMOTE_URL=https://cloud.caplets.dev opencode
 ```
 

--- a/apps/docs/src/content/docs/remote-attach.mdx
+++ b/apps/docs/src/content/docs/remote-attach.mdx
@@ -14,7 +14,7 @@ Caplets native integrations use the same mode names as `caplets attach`:
 | -------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `local`  | The agent should start Caplets against local user and project config.                                                     |
 | `remote` | The agent should connect to a self-hosted Caplets service.                                                                |
-| `cloud`  | The agent should connect to Caplets Cloud with explicit `CAPLETS_REMOTE_*` or `CAPLETS_CLOUD_*` environment values.       |
+| `cloud`  | The agent should connect to Caplets Cloud through a saved Remote Profile.                                                 |
 | `auto`   | Caplets should use Cloud for Cloud URLs, self-hosted remote for non-Cloud URLs, and local mode when no remote URL is set. |
 
 ## MCP client config
@@ -40,34 +40,27 @@ Generic MCP JSON:
 }
 ```
 
-## Environment
+## Remote Login
 
-For a self-hosted remote:
+For a self-hosted remote, log in once and then configure the agent to launch attach:
 
 ```sh
-export CAPLETS_MODE=remote
-export CAPLETS_REMOTE_URL=https://caplets.example.com/caplets
-export CAPLETS_REMOTE_TOKEN=...
-
-caplets attach
+caplets remote login https://caplets.example.com/caplets
+caplets attach --remote-url https://caplets.example.com/caplets
 ```
 
-Use `CAPLETS_REMOTE_USER` and `CAPLETS_REMOTE_PASSWORD` instead of
-`CAPLETS_REMOTE_TOKEN` when the remote uses Basic Auth.
-
-For Caplets Cloud native integrations, set the Cloud URL plus a workspace and token:
+For Caplets Cloud native integrations, log in once and then set the Cloud URL selector:
 
 ```sh
+caplets remote login https://cloud.caplets.dev
 export CAPLETS_MODE=cloud
 export CAPLETS_REMOTE_URL=https://cloud.caplets.dev
-export CAPLETS_REMOTE_WORKSPACE=...
-export CAPLETS_REMOTE_TOKEN=...
 
 opencode
 ```
 
-Saved Cloud auth from `caplets cloud auth login` is used by the `caplets attach` CLI path.
-Native integrations do not read the saved auth store directly.
+Saved Remote Profiles are used by `caplets attach` and native integrations. Agent configs
+should not contain Caplets remote tokens or passwords.
 
 Run a finite Project Binding smoke path before wiring an agent:
 

--- a/apps/docs/src/content/docs/remote-attach.mdx
+++ b/apps/docs/src/content/docs/remote-attach.mdx
@@ -24,7 +24,7 @@ Codex:
 ```toml
 [mcp_servers.caplets]
 command = "caplets"
-args = ["attach"]
+args = ["attach", "--remote-url", "https://caplets.example.com/caplets"]
 ```
 
 Generic MCP JSON:
@@ -34,7 +34,7 @@ Generic MCP JSON:
   "mcpServers": {
     "caplets": {
       "command": "caplets",
-      "args": ["attach"]
+      "args": ["attach", "--remote-url", "https://caplets.example.com/caplets"]
     }
   }
 }
@@ -42,12 +42,24 @@ Generic MCP JSON:
 
 ## Remote Login
 
-For a self-hosted remote, log in once and then configure the agent to launch attach:
+For a self-hosted remote, first create a short-lived Pairing Code on the server:
+
+```sh
+caplets remote host pair --host-url https://caplets.example.com/caplets
+```
+
+If the server uses a non-default credential state directory, pass the same directory with
+`--state-path` that the server uses for `caplets serve --remote-state-path`.
+
+Then log in once on the client and configure the agent to launch attach:
 
 ```sh
 caplets remote login https://caplets.example.com/caplets
 caplets attach --remote-url https://caplets.example.com/caplets
 ```
+
+Enter the Pairing Code at the hidden prompt from `caplets remote login`. Use
+`--code-stdin` for automation instead of putting Pairing Codes in shell history.
 
 For Caplets Cloud native integrations, log in once and then set the Cloud URL selector:
 

--- a/apps/docs/src/content/docs/troubleshooting.mdx
+++ b/apps/docs/src/content/docs/troubleshooting.mdx
@@ -123,24 +123,18 @@ Expected symptom: remote mode starts, but attach cannot reach the runtime or aut
 Confirm the remote environment:
 
 ```sh
-export CAPLETS_MODE=remote
-export CAPLETS_REMOTE_URL=https://caplets.example.com/caplets
-export CAPLETS_REMOTE_TOKEN=...
+caplets remote login https://caplets.example.com/caplets
 caplets doctor
-caplets attach
+caplets attach --remote-url https://caplets.example.com/caplets
 ```
 
-If the remote requires auth, set either `CAPLETS_REMOTE_TOKEN` or
-`CAPLETS_REMOTE_USER` plus `CAPLETS_REMOTE_PASSWORD`. If the URL belongs to Caplets Cloud,
-check whether your environment expects `CAPLETS_REMOTE_*` or `CAPLETS_CLOUD_*` values and
-keep the family consistent for that shell. Cloud-native integrations also need the selected
-workspace:
+If the URL belongs to Caplets Cloud, log in through Remote Login and keep the Cloud URL
+selector consistent for that shell:
 
 ```sh
+caplets remote login https://cloud.caplets.dev
 export CAPLETS_MODE=cloud
 export CAPLETS_REMOTE_URL=https://cloud.caplets.dev
-export CAPLETS_REMOTE_WORKSPACE=...
-export CAPLETS_REMOTE_TOKEN=...
 caplets attach --once
 ```
 

--- a/docs/brainstorms/2026-06-19-unified-remote-attach-auth-requirements.md
+++ b/docs/brainstorms/2026-06-19-unified-remote-attach-auth-requirements.md
@@ -1,0 +1,199 @@
+---
+date: 2026-06-19
+topic: unified-remote-attach-auth
+---
+
+# Unified Remote Attach Auth Requirements
+
+## Summary
+
+Caplets should use one remote login model for both Caplets Cloud and self-hosted Caplets. Users trust a Caplets host once, then MCP clients and native integrations launch `caplets attach --remote-url ...` without Basic Auth, env-secret plumbing, or Cloud-specific login commands.
+
+---
+
+## Problem Frame
+
+Remote attach currently splits by provider. Hosted Cloud uses `caplets cloud auth login` and saved Cloud Auth credentials, while self-hosted remotes use `CAPLETS_REMOTE_TOKEN` or Basic Auth through flags and environment variables.
+
+That split leaks into the first-run experience. MCP clients need launch commands, agent configs become a place where secrets can drift, and each provider adds its own setup wording. The problem is not only Codex env inheritance; any agent that starts a subprocess can become another place to debug PATH, env, token, and credential persistence.
+
+Caplets should own remote trust. Agent wiring should be reduced to installing the right attach command into the agent, while Caplets stores and refreshes the credentials needed to connect to the selected host.
+
+---
+
+## Key Decisions
+
+- **Remote login is the provider-neutral user model.** `caplets remote login <url>` replaces Cloud-specific login wording and self-hosted env-token setup in the primary docs.
+- **Pairing codes are not reusable credentials.** Self-hosted pairing produces a short-lived code that is exchanged for stored client credentials.
+- **Agent configs do not carry secrets.** `add-mcp` installs `caplets attach --remote-url ...`; Caplets resolves credentials from its own store at runtime.
+- **Basic Auth leaves the product path.** Self-hosted attach, MCP, and control routes should use issued client credentials rather than username/password auth.
+- **Backend OAuth stays separate.** `caplets auth login <caplet-id>` continues to mean authentication for a configured backend Caplet, not authentication to a Caplets host.
+- **Cloud becomes one host kind under remote login.** Existing Cloud browser/device auth can remain internally, but the user-facing command moves under the unified remote namespace.
+
+```mermaid
+flowchart TB
+  A["User chooses a Caplets host"] --> B{"Hosted Cloud?"}
+  B -->|yes| C["caplets remote login cloud URL"]
+  B -->|no| D["Server mints pairing code"]
+  D --> E["Client runs caplets remote login host URL --code"]
+  C --> F["Caplets stores host credentials"]
+  E --> F
+  F --> G["add-mcp installs caplets attach --remote-url host URL"]
+  G --> H["Agent starts attach with no env secrets"]
+```
+
+---
+
+## Actors
+
+- A1. **Self-hosted server operator.** Runs the Caplets HTTP service, creates pairing codes, and revokes paired clients.
+- A2. **Remote client user.** Logs a local machine into a Caplets host and configures agents to launch attach.
+- A3. **Agent or MCP client.** Starts `caplets attach --remote-url ...` and receives the remote-backed Caplets surface.
+- A4. **Caplets host.** Issues pairing codes, exchanges them for client credentials, validates attach requests, and records client identity.
+- A5. **Caplets Cloud.** Implements the same remote login contract while preserving hosted workspace selection and refresh behavior.
+
+---
+
+## Requirements
+
+**Unified remote login**
+
+- R1. `caplets remote login <url>` authenticates this machine to a Caplets host, whether the host is self-hosted or Caplets Cloud.
+- R2. `caplets remote status` shows saved remote credentials in redacted form, including host URL, host kind, selected workspace when applicable, client label, created time, and last-used time when available.
+- R3. `caplets remote logout <url>` removes this machine's saved credentials for that host.
+- R4. `caplets attach --remote-url <url>` resolves stored credentials for the normalized host URL without requiring `CAPLETS_REMOTE_TOKEN`, `CAPLETS_REMOTE_USER`, or `CAPLETS_REMOTE_PASSWORD`.
+- R5. Attach mode inference remains URL-driven: Cloud URLs use the hosted Cloud path, and non-Cloud URLs use the self-hosted path.
+
+**Self-hosted pairing**
+
+- R6. A self-hosted server operator can mint a short-lived one-time pairing code from the server environment.
+- R7. Pairing codes are scoped to one host, expire within minutes by default, are rate-limited, and are stored server-side only as non-reusable verification material.
+- R8. A client can exchange a valid pairing code through `caplets remote login <url> --code <code>`.
+- R9. Successful self-hosted login issues client credentials that are stored by Caplets on the client and can be revoked independently on the server.
+- R10. Pairing code exchange never turns the copied code into the long-lived bearer credential.
+
+**Credential lifecycle**
+
+- R11. Remote credentials are keyed by normalized host URL and, for hosted Cloud, selected workspace.
+- R12. Access credentials used for attach are audience-restricted to their issuing Caplets host.
+- R13. Long-lived refresh material is rotated or otherwise constrained so stealing one stale token is not enough for indefinite access.
+- R14. Credential storage is owned by Caplets and must use restrictive local permissions, with OS credential storage preferred when available.
+- R15. CLI output, diagnostics, JSON errors, and logs redact remote access and refresh credentials.
+- R16. The server can list and revoke paired clients by stable client identity, label, created time, and last-used time.
+
+**Cloud migration**
+
+- R17. `caplets cloud auth login` is deprecated in favor of `caplets remote login <cloud-url>`.
+- R18. Existing Cloud credentials continue to work during migration or are migrated automatically into the unified remote credential store.
+- R19. Cloud workspace selection is represented as part of the remote login profile, not as a separate auth model.
+- R20. Recovery messages that currently say `caplets cloud auth login` point users to the unified remote login command.
+
+**Agent setup and docs**
+
+- R21. First-run docs use `add-mcp` for generic MCP wiring instead of making `caplets setup` the primary path.
+- R22. Local MCP docs install `caplets serve` through `add-mcp`.
+- R23. Remote MCP docs install `caplets attach --remote-url <url>` through `add-mcp` after the user has completed `caplets remote login <url>`.
+- R24. Remote MCP docs do not recommend `add-mcp --env` for Caplets remote credentials.
+- R25. Native OpenCode and Pi docs use their native extension setup paths and the same remote login model.
+- R26. `caplets setup` is deprecated, removed, or reduced to a transitional router that points users at `add-mcp` and native extension docs.
+
+**Basic Auth removal**
+
+- R27. Self-hosted Basic Auth is removed from the primary self-hosted attach, MCP, and control model.
+- R28. If Basic Auth compatibility remains for one release, it is hidden from first-run docs, warns on use, and has a documented removal path.
+- R29. New tests and docs must not describe Basic Auth as a supported self-hosted setup path.
+
+---
+
+## Key Flows
+
+- F1. Self-hosted host pairing
+  - **Trigger:** A server operator wants to let a local machine attach to a self-hosted Caplets service.
+  - **Actors:** A1, A2, A4
+  - **Steps:** The operator starts the HTTP service, mints a pairing code on the server, copies the suggested login command to the client, and the client exchanges the code for stored credentials.
+  - **Covered by:** R6, R7, R8, R9, R10
+
+- F2. Cloud host login
+  - **Trigger:** A user wants to attach local agents to Caplets Cloud.
+  - **Actors:** A2, A5
+  - **Steps:** The user runs remote login against the Cloud URL, completes the existing hosted auth flow, selects or confirms the workspace, and Caplets stores the remote profile.
+  - **Covered by:** R1, R11, R17, R18, R19
+
+- F3. Agent wiring after remote login
+  - **Trigger:** The user wants an MCP client to use a remote-backed Caplets surface.
+  - **Actors:** A2, A3
+  - **Steps:** The user runs `add-mcp` with the `caplets attach --remote-url ...` command, the agent starts that command later, and Caplets resolves stored credentials before connecting to the host.
+  - **Covered by:** R4, R21, R23, R24
+
+- F4. Client revocation
+  - **Trigger:** A device is lost, replaced, or no longer trusted.
+  - **Actors:** A1, A2, A4
+  - **Steps:** The operator lists paired clients, identifies the client by label and metadata, revokes it, and future attach attempts from that client fail until it logs in again.
+  - **Covered by:** R3, R9, R16
+
+- F5. Legacy Cloud migration
+  - **Trigger:** A user has existing saved Cloud Auth credentials.
+  - **Actors:** A2, A5
+  - **Steps:** The user runs a command that needs remote credentials, Caplets reads or migrates the existing credential, and recovery messages teach the new `remote login` command.
+  - **Covered by:** R17, R18, R20
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R17, R19.** Given a user runs `caplets remote login https://cloud.caplets.dev`, when the hosted auth flow completes, then Caplets stores a Cloud remote profile with the selected workspace.
+- AE2. **Covers R6, R7, R8, R10.** Given a server operator creates a pairing code and a client exchanges it, when the client later attaches, then it uses issued client credentials rather than the original copied code.
+- AE3. **Covers R4, R23, R24.** Given a user has completed remote login, when they install `caplets attach --remote-url <url>` through `add-mcp`, then the agent config contains no remote token, password, or Caplets credential env vars.
+- AE4. **Covers R12, R13, R15.** Given a remote credential is stored locally, when attach refreshes or reports diagnostics, then credentials remain host-scoped and redacted from output.
+- AE5. **Covers R16.** Given a self-hosted operator lists paired clients, when they revoke one client, then that client's next attach attempt fails until it logs in again.
+- AE6. **Covers R18, R20.** Given a user still has legacy Cloud Auth state, when attach requires credentials, then Caplets either migrates the state or reports a recovery command using `caplets remote login`.
+- AE7. **Covers R21, R22, R23, R25.** Given a first-time user reads install docs, when they choose MCP or native setup, then the docs send them through `add-mcp` for MCP and native extension setup for OpenCode or Pi.
+- AE8. **Covers R27, R28, R29.** Given a user follows current docs, when they self-host and attach, then they never configure Basic Auth.
+
+---
+
+## Success Criteria
+
+- A first-time MCP user can install Caplets into an agent config without writing a remote secret into that config.
+- Cloud and self-hosted docs use the same remote-login vocabulary.
+- `caplets attach --once --remote-url <url> --json` gives credential recovery guidance that points to `caplets remote login`, not provider-specific or env-secret instructions.
+- Self-hosted revocation can identify and remove one paired client without rotating every client credential.
+- The install docs no longer require users to understand `CAPLETS_REMOTE_TOKEN`, `CAPLETS_REMOTE_USER`, or `CAPLETS_REMOTE_PASSWORD` for the normal path.
+
+---
+
+## Scope Boundaries
+
+**Deferred for later**
+
+- Hardware-backed or sender-constrained credentials beyond the best available software credential model.
+- Multi-user role and permission administration for self-hosted teams beyond client listing and revocation.
+- Automatic migration of every possible third-party MCP config that may already contain Caplets env secrets.
+
+**Outside this product's identity**
+
+- Using agent MCP configs as the source of truth for Caplets secrets.
+- Treating Basic Auth as the long-term self-hosted authentication model.
+- Replacing backend Caplet OAuth with remote host login.
+
+---
+
+## Dependencies / Assumptions
+
+- `add-mcp` remains the recommended third-party MCP config writer for broad provider coverage.
+- Caplets can persist remote credentials in a local store with restrictive permissions and can later improve the backing store without changing the command model.
+- Self-hosted pairing commands are run by someone with shell access to the server or equivalent administrative authority.
+- Caplets Cloud can expose the existing hosted login behavior through the unified remote command namespace.
+
+---
+
+## Sources / Research
+
+- `README.md` for the current quick-start, `caplets setup`, `caplets serve`, and `caplets attach` public contract.
+- `packages/core/src/cli.ts` for current `attach`, `cloud auth`, and setup command surfaces.
+- `packages/core/src/remote/options.ts` and `packages/core/src/remote/selection.ts` for current self-hosted and hosted remote credential resolution.
+- `apps/docs/src/content/docs/remote-attach.mdx`, `docs/project-binding.md`, and `docs/product/caplets-code-mode-prd.md` for current remote attach documentation.
+- `add-mcp@1.10.4` CLI help and package source for supported agents and `--env` handling.
+- [RFC 8628 OAuth 2.0 Device Authorization Grant](https://www.rfc-editor.org/rfc/rfc8628.html) for the short-code device authorization pattern.
+- [RFC 9700 OAuth 2.0 Security Best Current Practice](https://www.rfc-editor.org/rfc/rfc9700.html) for token lifecycle and refresh-token risk framing.
+- [OWASP OAuth2 Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/OAuth2_Cheat_Sheet.html) for OAuth security guidance.

--- a/docs/ideation/2026-06-18-open-ideation.html
+++ b/docs/ideation/2026-06-18-open-ideation.html
@@ -795,8 +795,7 @@
       </section>
 
       <footer class="composition-signal">
-        Composed 2026-06-18T00:00:00-04:00 by ce-ideate from open-ended surprise-me prompt in
-        <code>/Users/ianpascoe/src/caplets</code>.
+        Composed 2026-06-18T00:00:00-04:00 by ce-ideate from open-ended surprise-me prompt.
       </footer>
     </main>
   </body>

--- a/docs/ideation/2026-06-18-open-ideation.html
+++ b/docs/ideation/2026-06-18-open-ideation.html
@@ -1,0 +1,803 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Ideation: Caplets Surprise-Me Features</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@450;600;650;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --ember: #e0582f;
+        --parchment: #f6e8c8;
+        --charred: #1f2018;
+        --linen: #fbf7ec;
+        --paper: #fff8ea;
+        --ash: #e3d8c0;
+        --olive: #686b4e;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--linen);
+        color: var(--charred);
+        font-family:
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        font-size: 15px;
+        line-height: 1.55;
+      }
+      .page {
+        width: min(960px, calc(100vw - 32px));
+        margin: 0 auto;
+        padding: 42px 0 56px;
+      }
+      header,
+      .section {
+        border-bottom: 1px solid var(--ash);
+      }
+      header {
+        padding-bottom: 24px;
+        margin-bottom: 28px;
+      }
+      .eyebrow {
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.035em;
+        text-transform: uppercase;
+        color: var(--ember);
+      }
+      h1 {
+        margin: 8px 0 10px;
+        font-size: clamp(2rem, 4.5vw, 3.35rem);
+        line-height: 1.05;
+        letter-spacing: 0;
+        max-width: 13ch;
+      }
+      h2 {
+        font-size: 1.45rem;
+        line-height: 1.15;
+        margin: 34px 0 12px;
+        letter-spacing: 0;
+      }
+      h3 {
+        margin: 0 0 10px;
+        font-size: 1.04rem;
+        line-height: 1.25;
+        letter-spacing: 0;
+      }
+      p {
+        max-width: 72ch;
+        margin: 0 0 12px;
+      }
+      a {
+        color: var(--charred);
+        text-decoration-color: var(--ember);
+        text-underline-offset: 3px;
+      }
+      code {
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        font-size: 0.92em;
+        background: rgba(246, 232, 200, 0.75);
+        border: 1px solid rgba(227, 216, 192, 0.85);
+        border-radius: 4px;
+        padding: 0.05rem 0.25rem;
+      }
+      .meta,
+      .stats {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 16px;
+      }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        border: 1px solid var(--ash);
+        border-radius: 14px;
+        padding: 5px 9px;
+        background: var(--parchment);
+        color: var(--charred);
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.035em;
+      }
+      .section {
+        padding: 24px 0;
+      }
+      .summary-grid,
+      .idea-nav {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+        margin-top: 14px;
+      }
+      .note,
+      .idea-card,
+      .idea-nav a {
+        background: var(--paper);
+        border: 1px solid var(--ash);
+        border-radius: 10px;
+      }
+      .note {
+        padding: 14px 16px;
+      }
+      .idea-nav {
+        padding: 0;
+        list-style: none;
+        margin-bottom: 20px;
+      }
+      .idea-nav a {
+        display: block;
+        padding: 10px 12px;
+        text-decoration: none;
+        font-weight: 650;
+      }
+      .idea-card {
+        border-radius: 14px;
+        padding: 18px;
+        margin: 14px 0;
+      }
+      .idea-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+      .rank {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 34px;
+        height: 34px;
+        border-radius: 10px;
+        background: var(--charred);
+        color: var(--parchment);
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        font-weight: 700;
+      }
+      .idea-title {
+        flex: 1;
+      }
+      .idea-title p {
+        color: var(--olive);
+        margin: 2px 0 0;
+      }
+      dl {
+        display: grid;
+        grid-template-columns: 9rem 1fr;
+        gap: 8px 12px;
+        margin: 14px 0 0;
+      }
+      dt {
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.035em;
+        text-transform: uppercase;
+        color: var(--olive);
+      }
+      dd {
+        margin: 0;
+      }
+      .diagram {
+        margin-top: 14px;
+        border: 1px solid var(--ash);
+        border-radius: 10px;
+        background: #fffaf0;
+        padding: 12px;
+        overflow-x: auto;
+      }
+      svg {
+        max-width: 100%;
+        height: auto;
+        display: block;
+      }
+      .svg-label {
+        font:
+          650 13px Inter,
+          system-ui,
+          sans-serif;
+        fill: var(--charred);
+      }
+      .svg-small {
+        font:
+          600 11px Inter,
+          system-ui,
+          sans-serif;
+        fill: var(--olive);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 12px;
+        background: var(--paper);
+        border: 1px solid var(--ash);
+        border-radius: 10px;
+        overflow: hidden;
+      }
+      th,
+      td {
+        text-align: left;
+        vertical-align: top;
+        padding: 10px 12px;
+        border-bottom: 1px solid var(--ash);
+      }
+      th {
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        font-size: 0.75rem;
+        letter-spacing: 0.035em;
+        text-transform: uppercase;
+        background: var(--parchment);
+      }
+      tr:last-child td {
+        border-bottom: 0;
+      }
+      footer {
+        margin-top: 32px;
+        color: var(--olive);
+        font-size: 0.86rem;
+        border-top: 1px solid var(--ash);
+        padding-top: 16px;
+      }
+      @media (max-width: 760px) {
+        .page {
+          width: min(100vw - 24px, 960px);
+          padding-top: 24px;
+        }
+        .summary-grid,
+        .idea-nav {
+          grid-template-columns: 1fr;
+        }
+        .idea-head {
+          flex-direction: column;
+        }
+        dl {
+          grid-template-columns: 1fr;
+          gap: 4px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <header>
+        <div class="eyebrow">Ideation</div>
+        <h1>Caplets Surprise-Me Features</h1>
+        <p>
+          Open-ended feature ideation grounded in the current Caplets repo, recent plans, shipped
+          docs, and external MCP platform direction.
+        </p>
+        <div class="meta">
+          <span class="pill">DATE 2026-06-18</span><span class="pill">TOPIC open-ideation</span
+          ><span class="pill">MODE repo-grounded</span>
+        </div>
+        <div class="stats">
+          <span class="pill">20 raw</span><span class="pill">7 ranked</span
+          ><span class="pill">8 cut</span><span class="pill">axes skipped</span>
+        </div>
+      </header>
+
+      <section class="section" id="grounding-context">
+        <div class="eyebrow">Grounding Context</div>
+        <h2>Codebase Context</h2>
+        <p>
+          Caplets gives coding agents a compact Code Mode surface for MCP servers, APIs, and
+          commands. The repo states the core product problem plainly: flat tool lists inflate
+          context, force premature tool choice, add repeated round trips, make agents over-carry raw
+          payloads, and fragment semantics across local, remote, Cloud, and native integrations.
+        </p>
+        <div class="summary-grid">
+          <div class="note">
+            <strong>Product center.</strong> Code Mode is the default surface because it keeps
+            discovery, execution, filtering, and synthesis in one bounded agent call.
+          </div>
+          <div class="note">
+            <strong>Recent momentum.</strong> The current branch has recent work on reusable Code
+            Mode sessions, recovery journals, Google Discovery API backends, media artifacts,
+            Cloud/remote attach, native integration parity, docs, and benchmarks.
+          </div>
+          <div class="note">
+            <strong>Open product questions.</strong> The PRD asks which result-shaping hints should
+            become public contract, how much direct exposure should be default, which Cloud/Project
+            Binding semantics should become product contract, and which benchmark suites should
+            remain long-term guardrails.
+          </div>
+          <div class="note">
+            <strong>External pressure.</strong> MCP hosts are moving toward remote connectors,
+            managed MCP endpoints, Apps SDK surfaces, structured outputs, server-rendered UI,
+            stronger OAuth/authorization, and stateless remote protocol design.
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="topic-axes">
+        <div class="eyebrow">Topic Axes</div>
+        <h2>Topic Axes</h2>
+        <p>
+          <code>Decomposition skipped - surprise-me mode</code>. Different frames were allowed to
+          surface different subjects from the repo and external context.
+        </p>
+      </section>
+
+      <section class="section" id="ranked-ideas">
+        <div class="eyebrow">Ranked Ideas</div>
+        <h2>Ranked Ideas</h2>
+        <ul class="idea-nav">
+          <li><a href="#idea-1">1. Caplet Forge</a></li>
+          <li><a href="#idea-2">2. Trust Ledger</a></li>
+          <li><a href="#idea-3">3. Result Contracts</a></li>
+          <li><a href="#idea-4">4. Interactive Repair</a></li>
+          <li><a href="#idea-5">5. Benchmark Flights</a></li>
+          <li><a href="#idea-6">6. Remote Gateway Packs</a></li>
+          <li><a href="#idea-7">7. Capability Graph Workspace</a></li>
+        </ul>
+
+        <article class="idea-card" id="idea-1">
+          <div class="idea-head">
+            <span class="rank">1</span>
+            <div class="idea-title">
+              <h3>Caplet Forge: Workflow-to-Caplet Promotion</h3>
+              <p>
+                Turn a successful Code Mode session into a reusable, reviewable Caplet file or
+                Caplet-set recipe.
+              </p>
+            </div>
+            <span class="pill">CONF 86% · CX M</span>
+          </div>
+          <p>
+            <strong>Description:</strong> After an agent uses Code Mode to solve a repeated
+            workflow, Caplets can offer a promotion path: extract the handles, search terms,
+            described schemas, result shaping, setup commands, and recovery-safe helper code into a
+            draft Caplet recipe. The output would be a Markdown Caplet file with inferred
+            <code>useWhen</code>, <code>avoidWhen</code>, <code>setup.verify</code>, field-selection
+            defaults, and a deterministic smoke check.
+          </p>
+          <dl>
+            <dt>Basis</dt>
+            <dd>
+              direct: Code Mode sessions return <code>meta.sessionId</code> for reusable helpers and
+              cached discovery state, while recovery journals help reconstruct setup code manually
+              (<a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/docs/product/caplets-code-mode-prd.md#code-mode-contract"
+                >docs/product/caplets-code-mode-prd.md lines 104-117</a
+              >). Caplet files already support <code>useWhen</code>, <code>avoidWhen</code>,
+              <code>setup</code>, <code>projectBinding</code>, and runtime metadata (<a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/apps/docs/src/content/docs/reference/caplet-files.mdx"
+                >apps/docs/src/content/docs/reference/caplet-files.mdx lines 31-73</a
+              >).
+            </dd>
+            <dt>Rationale</dt>
+            <dd>
+              The product already captures enough runtime truth to know what worked. Turning that
+              into a durable capability artifact compounds agent work instead of letting every
+              session rediscover the same workflow.
+            </dd>
+            <dt>Downsides</dt>
+            <dd>
+              Needs careful distinction between reusable setup and side-effecting calls. The first
+              version should create drafts and tests, not silently install generated Caplets.
+            </dd>
+          </dl>
+          <div class="diagram" aria-label="Caplet Forge flow diagram">
+            <svg width="820" height="180" viewBox="0 0 820 180" role="img">
+              <rect x="22" y="48" width="150" height="74" rx="10" fill="#FFF8EA" stroke="#E3D8C0" />
+              <text x="44" y="78" class="svg-label">Live Code Mode</text>
+              <text x="44" y="100" class="svg-small">session + calls</text>
+              <path d="M180 85 H278" stroke="#686B4E" stroke-width="2" marker-end="url(#arrow1)" />
+              <rect
+                x="292"
+                y="35"
+                width="176"
+                height="100"
+                rx="10"
+                fill="#F6E8C8"
+                stroke="#E3D8C0"
+              />
+              <text x="318" y="67" class="svg-label">Extract Evidence</text>
+              <text x="318" y="90" class="svg-small">schemas, result shape, setup</text>
+              <text x="318" y="112" class="svg-small">safe helper candidates</text>
+              <path d="M476 85 H574" stroke="#686B4E" stroke-width="2" marker-end="url(#arrow1)" />
+              <rect
+                x="588"
+                y="48"
+                width="184"
+                height="74"
+                rx="10"
+                fill="#FFF8EA"
+                stroke="#E3D8C0"
+              />
+              <text x="616" y="78" class="svg-label">Draft CAPLET.md</text>
+              <text x="616" y="100" class="svg-small">reviewable + smoke-tested</text>
+              <defs>
+                <marker
+                  id="arrow1"
+                  markerWidth="8"
+                  markerHeight="8"
+                  refX="7"
+                  refY="4"
+                  orient="auto"
+                >
+                  <path d="M0,0 L8,4 L0,8 Z" fill="#686B4E" />
+                </marker>
+              </defs>
+            </svg>
+          </div>
+        </article>
+
+        <article class="idea-card" id="idea-2">
+          <div class="idea-head">
+            <span class="rank">2</span>
+            <div class="idea-title">
+              <h3>Trust Ledger: Capability Risk, Scope, and Action Preview</h3>
+              <p>
+                An inspectable ledger that tells users and agents what a Caplet can read, mutate,
+                sync, retain, and ask for before it is used.
+              </p>
+            </div>
+            <span class="pill">CONF 84% · CX M</span>
+          </div>
+          <p>
+            <strong>Description:</strong> Add a trust ledger to <code>inspect()</code>,
+            <code>doctor</code>, native metadata, and Cloud UI surfaces. For each Caplet, it would
+            summarize auth posture, inferred OAuth scopes, destructive/read-only hints, Project
+            Binding sync footprint, media artifact behavior, retained logs/recovery, and
+            remote/local execution mode.
+          </p>
+          <dl>
+            <dt>Basis</dt>
+            <dd>
+              direct: Caplets already treats trust details as product requirements: keep secrets
+              redacted, expose enough auth/status detail, validate schemas, bound responses, deny
+              unsafe Project Binding sync paths, and route I/O through Caplet handles (<a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/docs/product/caplets-code-mode-prd.md#trust-and-safety"
+                >docs/product/caplets-code-mode-prd.md lines 23-31 and 133-142</a
+              >). external: MCP guidance says tool UIs should make exposed tools and invocations
+              clear and keep a human in the loop for operations (<a
+                href="https://modelcontextprotocol.io/specification/draft/server/tools"
+                >MCP Tools specification</a
+              >).
+            </dd>
+            <dt>Rationale</dt>
+            <dd>
+              Caplets' main value is reducing surface area without hiding capability truth. A ledger
+              makes that promise legible for humans, agents, and enterprise reviewers.
+            </dd>
+            <dt>Downsides</dt>
+            <dd>
+              The ledger can become noisy if it prints every field. It should be a compact summary
+              with drill-down links, and it must avoid implying Code Mode is a sandbox boundary.
+            </dd>
+          </dl>
+        </article>
+
+        <article class="idea-card" id="idea-3">
+          <div class="idea-head">
+            <span class="rank">3</span>
+            <div class="idea-title">
+              <h3>Result Contracts: Self-Training Output Shapers</h3>
+              <p>
+                Promote observed downstream output shapes into typed, reusable result shapers that
+                agents can call directly inside Code Mode.
+              </p>
+            </div>
+            <span class="pill">CONF 82% · CX M</span>
+          </div>
+          <p>
+            <strong>Description:</strong> Caplets already stores observed output shapes and has
+            schema-aware field selection. Build a layer that suggests reusable result shapers:
+            <code>tool.describeResult()</code>, <code>tool.pickFields()</code>, or generated helper
+            snippets that return compact evidence for common tasks.
+          </p>
+          <dl>
+            <dt>Basis</dt>
+            <dd>
+              direct: The PRD names generic outputs as a problem and asks which result-shaping hints
+              should become stable public contract (<a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/docs/product/caplets-code-mode-prd.md#problem"
+                >docs/product/caplets-code-mode-prd.md lines 18 and 152-157</a
+              >). The code already stores observed shapes with type signatures, sample counts, TTLs,
+              and hashes (<a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/packages/core/src/observed-output-shapes/types.ts"
+                >packages/core/src/observed-output-shapes/types.ts lines 30-51</a
+              >), and field selection validates paths against output schema (<a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/packages/core/src/field-selection.ts"
+                >packages/core/src/field-selection.ts lines 11-40</a
+              >).
+            </dd>
+            <dt>Rationale</dt>
+            <dd>
+              This turns one of Caplets' deepest advantages into a public contract: not just smaller
+              tool lists, but smaller and more reliable answers.
+            </dd>
+            <dt>Downsides</dt>
+            <dd>
+              Observed shapes can drift. The contract needs confidence and invalidation semantics.
+            </dd>
+          </dl>
+        </article>
+
+        <article class="idea-card" id="idea-4">
+          <div class="idea-head">
+            <span class="rank">4</span>
+            <div class="idea-title">
+              <h3>Interactive Repair: Elicitation-Aware Recovery</h3>
+              <p>
+                Convert auth, setup, schema, and Project Binding failures into structured repair
+                prompts that agents can route through their host UI.
+              </p>
+            </div>
+            <span class="pill">CONF 76% · CX H</span>
+          </div>
+          <p>
+            <strong>Description:</strong> Many failures already have stable diagnostic codes and
+            recovery commands. Turn those into a portable "repair needed" result shape: missing env
+            var, Cloud login required, workspace switch required, sync size exceeded, operation
+            scope changed, unknown session with recovery available.
+          </p>
+          <dl>
+            <dt>Basis</dt>
+            <dd>
+              direct: Project Binding terminal states carry stable codes and recovery commands (<a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/docs/project-binding.md#states"
+                >docs/project-binding.md lines 23-57</a
+              >), and <code>doctor</code> reports remote, binding, sync, auth, exposure, Code Mode,
+              log storage, and observed output shape health (<a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/packages/core/src/cli/doctor.ts"
+                >packages/core/src/cli/doctor.ts lines 41-96 and 99-168</a
+              >). external: current MCP tool docs include input-required tool results, and Apps SDK
+              surfaces emphasize app UX, metadata, authentication, and state management.
+            </dd>
+            <dt>Rationale</dt>
+            <dd>
+              Agents are good at following structured next steps when the tool gives them exact
+              repair options. This would make Caplets feel less like a config parser and more like a
+              cooperative runtime.
+            </dd>
+            <dt>Downsides</dt>
+            <dd>
+              Host support will vary. The fallback must remain plain structured JSON plus recovery
+              commands; never request secrets through elicitation.
+            </dd>
+          </dl>
+        </article>
+
+        <article class="idea-card" id="idea-5">
+          <div class="idea-head">
+            <span class="rank">5</span>
+            <div class="idea-title">
+              <h3>Benchmark Flights: Per-Caplet Agent Evals</h3>
+              <p>
+                Let every serious Caplet ship with a tiny repeatable eval flight, not just docs and
+                setup commands.
+              </p>
+            </div>
+            <span class="pill">CONF 80% · CX M</span>
+          </div>
+          <p>
+            <strong>Description:</strong> Add a <code>caplets eval init</code> and Caplet-file eval
+            metadata that creates small, deterministic or opt-in live scenarios for a capability. A
+            Caplet author could specify task prompts, expected evidence fields, safe fixtures, and
+            competitor modes.
+          </p>
+          <dl>
+            <dt>Basis</dt>
+            <dd>
+              direct: The benchmark report already measures initial tool-surface reduction, Code
+              Mode round-trip reduction, session reuse, and live failure classes (<a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/docs/benchmarks/coding-agent.md"
+                >docs/benchmarks/coding-agent.md lines 14-23, 46-75, and 94-155</a
+              >). The PRD requires reproducible benchmark claims and marks live benchmarks as
+              directional rather than deterministic (<a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/docs/product/caplets-code-mode-prd.md#evidence"
+                >docs/product/caplets-code-mode-prd.md lines 144-150</a
+              >).
+            </dd>
+            <dt>Rationale</dt>
+            <dd>
+              The best way to prove a capability works for agents is to run agent-shaped tasks
+              against it. This makes Caplet quality visible and comparable at the configured
+              capability level.
+            </dd>
+            <dt>Downsides</dt>
+            <dd>
+              Eval authoring can be a burden. Start with generated scaffolds from recent successful
+              Code Mode calls and a small deterministic fixture path.
+            </dd>
+          </dl>
+        </article>
+
+        <article class="idea-card" id="idea-6">
+          <div class="idea-head">
+            <span class="rank">6</span>
+            <div class="idea-title">
+              <h3>Remote Capability Gateway Packs</h3>
+              <p>
+                Curated hosted/managed MCP and API packs that add Caplets policy, result shaping,
+                Project Binding, and trust metadata on top of vendor endpoints.
+              </p>
+            </div>
+            <span class="pill">CONF 72% · CX H</span>
+          </div>
+          <p>
+            <strong>Description:</strong> Create pack definitions for popular managed MCP or remote
+            API services: Google Cloud, GitHub, Linear, docs/search, package security, and internal
+            platform tools. A pack would define the remote endpoint, operation filters, auth/scopes,
+            result contracts, media artifact policy, runtime needs, eval flight, and trust ledger.
+          </p>
+          <dl>
+            <dt>Basis</dt>
+            <dd>
+              direct: Caplets supports local, self-hosted remote, Cloud, Project Binding,
+              config/Caplet files, nested sets, and multiple backend families (<a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/docs/architecture.md"
+                >docs/architecture.md lines 9-24 and 93-127</a
+              >). external: Google announced 50+ managed MCP servers with Agent Registry, IAM, Model
+              Armor, audit logs, and interoperability across Gemini CLI, Claude, ChatGPT, VS Code,
+              LangChain, ADK, and CrewAI (<a
+                href="https://cloud.google.com/blog/products/ai-machine-learning/google-managed-mcp-servers-are-available-for-everyone"
+                >Google Cloud blog</a
+              >).
+            </dd>
+            <dt>Rationale</dt>
+            <dd>
+              The market is moving from local MCP tinkering to managed remote tool ecosystems.
+              Caplets can be the layer that makes those endpoints agent-usable, policy-aware, and
+              benchmarked.
+            </dd>
+            <dt>Downsides</dt>
+            <dd>
+              This can drift into marketplace work. Keep the first version as repo-owned packs with
+              hard quality bars, not a broad public directory.
+            </dd>
+          </dl>
+        </article>
+
+        <article class="idea-card" id="idea-7">
+          <div class="idea-head">
+            <span class="rank">7</span>
+            <div class="idea-title">
+              <h3>Capability Graph Workspace</h3>
+              <p>
+                A machine-readable and human-readable map of capabilities, operations, resources,
+                prompts, auth, artifacts, and runtime requirements.
+              </p>
+            </div>
+            <span class="pill">CONF 74% · CX M</span>
+          </div>
+          <p>
+            <strong>Description:</strong> Add a graph export and docs/Cloud view that shows each
+            Caplet as a region: backend kind, available tools/resources/prompts, auth scopes, setup
+            state, Project Binding needs, result contracts, and likely next actions.
+          </p>
+          <dl>
+            <dt>Basis</dt>
+            <dd>
+              direct: The architecture already has a common manager shape for listing, searching,
+              describing, calling, checking, and exposing MCP resources/prompts/completion, while
+              Caplet files include source, setup, binding, runtime, and backend metadata (<a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/docs/architecture.md#engine"
+                >docs/architecture.md lines 25-53 and 103-121</a
+              >;
+              <a
+                href="https://github.com/spiritledsoftware/caplets/blob/main/apps/docs/src/content/docs/reference/code-mode-api.mdx"
+                >apps/docs/src/content/docs/reference/code-mode-api.mdx lines 130-160</a
+              >).
+            </dd>
+            <dt>Rationale</dt>
+            <dd>
+              The product metaphor is capability cards for sprawling tool stacks. A graph makes the
+              capability space inspectable without flattening it into a giant tool wall.
+            </dd>
+            <dt>Downsides</dt>
+            <dd>
+              Visual polish is secondary. The graph must first be useful as a stable JSON export
+              that agents and tests can consume.
+            </dd>
+          </dl>
+        </article>
+      </section>
+
+      <section class="section" id="rejection-summary">
+        <div class="eyebrow">Rejection Summary</div>
+        <h2>Rejection Summary</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Idea</th>
+              <th>Reason Rejected</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+              <td>Durable Heap Snapshots</td>
+              <td>
+                Rejected because current Code Mode deliberately uses live sessions plus recovery
+                journals, not durable heap persistence.
+              </td>
+            </tr>
+            <tr>
+              <td>2</td>
+              <td>Auto-Confirm Destructive Actions</td>
+              <td>
+                Rejected because Caplets exposes safety hints; clients and agents decide
+                confirmation.
+              </td>
+            </tr>
+            <tr>
+              <td>3</td>
+              <td>Inline Media Everywhere</td>
+              <td>
+                Rejected because media artifacts are already the accepted non-inline result
+                contract.
+              </td>
+            </tr>
+            <tr>
+              <td>4</td>
+              <td>Direct Fetch Escape Hatch</td>
+              <td>Rejected because Code Mode intentionally routes I/O through Caplet handles.</td>
+            </tr>
+            <tr>
+              <td>5</td>
+              <td>Global MCP Marketplace Clone</td>
+              <td>
+                Rejected as too broad and less differentiated than quality-gated Gateway Packs.
+              </td>
+            </tr>
+            <tr>
+              <td>6</td>
+              <td>Caplet Pairing Mode</td>
+              <td>
+                Interesting, but weaker than workflow promotion and evals as a near-term product
+                direction.
+              </td>
+            </tr>
+            <tr>
+              <td>7</td>
+              <td>Landing Playground</td>
+              <td>
+                Useful demo work, but less product-leveraged than core capability workflow features.
+              </td>
+            </tr>
+            <tr>
+              <td>8</td>
+              <td>Agent Memory Handoff Bundle</td>
+              <td>
+                Folded into Caplet Forge and Trust Ledger; not strong enough as a separate feature.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <footer class="composition-signal">
+        Composed 2026-06-18T00:00:00-04:00 by ce-ideate from open-ended surprise-me prompt in
+        <code>/Users/ianpascoe/src/caplets</code>.
+      </footer>
+    </main>
+  </body>
+</html>

--- a/docs/native-integrations.md
+++ b/docs/native-integrations.md
@@ -12,7 +12,7 @@ OpenCode and Pi use the same resolver as `caplets attach`.
 
 - `CAPLETS_MODE=local` exposes local/user/project Caplets only.
 - `CAPLETS_MODE=remote` requires `CAPLETS_REMOTE_URL` and connects to a self-hosted Caplets service.
-- `CAPLETS_MODE=cloud` requires `CAPLETS_REMOTE_URL` pointing at Caplets Cloud and uses saved `caplets cloud auth login` credentials.
+- `CAPLETS_MODE=cloud` requires `CAPLETS_REMOTE_URL` pointing at Caplets Cloud and uses the saved Remote Profile from `caplets remote login <cloud-url>`.
 - `CAPLETS_MODE=auto` treats Cloud URLs as Cloud, non-Cloud remote URLs as self-hosted, and no remote URL as local.
 
 Cloud mode starts Project Binding automatically for the current project and overlays local/project Caplets over the remote workspace.

--- a/docs/plans/2026-06-19-001-feat-unified-remote-attach-auth-plan.md
+++ b/docs/plans/2026-06-19-001-feat-unified-remote-attach-auth-plan.md
@@ -1,0 +1,554 @@
+---
+title: "feat: Unify remote attach authentication"
+type: feat
+date: 2026-06-19
+origin: docs/brainstorms/2026-06-19-unified-remote-attach-auth-requirements.md
+deepened: 2026-06-19
+---
+
+# feat: Unify remote attach authentication
+
+## Summary
+
+Implement provider-neutral Remote Login for Caplets Cloud and self-hosted Caplets. After this work, users trust a host once with `caplets remote login <url>`, then `caplets attach --remote-url <url>` and native integrations resolve Caplets-owned credentials without agent env secrets, env-token setup, or Basic Auth.
+
+This is a pre-1.0 breaking change. The plan removes Basic Auth and `CAPLETS_REMOTE_TOKEN` from the supported self-hosted remote attach, MCP, and control product path immediately rather than keeping a warning-backed compatibility fallback.
+
+---
+
+## Problem Frame
+
+Remote attach currently has two user models. Caplets Cloud uses saved Cloud Auth state through `caplets cloud auth login`, while self-hosted remotes rely on `CAPLETS_REMOTE_TOKEN` or Basic Auth through flags and environment variables. That split leaks into setup docs, native integration docs, MCP client config, recovery messages, and tests.
+
+The target product shape is that Caplets owns remote trust. Agent configs should install a launch command and host URL, not a credential. This aligns with the strategy track for making local, self-hosted remote, and Cloud-backed execution behave as one capability model with explicit auth refresh, diagnostics, and recovery.
+
+---
+
+## Requirements
+
+This plan carries the origin requirements, with R27-R30 expanded by the user's pre-1.0 decision to remove Basic Auth immediately, by review-confirmed coverage for env-token removal, and by proxy-origin hardening for callback and recovery URLs.
+
+**Unified remote login**
+
+- R1. `caplets remote login <url>` authenticates this machine to a Caplets host, whether the host is self-hosted or Caplets Cloud.
+- R2. `caplets remote status` shows saved remote credentials in redacted form, including host URL, host kind, selected workspace when applicable, client label, created time, and last-used time when available.
+- R3. `caplets remote logout <url>` removes this machine's saved credentials for that host.
+- R4. `caplets attach --remote-url <url>` resolves stored credentials for the normalized host URL without requiring `CAPLETS_REMOTE_TOKEN`, `CAPLETS_REMOTE_USER`, or `CAPLETS_REMOTE_PASSWORD`.
+- R5. Attach mode inference remains URL-driven: Cloud URLs use the hosted Cloud path, and non-Cloud URLs use the self-hosted path.
+
+**Self-hosted pairing**
+
+- R6. A self-hosted server operator can mint a short-lived one-time Pairing Code from the server environment.
+- R7. Pairing Codes are scoped to one host, expire within minutes by default, are rate-limited, and are stored server-side only as non-reusable verification material.
+- R8. A client can exchange a valid Pairing Code through `caplets remote login <url>` with a non-echoing prompt by default, a stdin path for automation, and any `--code` path treated as explicit noninteractive use with warnings.
+- R9. Successful self-hosted login issues client credentials that are stored by Caplets on the client and can be revoked independently on the server.
+- R10. Pairing Code exchange never turns the copied code into the long-lived bearer credential.
+
+**Credential lifecycle**
+
+- R11. Remote credentials are keyed by normalized host URL and, for hosted Cloud, selected workspace.
+- R12. Access credentials used for attach are audience-restricted to their issuing Caplets host.
+- R13. Long-lived refresh material is rotated or otherwise constrained so stealing one stale token is not enough for indefinite access.
+- R14. Credential storage is owned by Caplets and uses restrictive local permissions, with OS credential storage preferred when available.
+- R15. CLI output, diagnostics, JSON errors, and logs redact remote access credentials, refresh credentials, client secrets, and Pairing Codes.
+- R16. The server can list and revoke paired clients by stable client identity, label, created time, and last-used time.
+
+**Cloud migration**
+
+- R17. `caplets cloud auth login` is deprecated in favor of `caplets remote login <cloud-url>`.
+- R18. Existing Cloud credentials continue to work during migration or are migrated automatically into the unified remote credential store.
+- R19. Cloud workspace selection is represented as part of the Remote Profile, not as a separate auth model.
+- R20. Recovery messages that currently say `caplets cloud auth login` point users to the unified remote login command.
+
+**Agent setup and docs**
+
+- R21. First-run docs use `add-mcp` for generic MCP wiring instead of making `caplets setup` the primary path.
+- R22. Local MCP docs install `caplets serve` through `add-mcp`.
+- R23. Remote MCP docs install `caplets attach --remote-url <url>` through `add-mcp` after the user has completed `caplets remote login <url>`.
+- R24. Remote MCP docs do not recommend `add-mcp --env` for Caplets remote credentials.
+- R25. Native OpenCode and Pi docs use their native extension setup paths and the same Remote Login model.
+- R26. `caplets setup` is reduced to a transitional router that points users at `add-mcp`, Remote Login, and native extension docs.
+
+**Legacy self-hosted auth removal**
+
+- R27. Self-hosted Basic Auth is removed from the self-hosted attach, MCP, and control model.
+- R28. `CAPLETS_REMOTE_TOKEN`-based self-hosted attach is also removed from the supported path for this pre-1.0 change.
+- R29. New tests and docs must not describe Basic Auth or `CAPLETS_REMOTE_TOKEN` as a supported self-hosted setup path.
+
+**Proxy and callback origin safety**
+
+- R30. Callback and recovery URL generation behind a proxy uses an explicit public origin or trusted proxy-derived `Host`, `X-Forwarded-Host`, and `X-Forwarded-Proto` values, never arbitrary client-provided origin headers.
+
+---
+
+## Actors and Flows
+
+- A1. **Self-hosted server operator:** Runs the Caplets HTTP service, creates Pairing Codes, and revokes paired clients.
+- A2. **Remote client user:** Logs a local machine into a Caplets host and configures agents to launch attach.
+- A3. **Agent or MCP client:** Starts `caplets attach --remote-url ...` and receives the remote-backed Caplets surface.
+- A4. **Caplets host:** Issues Pairing Codes, exchanges them for client credentials, validates attach requests, and records client identity.
+- A5. **Caplets Cloud:** Implements the same Remote Login contract while preserving hosted workspace selection and refresh behavior.
+
+The implementation must preserve F1 self-hosted host pairing, F2 Cloud host login, F3 agent wiring after Remote Login, F4 client revocation, and F5 legacy Cloud migration from the origin document.
+
+---
+
+## Key Technical Decisions
+
+| ID     | Decision                                                                                                                                            | Rationale                                                                                                                                                               |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| KTD1.  | Remote Profile is the client-side source of truth for remote host trust.                                                                            | This satisfies R1-R5 and keeps agent configs free of remote secrets.                                                                                                    |
+| KTD2.  | Stored Remote Profile credentials replace `CAPLETS_REMOTE_TOKEN`, `CAPLETS_REMOTE_USER`, and `CAPLETS_REMOTE_PASSWORD` for supported attach auth.   | The normal path cannot depend on env-secret propagation if Caplets owns remote trust.                                                                                   |
+| KTD3.  | Self-hosted login uses a Caplets-native device-code-style Pairing Code exchange rather than turning self-hosted Caplets into a full OAuth provider. | RFC 8628 gives the right short-code constraints, while Caplets only needs host trust and client revocation.                                                             |
+| KTD4.  | Self-hosted remote auth uses explicit route classes instead of one blanket middleware rule.                                                         | Pairing exchange, refresh rotation, backend OAuth callback, MCP, attach, control, and operator lifecycle commands have different bootstrap and authorization needs.     |
+| KTD5.  | Self-hosted refresh material is a one-time rotating token family with hashed verification material and atomic rotation.                             | RFC 9700 and OWASP OAuth2 guidance both treat refresh-token replay and overbroad token audiences as core risks.                                                         |
+| KTD6.  | Cloud Auth internals are reused behind the Remote Login namespace and migrated into Remote Profiles.                                                | Cloud already has browser/device login, refresh, workspace, and scope behavior; the user-facing model should change without duplicating the hosted auth implementation. |
+| KTD7.  | `caplets setup` becomes a transitional router rather than the primary first-run path.                                                               | This keeps existing users oriented while moving docs and generated config guidance to `add-mcp`, Remote Login, and native extension setup.                              |
+| KTD8.  | Basic Auth is removed immediately instead of hidden for a release.                                                                                  | The project is pre-1.0, and keeping Basic Auth creates a second auth model exactly where the origin requirements remove it.                                             |
+| KTD9.  | Self-hosted client credential state is server-owned and durable.                                                                                    | R16 requires list and revoke by stable client identity, so the registry cannot be only in memory or derived from client-held secrets.                                   |
+| KTD10. | Client identity is derived from validated credentials, not client-supplied metadata.                                                                | A remote host may sit behind proxies or receive arbitrary headers, so revocation and last-used tracking must not trust forwarded identity fields.                       |
+| KTD11. | Cloud Remote Profiles include a per-host selected workspace pointer in addition to workspace-qualified profiles.                                    | Bare Cloud URLs remain ergonomic while multi-workspace status, logout, and attach stay deterministic.                                                                   |
+| KTD12. | Self-hosted server-operator lifecycle commands are server-environment operations in the first implementation.                                       | Pairing Code issuance and client list/revoke must work before any remote client exists and must not become unauthenticated network admin routes.                        |
+| KTD13. | Public-origin handling is explicit for proxied hosts.                                                                                               | Callback and recovery URLs must survive reverse proxies without trusting spoofable request headers from arbitrary clients.                                              |
+
+---
+
+## High-Level Technical Design
+
+### Component Topology
+
+```mermaid
+flowchart TB
+  CLI["caplets CLI"] --> RemoteCommands["remote login/status/logout"]
+  CLI --> HostCommands["server-local remote host pair/clients/revoke"]
+  CLI --> Attach["attach --remote-url"]
+  Native["OpenCode and Pi native services"] --> NativeResolver["native remote resolver"]
+  Agent["MCP client config"] --> Attach
+
+  RemoteCommands --> ProfileStore["Remote Profile store"]
+  RemoteCommands --> CloudAuth["Cloud Auth client/store adapter"]
+  HostCommands --> HostStore["server credential store"]
+  RemoteCommands --> PairExchange["Self-hosted Pairing Code exchange"]
+
+  Attach --> RemoteSelection["remote selection"]
+  NativeResolver --> RemoteSelection
+  RemoteSelection --> ProfileStore
+  RemoteSelection --> Refresh["credential refresh"]
+
+  PairExchange --> Host["Caplets host"]
+  Refresh --> Host
+  Attach --> Host
+  NativeResolver --> Host
+
+  Host --> Middleware["shared remote auth middleware"]
+  Middleware --> MCP["MCP route"]
+  Middleware --> AttachRoutes["attach routes"]
+  Middleware --> Control["admin/control routes"]
+  Middleware --> ProjectBinding["Project Binding routes"]
+```
+
+### Self-Hosted Remote Login Sequence
+
+```mermaid
+sequenceDiagram
+  participant Operator as Self-hosted operator
+  participant Host as Caplets host
+  participant Client as Client CLI
+  participant Store as Remote Profile store
+  participant Agent as Agent attach command
+
+  Operator->>Host: Create short-lived Pairing Code from server environment
+  Host-->>Operator: Suggested prompt-based login command
+  Client->>Client: Prompt for Pairing Code without echo
+  Client->>Host: Exchange Pairing Code for client credentials
+  Host->>Host: Verify code, rate limit, mark one-time use
+  Host-->>Client: Issue client identity, access credential, refresh material
+  Client->>Store: Save Remote Profile and secret material
+  Agent->>Client: Start caplets attach with remote URL
+  Client->>Store: Resolve and refresh credentials
+  Client->>Host: Connect with issued credential
+  Host->>Host: Validate audience, expiry, revocation, client identity
+```
+
+### Self-Hosted Remote Auth Contract
+
+| Route class                                             | Actor                         | Accepted credential                      | Plan requirement                                                                                                                         |
+| ------------------------------------------------------- | ----------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Health and version                                      | Any caller                    | Public                                   | Remain public and do not disclose remote credential state.                                                                               |
+| Pairing Code issuance                                   | Self-hosted server operator   | Server-environment authority only        | Runs against the server-owned credential store; no unauthenticated remote caller can mint Pairing Codes.                                 |
+| Pairing Code exchange                                   | Remote client user            | Valid Pairing Code verifier              | Network-reachable before login, but bound by host, TTL, one-time use, hashing, and rate limits.                                          |
+| Refresh and rotation                                    | Remote client runtime         | Refresh material                         | Uses a one-time rotating token family with hashed verifier, atomic compare-and-swap, stale-token reuse detection, and revocation checks. |
+| MCP, attach, Project Binding, and normal remote control | Agent or authenticated client | Issued access credential                 | Protected by the remote credential validator and derives client identity from validated credentials only.                                |
+| Backend OAuth callback                                  | Browser callback              | Flow id validated by backend OAuth state | Stays reachable without remote host credentials so `caplets auth login <caplet-id>` remains separate from Remote Login.                  |
+| Self-hosted client list and revoke                      | Self-hosted server operator   | Server-environment authority only        | Reads and mutates server-owned credential state; normal paired-client credentials cannot list, mint, or revoke clients.                  |
+
+The Basic-shaped HTTP auth state should be replaced with explicit modes such as `none`, `remote_credentials`, and `development_unauthenticated`. Serve option resolution, daemon serialization/redaction, service discovery auth metadata, DNS-rebinding allowed-host logic, and route middleware should treat `remote_credentials` as protected.
+
+### Attach Selection Flow
+
+```mermaid
+flowchart TB
+  Start["attach/native request has remote URL"] --> Normalize["Normalize host URL"]
+  Normalize --> Cloud{"Cloud URL?"}
+  Cloud -->|yes| CloudProfile["Load Cloud Remote Profile or migrate legacy Cloud Auth"]
+  Cloud -->|no| HostedProfile["Load self-hosted Remote Profile"]
+  CloudProfile --> Found{"Profile found?"}
+  HostedProfile --> Found
+  Found -->|no| Recover["Fail closed with remote login recovery"]
+  Found -->|yes| Fresh{"Access credential valid?"}
+  Fresh -->|yes| Connect["Connect with profile credential"]
+  Fresh -->|no| Refresh["Refresh or rotate credential"]
+  Refresh --> RefreshOk{"Refresh accepted?"}
+  RefreshOk -->|yes| Connect
+  RefreshOk -->|no| Recover
+```
+
+### Credential Lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> Unpaired
+  Unpaired --> PairingIssued: operator creates Pairing Code
+  PairingIssued --> ProfileStored: client exchanges valid code
+  PairingIssued --> Expired: ttl expires or attempts exhausted
+  ProfileStored --> AccessValid: access credential issued
+  AccessValid --> RefreshRotated: refresh succeeds
+  RefreshRotated --> AccessValid: store new material
+  AccessValid --> Revoked: operator revokes client
+  RefreshRotated --> Revoked: operator revokes client
+  AccessValid --> Expired: refresh fails closed
+  Revoked --> LoginRequired
+  Expired --> LoginRequired
+  LoginRequired --> PairingIssued: new Pairing Code
+```
+
+---
+
+## Implementation Units
+
+### U1. Remote Profile and Credential Storage
+
+- **Goal:** Introduce the client-side Remote Profile model and credential store that can represent Cloud and self-hosted host trust.
+- **Requirements:** R1-R4, R11-R15, R18-R19, F2, F5, AE1, AE4, AE6.
+- **Dependencies:** None.
+- **Files:**
+  - `packages/core/src/remote/profiles.ts` (new)
+  - `packages/core/src/remote/profile-store.ts` (new)
+  - `packages/core/src/remote/credential-store.ts` (new)
+  - `packages/core/src/remote/options.ts`
+  - `packages/core/src/cloud-auth/store.ts`
+  - `packages/core/src/auth/store.ts`
+  - `packages/core/src/redaction.ts`
+  - `packages/core/test/remote-profiles.test.ts` (new)
+  - `packages/core/test/cloud-auth.test.ts`
+  - `packages/core/test/redaction.test.ts`
+- **Approach:** Define a normalized Remote Profile key from host URL plus Cloud workspace when applicable. Store redacted metadata separately from secret material, and reuse the atomic restrictive file-write pattern already present in `packages/core/src/auth/store.ts`. The first implementation should use a concrete file-backed credential store behind the Remote Profile API; OS credential backend selection stays follow-up work. Cloud profiles should also maintain a per-host selected workspace pointer for bare Cloud-origin attach. Legacy Cloud Auth state should be read lazily, and migration must not delete the legacy record until after the new Remote Profile write succeeds.
+- **Execution note:** Implement the store tests first because every later unit depends on the credential lifecycle contract.
+- **Patterns to follow:** `packages/core/src/auth/store.ts` for restrictive permissions and atomic writes, `packages/core/src/cloud-auth/store.ts` for current Cloud credential shape, and `packages/core/src/remote/options.ts` for URL normalization.
+- **Test scenarios:**
+  - Covers AE1. Saving a Cloud Remote Profile with a selected workspace persists host kind, normalized URL, workspace, client label, and redacted status.
+  - Covers AE4. Loading profile status never returns raw access credentials, refresh credentials, client secrets, or Pairing Codes.
+  - Covers AE6. A legacy Cloud Auth record is migrated or read through the Remote Profile store without deleting the legacy record before the new write succeeds.
+  - A malformed or credential-bearing remote URL is rejected or normalized without persisting embedded username, password, query secret, or fragment secret.
+  - Two Cloud workspaces under the same Cloud host produce distinct profile keys and a redacted selected-workspace pointer.
+  - Logout removes the selected profile and its secret material without removing unrelated host profiles.
+  - A bare Cloud host with multiple profiles requires a selected workspace, explicit workspace selector, or all-workspaces operation before status/logout mutates anything.
+  - File-backed storage creates private directories and credential files with restrictive permissions on supported platforms.
+- **Verification:** Remote Profile status is redacted, Cloud legacy credentials still resolve through the new store, and credential files do not expose raw secrets through CLI or JSON status output.
+
+### U2. Self-Hosted Pairing and Server Credential Validation
+
+- **Goal:** Replace self-hosted Basic Auth and env-token auth with server-side Pairing Code issuance, issued client credential validation, and server-side revocation.
+- **Requirements:** R6-R7, R9-R10, R12-R16, R27-R30, F1, F4, AE5, AE8-AE10.
+- **Dependencies:** U1.
+- **Files:**
+  - `packages/core/src/remote/pairing.ts` (new)
+  - `packages/core/src/remote/server-credentials.ts` (new)
+  - `packages/core/src/remote/server-credential-store.ts` (new)
+  - `packages/core/src/serve/http.ts`
+  - `packages/core/src/serve/options.ts`
+  - `packages/core/src/server/options.ts`
+  - `packages/core/src/cli.ts`
+  - `packages/core/test/remote-pairing.test.ts` (new)
+  - `packages/core/test/serve-http.test.ts`
+  - `packages/core/test/serve-options.test.ts`
+  - `packages/core/test/server-options.test.ts`
+- **Approach:** Add server-side Pairing Code issuance and exchange APIs, storing only non-reusable verification material for short-lived codes. Successful exchange creates a stable client identity, metadata for list/revoke, access credential material, and refresh material constrained to the issuing host. Persist the self-hosted client registry and refresh state in single-node server-owned filesystem storage with a configurable state path, restrictive permissions, atomic write/rename, and advisory locking around refresh rotation. Replace the existing Basic Auth middleware path with the route-class contract above, including a remote credential validator for MCP, attach, normal remote control, and Project Binding routes. Pairing Code issuance plus client list/revoke stay server-environment operations for the first implementation. Derive client identity, revocation state, and last-used updates from validated credentials only; labels, request bodies, and forwarded headers are display or transport metadata, not authority. Remove Basic Auth flags, env parsing, env-token parsing, and product tests from the supported self-hosted auth path.
+- **Origin handling:** Server options should prefer an explicit configured public origin for generated callback, pairing, and recovery URLs. If proxy-derived origins are supported, they must require an explicit trusted-proxy mode and validate `Host`, `X-Forwarded-Host`, and `X-Forwarded-Proto` against the configured allowed host model.
+- **Technical design:** The pairing code should be human-copyable, but the server-side verifier must be high entropy and stored hashed. The copied code is bootstrap input only; attach requests must use issued credentials tied to a client identity.
+- **Patterns to follow:** The route grouping and central auth placement in `packages/core/src/serve/http.ts`, current non-loopback HTTP safety checks in `packages/core/src/serve/options.ts`, and RFC 8628's limited-lifetime code and polling/rate-limit constraints.
+- **Test scenarios:**
+  - Covers AE5. A listed client can be revoked by stable identity, and its next attach attempt fails until Remote Login runs again.
+  - Covers AE8. Basic Auth credentials and `CAPLETS_REMOTE_TOKEN` values are not accepted as the supported auth mechanism on self-hosted MCP, attach, control, or Project Binding routes.
+  - Covers AE10. Generated callback, pairing, and recovery URLs use configured public origin or trusted proxy headers only; untrusted `Host` or `X-Forwarded-*` spoofing cannot change them.
+  - Expired Pairing Codes, reused Pairing Codes, wrong-host Pairing Codes, and attempt-exhausted Pairing Codes fail closed.
+  - Pairing Code verification is rate-limited enough that repeated invalid attempts do not produce unlimited guesses.
+  - A valid issued credential is accepted by MCP, attach, Project Binding, and normal remote control routes, but not by server-operator pair/list/revoke commands.
+  - The backend OAuth callback remains flow-id-bound and reachable without a remote host credential, while normal admin/control actions require issued remote credentials.
+  - Refresh credentials form a one-time rotating token family with hashed verifier storage, atomic compare-and-swap, stale-token reuse detection, and family invalidation on superseded-token reuse.
+  - A stale refresh credential is not enough to regain access after rotation, superseded-token reuse, or revocation.
+  - A configured custom server state path stores client identity, revocation, and refresh state with restrictive permissions.
+  - Client list and revoke metadata survive a host restart when server-owned state is present.
+  - Revocation survives restart and invalidates both access and refresh material for the revoked client.
+  - Concurrent refresh attempts do not fork refresh state or leave two valid successors.
+  - Spoofed client labels, request metadata, or forwarded identity headers do not bypass revocation or alter the validated client identity.
+  - Non-loopback HTTP still refuses unsafe unauthenticated exposure unless the explicit unauthenticated development override is used.
+- **Verification:** Self-hosted routes are protected by issued remote credentials, client list/revoke works without rotating every client, and no Basic Auth or env-token branch remains as a supported remote auth contract.
+
+### U3. Unified Remote CLI and Cloud Migration
+
+- **Goal:** Add the provider-neutral `caplets remote` command family and route Cloud Auth behavior through Remote Profiles.
+- **Requirements:** R1-R3, R6, R8, R16-R20, F1, F2, F4, F5, AE1, AE2, AE5, AE6.
+- **Dependencies:** U1, U2.
+- **Files:**
+  - `packages/core/src/cli/commands.ts`
+  - `packages/core/src/cli.ts`
+  - `packages/core/src/cloud-auth/client.ts`
+  - `packages/core/src/cloud-auth/errors.ts`
+  - `packages/core/src/cloud-auth/store.ts`
+  - `packages/core/src/remote/selection.ts`
+  - `packages/core/src/remote/profiles.ts`
+  - `packages/core/test/remote-login-cli.test.ts` (new)
+  - `packages/core/test/cloud-auth-login-cli.test.ts`
+  - `packages/core/test/cloud-auth.test.ts`
+  - `packages/core/test/cli-completion.test.ts`
+- **Approach:** Add `remote login`, `remote status`, and `remote logout` as the primary client-profile commands. Cloud URLs should reuse the existing hosted login and workspace selection behavior behind the Remote Login name, writing a workspace-qualified Remote Profile and updating the selected-workspace pointer for that Cloud host. Self-hosted URLs should use the Pairing Code exchange API from U2, prompting for the Pairing Code without echo by default and supporting a non-echoing stdin path for automation. Keep any `--code` option explicit and warning-backed for noninteractive use only. Server-operator lifecycle commands should be separated from client-profile commands, such as under `caplets remote host`, so pairing issuance and client list/revoke are visibly server-environment operations. Keep `caplets cloud auth` commands as deprecated wrappers or aliases only where needed for migration; their output should point to `caplets remote`.
+- **Technical design:** Command naming should preserve the separate meaning of `caplets auth login <caplet-id>` for backend Caplet OAuth. Remote host auth commands must not be placed under `caplets auth`. Bare Cloud host status/logout should use the selected workspace when one is unambiguous, fail with redacted workspace choices when multiple profiles exist, and support explicit workspace selection plus an all-workspaces operation for destructive cleanup.
+- **Patterns to follow:** `packages/core/src/cli/commands.ts` for subcommand inventory, `packages/core/src/cli.ts` for current Cloud Auth command implementation, and `packages/core/test/cloud-auth-login-cli.test.ts` for CLI fixture style.
+- **Test scenarios:**
+  - Covers AE1. `remote login` against a Cloud URL stores a Cloud Remote Profile with selected workspace metadata.
+  - Covers AE2. `remote login` against a self-hosted URL prompts for a valid Pairing Code, stores a self-hosted Remote Profile, and later attach uses issued client credentials rather than the copied code.
+  - Covers AE5. Server-side client list output shows stable client identity, label, created time, and last-used time without secrets, and revoke invalidates that client.
+  - Covers AE6. Existing Cloud Auth state is accepted through the new Remote Profile path, and recovery guidance names `caplets remote login`.
+  - `remote status` redacts every credential field and can filter or select by host URL.
+  - `remote status` and `remote logout` handle one workspace, multiple workspaces under one Cloud host, workspace-qualified URLs, explicit workspace selection, and all-workspaces cleanup deterministically.
+  - `remote logout` removes local profile state and performs best-effort server revocation when a live credential is available.
+  - Generated self-hosted pairing commands do not echo Pairing Codes in argv, terminal output, or diagnostics.
+  - `caplets cloud auth login/status/logout/switch` either delegates to the Remote Profile implementation or emits deprecation guidance without creating a separate credential model.
+  - CLI completions include the new `remote` subcommands and omit removed Basic Auth flags.
+- **Verification:** Users can complete Cloud and self-hosted host login through one namespace, legacy Cloud users receive migration-safe behavior, and command help teaches Remote Login rather than provider-specific setup.
+
+### U4. Attach, Remote Control, and Native Resolution from Remote Profiles
+
+- **Goal:** Make CLI attach, remote control, OpenCode, and Pi resolve stored Remote Profiles before connecting to a host.
+- **Requirements:** R4-R5, R11-R15, R19-R20, R23-R25, R28-R29, F3, F5, AE3, AE4, AE6, AE9.
+- **Dependencies:** U1, U2, U3.
+- **Files:**
+  - `packages/core/src/remote/options.ts`
+  - `packages/core/src/remote/selection.ts`
+  - `packages/core/src/remote-control/client.ts`
+  - `packages/core/src/project-binding/attach.ts`
+  - `packages/core/src/project-binding/errors.ts`
+  - `packages/core/src/native/options.ts`
+  - `packages/core/src/native/service.ts`
+  - `packages/core/src/native/remote.ts`
+  - `packages/core/test/remote-options.test.ts`
+  - `packages/core/test/remote-selection.test.ts`
+  - `packages/core/test/remote-control-client.test.ts`
+  - `packages/core/test/attach-cli.test.ts`
+  - `packages/core/test/cloud-auth-refresh-attach.test.ts`
+  - `packages/core/test/native-options.test.ts`
+  - `packages/core/test/native-remote.test.ts`
+  - `packages/core/test/doctor-cli.test.ts`
+- **Approach:** Resolve remote mode from URL as today, then load the matching Remote Profile by normalized URL and workspace. For bare Cloud-origin URLs, resolve through the selected-workspace pointer; for workspace-qualified URLs, validate against that exact profile key. Refresh credentials before attach or native remote calls when needed. Remove secret-bearing env variables, env tokens, and Basic Auth fields from the supported resolver path; keep non-secret selectors such as remote URL, workspace, and mode only where they are still needed by existing native launch contracts. All missing, expired, revoked, or workspace-mismatched credentials should fail closed with Remote Login recovery text.
+- **Technical design:** Native services should use the same profile store and refresh behavior as `caplets attach`, not a parallel env-token path.
+- **Patterns to follow:** `packages/core/src/remote/selection.ts` for current Cloud refresh before attach, `packages/core/src/native/service.ts` for native Cloud selection, and `packages/core/src/project-binding/errors.ts` for structured recovery commands.
+- **Test scenarios:**
+  - Covers AE3. An agent config that runs only `caplets attach --remote-url <url>` succeeds when a matching Remote Profile exists.
+  - Covers AE4. Attach refresh and diagnostic output redact credentials and preserve host audience restrictions.
+  - Covers AE6. A Cloud URL with only legacy Cloud Auth state migrates or resolves through the Remote Profile path before attach.
+  - Self-hosted attach with no Remote Profile or only legacy env-token state fails with `caplets remote login <url>` recovery guidance.
+  - A stored self-hosted profile sends issued credential material, not `CAPLETS_REMOTE_TOKEN`, Basic Auth, or the Pairing Code.
+  - A bare Cloud-origin attach resolves the selected workspace, while multiple Cloud profiles without a selected workspace fail with redacted choices.
+  - Workspace mismatch on a Cloud profile fails with Remote Login or workspace selection guidance.
+  - Native OpenCode and Pi remote modes can connect with a remote URL plus stored profile, without remote credential env vars.
+  - Remote control 401/403 errors no longer instruct users to check Basic Auth env vars.
+- **Verification:** Every remote execution surface uses the same profile-backed auth model and every recovery path points to Remote Login.
+
+### U5. Agent Setup, Native Docs, and Public Docs Migration
+
+- **Goal:** Rewrite setup and docs around Remote Login, `add-mcp`, and native extension setup.
+- **Requirements:** R21-R29, F3, AE3, AE7-AE9.
+- **Dependencies:** U3, U4.
+- **Files:**
+  - `packages/core/src/cli/setup.ts`
+  - `packages/core/test/setup-runner.test.ts`
+  - `packages/core/test/agent-plugins.test.ts`
+  - `README.md`
+  - `packages/cli/README.md`
+  - `apps/docs/src/content/docs/index.mdx`
+  - `apps/docs/src/content/docs/install.mdx`
+  - `apps/docs/src/content/docs/agent-integrations.mdx`
+  - `apps/docs/src/content/docs/remote-attach.mdx`
+  - `apps/docs/src/content/docs/troubleshooting.mdx`
+  - `docs/native-integrations.md`
+  - `docs/project-binding.md`
+  - `docs/product/caplets-code-mode-prd.md`
+  - `docs/architecture.md`
+  - `packages/opencode/README.md`
+  - `packages/pi/README.md`
+- **Approach:** Make first-run docs say local MCP setup installs `caplets serve` through `add-mcp`, and remote MCP setup runs Remote Login first, then installs `caplets attach --remote-url <url>` through `add-mcp`. Do not recommend `add-mcp --env` or any env-secret path for Caplets remote credentials. Self-hosted pairing docs should show a prompt-based Remote Login flow and must not print Pairing Code values in generated commands. Update OpenCode and Pi docs to use native extension setup plus the same Remote Login model. Reduce `caplets setup` to a transitional router that points to the current setup path and no longer suggests remote secret env vars. Verify `add-mcp@1.10.4` syntax during implementation before finalizing examples.
+- **Patterns to follow:** Current README and docs structure, `packages/cli` prepack copying from `README.md`, and existing docs check scripts for generated public docs.
+- **Test scenarios:**
+  - Covers AE3. Generated or dry-run setup output for remote MCP contains the attach command and URL but no remote token, password, Basic Auth, or `add-mcp --env` credential instruction.
+  - Covers AE7. Install docs route MCP users through `add-mcp` and native users through OpenCode or Pi extension setup.
+  - Covers AE8. Current self-hosted docs never ask a user to configure Basic Auth.
+  - Current self-hosted docs never ask a user to configure `CAPLETS_REMOTE_TOKEN` for the supported path.
+  - Remote attach docs show Remote Login before attach for both Cloud and self-hosted hosts.
+  - Pairing docs and setup output do not echo Pairing Codes inside command argv, generated config, or diagnostics.
+  - Troubleshooting docs recover missing or revoked credentials with `caplets remote login`, not env-secret instructions.
+  - Package README copies or generated docs do not drift from the root README.
+- **Verification:** Public docs, package READMEs, and setup output all teach the same no-secret agent config model.
+
+### U6. Diagnostics, Redaction, Package Contract, and Release Gate
+
+- **Goal:** Align diagnostics, generated surfaces, package metadata, and release artifacts with the new auth model.
+- **Requirements:** R2, R12-R15, R20, R28-R29, AE4, AE6, AE8-AE9.
+- **Dependencies:** U1, U2, U3, U4, U5.
+- **Files:**
+  - `packages/core/src/cli/doctor.ts`
+  - `packages/core/src/redaction.ts`
+  - `packages/core/src/code-mode/logs.ts`
+  - `packages/core/src/project-binding/errors.ts`
+  - `packages/core/src/cloud-auth/errors.ts`
+  - `packages/core/src/index.ts`
+  - `packages/core/src/native.ts`
+  - `packages/core/test/doctor-cli.test.ts`
+  - `packages/core/test/redaction.test.ts`
+  - `packages/core/test/code-mode-logs.test.ts`
+  - `packages/core/test/cli-completion.test.ts`
+  - `.changeset/*.md`
+- **Approach:** Update doctor output to report Remote Profile status and Remote Login recovery. Extend redaction to new credential prefixes, refresh material, Pairing Codes, client secret fields, serialized Remote Profile secret payloads, and any noninteractive Pairing Code option. Ensure public exports expose only stable Remote Profile and native resolver types needed by downstream packages. Add a changeset because the CLI, core runtime, docs, and native packages change user-facing auth behavior.
+- **Patterns to follow:** Current doctor Cloud Auth checks, existing redaction helper coverage, and the Changesets release process already used by the repo.
+- **Test scenarios:**
+  - Covers AE4. Logs, doctor output, JSON errors, and Code Mode logs redact remote credentials and Pairing Codes.
+  - Covers AE6. Doctor and Project Binding recovery text name `caplets remote login` for missing or revoked Cloud credentials.
+  - Covers AE8. Completion and help output do not expose Basic Auth as a remote setup path.
+  - Completion, help, and doctor output do not expose `CAPLETS_REMOTE_TOKEN` as a supported self-hosted setup path.
+  - Missing profile diagnostics name host URL and workspace metadata only in redacted form.
+  - Exported package types compile after adding Remote Profile helpers and native profile-backed resolution.
+  - The changeset describes the breaking pre-1.0 auth model change.
+- **Verification:** Diagnostics are useful without leaking credentials, generated/API checks stay current, and the repo gate passes with the new public contract.
+
+---
+
+## Phased Delivery
+
+- **Phase 1: Credential substrate.** Land U1 and U2 so both client and server have one trust model and Basic Auth plus env-token auth are removed at the auth boundary.
+- **Phase 2: Command and runtime surfaces.** Land U3 and U4 so CLI, attach, remote control, OpenCode, and Pi use Remote Profiles.
+- **Phase 3: Public contract cleanup.** Land U5 and U6 so docs, setup, diagnostics, exports, and release notes match the implementation.
+
+The phases are dependency groups, not separate product promises. The branch should not ship publicly until Phase 3 is complete because partial shipping would leave docs or integrations teaching stale auth behavior.
+
+---
+
+## Scope Boundaries
+
+### Deferred for later
+
+- Hardware-backed or sender-constrained credentials beyond the best available software credential model.
+- Multi-user role and permission administration for self-hosted teams beyond client listing and revocation.
+- Automatic migration of every possible third-party MCP config that may already contain Caplets env secrets.
+
+### Outside this product's identity
+
+- Using agent MCP configs as the source of truth for Caplets secrets.
+- Treating Basic Auth as the long-term self-hosted authentication model.
+- Replacing backend Caplet OAuth with remote host login.
+
+### Deferred to Follow-Up Work
+
+- A full cross-platform OS keychain dependency decision after the first concrete file-backed Remote Profile credential store ships.
+- Automatic editing of existing third-party agent configs that already contain old Caplets credential env vars.
+- Fine-grained self-hosted user roles beyond the server operator's ability to list and revoke paired clients.
+
+---
+
+## System-Wide Impact
+
+- **CLI contract:** Adds `caplets remote` as a top-level auth namespace and demotes `caplets cloud auth` to migration guidance.
+- **HTTP auth boundary:** Replaces the current Basic Auth gate for remote host routes with explicit route classes and issued remote credential validation.
+- **Native integrations:** Makes OpenCode and Pi resolve stored Remote Profiles instead of secret env vars.
+- **Project Binding:** Changes Cloud and self-hosted recovery commands to Remote Login while preserving fail-closed behavior.
+- **Docs and setup:** Moves first-run MCP setup to `add-mcp` plus Remote Login, and keeps `caplets setup` as a transitional router.
+- **Release posture:** This is a breaking pre-1.0 auth change for `caplets`, `@caplets/core`, `@caplets/opencode`, and `@caplets/pi` users who rely on old self-hosted env-secret, `CAPLETS_REMOTE_TOKEN`, or Basic Auth setup.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given a user runs `caplets remote login https://cloud.caplets.dev`, when hosted auth completes, then Caplets stores a Cloud Remote Profile with the selected workspace.
+- AE2. Given a server operator creates a Pairing Code and a client enters it through prompt or stdin, when the client later attaches, then it uses issued client credentials rather than the original copied code.
+- AE3. Given a user has completed Remote Login, when they install `caplets attach --remote-url <url>` through `add-mcp`, then the agent config contains no remote token, password, or Caplets credential env vars.
+- AE4. Given a remote credential is stored locally, when attach refreshes or reports diagnostics, then credentials remain host-scoped and redacted from output.
+- AE5. Given a self-hosted operator lists paired clients, when they revoke one client, then that client's next attach attempt fails until it logs in again.
+- AE6. Given a user still has legacy Cloud Auth state, when attach requires credentials, then Caplets either migrates the state or reports a recovery command using `caplets remote login`.
+- AE7. Given a first-time user reads install docs, when they choose MCP or native setup, then the docs send them through `add-mcp` for MCP and native extension setup for OpenCode or Pi.
+- AE8. Given a user follows current docs, when they self-host and attach, then they never configure Basic Auth or `CAPLETS_REMOTE_TOKEN`.
+- AE9. Given a self-hosted user has only old `CAPLETS_REMOTE_TOKEN` state or env, when attach runs, then it fails closed with `caplets remote login <url>` recovery guidance and does not use the token.
+- AE10. Given a self-hosted host is behind a reverse proxy, when callback, pairing, or recovery URLs are generated, then they use configured public origin or trusted proxy headers and reject spoofed untrusted host/proto input.
+
+---
+
+## Risks and Mitigations
+
+| Risk                                                                              | Mitigation                                                                                                                                                                                                           |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A protected route keeps the old Basic Auth, env-token, or unauthenticated branch. | Replace auth in the shared HTTP middleware boundary and add route-category tests for MCP, attach, admin/control, Project Binding, backend OAuth callback, pairing, refresh, and server-operator routes.              |
+| Cloud migration breaks users with existing saved Cloud Auth.                      | Keep legacy Cloud Auth reads during migration and test legacy state before removing any old file.                                                                                                                    |
+| Pairing Codes become reusable credentials in practice.                            | Store only hashed verification material server-side, enforce one-time use, and test that copied codes cannot authenticate attach.                                                                                    |
+| Refresh-token replay gives long-term access after theft.                          | Use a one-time rotating token family with hashed verifier storage, atomic rotation, stale-token reuse detection, and revocation invalidation for both current access and refresh material.                           |
+| The self-hosted client registry is accidentally in-memory only.                   | Persist client identity, revocation, and refresh state in server-owned storage and test restart behavior.                                                                                                            |
+| A reverse proxy or malicious client injects identity or origin headers.           | Sanitize identity headers, derive client identity only from validated remote credentials, and generate public URLs only from configured public origin or explicitly trusted proxy `Host` and `X-Forwarded-*` inputs. |
+| Native integrations drift from CLI attach.                                        | Route OpenCode, Pi, and CLI attach through the same Remote Profile resolution and refresh helpers.                                                                                                                   |
+| Docs continue teaching env-secret setup through stale pages.                      | Include README, docs site, package READMEs, troubleshooting docs, and setup dry-run output in U5 verification.                                                                                                       |
+| `add-mcp` syntax or support changes during implementation.                        | Verify the current package help/source during U5 before finalizing docs examples; the planning pass confirmed npm package version `1.10.4`.                                                                          |
+
+---
+
+## Alternative Approaches Considered
+
+- **Keep Basic Auth for one release:** Rejected. The project is pre-1.0, and a hidden fallback would preserve the split auth model this plan removes.
+- **Keep Cloud Auth as a separate user-facing namespace:** Rejected. The origin requirement is one Remote Login model with Cloud as one host kind.
+- **Keep env-token auth for self-hosted remotes:** Rejected for supported setup. It keeps secrets in agent launch environments, splits recovery paths, and fails the no-secret config goal.
+- **Implement a complete OAuth provider for self-hosted Caplets:** Rejected. A Caplets-native device-code-style exchange covers host trust, client identity, refresh, and revocation without overbuilding identity administration.
+- **Block on full OS keychain parity before shipping Remote Profiles:** Rejected. The first implementation uses a concrete restrictive file-backed Remote Profile credential store so the command contract can ship while preserving a path to better platform storage.
+
+---
+
+## Documentation and Operational Notes
+
+- Public docs should use Remote Login vocabulary consistently: Remote Login, Pairing Code, and Remote Profile are already defined in `CONCEPTS.md`.
+- `caplets auth login <caplet-id>` must stay documented as backend Caplet OAuth, not remote host authentication.
+- Server operator docs need to state that Pairing Codes are short-lived bootstrap material and revocation is per paired client.
+- Pairing examples should use the prompt or stdin flow and should not put Pairing Code values in generated command argv, config, or diagnostics.
+- Troubleshooting docs should distinguish missing host login from backend Caplet OAuth failures.
+- Self-hosted deployment docs should state that TLS termination and reverse proxies must not inject trusted client identity into Caplets remote auth, and must document explicit public origin or trusted proxy handling for `Host`, `X-Forwarded-Host`, and `X-Forwarded-Proto`.
+- Package changes need a changeset because users may need to replace env-secret setup with Remote Login before upgrading.
+
+---
+
+## Verification Strategy
+
+- Focused unit tests should prove Remote Profile storage, redaction, Cloud migration, Pairing Code lifecycle, server revocation, and URL/workspace keying.
+- Integration tests should prove every protected remote route accepts issued credentials, rejects Basic Auth and `CAPLETS_REMOTE_TOKEN` as supported mechanisms, and preserves the backend OAuth callback exception.
+- CLI tests should prove `remote login/status/logout`, Cloud migration wrappers, recovery text, and completions match the new command model.
+- CLI tests should prove self-hosted login prompts for Pairing Codes or accepts stdin by default, treats `--code` as explicit warning-backed noninteractive use, and does not echo Pairing Codes in generated commands.
+- Native tests should prove OpenCode and Pi can connect using stored Remote Profiles and non-secret selectors.
+- Docs checks should prove public docs and package READMEs no longer teach Basic Auth or remote credential env vars as the normal path.
+- Proxy-origin tests should prove callback, pairing, and recovery URLs cannot be changed through untrusted `Host` or `X-Forwarded-*` headers.
+- The final repo gate should pass after generated docs, generated schemas, Code Mode API checks, typecheck, tests, deterministic benchmarks, and build are current.
+
+---
+
+## Sources and Research
+
+- Origin requirements: `docs/brainstorms/2026-06-19-unified-remote-attach-auth-requirements.md`.
+- Strategy and glossary: `STRATEGY.md`, `CONTEXT.md`, `CONCEPTS.md`, `docs/adr/0001-code-mode-default-exposure.md`.
+- Credential storage patterns: `packages/core/src/auth/store.ts`, `packages/core/src/cloud-auth/store.ts`.
+- Current CLI and setup surfaces: `packages/core/src/cli.ts`, `packages/core/src/cli/commands.ts`, `packages/core/src/cli/setup.ts`.
+- Current remote resolution: `packages/core/src/remote/options.ts`, `packages/core/src/remote/selection.ts`, `packages/core/src/remote-control/client.ts`.
+- Current server auth boundary: `packages/core/src/serve/http.ts`, `packages/core/src/serve/options.ts`, `packages/core/src/server/options.ts`.
+- Current native and Project Binding surfaces: `packages/core/src/native/options.ts`, `packages/core/src/native/service.ts`, `packages/core/src/native/remote.ts`, `packages/core/src/project-binding/errors.ts`.
+- Current docs to update: `README.md`, `apps/docs/src/content/docs/remote-attach.mdx`, `apps/docs/src/content/docs/install.mdx`, `apps/docs/src/content/docs/agent-integrations.mdx`, `apps/docs/src/content/docs/troubleshooting.mdx`, `docs/native-integrations.md`, `docs/project-binding.md`, `packages/opencode/README.md`, `packages/pi/README.md`.
+- External references: [RFC 8628 OAuth 2.0 Device Authorization Grant](https://www.rfc-editor.org/rfc/rfc8628.html), [RFC 9700 OAuth 2.0 Security Best Current Practice](https://www.rfc-editor.org/rfc/rfc9700.html), [OWASP OAuth2 Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/OAuth2_Cheat_Sheet.html), and [`add-mcp` on npm](https://www.npmjs.com/package/add-mcp).

--- a/docs/product/caplets-code-mode-prd.md
+++ b/docs/product/caplets-code-mode-prd.md
@@ -66,7 +66,7 @@ OpenCode and Pi use the native service from `@caplets/core/native`. They expose 
 
 ### Remote And Cloud
 
-Self-hosted remotes use `CAPLETS_MODE=remote` with `CAPLETS_REMOTE_URL` and token or Basic Auth credentials. Hosted Cloud uses `CAPLETS_MODE=cloud`, `CAPLETS_REMOTE_URL`, and saved `caplets cloud auth login` credentials. Project Binding connects a local project root to a remote runtime when Cloud or remote workflows need project-local files.
+Self-hosted remotes and hosted Cloud use `caplets remote login <url>` to create a saved Remote Profile, then use `CAPLETS_MODE` with `CAPLETS_REMOTE_URL` as a non-secret selector. Project Binding connects a local project root to a remote runtime when Cloud or remote workflows need project-local files.
 
 ## Capability Model
 

--- a/docs/project-binding.md
+++ b/docs/project-binding.md
@@ -8,7 +8,7 @@ Project Binding connects one local project root to a remote Caplets runtime so p
 
 `caplets attach` opens a foreground Binding Session. It reports state events, keeps the Project Binding lease alive, and exits only when interrupted or when the session reaches a terminal state.
 
-Hosted Cloud uses `caplets cloud auth login` and a Selected Workspace. Self-hosted remotes use `CAPLETS_REMOTE_URL` plus `CAPLETS_REMOTE_TOKEN` or Basic Auth credentials. Passing `--workspace` must match the saved Selected Workspace; use `caplets cloud auth switch <workspace>` for an explicit switch.
+Hosted Cloud and self-hosted remotes use `caplets remote login <url>` and a saved Remote Profile. Passing `--workspace` must match the saved Selected Workspace; run `caplets remote login <cloud-url> --workspace <workspace>` to select a different workspace.
 
 The attach client connects to the remote `/v1/attach` API for runtime Caplet discovery and calls. `/v1/mcp` remains the ordinary agent-facing MCP endpoint and continues to honor configured exposure policy.
 
@@ -51,7 +51,7 @@ Hosted defaults are Free 25 MiB per file and 250 MiB per project, Plus 100 MiB a
 
 ## Recovery
 
-- `cloud_auth_required`: `caplets cloud auth login`
-- `workspace_switch_required`: `caplets cloud auth switch <workspace>`
+- `cloud_auth_required`: `caplets remote login <cloud-url>`
+- `workspace_switch_required`: `caplets remote login <cloud-url> --workspace <workspace>`
 - `sync_size_limit_exceeded`: add exclusions to `.capletsignore` or upgrade the workspace plan
 - `endpoint_unavailable`: `caplets doctor`

--- a/docs/solutions/integration-issues/stale-remote-profile-credentials-refresh.md
+++ b/docs/solutions/integration-issues/stale-remote-profile-credentials-refresh.md
@@ -1,0 +1,142 @@
+---
+title: Native Remote Clients Refresh Runtime Credentials Before Polls and Reconnects
+date: 2026-06-19
+category: integration-issues
+module: Native remote
+problem_type: integration_issue
+component: authentication
+symptoms:
+  - background pollers kept using stale remote profile credentials after refresh
+  - attach event reconnects reused the old authorization header
+  - remote reloads and stale retries continued against outdated runtime options
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - native-remote
+  - remote-profile
+  - credential-refresh
+  - runtime-options
+  - background-polling
+  - attach-events
+  - reconnects
+---
+
+# Native Remote Clients Refresh Runtime Credentials Before Polls and Reconnects
+
+## Problem
+
+Native remote clients were constructed with a one-time snapshot of remote runtime options. That included auth-bearing `requestInit`, so background manifest polling and attach event stream reconnects could keep using stale Remote Profile credentials after the profile refreshed.
+
+The immediate fix was commit `c354eaf` (`fix(core): refresh native remote background auth`).
+
+## Symptoms
+
+- Background attach event reconnects could keep sending the original `Authorization` header.
+- Fallback polling for the remote attach manifest reused stale auth.
+- Explicit user actions could refresh through `ProfileBackedNativeCapletsService`, while long-lived SDK clients continued with captured options.
+- Stale-manifest retry logic inside tool execution did not help independent background fetch and reconnect paths.
+
+## What Didn't Work
+
+- Refreshing credentials before explicit `reload()` and `execute()` calls was not enough; the poll timer and SSE reconnect loop can run without a user action.
+- Resetting a remote client on session failures did not cover auth-stale background requests, because the failing background requests were using a stale but structurally valid client.
+- Retrying only after `ATTACH_MANIFEST_STALE` addressed changed exports, not changed credentials.
+- Env-based remote setup was the wrong product direction for this class of issue. Prior session history settled on `caplets remote login <url>` plus Caplets-owned Remote Profiles, because agent env inheritance can be unreliable and can persist secrets in agent config (session history).
+- One-time Remote Profile resolution at process startup fixed the first request but not long-running native services and attach streams after access credentials expired or rotated (session history).
+
+## Solution
+
+Make the SDK remote client resolve runtime options at request time rather than at construction time.
+
+The SDK client now accepts a resolver:
+
+```ts
+export type SdkRemoteCapletsClientOptions = RemoteCapletsClientOptions["remote"] & {
+  resolveRuntimeOptions?: () => Promise<RemoteCapletsClientOptions["remote"]>;
+};
+```
+
+Then all outbound remote operations go through current runtime options:
+
+```ts
+const fetchCurrentManifest = async (): Promise<AttachManifest> => {
+  const runtimeOptions = await resolveRuntimeOptions();
+  return await fetchAttachManifest(
+    runtimeOptions.url,
+    runtimeOptions.requestInit,
+    runtimeOptions.fetch ?? fetch,
+  );
+};
+
+const invokeCurrentExport = async (body: {
+  revision: string;
+  kind: string;
+  exportId: string;
+  input: unknown;
+}): Promise<unknown> => {
+  const runtimeOptions = await resolveRuntimeOptions();
+  return await invokeAttachExport(
+    runtimeOptions.url,
+    runtimeOptions.requestInit,
+    runtimeOptions.fetch ?? fetch,
+    body,
+  );
+};
+```
+
+Apply the same rule to attach event stream startup and reconnect:
+
+```ts
+const startEventsNow = async () => {
+  try {
+    const runtimeOptions = await resolveRuntimeOptions();
+    if (closed || eventsAbort || listeners.size === 0) return;
+    eventsAbort = startAttachEvents(
+      runtimeOptions.url,
+      runtimeOptions.requestInit,
+      runtimeOptions.fetch ?? fetch,
+      listeners,
+      onClose,
+    );
+  } catch {
+    scheduleEventsReconnect();
+  }
+};
+```
+
+The profile-backed service wires its existing profile resolver into the client factory:
+
+```ts
+const sdkOptions: SdkRemoteCapletsClientOptions = {
+  ...remoteOptions,
+  resolveRuntimeOptions: resolveRuntimeRemoteOptions,
+};
+```
+
+That keeps `RemoteNativeCapletsService` responsible for polling and subscription lifecycle while `ProfileBackedNativeCapletsService` remains responsible for turning Remote Profiles into current request credentials.
+
+## Why This Works
+
+The root cause was request-time staleness. The client had copied credentials into a long-lived closure, so later refreshes could update the profile without changing the headers used by pollers and reconnects.
+
+Resolving runtime options immediately before each remote request makes credential freshness independent of client lifetime:
+
+- manifest polling re-reads auth before each fetch
+- attach event stream reconnects re-read auth before opening the next stream
+- tool invokes and stale-manifest retries use the same request-time auth path
+- profile-backed Remote Login remains the source of truth instead of agent env or startup-only state
+
+The event path also tracks closed state and event-start in-flight state so reconnect attempts do not duplicate or continue after shutdown.
+
+## Prevention
+
+- Treat auth-bearing request options as runtime state whenever credentials can refresh independently of client lifetime.
+- Audit background HTTP paths separately from explicit user calls. Pollers, reconnect loops, heartbeat jobs, and retry helpers often bypass the refresh points used by direct commands.
+- Regression-test token rotation at the transport boundary. The tests added with this fix assert that a second attach event connection and a later fallback poll observe `Bearer token-2` after the token changes.
+- Keep Remote Profile resolution in the profile-backed layer and pass a resolver into lower-level clients instead of teaching lower layers how to read credential stores.
+
+## Related Issues
+
+- Related low-overlap doc: [Code Mode REPL sessions](../architecture-patterns/code-mode-repl-sessions.md). It covers stale live state and recovery behavior, but not Remote Profile auth, attach event streams, or background polling.
+- GitHub issue search found no matching issues for remote auth, attach profile, stale credentials, or polling event stream credentials.

--- a/packages/core/src/attach/options.ts
+++ b/packages/core/src/attach/options.ts
@@ -36,9 +36,6 @@ export async function resolveAttachServeOptions(
 
 function attachLocalServeOptions(raw: RawAttachServeOptions): RawServeOptions {
   const {
-    user: _user,
-    password: _password,
-    token: _token,
     remoteUrl: _remoteUrl,
     workspace: _workspace,
     fetch: _fetch,

--- a/packages/core/src/attach/options.ts
+++ b/packages/core/src/attach/options.ts
@@ -15,6 +15,7 @@ export type AttachServeOptions = ServeOptions & {
   configPath: string;
   projectRoot: string;
   projectConfigPath: string;
+  authDir?: string | undefined;
   selection: ResolvedRemoteSelection;
 };
 
@@ -30,6 +31,7 @@ export async function resolveAttachServeOptions(
     configPath: resolveConfigPath(env.CAPLETS_CONFIG?.trim() || undefined),
     projectRoot,
     projectConfigPath: env.CAPLETS_PROJECT_CONFIG?.trim() || resolveProjectConfigPath(projectRoot),
+    ...(raw.authDir ? { authDir: raw.authDir } : {}),
     selection,
   };
 }

--- a/packages/core/src/attach/options.ts
+++ b/packages/core/src/attach/options.ts
@@ -42,6 +42,7 @@ function attachLocalServeOptions(raw: RawAttachServeOptions): RawServeOptions {
     remoteUrl: _remoteUrl,
     workspace: _workspace,
     fetch: _fetch,
+    authDir: _authDir,
     projectRoot: _projectRoot,
     ...serve
   } = raw;

--- a/packages/core/src/attach/server.ts
+++ b/packages/core/src/attach/server.ts
@@ -1,8 +1,5 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio";
-import type { CapletsRemoteAuth } from "../remote/options";
-import { createSdkRemoteCapletsClient } from "../native/remote";
 import { createNativeCapletsService } from "../native/service";
-import type { NativeRemoteAuthOptions } from "../native/options";
 import { serveHttpWithSessionFactory } from "../serve/http";
 import { NativeCapletsMcpSession } from "../serve/native-session";
 import type { AttachServeOptions } from "./options";
@@ -39,6 +36,7 @@ function createAttachNativeService(options: AttachServeOptions, io: AttachServeI
     mode: options.selection.kind === "hosted_cloud" ? "cloud" : "remote",
     configPath: options.configPath,
     projectConfigPath: options.projectConfigPath,
+    ...(options.authDir ? { authDir: options.authDir } : {}),
     remote: {
       url: options.selection.remote.baseUrl.toString(),
       ...(options.selection.remote.fetch ? { fetch: options.selection.remote.fetch } : {}),
@@ -53,22 +51,7 @@ function createAttachNativeService(options: AttachServeOptions, io: AttachServeI
           }
         : {}),
     },
-    remoteClientFactory: (resolved) =>
-      createSdkRemoteCapletsClient({
-        ...resolved,
-        requestInit: options.selection.remote.requestInit,
-        auth: nativeAuthFromRemoteAuth(options.selection.remote.auth),
-        url: options.selection.remote.attachUrl,
-        ...(options.selection.remote.fetch ? { fetch: options.selection.remote.fetch } : {}),
-      }),
     exposeLocalArtifactPaths: false,
     ...(io.writeErr ? { writeErr: io.writeErr } : {}),
   });
-}
-
-function nativeAuthFromRemoteAuth(auth: CapletsRemoteAuth): NativeRemoteAuthOptions {
-  if (auth.type === "none") {
-    return { enabled: false, user: auth.user };
-  }
-  return { enabled: false, user: "caplets" };
 }

--- a/packages/core/src/attach/server.ts
+++ b/packages/core/src/attach/server.ts
@@ -67,9 +67,6 @@ function createAttachNativeService(options: AttachServeOptions, io: AttachServeI
 }
 
 function nativeAuthFromRemoteAuth(auth: CapletsRemoteAuth): NativeRemoteAuthOptions {
-  if (auth.type === "basic") {
-    return { enabled: true, user: auth.user, password: auth.password };
-  }
   if (auth.type === "none") {
     return { enabled: false, user: auth.user };
   }

--- a/packages/core/src/attach/server.ts
+++ b/packages/core/src/attach/server.ts
@@ -39,6 +39,9 @@ function createAttachNativeService(options: AttachServeOptions, io: AttachServeI
     ...(options.authDir ? { authDir: options.authDir } : {}),
     remote: {
       url: options.selection.remote.baseUrl.toString(),
+      ...(options.selection.kind === "hosted_cloud"
+        ? { workspace: options.selection.selectedWorkspace }
+        : {}),
       ...(options.selection.remote.fetch ? { fetch: options.selection.remote.fetch } : {}),
       ...(options.selection.kind === "hosted_cloud"
         ? {
@@ -55,3 +58,5 @@ function createAttachNativeService(options: AttachServeOptions, io: AttachServeI
     ...(io.writeErr ? { writeErr: io.writeErr } : {}),
   });
 }
+
+export const createAttachNativeServiceForTests = createAttachNativeService;

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -37,7 +37,6 @@ import {
 } from "./cli/completion";
 import { CloudAuthClient } from "./cloud-auth/client";
 import { openBrowserUrl } from "./cloud-auth/open-url";
-import { CloudAuthStore, type CloudAuthCredentials } from "./cloud-auth/store";
 import {
   formatCapletList,
   formatConfigPaths,
@@ -74,13 +73,16 @@ import { ProjectBindingError } from "./project-binding/errors";
 import type { ProjectBindingWebSocketFactory } from "./project-binding/transport";
 import { RemoteControlClient } from "./remote-control/client";
 import type { RemoteCliCommand } from "./remote-control/types";
-import { FileRemoteProfileStore } from "./remote/profile-store";
+import {
+  cloudCredentialsFromRemoteProfile,
+  createRemoteProfileStore,
+  type FileRemoteProfileStore,
+} from "./remote/profile-store";
 import { RemoteServerCredentialStore } from "./remote/server-credential-store";
 import { resolveRemoteSelection } from "./remote/selection";
 import {
   isCapletsCloudUrl,
   normalizeRemoteProfileHostUrl,
-  resolveCapletsRemote,
   resolveRemoteMode,
 } from "./remote/options";
 import type { RemoteProfileCredential, RemoteProfileStatus } from "./remote/profiles";
@@ -239,15 +241,7 @@ function remoteProfileStore(
   authDir: string | undefined,
   env: NodeJS.ProcessEnv | Record<string, string | undefined>,
 ): FileRemoteProfileStore {
-  const authRoot =
-    authDir ?? (env.CAPLETS_CLOUD_AUTH_PATH ? dirname(env.CAPLETS_CLOUD_AUTH_PATH) : undefined);
-  const root = join(authRoot ?? DEFAULT_AUTH_DIR, "remote-profiles");
-  return new FileRemoteProfileStore({
-    root,
-    legacyCloudAuthStore: new CloudAuthStore(
-      authDir ? { path: join(authDir, "cloud-auth.json") } : { env },
-    ),
-  });
+  return createRemoteProfileStore({ authDir, env });
 }
 
 function remoteServerCredentialStore(
@@ -376,8 +370,14 @@ async function loginCloudRemoteProfile(
 async function pairingCodeFromOptions(
   options: { code?: string; codeStdin?: boolean },
   readStdin: (() => Promise<string>) | undefined,
+  writeErr: (value: string) => void,
 ): Promise<string> {
-  if (options.code?.trim()) return options.code.trim();
+  if (options.code?.trim()) {
+    writeErr(
+      "Warning: --code may store the Pairing Code in shell history; prefer the hidden prompt or --code-stdin for automation.\n",
+    );
+    return options.code.trim();
+  }
   if (options.codeStdin) {
     const value = readStdin ? await readStdin() : await readAllStdin();
     const code = value.trim();
@@ -500,31 +500,20 @@ async function loadCloudRemoteProfileCredentials(
   return { status, credential };
 }
 
-function cloudCredentialsFromRemoteProfile(
-  status: RemoteProfileStatus,
-  credential: RemoteProfileCredential,
-): CloudAuthCredentials {
-  return {
-    version: 2,
-    cloudUrl: status.hostUrl,
-    workspaceId: status.workspaceId ?? "",
-    ...(status.workspaceSlug ? { workspaceSlug: status.workspaceSlug } : {}),
-    accessToken: credential.accessToken ?? "",
-    refreshToken: credential.refreshToken ?? "",
-    expiresAt: credential.expiresAt ?? new Date(0).toISOString(),
-    scope: credential.scope,
-    tokenType: credential.tokenType,
-    deviceName: status.clientLabel,
-    createdAt: status.createdAt,
-    lastRefreshAt: status.updatedAt,
-  };
-}
-
 function defaultCloudUrl(
   env: NodeJS.ProcessEnv | Record<string, string | undefined>,
   cloudUrl?: string,
 ): string {
   return cloudUrl ?? env.CAPLETS_CLOUD_URL ?? "https://cloud.caplets.dev";
+}
+
+function terminalSafeText(value: string): string {
+  let safe = "";
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    safe += code <= 0x1f || (code >= 0x7f && code <= 0x9f) ? "?" : char;
+  }
+  return safe;
 }
 
 function numberEnv(value: string | undefined, fallback: number): number {
@@ -1086,7 +1075,7 @@ export function createProgram(io: CliIO = {}): Command {
           return;
         }
 
-        const code = await pairingCodeFromOptions(options, io.readStdin);
+        const code = await pairingCodeFromOptions(options, io.readStdin, writeErr);
         const exchangeUrl = appendBasePath(
           new URL(normalizeRemoteProfileHostUrl(url)),
           "v1/remote/pairing/exchange",
@@ -1126,11 +1115,19 @@ export function createProgram(io: CliIO = {}): Command {
     .option("--json", "print JSON output")
     .action(async (url: string | undefined, options: { workspace?: string; json?: boolean }) => {
       if (!url) {
+        const store = remoteProfileStore(io.authDir, env);
+        const profiles = await store.listProfileStatuses();
         if (options.json) {
-          writeOut(`${JSON.stringify({ profiles: [] }, null, 2)}\n`);
+          writeOut(`${JSON.stringify({ profiles }, null, 2)}\n`);
           return;
         }
-        writeOut("Pass a Caplets host URL to inspect Remote Login status.\n");
+        if (profiles.length === 0) {
+          writeOut("No saved Remote Login profiles.\n");
+          return;
+        }
+        for (const profile of profiles) {
+          writeRemoteStatus(profile, false, writeOut);
+        }
         return;
       }
       const store = remoteProfileStore(io.authDir, env);
@@ -1221,7 +1218,7 @@ export function createProgram(io: CliIO = {}): Command {
       }
       for (const client of clients) {
         writeOut(
-          `${client.clientId}\t${client.clientLabel}\t${client.hostUrl}\t${client.revokedAt ? "revoked" : "active"}\n`,
+          `${client.clientId}\t${terminalSafeText(client.clientLabel)}\t${client.hostUrl}\t${client.revokedAt ? "revoked" : "active"}\n`,
         );
       }
     });
@@ -2463,8 +2460,29 @@ function remoteClientForCli(io: CliIO): RemoteControlClient | undefined {
   if (resolveRemoteMode({}, env).mode !== "remote") {
     return undefined;
   }
-  const server = resolveCapletsRemote(io.fetch ? { fetch: io.fetch } : {}, env);
-  return new RemoteControlClient(server);
+  return new RemoteControlClient({
+    resolve: async () => {
+      const selection = await resolveRemoteSelection(
+        {
+          mode: "remote",
+          ...(io.authDir ? { authDir: io.authDir } : {}),
+          ...(io.fetch ? { fetch: io.fetch } : {}),
+        },
+        env,
+      );
+      if (selection.kind !== "self_hosted_remote") {
+        throw new CapletsError(
+          "REQUEST_INVALID",
+          "--remote requires CAPLETS_MODE=remote and a self-hosted CAPLETS_REMOTE_URL",
+        );
+      }
+      return {
+        baseUrl: selection.remote.baseUrl,
+        requestInit: selection.remote.requestInit,
+        ...(selection.remote.fetch ? { fetch: selection.remote.fetch } : {}),
+      };
+    },
+  });
 }
 
 async function openBrowser(url: string): Promise<void> {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -2,6 +2,7 @@ import { Command, CommanderError } from "commander";
 import { Buffer } from "node:buffer";
 import { dirname, join } from "node:path";
 import { createInterface } from "node:readline/promises";
+import { Writable } from "node:stream";
 import { version as packageJsonVersion } from "../package.json";
 import {
   addCliCaplet,
@@ -36,11 +37,7 @@ import {
 } from "./cli/completion";
 import { CloudAuthClient } from "./cloud-auth/client";
 import { openBrowserUrl } from "./cloud-auth/open-url";
-import {
-  CloudAuthStore,
-  redactedCloudAuthStatus,
-  type CloudAuthCredentials,
-} from "./cloud-auth/store";
+import { CloudAuthStore, type CloudAuthCredentials } from "./cloud-auth/store";
 import {
   formatCapletList,
   formatConfigPaths,
@@ -79,13 +76,14 @@ import { RemoteControlClient } from "./remote-control/client";
 import type { RemoteCliCommand } from "./remote-control/types";
 import { FileRemoteProfileStore } from "./remote/profile-store";
 import { RemoteServerCredentialStore } from "./remote/server-credential-store";
+import { resolveRemoteSelection } from "./remote/selection";
 import {
   isCapletsCloudUrl,
   normalizeRemoteProfileHostUrl,
   resolveCapletsRemote,
   resolveRemoteMode,
 } from "./remote/options";
-import type { RemoteProfileStatus } from "./remote/profiles";
+import type { RemoteProfileCredential, RemoteProfileStatus } from "./remote/profiles";
 import {
   daemonLogs,
   daemonStatus,
@@ -237,23 +235,18 @@ function collectValues(value: string, previous: string[]): string[] {
   return [...previous, value];
 }
 
-function cloudAuthStore(
+function remoteProfileStore(
+  authDir: string | undefined,
   env: NodeJS.ProcessEnv | Record<string, string | undefined>,
-): CloudAuthStore {
-  return new CloudAuthStore({ env });
-}
-
-function cloudAuthStatus(credentials: CloudAuthCredentials | undefined): Record<string, unknown> {
-  return redactedCloudAuthStatus(credentials);
-}
-
-function remoteProfileStore(authDir: string | undefined): FileRemoteProfileStore {
-  const root = join(authDir ?? DEFAULT_AUTH_DIR, "remote-profiles");
+): FileRemoteProfileStore {
+  const authRoot =
+    authDir ?? (env.CAPLETS_CLOUD_AUTH_PATH ? dirname(env.CAPLETS_CLOUD_AUTH_PATH) : undefined);
+  const root = join(authRoot ?? DEFAULT_AUTH_DIR, "remote-profiles");
   return new FileRemoteProfileStore({
     root,
-    legacyCloudAuthStore: new CloudAuthStore({
-      path: join(authDir ?? DEFAULT_AUTH_DIR, "cloud-auth.json"),
-    }),
+    legacyCloudAuthStore: new CloudAuthStore(
+      authDir ? { path: join(authDir, "cloud-auth.json") } : { env },
+    ),
   });
 }
 
@@ -390,17 +383,39 @@ async function pairingCodeFromOptions(
     const code = value.trim();
     if (code) return code;
   }
-  const readline = createInterface({ input: process.stdin, output: process.stdout });
+  const output = new HiddenPromptOutput(process.stdout);
+  const readline = createInterface({ input: process.stdin, output });
   try {
     const code = (await readline.question("Pairing Code: ")).trim();
     if (code) return code;
   } finally {
     readline.close();
+    process.stdout.write("\n");
   }
   throw new CapletsError(
     "REQUEST_INVALID",
     "Pairing Code is required for self-hosted Remote Login.",
   );
+}
+
+class HiddenPromptOutput extends Writable {
+  private wrotePrompt = false;
+
+  constructor(private readonly output: NodeJS.WriteStream) {
+    super();
+  }
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    if (!this.wrotePrompt) {
+      this.output.write(chunk);
+      this.wrotePrompt = true;
+    }
+    callback();
+  }
 }
 
 async function readAllStdin(): Promise<string> {
@@ -468,6 +483,48 @@ function writeRemoteStatus(
     return;
   }
   writeOut(`Not authenticated to ${status.hostUrl}.\n`);
+}
+
+async function loadCloudRemoteProfileCredentials(
+  store: FileRemoteProfileStore,
+  input: { cloudUrl: string; workspace?: string | undefined },
+): Promise<{ status: RemoteProfileStatus; credential: RemoteProfileCredential }> {
+  const status = await store.getCloudProfileStatus({
+    hostUrl: input.cloudUrl,
+    ...(input.workspace ? { workspace: input.workspace } : {}),
+  });
+  const credential = status ? await store.credentials.load(status.key) : undefined;
+  if (!status || !credential?.accessToken) {
+    throw new CapletsError("AUTH_REQUIRED", "Run caplets remote login <cloud-url> first.");
+  }
+  return { status, credential };
+}
+
+function cloudCredentialsFromRemoteProfile(
+  status: RemoteProfileStatus,
+  credential: RemoteProfileCredential,
+): CloudAuthCredentials {
+  return {
+    version: 2,
+    cloudUrl: status.hostUrl,
+    workspaceId: status.workspaceId ?? "",
+    ...(status.workspaceSlug ? { workspaceSlug: status.workspaceSlug } : {}),
+    accessToken: credential.accessToken ?? "",
+    refreshToken: credential.refreshToken ?? "",
+    expiresAt: credential.expiresAt ?? new Date(0).toISOString(),
+    scope: credential.scope,
+    tokenType: credential.tokenType,
+    deviceName: status.clientLabel,
+    createdAt: status.createdAt,
+    lastRefreshAt: status.updatedAt,
+  };
+}
+
+function defaultCloudUrl(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+  cloudUrl?: string,
+): string {
+  return cloudUrl ?? env.CAPLETS_CLOUD_URL ?? "https://cloud.caplets.dev";
 }
 
 function numberEnv(value: string | undefined, fallback: number): number {
@@ -1018,7 +1075,7 @@ export function createProgram(io: CliIO = {}): Command {
           json?: boolean;
         },
       ) => {
-        const store = remoteProfileStore(io.authDir);
+        const store = remoteProfileStore(io.authDir, env);
         if (isCapletsCloudUrl(url)) {
           const status = await loginCloudRemoteProfile(url, options, store, {
             env,
@@ -1076,7 +1133,7 @@ export function createProgram(io: CliIO = {}): Command {
         writeOut("Pass a Caplets host URL to inspect Remote Login status.\n");
         return;
       }
-      const store = remoteProfileStore(io.authDir);
+      const store = remoteProfileStore(io.authDir, env);
       const normalizedHostUrl = normalizeRemoteProfileHostUrl(url);
       const status = isCapletsCloudUrl(url)
         ? await store.getCloudProfileStatus({ hostUrl: url, workspace: options.workspace })
@@ -1100,7 +1157,7 @@ export function createProgram(io: CliIO = {}): Command {
     .option("--workspace <workspace>", "Cloud workspace ID or slug")
     .option("--json", "print JSON output")
     .action(async (url: string, options: { workspace?: string; json?: boolean }) => {
-      const store = remoteProfileStore(io.authDir);
+      const store = remoteProfileStore(io.authDir, env);
       const removed = isCapletsCloudUrl(url)
         ? await store.logoutCloudProfile({ hostUrl: url, workspace: options.workspace })
         : await store.logoutSelfHostedProfile({ hostUrl: url });
@@ -1203,93 +1260,95 @@ export function createProgram(io: CliIO = {}): Command {
         open?: boolean;
         json?: boolean;
       }) => {
-        const cloudUrl = options.cloudUrl ?? env.CAPLETS_CLOUD_URL ?? "https://cloud.caplets.dev";
-        const client = new CloudAuthClient({ cloudUrl, ...(io.fetch ? { fetch: io.fetch } : {}) });
-        const started = await client.startLogin({
-          requestedWorkspace: options.workspace,
-          deviceName: options.deviceName ?? env.CAPLETS_DEVICE_NAME ?? "Caplets CLI",
-        });
-        if (options.open !== false) await openBrowserUrl(started.loginUrl);
-        if (!options.json) {
-          writeOut(`Open ${started.loginUrl}\n`);
-          writeOut(`Enter code ${started.userCode} if prompted.\n`);
-        }
-
-        const completed = await waitForCloudLogin(client, started.loginId, env);
-        if (completed.status !== "completed") {
-          throw new CapletsError("AUTH_FAILED", `Cloud Auth login ${completed.status}.`);
-        }
-        const exchanged = await client.exchangeToken({
-          loginId: started.loginId,
-          oneTimeCode: completed.oneTimeCode,
-        });
-        const now = new Date().toISOString();
-        const credentials: CloudAuthCredentials = {
-          version: 2,
-          cloudUrl: exchanged.cloudUrl,
-          workspaceId: exchanged.workspaceId,
-          ...(exchanged.workspaceSlug ? { workspaceSlug: exchanged.workspaceSlug } : {}),
-          accessToken: exchanged.accessToken,
-          refreshToken: exchanged.refreshToken ?? "",
-          expiresAt: exchanged.expiresAt,
-          scope: exchanged.scope,
-          tokenType: exchanged.tokenType,
-          credentialFamilyId: exchanged.credentialFamilyId,
-          deviceName: exchanged.deviceName ?? options.deviceName ?? "Caplets CLI",
-          createdAt: now,
-          lastRefreshAt: now,
-        };
-        await cloudAuthStore(env).save(credentials);
-        const status = cloudAuthStatus(credentials);
-        if (options.json) {
-          writeOut(`${JSON.stringify(status, null, 2)}\n`);
-          return;
-        }
-        writeOut(
-          `Authenticated to ${credentials.cloudUrl} as workspace ${credentials.workspaceSlug ?? credentials.workspaceId}.\n`,
+        const status = await loginCloudRemoteProfile(
+          defaultCloudUrl(env, options.cloudUrl),
+          options,
+          remoteProfileStore(io.authDir, env),
+          {
+            env,
+            ...(io.fetch ? { fetch: io.fetch } : {}),
+            writeOut,
+          },
         );
+        writeRemoteStatus(status, options.json === true, writeOut);
       },
     );
   cloudAuth
     .command("status")
     .description("Show hosted Caplets Cloud authentication status.")
+    .option("--cloud-url <url>", "hosted Caplets Cloud URL")
+    .option("--workspace <workspace>", "workspace ID or slug")
     .option("--json", "print JSON output")
-    .action(async (options: { json?: boolean }) => {
-      const credentials = await cloudAuthStore(env).load();
-      if (options.json) {
-        writeOut(`${JSON.stringify(cloudAuthStatus(credentials), null, 2)}\n`);
-        return;
-      }
-      writeOut(
-        credentials
-          ? `Authenticated to ${credentials.cloudUrl} as workspace ${credentials.workspaceSlug ?? credentials.workspaceId}.\n`
-          : "Not authenticated to hosted Caplets Cloud.\n",
+    .action(async (options: { cloudUrl?: string; workspace?: string; json?: boolean }) => {
+      const cloudUrl = defaultCloudUrl(env, options.cloudUrl);
+      const status = await remoteProfileStore(io.authDir, env).getCloudProfileStatus({
+        hostUrl: cloudUrl,
+        ...(options.workspace ? { workspace: options.workspace } : {}),
+      });
+      writeRemoteStatus(
+        status ?? {
+          authenticated: false,
+          status: "unauthenticated",
+          hostUrl: normalizeRemoteProfileHostUrl(cloudUrl),
+          kind: "cloud",
+        },
+        options.json === true,
+        writeOut,
       );
     });
   cloudAuth
     .command("logout")
     .description("Log out of hosted Caplets Cloud.")
-    .action(async () => {
-      const store = cloudAuthStore(env);
-      const credentials = await store.load();
-      if (credentials?.refreshToken) {
+    .option("--cloud-url <url>", "hosted Caplets Cloud URL")
+    .option("--workspace <workspace>", "workspace ID or slug")
+    .option("--json", "print JSON output")
+    .action(async (options: { cloudUrl?: string; workspace?: string; json?: boolean }) => {
+      const cloudUrl = defaultCloudUrl(env, options.cloudUrl);
+      const store = remoteProfileStore(io.authDir, env);
+      const status = await store.getCloudProfileStatus({
+        hostUrl: cloudUrl,
+        ...(options.workspace ? { workspace: options.workspace } : {}),
+      });
+      const credential = status ? await store.credentials.load(status.key) : undefined;
+      if (credential?.refreshToken) {
         await new CloudAuthClient({
-          cloudUrl: credentials.cloudUrl,
+          cloudUrl,
           ...(io.fetch ? { fetch: io.fetch } : {}),
         })
-          .logout(credentials.refreshToken)
+          .logout(credential.refreshToken)
           .catch(() => undefined);
       }
-      await store.clear();
-      writeOut("Logged out of hosted Caplets Cloud.\n");
+      const removed = await store.logoutCloudProfile({
+        hostUrl: cloudUrl,
+        ...(options.workspace ? { workspace: options.workspace } : {}),
+      });
+      if (options.json) {
+        writeOut(
+          `${JSON.stringify({ loggedOut: removed, hostUrl: normalizeRemoteProfileHostUrl(cloudUrl) }, null, 2)}\n`,
+        );
+        return;
+      }
+      writeOut(
+        removed
+          ? `Logged out of ${normalizeRemoteProfileHostUrl(cloudUrl)}.\n`
+          : `No Remote Login profile found for ${normalizeRemoteProfileHostUrl(cloudUrl)}.\n`,
+      );
     });
   cloudAuth
     .command("workspaces")
     .description("List hosted Caplets Cloud workspaces.")
+    .option("--cloud-url <url>", "hosted Caplets Cloud URL")
     .option("--json", "print JSON output")
-    .action(async (options: { json?: boolean }) => {
-      const credentials = await cloudAuthStore(env).load();
-      const workspaces = credentials?.accessToken
+    .action(async (options: { cloudUrl?: string; json?: boolean }) => {
+      const store = remoteProfileStore(io.authDir, env);
+      const cloudUrl = defaultCloudUrl(env, options.cloudUrl);
+      const loaded = await store.getCloudProfileStatus({ hostUrl: cloudUrl });
+      const credential = loaded ? await store.credentials.load(loaded.key) : undefined;
+      const credentials =
+        loaded && credential?.accessToken
+          ? cloudCredentialsFromRemoteProfile(loaded, credential)
+          : undefined;
+      const workspaces = credentials
         ? (
             await new CloudAuthClient({
               cloudUrl: credentials.cloudUrl,
@@ -1329,13 +1388,13 @@ export function createProgram(io: CliIO = {}): Command {
     .command("switch")
     .description("Switch the hosted Caplets Cloud Selected Workspace.")
     .argument("<workspace>", "workspace ID or slug")
+    .option("--cloud-url <url>", "hosted Caplets Cloud URL")
     .option("--json", "print JSON output")
-    .action(async (workspace: string, options: { json?: boolean }) => {
-      const store = cloudAuthStore(env);
-      const credentials = await store.load();
-      if (!credentials) {
-        throw new CapletsError("AUTH_REQUIRED", "Run caplets remote login <cloud-url> first.");
-      }
+    .action(async (workspace: string, options: { cloudUrl?: string; json?: boolean }) => {
+      const store = remoteProfileStore(io.authDir, env);
+      const cloudUrl = defaultCloudUrl(env, options.cloudUrl);
+      const loaded = await loadCloudRemoteProfileCredentials(store, { cloudUrl });
+      const credentials = cloudCredentialsFromRemoteProfile(loaded.status, loaded.credential);
       const client = new CloudAuthClient({
         cloudUrl: credentials.cloudUrl,
         ...(io.fetch ? { fetch: io.fetch } : {}),
@@ -1346,26 +1405,20 @@ export function createProgram(io: CliIO = {}): Command {
         workspace,
         deviceName: credentials.deviceName,
       });
-      const now = new Date().toISOString();
-      const next: CloudAuthCredentials = {
-        ...credentials,
+      const status = await store.saveCloudProfile({
+        hostUrl: credentials.cloudUrl,
         workspaceId: switched.workspaceId,
-        workspaceSlug: switched.workspaceSlug,
-        accessToken: switched.accessToken,
-        refreshToken: switched.refreshToken ?? credentials.refreshToken,
-        expiresAt: switched.expiresAt,
-        scope: switched.scope,
-        tokenType: switched.tokenType,
-        credentialFamilyId: switched.credentialFamilyId,
-        lastRefreshAt: now,
-        selectedWorkspaceSwitchedAt: now,
-      };
-      await store.save(next);
-      if (options.json) {
-        writeOut(`${JSON.stringify(cloudAuthStatus(next), null, 2)}\n`);
-        return;
-      }
-      writeOut(`Selected workspace ${next.workspaceSlug ?? next.workspaceId}.\n`);
+        ...(switched.workspaceSlug ? { workspaceSlug: switched.workspaceSlug } : {}),
+        clientLabel: credentials.deviceName,
+        credentials: {
+          accessToken: switched.accessToken,
+          refreshToken: switched.refreshToken ?? credentials.refreshToken,
+          expiresAt: switched.expiresAt,
+          scope: switched.scope,
+          tokenType: switched.tokenType,
+        },
+      });
+      writeRemoteStatus(status, options.json === true, writeOut);
     });
 
   cloud
@@ -1380,18 +1433,27 @@ export function createProgram(io: CliIO = {}): Command {
         pathInput: string,
         options: { cloudUrl?: string; workspace?: string; json?: boolean },
       ) => {
-        const credentials = await cloudAuthStore(env).load();
-        if (!credentials) {
-          throw new CapletsError("AUTH_REQUIRED", "Run caplets remote login <cloud-url> first.");
+        const cloudUrl = defaultCloudUrl(env, options.cloudUrl);
+        const selection = await resolveRemoteSelection(
+          {
+            mode: "cloud",
+            remoteUrl: cloudUrl,
+            ...(options.workspace ? { workspace: options.workspace } : {}),
+            ...(io.authDir ? { authDir: io.authDir } : {}),
+            ...(io.fetch ? { fetch: io.fetch } : {}),
+          },
+          { ...env, CAPLETS_MODE: "cloud", CAPLETS_REMOTE_URL: cloudUrl },
+        );
+        if (selection.kind !== "hosted_cloud") {
+          throw new CapletsError("REQUEST_INVALID", "caplets cloud add requires Caplets Cloud.");
         }
-        const cloudUrl = options.cloudUrl ?? credentials.cloudUrl;
-        const workspace = options.workspace ?? credentials.workspaceSlug ?? credentials.workspaceId;
+        const workspace = selection.selectedWorkspace;
         const bundle = buildCloudCapletBundle(pathInput);
         const result = await new CloudAuthClient({
           cloudUrl,
           ...(io.fetch ? { fetch: io.fetch } : {}),
         }).addCaplets({
-          accessToken: credentials.accessToken,
+          accessToken: selection.credentials.accessToken,
           workspace,
           bundle,
         });

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1,4 +1,5 @@
 import { Command, CommanderError } from "commander";
+import { Buffer } from "node:buffer";
 import { dirname, join } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { version as packageJsonVersion } from "../package.json";
@@ -76,7 +77,15 @@ import { ProjectBindingError } from "./project-binding/errors";
 import type { ProjectBindingWebSocketFactory } from "./project-binding/transport";
 import { RemoteControlClient } from "./remote-control/client";
 import type { RemoteCliCommand } from "./remote-control/types";
-import { resolveCapletsRemote, resolveRemoteMode } from "./remote/options";
+import { FileRemoteProfileStore } from "./remote/profile-store";
+import { RemoteServerCredentialStore } from "./remote/server-credential-store";
+import {
+  isCapletsCloudUrl,
+  normalizeRemoteProfileHostUrl,
+  resolveCapletsRemote,
+  resolveRemoteMode,
+} from "./remote/options";
+import type { RemoteProfileStatus } from "./remote/profiles";
 import {
   daemonLogs,
   daemonStatus,
@@ -93,6 +102,8 @@ import {
   type DaemonOperationOptions,
 } from "./daemon";
 import { resolveServeOptions, serveResolvedCaplets, type ServeOptions } from "./serve";
+import { DEFAULT_AUTH_DIR } from "./config/paths";
+import { appendBasePath } from "./server/options";
 
 export { initConfig, starterConfig } from "./cli/init";
 export { installCaplets, normalizeGitRepo } from "./cli/install";
@@ -240,6 +251,26 @@ function cloudAuthStatus(credentials: CloudAuthCredentials | undefined): Record<
   return redactedCloudAuthStatus(credentials);
 }
 
+function remoteProfileStore(authDir: string | undefined): FileRemoteProfileStore {
+  const root = join(authDir ?? DEFAULT_AUTH_DIR, "remote-profiles");
+  return new FileRemoteProfileStore({
+    root,
+    legacyCloudAuthStore: new CloudAuthStore({
+      path: join(authDir ?? DEFAULT_AUTH_DIR, "cloud-auth.json"),
+    }),
+  });
+}
+
+function remoteServerCredentialStore(
+  statePath: string | undefined,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): RemoteServerCredentialStore {
+  return new RemoteServerCredentialStore({
+    dir:
+      statePath ?? env.CAPLETS_REMOTE_SERVER_STATE_DIR ?? join(DEFAULT_AUTH_DIR, "remote-server"),
+  });
+}
+
 function compactCloudCaplet(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   const record = value as Record<string, unknown>;
@@ -304,6 +335,145 @@ async function waitForCloudLogin(
     await sleep(intervalMs);
   }
   return { status: "expired" as const, message: "Cloud Auth login timed out." };
+}
+
+async function loginCloudRemoteProfile(
+  url: string,
+  options: {
+    workspace?: string;
+    deviceName?: string;
+    open?: boolean;
+    json?: boolean;
+  },
+  store: FileRemoteProfileStore,
+  io: {
+    env: NodeJS.ProcessEnv | Record<string, string | undefined>;
+    fetch?: typeof fetch;
+    writeOut: (value: string) => void;
+  },
+): Promise<RemoteProfileStatus> {
+  const client = new CloudAuthClient({ cloudUrl: url, ...(io.fetch ? { fetch: io.fetch } : {}) });
+  const started = await client.startLogin({
+    requestedWorkspace: options.workspace,
+    deviceName: options.deviceName ?? io.env.CAPLETS_DEVICE_NAME ?? "Caplets CLI",
+  });
+  if (options.open !== false) await openBrowserUrl(started.loginUrl);
+  if (!options.json) {
+    io.writeOut(`Open ${started.loginUrl}\n`);
+    io.writeOut(`Enter code ${started.userCode} if prompted.\n`);
+  }
+
+  const completed = await waitForCloudLogin(client, started.loginId, io.env);
+  if (completed.status !== "completed") {
+    throw new CapletsError("AUTH_FAILED", `Remote Login Cloud flow ${completed.status}.`);
+  }
+  const exchanged = await client.exchangeToken({
+    loginId: started.loginId,
+    oneTimeCode: completed.oneTimeCode,
+  });
+  return store.saveCloudProfile({
+    hostUrl: exchanged.cloudUrl,
+    workspaceId: exchanged.workspaceId,
+    ...(exchanged.workspaceSlug ? { workspaceSlug: exchanged.workspaceSlug } : {}),
+    clientLabel: exchanged.deviceName ?? options.deviceName ?? "Caplets CLI",
+    credentials: {
+      accessToken: exchanged.accessToken,
+      refreshToken: exchanged.refreshToken ?? "",
+      expiresAt: exchanged.expiresAt,
+      scope: exchanged.scope,
+      tokenType: exchanged.tokenType,
+    },
+  });
+}
+
+async function pairingCodeFromOptions(
+  options: { code?: string; codeStdin?: boolean },
+  readStdin: (() => Promise<string>) | undefined,
+): Promise<string> {
+  if (options.code?.trim()) return options.code.trim();
+  if (options.codeStdin) {
+    const value = readStdin ? await readStdin() : await readAllStdin();
+    const code = value.trim();
+    if (code) return code;
+  }
+  const readline = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const code = (await readline.question("Pairing Code: ")).trim();
+    if (code) return code;
+  } finally {
+    readline.close();
+  }
+  throw new CapletsError(
+    "REQUEST_INVALID",
+    "Pairing Code is required for self-hosted Remote Login.",
+  );
+}
+
+async function readAllStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+type RemoteLoginCredentialsResponse = {
+  clientId: string;
+  clientLabel: string;
+  accessToken: string;
+  refreshToken: string;
+  tokenType?: string | undefined;
+  expiresAt?: string | undefined;
+};
+
+async function parseRemoteLoginCredentials(
+  response: Response,
+): Promise<RemoteLoginCredentialsResponse> {
+  const parsed = await response.json();
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new CapletsError("DOWNSTREAM_PROTOCOL_ERROR", "Remote Login response must be an object.");
+  }
+  const record = parsed as Record<string, unknown>;
+  if (
+    typeof record.clientId !== "string" ||
+    typeof record.accessToken !== "string" ||
+    typeof record.refreshToken !== "string"
+  ) {
+    throw new CapletsError(
+      "DOWNSTREAM_PROTOCOL_ERROR",
+      "Remote Login response is missing credentials.",
+    );
+  }
+  return {
+    clientId: record.clientId,
+    clientLabel: typeof record.clientLabel === "string" ? record.clientLabel : "Caplets CLI",
+    accessToken: record.accessToken,
+    refreshToken: record.refreshToken,
+    ...(typeof record.tokenType === "string" ? { tokenType: record.tokenType } : {}),
+    ...(typeof record.expiresAt === "string" ? { expiresAt: record.expiresAt } : {}),
+  };
+}
+
+function writeRemoteStatus(
+  status: RemoteProfileStatus | Record<string, unknown>,
+  json: boolean,
+  writeOut: (value: string) => void,
+): void {
+  if (json) {
+    writeOut(`${JSON.stringify(status, null, 2)}\n`);
+    return;
+  }
+  if (status.authenticated) {
+    const workspace =
+      typeof status.workspaceSlug === "string"
+        ? ` workspace ${status.workspaceSlug}`
+        : typeof status.workspaceId === "string"
+          ? ` workspace ${status.workspaceId}`
+          : "";
+    writeOut(`Authenticated to ${status.hostUrl}${workspace}.\n`);
+    return;
+  }
+  writeOut(`Not authenticated to ${status.hostUrl}.\n`);
 }
 
 function numberEnv(value: string | undefined, fallback: number): number {
@@ -834,6 +1004,196 @@ export function createProgram(io: CliIO = {}): Command {
         }
       },
     );
+
+  const remote = program.command(cliCommands.remote).description("Manage Caplets Remote Login.");
+  remote
+    .command("login")
+    .description("Log this machine into a Caplets host.")
+    .argument("<url>", "Caplets host URL")
+    .option("--workspace <workspace>", "Cloud workspace ID or slug to select")
+    .option("--client-label <label>", "client label for this machine")
+    .option("--device-name <name>", "Cloud device label for this machine")
+    .option("--code <code>", "Pairing Code for explicit noninteractive self-hosted login")
+    .option("--code-stdin", "read the Pairing Code from stdin")
+    .option("--no-open", "print the Cloud login URL without opening a browser")
+    .option("--json", "print JSON output")
+    .action(
+      async (
+        url: string,
+        options: {
+          workspace?: string;
+          clientLabel?: string;
+          deviceName?: string;
+          code?: string;
+          codeStdin?: boolean;
+          open?: boolean;
+          json?: boolean;
+        },
+      ) => {
+        const store = remoteProfileStore(io.authDir);
+        if (isCapletsCloudUrl(url)) {
+          const status = await loginCloudRemoteProfile(url, options, store, {
+            env,
+            ...(io.fetch ? { fetch: io.fetch } : {}),
+            writeOut,
+          });
+          writeRemoteStatus(status, options.json === true, writeOut);
+          return;
+        }
+
+        const code = await pairingCodeFromOptions(options, io.readStdin);
+        const exchangeUrl = appendBasePath(
+          new URL(normalizeRemoteProfileHostUrl(url)),
+          "v1/remote/pairing/exchange",
+        );
+        const response = await (io.fetch ?? fetch)(exchangeUrl, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            code,
+            ...(options.clientLabel ? { clientLabel: options.clientLabel } : {}),
+          }),
+        });
+        if (!response.ok) {
+          throw new CapletsError("AUTH_FAILED", "Remote Login pairing exchange failed.");
+        }
+        const credentials = await parseRemoteLoginCredentials(response);
+        const status = await store.saveSelfHostedProfile({
+          hostUrl: url,
+          clientId: credentials.clientId,
+          clientLabel: credentials.clientLabel,
+          credentials: {
+            accessToken: credentials.accessToken,
+            refreshToken: credentials.refreshToken,
+            tokenType: credentials.tokenType,
+            expiresAt: credentials.expiresAt,
+          },
+        });
+        writeRemoteStatus(status, options.json === true, writeOut);
+      },
+    );
+
+  remote
+    .command("status")
+    .description("Show saved Remote Login status.")
+    .argument("[url]", "Caplets host URL")
+    .option("--workspace <workspace>", "Cloud workspace ID or slug")
+    .option("--json", "print JSON output")
+    .action(async (url: string | undefined, options: { workspace?: string; json?: boolean }) => {
+      if (!url) {
+        if (options.json) {
+          writeOut(`${JSON.stringify({ profiles: [] }, null, 2)}\n`);
+          return;
+        }
+        writeOut("Pass a Caplets host URL to inspect Remote Login status.\n");
+        return;
+      }
+      const store = remoteProfileStore(io.authDir);
+      const normalizedHostUrl = normalizeRemoteProfileHostUrl(url);
+      const status = isCapletsCloudUrl(url)
+        ? await store.getCloudProfileStatus({ hostUrl: url, workspace: options.workspace })
+        : await store.getSelfHostedProfileStatus({ hostUrl: url });
+      writeRemoteStatus(
+        status ?? {
+          authenticated: false,
+          status: "unauthenticated",
+          hostUrl: normalizedHostUrl,
+          kind: isCapletsCloudUrl(url) ? "cloud" : "self-hosted",
+        },
+        options.json === true,
+        writeOut,
+      );
+    });
+
+  remote
+    .command("logout")
+    .description("Remove saved Remote Login credentials for a host.")
+    .argument("<url>", "Caplets host URL")
+    .option("--workspace <workspace>", "Cloud workspace ID or slug")
+    .option("--json", "print JSON output")
+    .action(async (url: string, options: { workspace?: string; json?: boolean }) => {
+      const store = remoteProfileStore(io.authDir);
+      const removed = isCapletsCloudUrl(url)
+        ? await store.logoutCloudProfile({ hostUrl: url, workspace: options.workspace })
+        : await store.logoutSelfHostedProfile({ hostUrl: url });
+      if (options.json) {
+        writeOut(
+          `${JSON.stringify({ loggedOut: removed, hostUrl: normalizeRemoteProfileHostUrl(url) }, null, 2)}\n`,
+        );
+        return;
+      }
+      writeOut(
+        removed
+          ? `Logged out of ${normalizeRemoteProfileHostUrl(url)}.\n`
+          : `No Remote Login profile found for ${normalizeRemoteProfileHostUrl(url)}.\n`,
+      );
+    });
+
+  const remoteHost = remote.command("host").description("Manage self-hosted remote credentials.");
+  remoteHost
+    .command("pair")
+    .description("Create a short-lived self-hosted Pairing Code from the server environment.")
+    .requiredOption("--host-url <url>", "public Caplets host URL")
+    .option("--state-path <path>", "server-owned remote credential state directory")
+    .option("--client-label <label>", "suggested client label")
+    .option("--json", "print JSON output")
+    .action(
+      async (options: {
+        hostUrl: string;
+        statePath?: string;
+        clientLabel?: string;
+        json?: boolean;
+      }) => {
+        const issued = remoteServerCredentialStore(options.statePath, env).createPairingCode({
+          hostUrl: options.hostUrl,
+          ...(options.clientLabel ? { clientLabel: options.clientLabel } : {}),
+        });
+        if (options.json) {
+          writeOut(`${JSON.stringify(issued, null, 2)}\n`);
+          return;
+        }
+        writeOut(`Pairing Code: ${issued.code}\n`);
+        writeOut(`Expires At: ${issued.expiresAt}\n`);
+        writeOut(
+          `Run caplets remote login ${normalizeRemoteProfileHostUrl(options.hostUrl)} and enter the Pairing Code when prompted.\n`,
+        );
+      },
+    );
+  remoteHost
+    .command("clients")
+    .description("List paired self-hosted remote clients from server state.")
+    .option("--state-path <path>", "server-owned remote credential state directory")
+    .option("--json", "print JSON output")
+    .action((options: { statePath?: string; json?: boolean }) => {
+      const clients = remoteServerCredentialStore(options.statePath, env).listClients();
+      if (options.json) {
+        writeOut(`${JSON.stringify({ clients }, null, 2)}\n`);
+        return;
+      }
+      if (clients.length === 0) {
+        writeOut("No paired remote clients.\n");
+        return;
+      }
+      for (const client of clients) {
+        writeOut(
+          `${client.clientId}\t${client.clientLabel}\t${client.hostUrl}\t${client.revokedAt ? "revoked" : "active"}\n`,
+        );
+      }
+    });
+  remoteHost
+    .command("revoke")
+    .description("Revoke one paired self-hosted remote client from server state.")
+    .argument("<client-id>", "remote client ID")
+    .option("--state-path <path>", "server-owned remote credential state directory")
+    .option("--json", "print JSON output")
+    .action((clientId: string, options: { statePath?: string; json?: boolean }) => {
+      const revoked = remoteServerCredentialStore(options.statePath, env).revokeClient(clientId);
+      if (options.json) {
+        writeOut(`${JSON.stringify({ revoked, clientId }, null, 2)}\n`);
+        return;
+      }
+      writeOut(revoked ? `Revoked ${clientId}.\n` : `No remote client found for ${clientId}.\n`);
+    });
 
   const cloud = program.command(cliCommands.cloud).description("Manage hosted Caplets Cloud.");
   const cloudAuth = cloud

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -478,6 +478,26 @@ async function revokeSelfHostedRemoteClient(
   });
 }
 
+async function selfHostedLogoutAccessToken(
+  remoteUrl: string,
+  credential: RemoteProfileCredential & { accessToken: string },
+  input: { authDir?: string | undefined; fetch?: typeof fetch | undefined },
+  env: Record<string, string | undefined>,
+): Promise<string> {
+  const selection = await resolveRemoteSelection(
+    {
+      mode: "remote",
+      remoteUrl,
+      ...(input.authDir ? { authDir: input.authDir } : {}),
+      ...(input.fetch ? { fetch: input.fetch } : {}),
+    },
+    env,
+  );
+  return selection.kind === "self_hosted_remote" && selection.remote.auth.type === "bearer"
+    ? selection.remote.auth.token
+    : credential.accessToken;
+}
+
 function writeRemoteStatus(
   status: RemoteProfileStatus | Record<string, unknown>,
   json: boolean,
@@ -1182,10 +1202,15 @@ export function createProgram(io: CliIO = {}): Command {
           .logout(credential.refreshToken)
           .catch(() => undefined);
       }
-      if (!isCapletsCloudUrl(url) && credential?.accessToken) {
-        await revokeSelfHostedRemoteClient(url, credential.accessToken, io.fetch).catch(
-          () => undefined,
-        );
+      const storedAccessToken = credential?.accessToken;
+      if (!isCapletsCloudUrl(url) && storedAccessToken) {
+        const accessToken = await selfHostedLogoutAccessToken(
+          url,
+          { ...credential, accessToken: storedAccessToken },
+          { authDir: io.authDir, ...(io.fetch ? { fetch: io.fetch } : {}) },
+          env,
+        ).catch(() => storedAccessToken);
+        await revokeSelfHostedRemoteClient(url, accessToken, io.fetch).catch(() => undefined);
       }
       const removed = status
         ? isCapletsCloudUrl(url)

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -81,6 +81,7 @@ import {
 import { RemoteServerCredentialStore } from "./remote/server-credential-store";
 import { resolveRemoteSelection } from "./remote/selection";
 import {
+  hostedCloudWorkspaceFromRemoteUrl,
   isCapletsCloudUrl,
   normalizeRemoteProfileHostUrl,
   resolveRemoteMode,
@@ -334,8 +335,9 @@ async function loginCloudRemoteProfile(
   },
 ): Promise<RemoteProfileStatus> {
   const client = new CloudAuthClient({ cloudUrl: url, ...(io.fetch ? { fetch: io.fetch } : {}) });
+  const requestedWorkspace = options.workspace ?? hostedCloudWorkspaceFromRemoteUrl(url);
   const started = await client.startLogin({
-    requestedWorkspace: options.workspace,
+    requestedWorkspace,
     deviceName: options.deviceName ?? io.env.CAPLETS_DEVICE_NAME ?? "Caplets CLI",
   });
   if (options.open !== false) await openBrowserUrl(started.loginUrl);

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -899,9 +899,6 @@ export function createProgram(io: CliIO = {}): Command {
     .option("--port <port>", "HTTP bind port")
     .option("--path <path>", "HTTP service base path")
     .option("--remote-url <url>", "remote Caplets service base URL")
-    .option("--user <user>", "remote Basic Auth username")
-    .option("--password <password>", "remote Basic Auth password")
-    .option("--token <token>", "remote bearer token")
     .option("--workspace <workspace>", "hosted Cloud workspace ID or slug")
     .option(
       "--allow-unauthenticated-http",
@@ -919,9 +916,6 @@ export function createProgram(io: CliIO = {}): Command {
         host?: string;
         port?: string;
         path?: string;
-        user?: string;
-        password?: string;
-        token?: string;
         workspace?: string;
         allowUnauthenticatedHttp?: boolean;
         trustProxy?: boolean;

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -384,7 +384,7 @@ async function pairingCodeFromOptions(
     if (code) return code;
   }
   const output = new HiddenPromptOutput(process.stdout);
-  const readline = createInterface({ input: process.stdin, output });
+  const readline = createInterface({ input: process.stdin, output, terminal: true });
   try {
     const code = (await readline.question("Pairing Code: ")).trim();
     if (code) return code;

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -164,8 +164,6 @@ type DaemonInstallCommandOptions = {
   host?: string;
   port?: string;
   path?: string;
-  user?: string;
-  password?: string;
   remoteStatePath?: string;
   allowUnauthenticatedHttp?: boolean;
   trustProxy?: boolean;
@@ -200,8 +198,6 @@ function addDaemonInstallOptions(command: Command): Command {
     .option("--host <host>", "HTTP bind host")
     .option("--port <port>", "HTTP bind port")
     .option("--path <path>", "HTTP service base path")
-    .option("--user <user>", "HTTP Basic Auth username")
-    .option("--password <password>", "HTTP Basic Auth password")
     .option("--remote-state-path <path>", "server-owned remote credential state directory")
     .option(
       "--allow-unauthenticated-http",
@@ -299,8 +295,6 @@ function daemonInstallOptions(options: DaemonInstallCommandOptions): DaemonInsta
     ...(options.host !== undefined ? { host: options.host } : {}),
     ...(options.port !== undefined ? { port: options.port } : {}),
     ...(options.path !== undefined ? { path: options.path } : {}),
-    ...(options.user !== undefined ? { user: options.user } : {}),
-    ...(options.password !== undefined ? { password: options.password } : {}),
     ...(options.remoteStatePath !== undefined ? { remoteStatePath: options.remoteStatePath } : {}),
     ...(options.allowUnauthenticatedHttp !== undefined
       ? { allowUnauthenticatedHttp: options.allowUnauthenticatedHttp }
@@ -702,8 +696,6 @@ export function createProgram(io: CliIO = {}): Command {
     .option("--host <host>", "HTTP bind host")
     .option("--port <port>", "HTTP bind port")
     .option("--path <path>", "HTTP service base path")
-    .option("--user <user>", "HTTP Basic Auth username")
-    .option("--password <password>", "HTTP Basic Auth password")
     .option("--remote-state-path <path>", "server-owned remote credential state directory")
     .option(
       "--allow-unauthenticated-http",
@@ -716,8 +708,6 @@ export function createProgram(io: CliIO = {}): Command {
         host?: string;
         port?: string;
         path?: string;
-        user?: string;
-        password?: string;
         remoteStatePath?: string;
         allowUnauthenticatedHttp?: boolean;
         trustProxy?: boolean;

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -382,6 +382,10 @@ async function pairingCodeFromOptions(
     const value = readStdin ? await readStdin() : await readAllStdin();
     const code = value.trim();
     if (code) return code;
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "Pairing Code is required when --code-stdin is used.",
+    );
   }
   const output = new HiddenPromptOutput(process.stdout);
   const readline = createInterface({ input: process.stdin, output, terminal: true });

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -931,7 +931,11 @@ export function createProgram(io: CliIO = {}): Command {
         projectRoot?: string;
       }) => {
         try {
-          const attachOptions = { ...options, ...(io.fetch ? { fetch: io.fetch } : {}) };
+          const attachOptions = {
+            ...options,
+            ...(io.fetch ? { fetch: io.fetch } : {}),
+            ...(io.authDir ? { authDir: io.authDir } : {}),
+          };
           if (!options.once) {
             const resolved = await resolveAttachServeOptions(attachOptions, env);
             await (

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1316,7 +1316,9 @@ export function createProgram(io: CliIO = {}): Command {
         return;
       }
       if (workspaces.length === 0) {
-        writeOut("No hosted Caplets Cloud workspaces available. Run caplets cloud auth login.\n");
+        writeOut(
+          "No hosted Caplets Cloud workspaces available. Run caplets remote login <cloud-url>.\n",
+        );
         return;
       }
       for (const workspace of workspaces) {
@@ -1332,7 +1334,7 @@ export function createProgram(io: CliIO = {}): Command {
       const store = cloudAuthStore(env);
       const credentials = await store.load();
       if (!credentials) {
-        throw new CapletsError("AUTH_REQUIRED", "Run caplets cloud auth login first.");
+        throw new CapletsError("AUTH_REQUIRED", "Run caplets remote login <cloud-url> first.");
       }
       const client = new CloudAuthClient({
         cloudUrl: credentials.cloudUrl,
@@ -1380,7 +1382,7 @@ export function createProgram(io: CliIO = {}): Command {
       ) => {
         const credentials = await cloudAuthStore(env).load();
         if (!credentials) {
-          throw new CapletsError("AUTH_REQUIRED", "Run caplets cloud auth login first.");
+          throw new CapletsError("AUTH_REQUIRED", "Run caplets remote login <cloud-url> first.");
         }
         const cloudUrl = options.cloudUrl ?? credentials.cloudUrl;
         const workspace = options.workspace ?? credentials.workspaceSlug ?? credentials.workspaceId;

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -463,6 +463,21 @@ async function parseRemoteLoginCredentials(
   };
 }
 
+async function revokeSelfHostedRemoteClient(
+  remoteUrl: string,
+  accessToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const revokeUrl = appendBasePath(
+    new URL(normalizeRemoteProfileHostUrl(remoteUrl)),
+    "v1/remote/client",
+  );
+  await fetchImpl(revokeUrl, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+}
+
 function writeRemoteStatus(
   status: RemoteProfileStatus | Record<string, unknown>,
   json: boolean,
@@ -1155,9 +1170,28 @@ export function createProgram(io: CliIO = {}): Command {
     .option("--json", "print JSON output")
     .action(async (url: string, options: { workspace?: string; json?: boolean }) => {
       const store = remoteProfileStore(io.authDir, env);
-      const removed = isCapletsCloudUrl(url)
-        ? await store.logoutCloudProfile({ hostUrl: url, workspace: options.workspace })
-        : await store.logoutSelfHostedProfile({ hostUrl: url });
+      const status = isCapletsCloudUrl(url)
+        ? await store.getCloudProfileStatus({ hostUrl: url, workspace: options.workspace })
+        : await store.getSelfHostedProfileStatus({ hostUrl: url });
+      const credential = status ? await store.credentials.load(status.key) : undefined;
+      if (isCapletsCloudUrl(url) && credential?.refreshToken) {
+        await new CloudAuthClient({
+          cloudUrl: url,
+          ...(io.fetch ? { fetch: io.fetch } : {}),
+        })
+          .logout(credential.refreshToken)
+          .catch(() => undefined);
+      }
+      if (!isCapletsCloudUrl(url) && credential?.accessToken) {
+        await revokeSelfHostedRemoteClient(url, credential.accessToken, io.fetch).catch(
+          () => undefined,
+        );
+      }
+      const removed = status
+        ? isCapletsCloudUrl(url)
+          ? await store.logoutCloudProfile({ hostUrl: url, workspace: options.workspace })
+          : await store.logoutSelfHostedProfile({ hostUrl: url })
+        : false;
       if (options.json) {
         writeOut(
           `${JSON.stringify({ loggedOut: removed, hostUrl: normalizeRemoteProfileHostUrl(url) }, null, 2)}\n`,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -155,6 +155,7 @@ type DaemonInstallCommandOptions = {
   path?: string;
   user?: string;
   password?: string;
+  remoteStatePath?: string;
   allowUnauthenticatedHttp?: boolean;
   trustProxy?: boolean;
   json?: boolean;
@@ -190,6 +191,7 @@ function addDaemonInstallOptions(command: Command): Command {
     .option("--path <path>", "HTTP service base path")
     .option("--user <user>", "HTTP Basic Auth username")
     .option("--password <password>", "HTTP Basic Auth password")
+    .option("--remote-state-path <path>", "server-owned remote credential state directory")
     .option(
       "--allow-unauthenticated-http",
       "allow unauthenticated HTTP serving on non-loopback hosts",
@@ -268,6 +270,7 @@ function daemonInstallOptions(options: DaemonInstallCommandOptions): DaemonInsta
     ...(options.path !== undefined ? { path: options.path } : {}),
     ...(options.user !== undefined ? { user: options.user } : {}),
     ...(options.password !== undefined ? { password: options.password } : {}),
+    ...(options.remoteStatePath !== undefined ? { remoteStatePath: options.remoteStatePath } : {}),
     ...(options.allowUnauthenticatedHttp !== undefined
       ? { allowUnauthenticatedHttp: options.allowUnauthenticatedHttp }
       : {}),
@@ -531,6 +534,7 @@ export function createProgram(io: CliIO = {}): Command {
     .option("--path <path>", "HTTP service base path")
     .option("--user <user>", "HTTP Basic Auth username")
     .option("--password <password>", "HTTP Basic Auth password")
+    .option("--remote-state-path <path>", "server-owned remote credential state directory")
     .option(
       "--allow-unauthenticated-http",
       "allow unauthenticated HTTP serving on non-loopback hosts",
@@ -544,6 +548,7 @@ export function createProgram(io: CliIO = {}): Command {
         path?: string;
         user?: string;
         password?: string;
+        remoteStatePath?: string;
         allowUnauthenticatedHttp?: boolean;
         trustProxy?: boolean;
       }) => {

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -8,6 +8,7 @@ export const cliCommands = {
   daemon: "daemon",
   serve: "serve",
   attach: "attach",
+  remote: "remote",
   cloud: "cloud",
   init: "init",
   setup: "setup",
@@ -38,6 +39,7 @@ export const topLevelCommandNames = [
   cliCommands.daemon,
   cliCommands.codeMode,
   cliCommands.attach,
+  cliCommands.remote,
   cliCommands.cloud,
   cliCommands.init,
   cliCommands.setup,
@@ -68,12 +70,19 @@ export const cliSubcommands = {
   [cliCommands.add]: ["cli", "mcp", "openapi", "google-discovery", "graphql", "http"],
   [cliCommands.auth]: ["login", "logout", "list", "refresh"],
   [cliCommands.cloud]: ["auth"],
+  [cliCommands.remote]: ["login", "status", "logout", "host"],
   [cliCommands.codeMode]: ["types"],
   [cliCommands.completion]: [...completionShells],
   [cliCommands.config]: ["path", "paths"],
   [cliCommands.daemon]: ["install", "uninstall", "start", "restart", "stop", "status", "logs"],
   [cliCommands.setup]: ["codex", "claude-code", "opencode", "pi", "mcp-client"],
 } as const satisfies Record<string, readonly string[]>;
+
+export const cliNestedSubcommands = {
+  [cliCommands.remote]: {
+    host: ["pair", "clients", "revoke"],
+  },
+} as const satisfies Record<string, Record<string, readonly string[]>>;
 
 export const capletIdCommands = new Set<string>([
   cliCommands.inspect,

--- a/packages/core/src/cli/completion.ts
+++ b/packages/core/src/cli/completion.ts
@@ -9,6 +9,7 @@ import { listCaplets } from "./inspection";
 import {
   capletIdCommands,
   cliCommands,
+  cliNestedSubcommands,
   cliSubcommands,
   qualifiedPromptCommands,
   qualifiedToolCommands,
@@ -103,6 +104,11 @@ export async function completeCliWords(
       return prefixFilter(cliSubcommands[command as keyof typeof cliSubcommands], current);
     }
 
+    const nestedStaticSubcommands = nestedSubcommandsFor(command, subcommand);
+    if (normalized.length === 3 && nestedStaticSubcommands) {
+      return prefixFilter(nestedStaticSubcommands, current);
+    }
+
     if (normalized.length === 2 && capletIdCommands.has(command)) {
       const ids = promptResourceCommands.has(command)
         ? configuredCapletIds(options, { backend: "mcp" })
@@ -174,6 +180,11 @@ function suggestionsForOptionValue(
     optionValueSuggestions[command]?.[previous] ??
     optionValueSuggestions["*"]?.[previous]
   );
+}
+
+function nestedSubcommandsFor(command: string, subcommand: string): readonly string[] | undefined {
+  if (command !== cliCommands.remote || subcommand !== "host") return undefined;
+  return cliNestedSubcommands.remote.host;
 }
 
 const promptResourceCommands = new Set<string>([

--- a/packages/core/src/cli/doctor.ts
+++ b/packages/core/src/cli/doctor.ts
@@ -1,19 +1,20 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { createNativeCapletsService } from "../native/service";
 import { findProjectRoot, fingerprintProjectRoot } from "../cloud/project-root";
-import {
-  CloudAuthStore,
-  redactedCloudAuthStatus,
-  type CloudAuthCredentials,
-} from "../cloud-auth/store";
+import { CloudAuthStore } from "../cloud-auth/store";
 import { projectBindingWorkspacePaths } from "../project-binding/workspaces";
 import {
+  hostedCloudWorkspaceFromRemoteUrl,
+  isCapletsCloudUrl,
+  normalizeRemoteProfileHostUrl,
   resolveCapletsRemote,
   resolveHostedCloudRemote,
   resolveRemoteMode,
 } from "../remote/options";
+import { FileRemoteProfileStore } from "../remote/profile-store";
+import type { RemoteProfileCredential, RemoteProfileStatus } from "../remote/profiles";
 import { resolveCapletsServer } from "../server/options";
 import type { MutagenProjectSyncDoctorData } from "../project-binding/mutagen";
 import { generateCodeModeDeclarations } from "../code-mode/declarations";
@@ -23,6 +24,7 @@ import { runCodeMode } from "../code-mode/runner";
 import { listCodeModeCallableCaplets } from "../code-mode/api";
 import {
   DEFAULT_OBSERVED_OUTPUT_SHAPE_CACHE_DIR,
+  DEFAULT_AUTH_DIR,
   resolveConfigPath,
   resolveProjectConfigPath,
 } from "../config/paths";
@@ -36,6 +38,7 @@ export type DoctorOptions = {
   cwd?: string;
   syncStatus?: MutagenProjectSyncDoctorData;
   cloudAuthStore?: CloudAuthStore;
+  authDir?: string;
   observedOutputShapeCacheDir?: string;
   daemon?: DaemonOperationOptions;
 };
@@ -46,7 +49,7 @@ export type DoctorJsonReport = {
   projectBinding: Record<string, unknown>;
   sync: Record<string, unknown>;
   daemon: Record<string, unknown>;
-  cloudAuth: Record<string, unknown>;
+  remoteLogin: Record<string, unknown>;
   exposure: Record<string, unknown>;
   codeMode: Record<string, unknown>;
 };
@@ -56,9 +59,9 @@ export async function doctorJsonReport(options: DoctorOptions = {}): Promise<Doc
   const root = findProjectRoot(options.cwd ?? process.cwd());
   const projectFingerprint = fingerprintProjectRoot(root);
   const paths = projectBindingWorkspacePaths(projectFingerprint, { env });
-  const credentials = await (options.cloudAuthStore ?? new CloudAuthStore({ env })).load();
+  const remoteLogin = await resolveRemoteLoginSection(options, env);
   const server = resolveServerSection(env);
-  const remote = resolveRemoteSection(env, credentials);
+  const remote = resolveRemoteSection(env, remoteLogin);
 
   return {
     server,
@@ -68,18 +71,22 @@ export async function doctorJsonReport(options: DoctorOptions = {}): Promise<Doc
       projectRoot: root,
       projectFingerprint,
       workspacePath: paths.project,
-      authMode: credentials
-        ? "hosted_cloud"
+      authMode: remoteLogin.authenticated
+        ? remoteLogin.kind === "cloud"
+          ? "hosted_cloud"
+          : "self_hosted_remote"
         : remote.configured
-          ? "self_hosted_remote"
+          ? "remote_login_required"
           : "unconfigured",
-      selectedWorkspace:
-        credentials?.workspaceSlug ?? credentials?.workspaceId ?? remote.workspace ?? null,
+      selectedWorkspace: remoteLogin.selectedWorkspace ?? remote.workspace ?? null,
       webSocketUrl: remote.webSocketUrl,
       lease: null,
       lastUpgradeError: null,
-      recoveryCommand:
-        credentials || remote.configured ? "caplets attach --once" : "caplets remote login <url>",
+      recoveryCommand: remoteLogin.authenticated
+        ? "caplets attach --once"
+        : remote.configured
+          ? `caplets remote login ${remoteLogin.hostUrl ?? "<url>"}`
+          : "caplets remote login <url>",
     },
     sync: {
       state: options.syncStatus?.state ?? "idle",
@@ -89,7 +96,7 @@ export async function doctorJsonReport(options: DoctorOptions = {}): Promise<Doc
       lastCommand: options.syncStatus?.lastCommand ?? null,
     },
     daemon: await resolveDaemonSection(env, options.daemon),
-    cloudAuth: redactedCloudAuthStatus(credentials),
+    remoteLogin: remoteLogin.report,
     exposure: await resolveExposureSection(env),
     codeMode: await resolveCodeModeSection(options, env),
   };
@@ -135,12 +142,17 @@ export async function formatDoctorReport(options: DoctorOptions = {}): Promise<s
     ...(report.daemon.nativeState ? [`  Native state: ${report.daemon.nativeState}`] : []),
     ...(report.daemon.health ? [`  Health: ${doctorOk(report.daemon.health)}`] : []),
     "",
-    "Cloud Auth",
-    `  Authenticated: ${yesNo(Boolean(report.cloudAuth.authenticated))}`,
-    ...(report.cloudAuth.cloudUrl ? [`  Cloud URL: ${report.cloudAuth.cloudUrl}`] : []),
-    ...(report.cloudAuth.workspaceSlug || report.cloudAuth.workspaceId
-      ? [`  Selected Workspace: ${report.cloudAuth.workspaceSlug ?? report.cloudAuth.workspaceId}`]
+    "Remote Login",
+    `  Configured: ${yesNo(Boolean(report.remoteLogin.configured))}`,
+    `  Authenticated: ${yesNo(Boolean(report.remoteLogin.authenticated))}`,
+    ...(report.remoteLogin.hostUrl ? [`  Host URL: ${report.remoteLogin.hostUrl}`] : []),
+    ...(report.remoteLogin.kind ? [`  Kind: ${report.remoteLogin.kind}`] : []),
+    ...(report.remoteLogin.workspaceSlug || report.remoteLogin.workspaceId
+      ? [
+          `  Selected Workspace: ${report.remoteLogin.workspaceSlug ?? report.remoteLogin.workspaceId}`,
+        ]
       : []),
+    ...(report.remoteLogin.clientId ? [`  Client: ${report.remoteLogin.clientId}`] : []),
     "",
     "Exposure",
     `  Default: ${report.exposure.default ?? "unknown"}`,
@@ -261,16 +273,82 @@ function resolveServerSection(env: NodeJS.ProcessEnv | Record<string, string | u
   }
 }
 
+type DoctorRemoteLoginSection = {
+  report: Record<string, unknown>;
+  configured: boolean;
+  authenticated: boolean;
+  kind?: "cloud" | "self-hosted" | undefined;
+  hostUrl?: string | undefined;
+  selectedWorkspace?: string | undefined;
+  status?: RemoteProfileStatus | undefined;
+  credential?: RemoteProfileCredential | undefined;
+};
+
+async function resolveRemoteLoginSection(
+  options: DoctorOptions,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): Promise<DoctorRemoteLoginSection> {
+  const remoteUrl = env.CAPLETS_REMOTE_URL;
+  if (!remoteUrl) {
+    return {
+      configured: false,
+      authenticated: false,
+      report: { configured: false, authenticated: false },
+    };
+  }
+  const store = new FileRemoteProfileStore({
+    root: join(
+      options.authDir ??
+        (env.CAPLETS_CLOUD_AUTH_PATH ? dirname(env.CAPLETS_CLOUD_AUTH_PATH) : DEFAULT_AUTH_DIR),
+      "remote-profiles",
+    ),
+    legacyCloudAuthStore: options.cloudAuthStore ?? new CloudAuthStore({ env }),
+  });
+  const hostUrl = normalizeRemoteProfileHostUrl(remoteUrl);
+  const status = isCapletsCloudUrl(remoteUrl)
+    ? await store.getCloudProfileStatus({
+        hostUrl: remoteUrl,
+        workspace: env.CAPLETS_REMOTE_WORKSPACE ?? hostedCloudWorkspaceFromRemoteUrl(remoteUrl),
+      })
+    : await store.getSelfHostedProfileStatus({ hostUrl: remoteUrl });
+  const credential = status ? await store.credentials.load(status.key) : undefined;
+  const selectedWorkspace = status?.workspaceSlug ?? status?.workspaceId;
+  const report = {
+    configured: true,
+    authenticated: Boolean(status?.authenticated && credential?.accessToken),
+    hostUrl,
+    kind: isCapletsCloudUrl(remoteUrl) ? "cloud" : "self-hosted",
+    ...(status?.key ? { key: status.key } : {}),
+    ...(status?.workspaceId ? { workspaceId: status.workspaceId } : {}),
+    ...(status?.workspaceSlug ? { workspaceSlug: status.workspaceSlug } : {}),
+    ...(status?.clientId ? { clientId: status.clientId } : {}),
+    ...(status?.clientLabel ? { clientLabel: status.clientLabel } : {}),
+    ...(status?.expiresAt ? { expiresAt: status.expiresAt } : {}),
+    ...(status?.scope ? { scope: status.scope } : {}),
+    ...(status?.tokenType ? { tokenType: status.tokenType } : {}),
+  };
+  return {
+    configured: true,
+    authenticated: Boolean(status?.authenticated && credential?.accessToken),
+    kind: isCapletsCloudUrl(remoteUrl) ? "cloud" : "self-hosted",
+    hostUrl,
+    selectedWorkspace,
+    status,
+    credential,
+    report,
+  };
+}
+
 function resolveRemoteSection(
   env: NodeJS.ProcessEnv | Record<string, string | undefined>,
-  credentials?: CloudAuthCredentials | null,
+  remoteLogin: DoctorRemoteLoginSection,
 ) {
   try {
     const mode = resolveRemoteMode({}, env);
     const remote =
       mode.mode === "cloud"
-        ? resolveHostedCloudRemote(hostedCloudDoctorInput(credentials), env)
-        : resolveCapletsRemote({}, env);
+        ? resolveHostedCloudRemote(hostedCloudDoctorInput(remoteLogin), env)
+        : resolveCapletsRemote(selfHostedDoctorInput(remoteLogin), env);
     return {
       configured: true,
       baseUrl: remote.baseUrl.href,
@@ -287,13 +365,18 @@ function resolveRemoteSection(
   }
 }
 
-function hostedCloudDoctorInput(credentials?: CloudAuthCredentials | null) {
-  if (!credentials?.accessToken) return {};
-  const workspace = credentials.workspaceSlug ?? credentials.workspaceId;
+function hostedCloudDoctorInput(remoteLogin: DoctorRemoteLoginSection) {
+  if (!remoteLogin.credential?.accessToken) return {};
+  const workspace = remoteLogin.selectedWorkspace;
   return {
-    token: credentials.accessToken,
+    token: remoteLogin.credential.accessToken,
     ...(workspace ? { workspace } : {}),
   };
+}
+
+function selfHostedDoctorInput(remoteLogin: DoctorRemoteLoginSection) {
+  if (!remoteLogin.credential?.accessToken) return {};
+  return { token: remoteLogin.credential.accessToken };
 }
 
 function yesNo(value: boolean): string {

--- a/packages/core/src/cli/doctor.ts
+++ b/packages/core/src/cli/doctor.ts
@@ -74,7 +74,7 @@ export async function doctorJsonReport(options: DoctorOptions = {}): Promise<Doc
         ? remoteLogin.kind === "cloud"
           ? "hosted_cloud"
           : "self_hosted_remote"
-        : remote.configured
+        : remote.configured || remoteLogin.configured
           ? "remote_login_required"
           : "unconfigured",
       selectedWorkspace: remoteLogin.selectedWorkspace ?? remote.workspace ?? null,
@@ -83,7 +83,7 @@ export async function doctorJsonReport(options: DoctorOptions = {}): Promise<Doc
       lastUpgradeError: null,
       recoveryCommand: remoteLogin.authenticated
         ? "caplets attach --once"
-        : remote.configured
+        : remote.configured || remoteLogin.configured
           ? `caplets remote login ${remoteLogin.hostUrl ?? "<url>"}`
           : "caplets remote login <url>",
     },
@@ -301,12 +301,18 @@ async function resolveRemoteLoginSection(
     ...(options.cloudAuthStore ? { legacyCloudAuthStore: options.cloudAuthStore } : {}),
   });
   const hostUrl = normalizeRemoteProfileHostUrl(remoteUrl);
-  const status = isCapletsCloudUrl(remoteUrl)
-    ? await store.getCloudProfileStatus({
-        hostUrl: remoteUrl,
-        workspace: env.CAPLETS_REMOTE_WORKSPACE ?? hostedCloudWorkspaceFromRemoteUrl(remoteUrl),
-      })
-    : await store.getSelfHostedProfileStatus({ hostUrl: remoteUrl });
+  let status: RemoteProfileStatus | undefined;
+  let statusError: string | undefined;
+  try {
+    status = isCapletsCloudUrl(remoteUrl)
+      ? await store.getCloudProfileStatus({
+          hostUrl: remoteUrl,
+          workspace: env.CAPLETS_REMOTE_WORKSPACE ?? hostedCloudWorkspaceFromRemoteUrl(remoteUrl),
+        })
+      : await store.getSelfHostedProfileStatus({ hostUrl: remoteUrl });
+  } catch (error) {
+    statusError = error instanceof Error ? error.message : String(error);
+  }
   const credential = status ? await store.credentials.load(status.key) : undefined;
   const selectedWorkspace = status?.workspaceSlug ?? status?.workspaceId;
   const report = {
@@ -322,6 +328,7 @@ async function resolveRemoteLoginSection(
     ...(status?.expiresAt ? { expiresAt: status.expiresAt } : {}),
     ...(status?.scope ? { scope: status.scope } : {}),
     ...(status?.tokenType ? { tokenType: status.tokenType } : {}),
+    ...(statusError ? { error: statusError } : {}),
   };
   return {
     configured: true,

--- a/packages/core/src/cli/doctor.ts
+++ b/packages/core/src/cli/doctor.ts
@@ -79,7 +79,7 @@ export async function doctorJsonReport(options: DoctorOptions = {}): Promise<Doc
       lease: null,
       lastUpgradeError: null,
       recoveryCommand:
-        credentials || remote.configured ? "caplets attach --once" : "caplets cloud auth login",
+        credentials || remote.configured ? "caplets attach --once" : "caplets remote login <url>",
     },
     sync: {
       state: options.syncStatus?.state ?? "idle",

--- a/packages/core/src/cli/doctor.ts
+++ b/packages/core/src/cli/doctor.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { createNativeCapletsService } from "../native/service";
 import { findProjectRoot, fingerprintProjectRoot } from "../cloud/project-root";
 import { CloudAuthStore } from "../cloud-auth/store";
@@ -13,7 +13,7 @@ import {
   resolveHostedCloudRemote,
   resolveRemoteMode,
 } from "../remote/options";
-import { FileRemoteProfileStore } from "../remote/profile-store";
+import { createRemoteProfileStore } from "../remote/profile-store";
 import type { RemoteProfileCredential, RemoteProfileStatus } from "../remote/profiles";
 import { resolveCapletsServer } from "../server/options";
 import type { MutagenProjectSyncDoctorData } from "../project-binding/mutagen";
@@ -24,7 +24,6 @@ import { runCodeMode } from "../code-mode/runner";
 import { listCodeModeCallableCaplets } from "../code-mode/api";
 import {
   DEFAULT_OBSERVED_OUTPUT_SHAPE_CACHE_DIR,
-  DEFAULT_AUTH_DIR,
   resolveConfigPath,
   resolveProjectConfigPath,
 } from "../config/paths";
@@ -296,13 +295,10 @@ async function resolveRemoteLoginSection(
       report: { configured: false, authenticated: false },
     };
   }
-  const store = new FileRemoteProfileStore({
-    root: join(
-      options.authDir ??
-        (env.CAPLETS_CLOUD_AUTH_PATH ? dirname(env.CAPLETS_CLOUD_AUTH_PATH) : DEFAULT_AUTH_DIR),
-      "remote-profiles",
-    ),
-    legacyCloudAuthStore: options.cloudAuthStore ?? new CloudAuthStore({ env }),
+  const store = createRemoteProfileStore({
+    authDir: options.authDir,
+    env,
+    ...(options.cloudAuthStore ? { legacyCloudAuthStore: options.cloudAuthStore } : {}),
   });
   const hostUrl = normalizeRemoteProfileHostUrl(remoteUrl);
   const status = isCapletsCloudUrl(remoteUrl)

--- a/packages/core/src/cli/doctor.ts
+++ b/packages/core/src/cli/doctor.ts
@@ -300,16 +300,17 @@ async function resolveRemoteLoginSection(
     env,
     ...(options.cloudAuthStore ? { legacyCloudAuthStore: options.cloudAuthStore } : {}),
   });
-  const hostUrl = normalizeRemoteProfileHostUrl(remoteUrl);
+  let hostUrl: string | undefined;
   let status: RemoteProfileStatus | undefined;
   let statusError: string | undefined;
   try {
+    hostUrl = normalizeRemoteProfileHostUrl(remoteUrl);
     status = isCapletsCloudUrl(remoteUrl)
       ? await store.getCloudProfileStatus({
-          hostUrl: remoteUrl,
+          hostUrl,
           workspace: env.CAPLETS_REMOTE_WORKSPACE ?? hostedCloudWorkspaceFromRemoteUrl(remoteUrl),
         })
-      : await store.getSelfHostedProfileStatus({ hostUrl: remoteUrl });
+      : await store.getSelfHostedProfileStatus({ hostUrl });
   } catch (error) {
     statusError = error instanceof Error ? error.message : String(error);
   }
@@ -318,8 +319,8 @@ async function resolveRemoteLoginSection(
   const report = {
     configured: true,
     authenticated: Boolean(status?.authenticated && credential?.accessToken),
-    hostUrl,
     kind: isCapletsCloudUrl(remoteUrl) ? "cloud" : "self-hosted",
+    ...(hostUrl ? { hostUrl } : {}),
     ...(status?.key ? { key: status.key } : {}),
     ...(status?.workspaceId ? { workspaceId: status.workspaceId } : {}),
     ...(status?.workspaceSlug ? { workspaceSlug: status.workspaceSlug } : {}),

--- a/packages/core/src/cli/doctor.ts
+++ b/packages/core/src/cli/doctor.ts
@@ -254,7 +254,7 @@ function resolveServerSection(env: NodeJS.ProcessEnv | Record<string, string | u
       mcpUrl: server.mcpUrl.href,
       controlUrl: server.controlUrl.href,
       healthUrl: server.healthUrl.href,
-      auth: server.auth.enabled ? "basic" : "none",
+      auth: server.auth.type,
     };
   } catch {
     return { configured: false };

--- a/packages/core/src/cli/setup.ts
+++ b/packages/core/src/cli/setup.ts
@@ -3,6 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { promisify } from "node:util";
 import { CapletsError } from "../errors";
+import { isCapletsCloudUrl } from "../remote/options";
 import { runCapletSetupCli } from "./setup-caplet";
 import { isSetupTargetKind, type SetupTargetKind } from "../setup/types";
 
@@ -315,6 +316,7 @@ function remoteSetupDefinition(
     nonEmpty(options.serverUrl) ??
     nonEmpty(options.env?.CAPLETS_REMOTE_URL) ??
     "https://caplets.example.com/caplets";
+  const mode = isCapletsCloudUrl(serverUrl) ? "cloud" : "remote";
 
   if (id === "opencode") {
     return {
@@ -329,7 +331,7 @@ function remoteSetupDefinition(
       ],
       nextSteps: [
         `Run caplets remote login ${serverUrl} before starting OpenCode.`,
-        `Run OpenCode with CAPLETS_MODE=remote and CAPLETS_REMOTE_URL=${serverUrl}.`,
+        `Run OpenCode with CAPLETS_MODE=${mode} and CAPLETS_REMOTE_URL=${serverUrl}.`,
       ],
     };
   }
@@ -347,7 +349,7 @@ function remoteSetupDefinition(
       ],
       nextSteps: [
         `Run caplets remote login ${serverUrl} before starting Pi.`,
-        `Start Pi with CAPLETS_MODE=remote and CAPLETS_REMOTE_URL=${serverUrl}.`,
+        `Start Pi with CAPLETS_MODE=${mode} and CAPLETS_REMOTE_URL=${serverUrl}.`,
       ],
     };
   }

--- a/packages/core/src/cli/setup.ts
+++ b/packages/core/src/cli/setup.ts
@@ -328,8 +328,8 @@ function remoteSetupDefinition(
         },
       ],
       nextSteps: [
+        `Run caplets remote login ${serverUrl} before starting OpenCode.`,
         `Run OpenCode with CAPLETS_MODE=remote and CAPLETS_REMOTE_URL=${serverUrl}.`,
-        "Keep CAPLETS_REMOTE_TOKEN or CAPLETS_REMOTE_PASSWORD in your shell or secret manager.",
       ],
     };
   }
@@ -346,8 +346,8 @@ function remoteSetupDefinition(
         },
       ],
       nextSteps: [
+        `Run caplets remote login ${serverUrl} before starting Pi.`,
         `Start Pi with CAPLETS_MODE=remote and CAPLETS_REMOTE_URL=${serverUrl}.`,
-        "Keep CAPLETS_REMOTE_TOKEN or CAPLETS_REMOTE_PASSWORD in your shell or secret manager.",
       ],
     };
   }
@@ -364,8 +364,8 @@ function remoteSetupDefinition(
         },
       ],
       nextSteps: [
+        `Run caplets remote login ${serverUrl} before using this MCP config.`,
         "In Codex, run /mcp to confirm the caplets server is connected.",
-        "Keep remote credentials in your shell or secret manager; do not hardcode them in config.",
       ],
     };
   }
@@ -382,8 +382,8 @@ function remoteSetupDefinition(
         },
       ],
       nextSteps: [
+        `Run caplets remote login ${serverUrl} before using this MCP config.`,
         "In Claude Code, run /mcp to confirm the caplets server is connected.",
-        "Keep remote credentials in your shell or secret manager; do not hardcode them in config.",
       ],
     };
   }
@@ -403,15 +403,22 @@ function remoteSetupDefinition(
         label: "Write remote MCP config",
         path: options.output,
         content: `${JSON.stringify(
-          { mcpServers: { caplets: { url: `${serverUrl.replace(/\/$/, "")}/v1/mcp` } } },
+          {
+            mcpServers: {
+              caplets: {
+                command: "caplets",
+                args: ["attach", "--remote-url", serverUrl],
+              },
+            },
+          },
           null,
           2,
         )}\n`,
       },
     ],
     nextSteps: [
-      "Add Basic Auth credentials through your agent's secret mechanism.",
-      "Do not hardcode CAPLETS_REMOTE_TOKEN or CAPLETS_REMOTE_PASSWORD in a committed config file.",
+      `Run caplets remote login ${serverUrl} before using this MCP config.`,
+      "Import the written MCP config into your MCP client.",
     ],
   };
 }

--- a/packages/core/src/cloud-auth/client.ts
+++ b/packages/core/src/cloud-auth/client.ts
@@ -159,8 +159,8 @@ export class CloudAuthClient {
         message,
         recoveryCommand:
           code === "workspace_switch_required"
-            ? "caplets cloud auth switch <workspace>"
-            : "caplets cloud auth login",
+            ? "caplets remote login <cloud-url> --workspace <workspace>"
+            : "caplets remote login <cloud-url>",
         requestId,
       };
       throw new CapletsError("AUTH_FAILED", message, redactCloudAuthSecrets(recovery));

--- a/packages/core/src/cloud-auth/errors.ts
+++ b/packages/core/src/cloud-auth/errors.ts
@@ -37,10 +37,10 @@ export function redactCloudAuthSecrets(value: unknown): unknown {
 export function cloudAuthRecovery(code: CloudAuthErrorCode, detail?: string): CloudAuthRecovery {
   const recoveryCommand =
     code === "workspace_switch_required"
-      ? "caplets cloud auth switch <workspace>"
+      ? "caplets remote login <cloud-url> --workspace <workspace>"
       : code === "workspace_selection_required"
-        ? "caplets cloud auth login --workspace <workspace>"
-        : "caplets cloud auth login";
+        ? "caplets remote login <cloud-url> --workspace <workspace>"
+        : "caplets remote login <cloud-url>";
   return {
     code,
     message: detail ?? defaultMessage(code),
@@ -69,6 +69,6 @@ function defaultMessage(code: CloudAuthErrorCode): string {
       return "Hosted Caplets Cloud is unavailable.";
     case "cloud_auth_required":
     default:
-      return "Run caplets cloud auth login before using hosted Project Binding.";
+      return "Run caplets remote login <cloud-url> before using hosted Project Binding.";
   }
 }

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -395,6 +395,7 @@ export function redactDaemonInstallResult(result: DaemonInstallResult): DaemonIn
 
 function redactDaemonConfig(config: DaemonConfig): DaemonConfig {
   const env = redactEnv(config.env.values);
+  const serve = redactLegacyDaemonServeAuth(config.serve);
   return {
     ...config,
     env: {
@@ -402,7 +403,7 @@ function redactDaemonConfig(config: DaemonConfig): DaemonConfig {
       values: env,
     },
     serve: {
-      ...config.serve,
+      ...serve,
       ...(config.serve.remoteCredentialStateDir ? { remoteCredentialStateDir: "[REDACTED]" } : {}),
     },
     command: {
@@ -411,6 +412,18 @@ function redactDaemonConfig(config: DaemonConfig): DaemonConfig {
       env: redactEnv(config.command.env),
     },
   };
+}
+
+function redactLegacyDaemonServeAuth(serve: DaemonConfig["serve"]): DaemonConfig["serve"] {
+  const legacyAuth = legacyDaemonServeAuth(serve);
+  if (!legacyAuth?.password) return serve;
+  return {
+    ...serve,
+    auth: {
+      ...legacyAuth,
+      password: "[redacted]",
+    },
+  } as unknown as DaemonConfig["serve"];
 }
 
 function redactNativeStatus(
@@ -428,6 +441,7 @@ function collectDaemonSecrets(config: DaemonConfig): string[] {
     new Set(
       [
         config.serve.remoteCredentialStateDir,
+        legacyDaemonServeAuth(config.serve)?.password,
         ...Object.values(config.env.values),
         ...Object.values(config.command.env),
       ].filter((value): value is string => value !== undefined && value.length > 0),
@@ -436,6 +450,18 @@ function collectDaemonSecrets(config: DaemonConfig): string[] {
   return Array.from(new Set(secrets.flatMap(secretRedactionVariants))).sort(
     (left, right) => right.length - left.length,
   );
+}
+
+function legacyDaemonServeAuth(
+  serve: DaemonConfig["serve"],
+): ({ password?: string | undefined } & Record<string, unknown>) | undefined {
+  const auth = (serve as { auth?: unknown }).auth;
+  if (!auth || typeof auth !== "object" || Array.isArray(auth)) return undefined;
+  const record = auth as Record<string, unknown>;
+  return {
+    ...record,
+    ...(typeof record.password === "string" ? { password: record.password } : {}),
+  };
 }
 
 function redactNativeValue(value: unknown, secrets: string[]): unknown {

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -403,13 +403,13 @@ function redactDaemonConfig(config: DaemonConfig): DaemonConfig {
     },
     serve: {
       ...config.serve,
-      auth: config.serve.auth.enabled
-        ? { ...config.serve.auth, password: "[redacted]" }
-        : config.serve.auth,
+      ...(config.serve.remoteCredentialStateDir
+        ? { remoteCredentialStateDir: "[REDACTED]" }
+        : {}),
     },
     command: {
       ...config.command,
-      args: redactPasswordArgs(config.command.args),
+      args: redactSensitiveArgs(config.command.args),
       env: redactEnv(config.command.env),
     },
   };
@@ -429,7 +429,7 @@ function collectDaemonSecrets(config: DaemonConfig): string[] {
   const secrets = Array.from(
     new Set(
       [
-        config.serve.auth.enabled ? config.serve.auth.password : undefined,
+        config.serve.remoteCredentialStateDir,
         ...Object.values(config.env.values),
         ...Object.values(config.command.env),
       ].filter((value): value is string => value !== undefined && value.length > 0),
@@ -441,7 +441,7 @@ function collectDaemonSecrets(config: DaemonConfig): string[] {
 }
 
 function redactNativeValue(value: unknown, secrets: string[]): unknown {
-  if (typeof value === "string") return redactSecrets(redactPasswordString(value), secrets);
+  if (typeof value === "string") return redactSecrets(redactSensitiveFlagString(value), secrets);
   if (Array.isArray(value)) return value.map((item) => redactNativeValue(item, secrets));
   if (value && typeof value === "object") {
     return Object.fromEntries(
@@ -518,14 +518,22 @@ function posixShellQuotedSecret(secret: string): string {
   return `'${posixShellEscapedSecret(secret)}'`;
 }
 
-function redactPasswordString(value: string): string {
-  return value.replace(/(--password(?:=|\s+))("[^"]*"|'[^']*'|\S+)/giu, "$1[redacted]");
+function redactSensitiveFlagString(value: string): string {
+  return value.replace(
+    /(--(?:password|remote-state-path)(?:=|\s+))("[^"]*"|'[^']*'|\S+)/giu,
+    "$1[redacted]",
+  );
 }
 
-function redactPasswordArgs(args: string[]): string[] {
+function redactSensitiveArgs(args: string[]): string[] {
   const redacted = [...args];
   for (let index = 0; index < redacted.length; index += 1) {
-    if (redacted[index] === "--password" && redacted[index + 1]) redacted[index + 1] = "[redacted]";
+    if (
+      (redacted[index] === "--password" || redacted[index] === "--remote-state-path") &&
+      redacted[index + 1]
+    ) {
+      redacted[index + 1] = "[redacted]";
+    }
   }
   return redacted;
 }
@@ -602,15 +610,10 @@ function mergeServeOptions(
       : existing?.serve.path
         ? { path: existing.serve.path }
         : {}),
-    ...(install.user !== undefined
-      ? { user: install.user }
-      : existing?.serve.auth.enabled
-        ? { user: existing.serve.auth.user }
-        : {}),
-    ...(install.password !== undefined
-      ? { password: install.password }
-      : existing?.serve.auth.enabled
-        ? { password: existing.serve.auth.password }
+    ...(install.remoteStatePath !== undefined
+      ? { remoteStatePath: install.remoteStatePath }
+      : existing?.serve.remoteCredentialStateDir
+        ? { remoteStatePath: existing.serve.remoteCredentialStateDir }
         : {}),
     ...(install.allowUnauthenticatedHttp !== undefined
       ? { allowUnauthenticatedHttp: install.allowUnauthenticatedHttp }
@@ -623,9 +626,8 @@ function mergeServeOptions(
         ? { trustProxy: existing.serve.trustProxy }
         : {}),
     ...(existing &&
-    !existing.serve.auth.enabled &&
-    install.user === undefined &&
-    install.password === undefined
+    existing.serve.auth.type === "development_unauthenticated" &&
+    install.allowUnauthenticatedHttp === undefined
       ? { preserveUnauthenticatedAuth: true }
       : {}),
   };

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -403,9 +403,7 @@ function redactDaemonConfig(config: DaemonConfig): DaemonConfig {
     },
     serve: {
       ...config.serve,
-      ...(config.serve.remoteCredentialStateDir
-        ? { remoteCredentialStateDir: "[REDACTED]" }
-        : {}),
+      ...(config.serve.remoteCredentialStateDir ? { remoteCredentialStateDir: "[REDACTED]" } : {}),
     },
     command: {
       ...config.command,

--- a/packages/core/src/daemon/process.ts
+++ b/packages/core/src/daemon/process.ts
@@ -22,11 +22,9 @@ export function resolveDaemonHttpServeOptions(
       "caplets daemon install does not accept --transport.",
     );
   }
-  const { preserveUnauthenticatedAuth, ...serveRaw } = raw;
-  const serveEnv = preserveUnauthenticatedAuth
-    ? { ...env, CAPLETS_SERVER_USER: undefined, CAPLETS_SERVER_PASSWORD: undefined }
-    : env;
-  return resolveServeOptions({ ...serveRaw, transport: "http" }, serveEnv) as HttpServeOptions;
+  const serveRaw = { ...raw };
+  delete serveRaw.preserveUnauthenticatedAuth;
+  return resolveServeOptions({ ...serveRaw, transport: "http" }, env) as HttpServeOptions;
 }
 
 export function daemonServeArgs(options: HttpServeOptions): string[] {
@@ -41,8 +39,9 @@ export function daemonServeArgs(options: HttpServeOptions): string[] {
     "--path",
     options.path,
   ];
-  if (options.auth.enabled)
-    args.push("--user", options.auth.user, "--password", options.auth.password);
+  if (options.auth.type === "remote_credentials" && options.remoteCredentialStateDir) {
+    args.push("--remote-state-path", options.remoteCredentialStateDir);
+  }
   if (options.allowUnauthenticatedHttp) args.push("--allow-unauthenticated-http");
   if (options.trustProxy) args.push("--trust-proxy");
   return args;

--- a/packages/core/src/native/options.ts
+++ b/packages/core/src/native/options.ts
@@ -129,9 +129,6 @@ function optionalWorkspace(
 }
 
 function nativeAuthFromRemoteAuth(auth: CapletsRemoteAuth): NativeRemoteAuthOptions {
-  if (auth.type === "basic") {
-    return { enabled: true, user: auth.user, password: auth.password };
-  }
   if (auth.type === "none") {
     return { enabled: false, user: auth.user };
   }

--- a/packages/core/src/native/options.ts
+++ b/packages/core/src/native/options.ts
@@ -1,5 +1,6 @@
 import { CapletsError } from "../errors";
 import {
+  isCapletsCloudUrl,
   resolveCapletsRemote,
   resolveHostedCloudRemote,
   resolveRemoteMode,
@@ -80,7 +81,7 @@ export function resolveNativeCapletsServiceOptions(
   const remoteFetch = input.remote?.fetch;
   const server =
     mode.mode === "cloud"
-      ? resolveNativeHostedCloudRemote(
+      ? resolveNativeHostedCloudRemoteOrPlaceholder(
           input.remote?.url ?? env.CAPLETS_REMOTE_URL ?? "",
           optionalWorkspace(input, env).workspace,
           remoteFetch,
@@ -114,6 +115,18 @@ function resolveNativeHostedCloudRemote(
     ...(workspace ? { workspace } : {}),
     ...(fetch ? { fetch } : {}),
   });
+}
+
+function resolveNativeHostedCloudRemoteOrPlaceholder(
+  url: string,
+  workspace: string | undefined,
+  fetch: typeof globalThis.fetch | undefined,
+): ReturnType<typeof resolveHostedCloudRemote> {
+  if (!isCapletsCloudUrl(url)) {
+    throw new CapletsError("REQUEST_INVALID", "CAPLETS_MODE=cloud requires Caplets Cloud.");
+  }
+  if (workspace) return resolveNativeHostedCloudRemote(url, workspace, fetch);
+  return resolveCapletsRemote({ url, ...(fetch ? { fetch } : {}) }, {});
 }
 
 function optionalWorkspace(

--- a/packages/core/src/native/options.ts
+++ b/packages/core/src/native/options.ts
@@ -6,14 +6,16 @@ import {
   resolveRemoteMode,
   type CapletsRemoteAuth,
   type CapletsRemoteEnv,
-  type CapletsRemoteInput,
 } from "../remote/options";
 
 type CapletsMode = "auto" | "local" | "remote" | "cloud";
 
 export type NativeCapletsMode = CapletsMode;
 
-export type NativeRemoteCapletsOptions = CapletsRemoteInput & {
+export type NativeRemoteCapletsOptions = {
+  url?: string;
+  workspace?: string;
+  fetch?: typeof fetch;
   pollIntervalMs?: number;
   cloud?: NativeCloudPresenceInput;
 };
@@ -86,7 +88,14 @@ export function resolveNativeCapletsServiceOptions(
           optionalWorkspace(input, env).workspace,
           remoteFetch,
         )
-      : resolveCapletsRemote(input.remote, env);
+      : resolveCapletsRemote(
+          {
+            ...(input.remote?.url ? { url: input.remote.url } : {}),
+            ...(input.remote?.workspace ? { workspace: input.remote.workspace } : {}),
+            ...(remoteFetch ? { fetch: remoteFetch } : {}),
+          },
+          env,
+        );
 
   const cloud = resolveNativeCloudPresence(input.remote?.cloud, env);
   return {

--- a/packages/core/src/native/remote.ts
+++ b/packages/core/src/native/remote.ts
@@ -57,6 +57,8 @@ export type RemoteCapletsClientOptions = ResolvedNativeCapletsServiceOptions & {
 
 export type SdkRemoteCapletsClientOptions = RemoteCapletsClientOptions["remote"] & {
   resolveRuntimeOptions?: () => Promise<RemoteCapletsClientOptions["remote"]>;
+  authKind?: "self_hosted_remote" | "hosted_cloud";
+  writeErr?: (value: string) => void;
 };
 
 export type RemoteNativeCapletsServiceOptions = {
@@ -141,7 +143,13 @@ export function createSdkRemoteCapletsClient(
           scheduleEventsReconnect();
         },
       );
-    } catch {
+    } catch (error) {
+      if (isPermanentRemoteCredentialsError(error)) {
+        options.writeErr?.(
+          `${remoteAuthError(options.authKind ?? "self_hosted_remote").message}\n`,
+        );
+        return;
+      }
       scheduleEventsReconnect();
     }
   };
@@ -1046,4 +1054,24 @@ function isAuthFailure(error: unknown): boolean {
     return true;
   }
   return /\b(401|403|unauthorized|forbidden)\b/iu.test(errorMessage(error));
+}
+
+function isPermanentRemoteCredentialsError(error: unknown): boolean {
+  const candidate = error as {
+    projectBindingCode?: unknown;
+    details?: unknown;
+  };
+  if (
+    candidate?.projectBindingCode === "remote_credentials_required" ||
+    candidate?.projectBindingCode === "remote_auth_failed"
+  ) {
+    return true;
+  }
+  if (isPlainObject(candidate?.details)) {
+    const code = candidate.details.code;
+    if (code === "remote_credentials_required" || code === "remote_auth_failed") {
+      return true;
+    }
+  }
+  return isAuthFailure(error);
 }

--- a/packages/core/src/native/remote.ts
+++ b/packages/core/src/native/remote.ts
@@ -55,6 +55,10 @@ export type RemoteCapletsClientOptions = ResolvedNativeCapletsServiceOptions & {
   mode: "remote" | "cloud";
 };
 
+export type SdkRemoteCapletsClientOptions = RemoteCapletsClientOptions["remote"] & {
+  resolveRuntimeOptions?: () => Promise<RemoteCapletsClientOptions["remote"]>;
+};
+
 export type RemoteNativeCapletsServiceOptions = {
   client: RemoteCapletsClient;
   clientFactory?: () => RemoteCapletsClient;
@@ -64,14 +68,46 @@ export type RemoteNativeCapletsServiceOptions = {
 };
 
 export function createSdkRemoteCapletsClient(
-  options: RemoteCapletsClientOptions["remote"],
+  options: SdkRemoteCapletsClientOptions,
 ): RemoteCapletsClient {
-  const fetchImpl = options.fetch ?? fetch;
   const listeners = new Set<() => void>();
   let manifest: AttachManifest | undefined;
   let exportByName = new Map<string, AttachManifestExport>();
   let eventsAbort: AbortController | undefined;
+  let eventsStartInFlight: Promise<void> | undefined;
   let eventsReconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  let closed = false;
+
+  const resolveRuntimeOptions = async (): Promise<RemoteCapletsClientOptions["remote"]> => {
+    return options.resolveRuntimeOptions ? await options.resolveRuntimeOptions() : options;
+  };
+
+  const fetchFor = (runtimeOptions: RemoteCapletsClientOptions["remote"]): typeof fetch =>
+    runtimeOptions.fetch ?? fetch;
+
+  const fetchCurrentManifest = async (): Promise<AttachManifest> => {
+    const runtimeOptions = await resolveRuntimeOptions();
+    return await fetchAttachManifest(
+      runtimeOptions.url,
+      runtimeOptions.requestInit,
+      fetchFor(runtimeOptions),
+    );
+  };
+
+  const invokeCurrentExport = async (body: {
+    revision: string;
+    kind: string;
+    exportId: string;
+    input: unknown;
+  }): Promise<unknown> => {
+    const runtimeOptions = await resolveRuntimeOptions();
+    return await invokeAttachExport(
+      runtimeOptions.url,
+      runtimeOptions.requestInit,
+      fetchFor(runtimeOptions),
+      body,
+    );
+  };
 
   const clearEventsReconnectTimer = () => {
     if (eventsReconnectTimer) {
@@ -79,35 +115,57 @@ export function createSdkRemoteCapletsClient(
       eventsReconnectTimer = undefined;
     }
   };
+
+  const scheduleEventsReconnect = () => {
+    if (closed || listeners.size === 0) return;
+    clearEventsReconnectTimer();
+    eventsReconnectTimer = setTimeout(() => {
+      eventsReconnectTimer = undefined;
+      startEvents();
+    }, 1_000);
+  };
+
+  const startEventsNow = async () => {
+    try {
+      const runtimeOptions = await resolveRuntimeOptions();
+      if (closed || eventsAbort || listeners.size === 0) return;
+      eventsAbort = startAttachEvents(
+        runtimeOptions.url,
+        runtimeOptions.requestInit,
+        fetchFor(runtimeOptions),
+        listeners,
+        (closedAbort, retry) => {
+          if (eventsAbort !== closedAbort) return;
+          eventsAbort = undefined;
+          if (!retry || closedAbort.signal.aborted || listeners.size === 0) return;
+          scheduleEventsReconnect();
+        },
+      );
+    } catch {
+      scheduleEventsReconnect();
+    }
+  };
+
   const startEvents = () => {
-    if (eventsAbort || listeners.size === 0) return;
-    eventsAbort = startAttachEvents(
-      options.url,
-      options.requestInit,
-      fetchImpl,
-      listeners,
-      (closedAbort, retry) => {
-        if (eventsAbort !== closedAbort) return;
-        eventsAbort = undefined;
-        if (!retry || closedAbort.signal.aborted || listeners.size === 0) return;
-        clearEventsReconnectTimer();
-        eventsReconnectTimer = setTimeout(() => {
-          eventsReconnectTimer = undefined;
-          startEvents();
-        }, 1_000);
-      },
-    );
+    if (closed || eventsAbort || eventsStartInFlight || listeners.size === 0) return;
+    const start = startEventsNow();
+    eventsStartInFlight = start;
+    void start.finally(() => {
+      if (eventsStartInFlight === start) {
+        eventsStartInFlight = undefined;
+      }
+    });
   };
 
   return {
     async listTools() {
-      manifest = await fetchAttachManifest(options.url, options.requestInit, fetchImpl);
+      manifest = await fetchCurrentManifest();
       exportByName = exportMapFor(manifest);
       return toolsFromManifest(manifest);
     },
     async callTool(name, args) {
       if (!manifest) {
-        manifest = await fetchAttachManifest(options.url, options.requestInit, fetchImpl);
+        manifest = await fetchCurrentManifest();
         exportByName = exportMapFor(manifest);
       }
       const invokeWithStaleRetry = async (
@@ -115,7 +173,7 @@ export function createSdkRemoteCapletsClient(
         input: unknown,
       ): Promise<unknown> => {
         try {
-          return await invokeAttachExport(options.url, options.requestInit, fetchImpl, {
+          return await invokeCurrentExport({
             revision: manifest!.revision,
             kind: entry.kind,
             exportId: entry.exportId,
@@ -123,11 +181,7 @@ export function createSdkRemoteCapletsClient(
           });
         } catch (error) {
           if (!isAttachManifestStale(error)) throw error;
-          const nextManifest = await fetchAttachManifest(
-            options.url,
-            options.requestInit,
-            fetchImpl,
-          );
+          const nextManifest = await fetchCurrentManifest();
           const nextEntry = compatibleExport(nextManifest, entry);
           manifest = nextManifest;
           exportByName = exportMapFor(nextManifest);
@@ -137,7 +191,7 @@ export function createSdkRemoteCapletsClient(
               "Attach export changed after manifest refresh; refetch the manifest before retrying.",
             );
           }
-          return await invokeAttachExport(options.url, options.requestInit, fetchImpl, {
+          return await invokeCurrentExport({
             revision: nextManifest.revision,
             kind: nextEntry.kind,
             exportId: nextEntry.exportId,
@@ -168,6 +222,7 @@ export function createSdkRemoteCapletsClient(
       };
     },
     async close() {
+      closed = true;
       clearEventsReconnectTimer();
       eventsAbort?.abort();
       eventsAbort = undefined;

--- a/packages/core/src/native/remote.ts
+++ b/packages/core/src/native/remote.ts
@@ -953,8 +953,8 @@ function remoteAuthError(kind: "self_hosted_remote" | "hosted_cloud"): CapletsEr
   return new CapletsError(
     "AUTH_FAILED",
     kind === "hosted_cloud"
-      ? "Caplets Cloud authentication failed; run caplets cloud auth login."
-      : "Remote Caplets authentication failed; check CAPLETS_REMOTE_TOKEN or CAPLETS_REMOTE_USER and CAPLETS_REMOTE_PASSWORD.",
+      ? "Caplets Cloud authentication failed; run caplets remote login <cloud-url>."
+      : "Remote Caplets authentication failed; run caplets remote login <url>.",
   );
 }
 

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -795,6 +795,7 @@ class ProfileBackedNativeCapletsService implements NativeCapletsService {
       {
         mode: this.authKind === "hosted_cloud" ? "cloud" : "remote",
         remoteUrl,
+        ...(this.options.remote?.workspace ? { workspace: this.options.remote.workspace } : {}),
         ...(this.options.authDir ? { authDir: this.options.authDir } : {}),
         ...(cloudFetch ? { fetch: cloudFetch } : {}),
       },

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -12,6 +12,7 @@ import {
   createSdkRemoteCapletsClient,
   RemoteNativeCapletsService,
   type RemoteCapletsClient,
+  type SdkRemoteCapletsClientOptions,
 } from "./remote";
 import { CapletsEngine } from "../engine";
 import { CapletsError } from "../errors";
@@ -631,18 +632,33 @@ function createCompositeRemoteParts(
   local: NativeCapletsService,
   options: NativeCapletsServiceOptions,
   authKind: "self_hosted_remote" | "hosted_cloud",
+  resolveRuntimeRemoteOptions?: () => Promise<ResolvedNativeRemoteOptions>,
 ): { remote: NativeCapletsService; presence?: ProjectBindingSessionManager } {
-  const client = (options.remoteClientFactory ?? createSdkRemoteCapletsClient)(remoteOptions);
+  const client = createRemoteClient(remoteOptions, options, resolveRuntimeRemoteOptions);
   const remote = new RemoteNativeCapletsService({
     client,
-    clientFactory: () =>
-      (options.remoteClientFactory ?? createSdkRemoteCapletsClient)(remoteOptions),
+    clientFactory: () => createRemoteClient(remoteOptions, options, resolveRuntimeRemoteOptions),
     pollIntervalMs: remoteOptions.pollIntervalMs,
     authKind,
     ...(options.writeErr ? { writeErr: options.writeErr } : {}),
   });
   const presence = createProjectBindingSessionManager(remoteOptions.cloud, local, options);
   return { remote, ...(presence ? { presence } : {}) };
+}
+
+function createRemoteClient(
+  remoteOptions: ResolvedNativeRemoteOptions,
+  options: NativeCapletsServiceOptions,
+  resolveRuntimeRemoteOptions?: () => Promise<ResolvedNativeRemoteOptions>,
+): RemoteCapletsClient {
+  if (options.remoteClientFactory) {
+    return options.remoteClientFactory(remoteOptions);
+  }
+  const sdkOptions: SdkRemoteCapletsClientOptions = {
+    ...remoteOptions,
+    ...(resolveRuntimeRemoteOptions ? { resolveRuntimeOptions: resolveRuntimeRemoteOptions } : {}),
+  };
+  return createSdkRemoteCapletsClient(sdkOptions);
 }
 
 class ProfileBackedNativeCapletsService implements NativeCapletsService {
@@ -729,6 +745,7 @@ class ProfileBackedNativeCapletsService implements NativeCapletsService {
           this.local,
           this.options,
           this.authKind,
+          () => this.resolveProfileRemoteOptions(),
         );
         this.delegate = new CompositeNativeCapletsService(
           remote,
@@ -747,6 +764,7 @@ class ProfileBackedNativeCapletsService implements NativeCapletsService {
         this.local,
         this.options,
         this.authKind,
+        () => this.resolveProfileRemoteOptions(),
       );
       await this.delegate.replaceRemote(remote, presence);
       this.remoteSignature = signature;

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -634,10 +634,11 @@ function createCompositeRemoteParts(
   authKind: "self_hosted_remote" | "hosted_cloud",
   resolveRuntimeRemoteOptions?: () => Promise<ResolvedNativeRemoteOptions>,
 ): { remote: NativeCapletsService; presence?: ProjectBindingSessionManager } {
-  const client = createRemoteClient(remoteOptions, options, resolveRuntimeRemoteOptions);
+  const client = createRemoteClient(remoteOptions, options, authKind, resolveRuntimeRemoteOptions);
   const remote = new RemoteNativeCapletsService({
     client,
-    clientFactory: () => createRemoteClient(remoteOptions, options, resolveRuntimeRemoteOptions),
+    clientFactory: () =>
+      createRemoteClient(remoteOptions, options, authKind, resolveRuntimeRemoteOptions),
     pollIntervalMs: remoteOptions.pollIntervalMs,
     authKind,
     ...(options.writeErr ? { writeErr: options.writeErr } : {}),
@@ -649,6 +650,7 @@ function createCompositeRemoteParts(
 function createRemoteClient(
   remoteOptions: ResolvedNativeRemoteOptions,
   options: NativeCapletsServiceOptions,
+  authKind: "self_hosted_remote" | "hosted_cloud",
   resolveRuntimeRemoteOptions?: () => Promise<ResolvedNativeRemoteOptions>,
 ): RemoteCapletsClient {
   if (options.remoteClientFactory) {
@@ -656,6 +658,8 @@ function createRemoteClient(
   }
   const sdkOptions: SdkRemoteCapletsClientOptions = {
     ...remoteOptions,
+    authKind,
+    ...(options.writeErr ? { writeErr: options.writeErr } : {}),
     ...(resolveRuntimeRemoteOptions ? { resolveRuntimeOptions: resolveRuntimeRemoteOptions } : {}),
   };
   return createSdkRemoteCapletsClient(sdkOptions);

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -766,6 +766,10 @@ class ProfileBackedNativeCapletsService implements NativeCapletsService {
         this.authKind,
         () => this.resolveProfileRemoteOptions(),
       );
+      if (!(await remote.reload())) {
+        await Promise.all([remote.close(), presence?.close()]);
+        return;
+      }
       await this.delegate.replaceRemote(remote, presence);
       this.remoteSignature = signature;
       this.credentialExpiresAt = remoteOptions.credentialExpiresAt;

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -737,9 +737,6 @@ class CloudNativeCapletsService implements NativeCapletsService {
 }
 
 function nativeAuthFromRemoteAuth(auth: CapletsRemoteAuth): NativeRemoteAuthOptions {
-  if (auth.type === "basic") {
-    return { enabled: true, user: auth.user, password: auth.password };
-  }
   if (auth.type === "none") {
     return { enabled: false, user: auth.user };
   }

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -988,6 +988,7 @@ class CompositeNativeCapletsService implements NativeCapletsService {
     this.presence = presence;
     this.unsubscribeRemote = this.remote.onToolsChanged(() => this.updateMergedTools());
     await Promise.all([previousRemote.close(), previousPresence?.close()]);
+    if (this.closed) return;
     this.startPresence();
     this.updateMergedTools();
   }

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -99,25 +99,28 @@ export function createNativeCapletsService(
 ): NativeCapletsService {
   const resolved = resolveNativeCapletsServiceOptions(options);
   if (resolved.mode === "remote") {
-    const local = createLocalOverlayService(options);
-    try {
-      return createCompositeRemoteService(resolved.remote, local, options, "self_hosted_remote");
-    } catch (error) {
-      if (options.mode !== "remote") {
-        warnRemoteProjectBindingFallback(options);
-        return local;
+    if (options.remoteClientFactory) {
+      const local = createLocalOverlayService(options);
+      try {
+        return createCompositeRemoteService(resolved.remote, local, options, "self_hosted_remote");
+      } catch (error) {
+        if (options.mode !== "remote") {
+          warnRemoteProjectBindingFallback(options);
+          return local;
+        }
+        void local.close().catch((closeError) => {
+          writeErr(
+            options,
+            `Could not close local overlay Caplets service: ${errorMessage(closeError)}\n`,
+          );
+        });
+        throw error;
       }
-      void local.close().catch((closeError) => {
-        writeErr(
-          options,
-          `Could not close local overlay Caplets service: ${errorMessage(closeError)}\n`,
-        );
-      });
-      throw error;
     }
+    return new ProfileBackedNativeCapletsService(options, resolved.remote, "self_hosted_remote");
   }
   if (resolved.mode === "cloud") {
-    return new CloudNativeCapletsService(options, resolved.remote);
+    return new ProfileBackedNativeCapletsService(options, resolved.remote, "hosted_cloud");
   }
   return new DefaultNativeCapletsService(options);
 }
@@ -632,7 +635,7 @@ function createCompositeRemoteService(
   return new CompositeNativeCapletsService(remote, local, options, presence);
 }
 
-class CloudNativeCapletsService implements NativeCapletsService {
+class ProfileBackedNativeCapletsService implements NativeCapletsService {
   private readonly local: NativeCapletsService;
   private readonly listeners = new Set<NativeCapletsToolsChangedListener>();
   private delegate: NativeCapletsService | undefined;
@@ -642,6 +645,7 @@ class CloudNativeCapletsService implements NativeCapletsService {
   constructor(
     private readonly options: NativeCapletsServiceOptions,
     private readonly baseRemote: ResolvedNativeRemoteOptions,
+    private readonly authKind: "self_hosted_remote" | "hosted_cloud",
   ) {
     this.local = createLocalOverlayService(options);
   }
@@ -664,51 +668,63 @@ class CloudNativeCapletsService implements NativeCapletsService {
       try {
         const cloudFetch = this.options.remote?.fetch;
         const remoteUrl =
-          this.options.remote?.url ?? this.baseRemote.url.toString().replace(/\/mcp$/u, "");
+          this.options.remote?.url ??
+          process.env.CAPLETS_REMOTE_URL ??
+          this.baseRemote.url.toString().replace(/\/v1(?:\/ws\/[^/]+)?\/attach$/u, "");
         const selection = await resolveRemoteSelection(
           {
-            mode: "cloud",
+            mode: this.authKind === "hosted_cloud" ? "cloud" : "remote",
             remoteUrl,
+            ...(this.options.authDir ? { authDir: this.options.authDir } : {}),
             ...(cloudFetch ? { fetch: cloudFetch } : {}),
           },
           {
             ...process.env,
-            CAPLETS_MODE: "cloud",
+            CAPLETS_MODE: this.authKind === "hosted_cloud" ? "cloud" : "remote",
             CAPLETS_REMOTE_URL: remoteUrl,
           },
         );
-        if (selection.kind !== "hosted_cloud") {
+        if (this.authKind === "hosted_cloud" && selection.kind !== "hosted_cloud") {
           throw new CapletsError("REQUEST_INVALID", "CAPLETS_MODE=cloud requires Caplets Cloud.");
         }
-        const cloudPresence = {
-          url: selection.cloudPresence.url,
-          accessToken: selection.cloudPresence.accessToken,
-          workspaceId: selection.cloudPresence.workspaceId,
-          ...(this.options.remote?.cloud?.projectRoot
-            ? { projectRoot: this.options.remote.cloud.projectRoot }
-            : {}),
-          heartbeatIntervalMs:
-            this.options.remote?.cloud?.heartbeatIntervalMs ??
-            this.baseRemote.cloud?.heartbeatIntervalMs ??
-            30_000,
-        } satisfies ResolvedNativeCloudPresenceOptions;
+        if (this.authKind === "self_hosted_remote" && selection.kind !== "self_hosted_remote") {
+          throw new CapletsError(
+            "REQUEST_INVALID",
+            "CAPLETS_MODE=remote requires self-hosted Caplets.",
+          );
+        }
+        const cloudPresence =
+          selection.kind === "hosted_cloud"
+            ? ({
+                url: selection.cloudPresence.url,
+                accessToken: selection.cloudPresence.accessToken,
+                workspaceId: selection.cloudPresence.workspaceId,
+                ...(this.options.remote?.cloud?.projectRoot
+                  ? { projectRoot: this.options.remote.cloud.projectRoot }
+                  : {}),
+                heartbeatIntervalMs:
+                  this.options.remote?.cloud?.heartbeatIntervalMs ??
+                  this.baseRemote.cloud?.heartbeatIntervalMs ??
+                  30_000,
+              } satisfies ResolvedNativeCloudPresenceOptions)
+            : undefined;
         const remoteOptions = {
           ...this.baseRemote,
           url: selection.remote.attachUrl,
           auth: nativeAuthFromRemoteAuth(selection.remote.auth),
           requestInit: selection.remote.requestInit,
           ...(selection.remote.fetch ? { fetch: selection.remote.fetch } : {}),
-          cloud: cloudPresence,
+          ...(cloudPresence ? { cloud: cloudPresence } : {}),
         } satisfies ResolvedNativeRemoteOptions;
         this.delegate = createCompositeRemoteService(
           remoteOptions,
           this.local,
           this.options,
-          "hosted_cloud",
+          this.authKind,
         );
         this.unsubscribeDelegate = this.delegate.onToolsChanged((tools) => this.emit(tools));
       } catch (error) {
-        if (this.options.mode === "cloud") throw error;
+        if (this.options.mode === "cloud" || this.options.mode === "remote") throw error;
         warnRemoteProjectBindingFallback(this.options);
         return await this.local.reload();
       }

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -652,6 +652,7 @@ class ProfileBackedNativeCapletsService implements NativeCapletsService {
   private unsubscribeDelegate: (() => void) | undefined;
   private remoteSignature: string | undefined;
   private credentialExpiresAt: string | undefined;
+  private ensureDelegateCurrentInFlight: Promise<void> | undefined;
   private closed = false;
 
   constructor(
@@ -703,6 +704,22 @@ class ProfileBackedNativeCapletsService implements NativeCapletsService {
   }
 
   private async ensureDelegateCurrent(): Promise<void> {
+    if (this.ensureDelegateCurrentInFlight) {
+      await this.ensureDelegateCurrentInFlight;
+      return;
+    }
+    const refresh = this.ensureDelegateCurrentNow();
+    this.ensureDelegateCurrentInFlight = refresh;
+    try {
+      await refresh;
+    } finally {
+      if (this.ensureDelegateCurrentInFlight === refresh) {
+        this.ensureDelegateCurrentInFlight = undefined;
+      }
+    }
+  }
+
+  private async ensureDelegateCurrentNow(): Promise<void> {
     try {
       const remoteOptions = await this.resolveProfileRemoteOptions();
       const signature = remoteOptionsSignature(remoteOptions);

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -47,7 +47,7 @@ import {
 } from "../config";
 import { generatedToolInputJsonSchemaForCaplet } from "../generated-tool-input-schema";
 import type { CapletsRemoteAuth } from "../remote/options";
-import { resolveRemoteSelection } from "../remote/selection";
+import { resolveRemoteSelection, type ResolvedRemoteSelection } from "../remote/selection";
 
 const REMOTE_PROJECT_BINDING_FALLBACK_WARNING =
   "Remote project binding unavailable; using local Caplets only. Run caplets doctor for details.\n";
@@ -622,6 +622,16 @@ function createCompositeRemoteService(
   options: NativeCapletsServiceOptions,
   authKind: "self_hosted_remote" | "hosted_cloud",
 ): NativeCapletsService {
+  const { remote, presence } = createCompositeRemoteParts(remoteOptions, local, options, authKind);
+  return new CompositeNativeCapletsService(remote, local, options, presence);
+}
+
+function createCompositeRemoteParts(
+  remoteOptions: ResolvedNativeRemoteOptions,
+  local: NativeCapletsService,
+  options: NativeCapletsServiceOptions,
+  authKind: "self_hosted_remote" | "hosted_cloud",
+): { remote: NativeCapletsService; presence?: ProjectBindingSessionManager } {
   const client = (options.remoteClientFactory ?? createSdkRemoteCapletsClient)(remoteOptions);
   const remote = new RemoteNativeCapletsService({
     client,
@@ -632,14 +642,16 @@ function createCompositeRemoteService(
     ...(options.writeErr ? { writeErr: options.writeErr } : {}),
   });
   const presence = createProjectBindingSessionManager(remoteOptions.cloud, local, options);
-  return new CompositeNativeCapletsService(remote, local, options, presence);
+  return { remote, ...(presence ? { presence } : {}) };
 }
 
 class ProfileBackedNativeCapletsService implements NativeCapletsService {
   private readonly local: NativeCapletsService;
   private readonly listeners = new Set<NativeCapletsToolsChangedListener>();
-  private delegate: NativeCapletsService | undefined;
+  private delegate: CompositeNativeCapletsService | undefined;
   private unsubscribeDelegate: (() => void) | undefined;
+  private remoteSignature: string | undefined;
+  private credentialExpiresAt: string | undefined;
   private closed = false;
 
   constructor(
@@ -655,6 +667,9 @@ class ProfileBackedNativeCapletsService implements NativeCapletsService {
   }
 
   async execute(capletId: string, request: unknown): Promise<unknown> {
+    if (!this.delegate || nativeCredentialsNeedRefresh(this.credentialExpiresAt)) {
+      await this.ensureDelegateCurrent();
+    }
     return await (this.delegate ?? this.local).execute(capletId, request);
   }
 
@@ -664,72 +679,8 @@ class ProfileBackedNativeCapletsService implements NativeCapletsService {
 
   async reload(): Promise<boolean> {
     if (this.closed) return false;
-    if (!this.delegate) {
-      try {
-        const cloudFetch = this.options.remote?.fetch;
-        const remoteUrl =
-          this.options.remote?.url ??
-          process.env.CAPLETS_REMOTE_URL ??
-          this.baseRemote.url.toString().replace(/\/v1(?:\/ws\/[^/]+)?\/attach$/u, "");
-        const selection = await resolveRemoteSelection(
-          {
-            mode: this.authKind === "hosted_cloud" ? "cloud" : "remote",
-            remoteUrl,
-            ...(this.options.authDir ? { authDir: this.options.authDir } : {}),
-            ...(cloudFetch ? { fetch: cloudFetch } : {}),
-          },
-          {
-            ...process.env,
-            CAPLETS_MODE: this.authKind === "hosted_cloud" ? "cloud" : "remote",
-            CAPLETS_REMOTE_URL: remoteUrl,
-          },
-        );
-        if (this.authKind === "hosted_cloud" && selection.kind !== "hosted_cloud") {
-          throw new CapletsError("REQUEST_INVALID", "CAPLETS_MODE=cloud requires Caplets Cloud.");
-        }
-        if (this.authKind === "self_hosted_remote" && selection.kind !== "self_hosted_remote") {
-          throw new CapletsError(
-            "REQUEST_INVALID",
-            "CAPLETS_MODE=remote requires self-hosted Caplets.",
-          );
-        }
-        const cloudPresence =
-          selection.kind === "hosted_cloud"
-            ? ({
-                url: selection.cloudPresence.url,
-                accessToken: selection.cloudPresence.accessToken,
-                workspaceId: selection.cloudPresence.workspaceId,
-                ...(this.options.remote?.cloud?.projectRoot
-                  ? { projectRoot: this.options.remote.cloud.projectRoot }
-                  : {}),
-                heartbeatIntervalMs:
-                  this.options.remote?.cloud?.heartbeatIntervalMs ??
-                  this.baseRemote.cloud?.heartbeatIntervalMs ??
-                  30_000,
-              } satisfies ResolvedNativeCloudPresenceOptions)
-            : undefined;
-        const remoteOptions = {
-          ...this.baseRemote,
-          url: selection.remote.attachUrl,
-          auth: nativeAuthFromRemoteAuth(selection.remote.auth),
-          requestInit: selection.remote.requestInit,
-          ...(selection.remote.fetch ? { fetch: selection.remote.fetch } : {}),
-          ...(cloudPresence ? { cloud: cloudPresence } : {}),
-        } satisfies ResolvedNativeRemoteOptions;
-        this.delegate = createCompositeRemoteService(
-          remoteOptions,
-          this.local,
-          this.options,
-          this.authKind,
-        );
-        this.unsubscribeDelegate = this.delegate.onToolsChanged((tools) => this.emit(tools));
-      } catch (error) {
-        if (this.options.mode === "cloud" || this.options.mode === "remote") throw error;
-        warnRemoteProjectBindingFallback(this.options);
-        return await this.local.reload();
-      }
-    }
-    return await this.delegate.reload();
+    await this.ensureDelegateCurrent();
+    return await (this.delegate ?? this.local).reload();
   }
 
   onToolsChanged(listener: NativeCapletsToolsChangedListener): () => void {
@@ -750,6 +701,145 @@ class ProfileBackedNativeCapletsService implements NativeCapletsService {
       listener(tools);
     }
   }
+
+  private async ensureDelegateCurrent(): Promise<void> {
+    try {
+      const remoteOptions = await this.resolveProfileRemoteOptions();
+      const signature = remoteOptionsSignature(remoteOptions);
+      if (!this.delegate) {
+        const { remote, presence } = createCompositeRemoteParts(
+          remoteOptions,
+          this.local,
+          this.options,
+          this.authKind,
+        );
+        this.delegate = new CompositeNativeCapletsService(
+          remote,
+          this.local,
+          this.options,
+          presence,
+        );
+        this.unsubscribeDelegate = this.delegate.onToolsChanged((tools) => this.emit(tools));
+        this.remoteSignature = signature;
+        this.credentialExpiresAt = remoteOptions.credentialExpiresAt;
+        return;
+      }
+      if (signature === this.remoteSignature) return;
+      const { remote, presence } = createCompositeRemoteParts(
+        remoteOptions,
+        this.local,
+        this.options,
+        this.authKind,
+      );
+      await this.delegate.replaceRemote(remote, presence);
+      this.remoteSignature = signature;
+      this.credentialExpiresAt = remoteOptions.credentialExpiresAt;
+    } catch (error) {
+      if (this.options.mode === "cloud" || this.options.mode === "remote") {
+        if (this.delegate) throw error;
+        await this.close().catch((closeError: unknown) => {
+          writeErr(
+            this.options,
+            `Could not close local overlay Caplets service: ${errorMessage(closeError)}\n`,
+          );
+        });
+        throw error;
+      }
+      warnRemoteProjectBindingFallback(this.options);
+      if (!this.delegate) await this.local.reload();
+    }
+  }
+
+  private async resolveProfileRemoteOptions(): Promise<ProfileResolvedNativeRemoteOptions> {
+    const cloudFetch = this.options.remote?.fetch;
+    const remoteUrl =
+      this.options.remote?.url ??
+      process.env.CAPLETS_REMOTE_URL ??
+      this.baseRemote.url.toString().replace(/\/v1(?:\/ws\/[^/]+)?\/attach$/u, "");
+    const selection = await resolveRemoteSelection(
+      {
+        mode: this.authKind === "hosted_cloud" ? "cloud" : "remote",
+        remoteUrl,
+        ...(this.options.authDir ? { authDir: this.options.authDir } : {}),
+        ...(cloudFetch ? { fetch: cloudFetch } : {}),
+      },
+      {
+        ...process.env,
+        CAPLETS_MODE: this.authKind === "hosted_cloud" ? "cloud" : "remote",
+        CAPLETS_REMOTE_URL: remoteUrl,
+      },
+    );
+    if (this.authKind === "hosted_cloud" && selection.kind !== "hosted_cloud") {
+      throw new CapletsError("REQUEST_INVALID", "CAPLETS_MODE=cloud requires Caplets Cloud.");
+    }
+    if (this.authKind === "self_hosted_remote" && selection.kind !== "self_hosted_remote") {
+      throw new CapletsError(
+        "REQUEST_INVALID",
+        "CAPLETS_MODE=remote requires self-hosted Caplets.",
+      );
+    }
+    const cloudPresence =
+      selection.kind === "hosted_cloud"
+        ? ({
+            url: selection.cloudPresence.url,
+            accessToken: selection.cloudPresence.accessToken,
+            workspaceId: selection.cloudPresence.workspaceId,
+            ...(this.options.remote?.cloud?.projectRoot
+              ? { projectRoot: this.options.remote.cloud.projectRoot }
+              : {}),
+            heartbeatIntervalMs:
+              this.options.remote?.cloud?.heartbeatIntervalMs ??
+              this.baseRemote.cloud?.heartbeatIntervalMs ??
+              30_000,
+          } satisfies ResolvedNativeCloudPresenceOptions)
+        : undefined;
+    return remoteOptionsFromSelection(selection, this.baseRemote, cloudPresence);
+  }
+}
+
+type ProfileResolvedNativeRemoteOptions = ResolvedNativeRemoteOptions & {
+  credentialExpiresAt?: string | undefined;
+};
+
+function remoteOptionsFromSelection(
+  selection: ResolvedRemoteSelection,
+  baseRemote: ResolvedNativeRemoteOptions,
+  cloudPresence: ResolvedNativeCloudPresenceOptions | undefined,
+): ProfileResolvedNativeRemoteOptions {
+  return {
+    ...baseRemote,
+    url: selection.remote.attachUrl,
+    auth: nativeAuthFromRemoteAuth(selection.remote.auth),
+    requestInit: selection.remote.requestInit,
+    ...(selection.remote.fetch ? { fetch: selection.remote.fetch } : {}),
+    ...(cloudPresence ? { cloud: cloudPresence } : {}),
+    ...(selection.credentialExpiresAt
+      ? { credentialExpiresAt: selection.credentialExpiresAt }
+      : {}),
+  } satisfies ProfileResolvedNativeRemoteOptions;
+}
+
+function remoteOptionsSignature(remoteOptions: ProfileResolvedNativeRemoteOptions): string {
+  return JSON.stringify({
+    url: remoteOptions.url.toString(),
+    requestInit: remoteOptions.requestInit,
+    credentialExpiresAt: remoteOptions.credentialExpiresAt,
+    cloud: remoteOptions.cloud
+      ? {
+          url: remoteOptions.cloud.url.toString(),
+          accessToken: remoteOptions.cloud.accessToken,
+          workspaceId: remoteOptions.cloud.workspaceId,
+          projectRoot: remoteOptions.cloud.projectRoot,
+          heartbeatIntervalMs: remoteOptions.cloud.heartbeatIntervalMs,
+        }
+      : undefined,
+  });
+}
+
+function nativeCredentialsNeedRefresh(expiresAt: string | undefined): boolean {
+  if (!expiresAt) return false;
+  const parsed = Date.parse(expiresAt);
+  return Number.isFinite(parsed) && parsed <= Date.now() + 60_000;
 }
 
 function nativeAuthFromRemoteAuth(auth: CapletsRemoteAuth): NativeRemoteAuthOptions {
@@ -761,7 +851,8 @@ function nativeAuthFromRemoteAuth(auth: CapletsRemoteAuth): NativeRemoteAuthOpti
 
 class CompositeNativeCapletsService implements NativeCapletsService {
   private readonly listeners = new Set<NativeCapletsToolsChangedListener>();
-  private readonly unsubscribers: Array<() => void>;
+  private unsubscribeRemote: () => void;
+  private readonly unsubscribeLocal: () => void;
   private readonly warnedShadowedLocalCaplets = new Set<string>();
   private tools: NativeCapletTool[] = [];
   private closed = false;
@@ -769,22 +860,15 @@ class CompositeNativeCapletsService implements NativeCapletsService {
   private readonly codeModeSessions = new CodeModeSessionManager();
 
   constructor(
-    private readonly remote: NativeCapletsService,
+    private remote: NativeCapletsService,
     private readonly local: NativeCapletsService,
     private readonly options: NativeCapletsServiceOptions,
-    private readonly presence?: ProjectBindingSessionManager,
+    private presence?: ProjectBindingSessionManager,
   ) {
-    this.unsubscribers = [
-      this.remote.onToolsChanged(() => this.updateMergedTools()),
-      this.local.onToolsChanged(() => this.updateMergedTools()),
-    ];
+    this.unsubscribeRemote = this.remote.onToolsChanged(() => this.updateMergedTools());
+    this.unsubscribeLocal = this.local.onToolsChanged(() => this.updateMergedTools());
     this.tools = this.mergeTools();
-    void this.presence?.start().catch((error) => {
-      writeErr(
-        options,
-        `Could not register Caplets Cloud Project Binding: ${errorMessage(error)}\n`,
-      );
-    });
+    this.startPresence();
   }
 
   listTools(): NativeCapletTool[] {
@@ -842,12 +926,30 @@ class CompositeNativeCapletsService implements NativeCapletsService {
       return;
     }
     this.closed = true;
-    for (const unsubscribe of this.unsubscribers.splice(0)) {
-      unsubscribe();
-    }
+    this.unsubscribeRemote();
+    this.unsubscribeLocal();
     this.listeners.clear();
     this.codeModeSessions.close();
     await Promise.all([this.remote.close(), this.local.close(), this.presence?.close()]);
+  }
+
+  async replaceRemote(
+    remote: NativeCapletsService,
+    presence?: ProjectBindingSessionManager,
+  ): Promise<void> {
+    if (this.closed) {
+      await Promise.all([remote.close(), presence?.close()]);
+      return;
+    }
+    const previousRemote = this.remote;
+    const previousPresence = this.presence;
+    this.unsubscribeRemote();
+    this.remote = remote;
+    this.presence = presence;
+    this.unsubscribeRemote = this.remote.onToolsChanged(() => this.updateMergedTools());
+    await Promise.all([previousRemote.close(), previousPresence?.close()]);
+    this.startPresence();
+    this.updateMergedTools();
   }
 
   private updateMergedTools(): void {
@@ -928,6 +1030,15 @@ class CompositeNativeCapletsService implements NativeCapletsService {
       );
       return undefined;
     }
+  }
+
+  private startPresence(): void {
+    void this.presence?.start().catch((error) => {
+      writeErr(
+        this.options,
+        `Could not register Caplets Cloud Project Binding: ${errorMessage(error)}\n`,
+      );
+    });
   }
 }
 

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -738,6 +738,7 @@ class ProfileBackedNativeCapletsService implements NativeCapletsService {
   private async ensureDelegateCurrentNow(): Promise<void> {
     try {
       const remoteOptions = await this.resolveProfileRemoteOptions();
+      if (this.closed) return;
       const signature = remoteOptionsSignature(remoteOptions);
       if (!this.delegate) {
         const { remote, presence } = createCompositeRemoteParts(

--- a/packages/core/src/project-binding/attach.ts
+++ b/packages/core/src/project-binding/attach.ts
@@ -11,9 +11,6 @@ import type { ProjectBindingWebSocketFactory } from "./transport";
 
 export type RawAttachOptions = {
   remoteUrl?: string;
-  user?: string;
-  password?: string;
-  token?: string;
   workspace?: string;
   json?: boolean;
   verbose?: boolean;
@@ -46,9 +43,6 @@ export async function resolveAttachOptionsForRun(
 ): Promise<ResolvedAttachOptions> {
   const remoteInput = {
     ...(raw.remoteUrl !== undefined ? { remoteUrl: raw.remoteUrl } : {}),
-    ...(raw.user !== undefined ? { user: raw.user } : {}),
-    ...(raw.password !== undefined ? { password: raw.password } : {}),
-    ...(raw.token !== undefined ? { token: raw.token } : {}),
     ...(raw.workspace !== undefined ? { workspace: raw.workspace } : {}),
     ...(raw.fetch !== undefined ? { fetch: raw.fetch } : {}),
     ...(raw.authDir !== undefined ? { authDir: raw.authDir } : {}),

--- a/packages/core/src/project-binding/attach.ts
+++ b/packages/core/src/project-binding/attach.ts
@@ -105,6 +105,7 @@ export async function attachProjectSession(
   return await runProjectBindingSession({
     projectRoot: resolved.projectRoot,
     remote: resolved.remote,
+    remoteResolver: async () => (await resolveAttachOptionsForRun(raw, env)).remote,
     fetch: resolved.remote.fetch,
     signal: options.signal,
     heartbeatIntervalMs: options.heartbeatIntervalMs,

--- a/packages/core/src/project-binding/attach.ts
+++ b/packages/core/src/project-binding/attach.ts
@@ -100,12 +100,15 @@ export async function attachProjectSession(
   } = {},
 ) {
   const resolved = await resolveAttachOptionsForRun(raw, env);
+  const pinnedRaw = resolved.selectedWorkspace
+    ? { ...raw, workspace: resolved.selectedWorkspace }
+    : raw;
   bootstrapProjectBindingGitignore(resolved.projectRoot);
   preflightProjectSync(resolved.projectRoot, hostedTier(env));
   return await runProjectBindingSession({
     projectRoot: resolved.projectRoot,
     remote: resolved.remote,
-    remoteResolver: async () => (await resolveAttachOptionsForRun(raw, env)).remote,
+    remoteResolver: async () => (await resolveAttachOptionsForRun(pinnedRaw, env)).remote,
     fetch: resolved.remote.fetch,
     signal: options.signal,
     heartbeatIntervalMs: options.heartbeatIntervalMs,

--- a/packages/core/src/project-binding/attach.ts
+++ b/packages/core/src/project-binding/attach.ts
@@ -20,6 +20,7 @@ export type RawAttachOptions = {
   once?: boolean;
   projectRoot?: string;
   fetch?: typeof fetch;
+  authDir?: string;
 };
 
 export type ResolvedAttachOptions = {
@@ -50,6 +51,7 @@ export async function resolveAttachOptionsForRun(
     ...(raw.token !== undefined ? { token: raw.token } : {}),
     ...(raw.workspace !== undefined ? { workspace: raw.workspace } : {}),
     ...(raw.fetch !== undefined ? { fetch: raw.fetch } : {}),
+    ...(raw.authDir !== undefined ? { authDir: raw.authDir } : {}),
   };
   const selection = await resolveRemoteSelection(remoteInput, env);
   return {

--- a/packages/core/src/project-binding/errors.ts
+++ b/packages/core/src/project-binding/errors.ts
@@ -71,14 +71,14 @@ function recoveryCommandFor(code: ProjectBindingErrorCode): string | undefined {
     case "cloud_auth_expired":
     case "cloud_auth_revoked":
     case "workspace_selection_required":
-      return "caplets cloud auth login";
+      return "caplets remote login <cloud-url>";
     case "workspace_switch_required":
-      return "caplets cloud auth switch <workspace>";
+      return "caplets remote login <cloud-url> --workspace <workspace>";
     case "sync_size_limit_exceeded":
       return "Add exclusions to .capletsignore or upgrade the workspace plan.";
     case "remote_credentials_required":
     case "remote_auth_failed":
-      return "Set CAPLETS_REMOTE_URL and remote credentials.";
+      return "caplets remote login <url>";
     case "endpoint_unavailable":
     case "websocket_upgrade_required":
       return "caplets doctor";
@@ -94,7 +94,7 @@ function defaultProjectBindingMessage(code: ProjectBindingErrorCode): string {
     case "workspace_switch_required":
       return "The requested workspace differs from the saved Selected Workspace.";
     case "cloud_auth_required":
-      return "Hosted Project Binding requires Cloud Auth.";
+      return "Hosted Project Binding requires Remote Login.";
     case "endpoint_unavailable":
     case "websocket_upgrade_required":
       return "Project Binding endpoint is unavailable.";

--- a/packages/core/src/project-binding/session.ts
+++ b/packages/core/src/project-binding/session.ts
@@ -63,6 +63,7 @@ export type ProjectBindingSocketClientMessage =
 export type RunProjectBindingSessionInput = {
   projectRoot: string;
   remote: ResolvedCapletsRemote;
+  remoteResolver?: (() => Promise<ResolvedCapletsRemote>) | undefined;
   fetch?: typeof fetch | undefined;
   webSocketFactory?: ProjectBindingWebSocketFactory | undefined;
   signal?: AbortSignal | undefined;
@@ -79,13 +80,19 @@ export async function runProjectBindingSession(input: RunProjectBindingSessionIn
   webSocketUrl: string;
   ended: true;
 }> {
-  const fetchImpl = input.fetch ?? input.remote.fetch ?? fetch;
   const webSocketFactory = input.webSocketFactory ?? defaultProjectBindingWebSocketFactory;
   const heartbeatIntervalMs = input.heartbeatIntervalMs ?? 15_000;
   const projectFingerprint = fingerprintProjectRoot(input.projectRoot);
-  const requestInit = input.remote.requestInit;
+  let remote = input.remote;
+  const refreshRemote = async () => {
+    remote = input.remoteResolver ? await input.remoteResolver() : remote;
+    return remote;
+  };
+  const fetchFor = (resolvedRemote: ResolvedCapletsRemote) =>
+    input.fetch ?? resolvedRemote.fetch ?? fetch;
   input.onEvent?.({ type: "state", state: "attaching" });
 
+  const initialRemote = await refreshRemote();
   const created = await postJson<{
     binding: {
       bindingId: string;
@@ -93,10 +100,10 @@ export async function runProjectBindingSession(input: RunProjectBindingSessionIn
       syncState?: ProjectBindingSyncState;
     };
     sessionId: string;
-  }>(fetchImpl, sessionUrl(input.remote), requestInit, {
+  }>(fetchFor(initialRemote), sessionUrl(initialRemote), initialRemote.requestInit, {
     projectRoot: input.projectRoot,
     projectFingerprint,
-    workspaceId: input.remote.workspace ?? "default",
+    workspaceId: initialRemote.workspace ?? "default",
   });
   const bindingId = created.binding.bindingId;
   const sessionId = created.sessionId;
@@ -104,9 +111,7 @@ export async function runProjectBindingSession(input: RunProjectBindingSessionIn
   let syncState: ProjectBindingSyncState = created.binding.syncState ?? "pending";
   let ended = false;
   let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
-  const publicWebSocketUrl = input.remote.projectBindingWebSocketUrl.toString();
-  const socketUrl = bindingSocketUrl(input.remote, bindingId, sessionId, projectFingerprint);
-  const socketProtocols = bindingSocketProtocols(input.remote);
+  const publicWebSocketUrl = initialRemote.projectBindingWebSocketUrl.toString();
 
   const emitReady = (requestId?: string | undefined) => {
     input.onEvent?.({
@@ -121,6 +126,7 @@ export async function runProjectBindingSession(input: RunProjectBindingSessionIn
   };
 
   const heartbeat = async (socket?: ProjectBindingWebSocket | undefined) => {
+    const heartbeatRemote = await refreshRemote();
     const payload: ProjectBindingSocketClientMessage = {
       type: "heartbeat",
       bindingId,
@@ -131,15 +137,23 @@ export async function runProjectBindingSession(input: RunProjectBindingSessionIn
     if (socket?.readyState === PROJECT_BINDING_SOCKET_OPEN) {
       socket.send(JSON.stringify(payload));
     }
-    await postJson(fetchImpl, heartbeatUrl(input.remote, bindingId), requestInit, {
-      sessionId,
-      state,
-      syncState,
-    }).catch(() => undefined);
+    await postJson(
+      fetchFor(heartbeatRemote),
+      heartbeatUrl(heartbeatRemote, bindingId),
+      heartbeatRemote.requestInit,
+      {
+        sessionId,
+        state,
+        syncState,
+      },
+    );
     input.onEvent?.({ type: "heartbeat", bindingId, sessionId, state });
   };
 
   const connect = async (attempt: number): Promise<void> => {
+    const socketRemote = await refreshRemote();
+    const socketUrl = bindingSocketUrl(socketRemote, bindingId, sessionId, projectFingerprint);
+    const socketProtocols = bindingSocketProtocols(socketRemote);
     const socket = webSocketFactory(socketUrl, socketProtocols);
     await waitForOpen(socket, input.signal);
     if (input.signal?.aborted) {
@@ -187,8 +201,12 @@ export async function runProjectBindingSession(input: RunProjectBindingSessionIn
       });
     });
 
+    let heartbeatFailure: unknown;
     heartbeatTimer = setInterval(() => {
-      void heartbeat(socket);
+      void heartbeat(socket).catch((error) => {
+        heartbeatFailure = error;
+        closeSocket(socket, 1008, "Project Binding heartbeat failed.");
+      });
     }, heartbeatIntervalMs);
     await heartbeat(socket);
 
@@ -198,6 +216,7 @@ export async function runProjectBindingSession(input: RunProjectBindingSessionIn
     closeSocket(socket, 1000, "Binding Session closed.");
 
     if (closed === "abort") return;
+    if (heartbeatFailure) throw heartbeatFailure;
     if (closed.reconnect) {
       input.onEvent?.({
         type: "reconnecting",
@@ -218,7 +237,15 @@ export async function runProjectBindingSession(input: RunProjectBindingSessionIn
     const reason: BindingTerminalReason = input.signal?.aborted
       ? { code: "interrupted", message: "Binding Session ended." }
       : { code: "completed", message: "Binding Session completed." };
-    await endRemoteSession(fetchImpl, input.remote, requestInit, bindingId, sessionId, reason);
+    const endingRemote = await refreshRemote().catch(() => remote);
+    await endRemoteSession(
+      fetchFor(endingRemote),
+      endingRemote,
+      endingRemote.requestInit,
+      bindingId,
+      sessionId,
+      reason,
+    );
     input.onEvent?.({ type: "ended", bindingId, sessionId, reason });
   }
 

--- a/packages/core/src/remote-control/client.ts
+++ b/packages/core/src/remote-control/client.ts
@@ -9,31 +9,43 @@ export type RemoteControlClientOptions = {
   fetch?: typeof fetch;
 };
 
-export class RemoteControlClient {
-  readonly #baseUrl: URL;
-  readonly #requestInit: RequestInit;
-  readonly #fetch: typeof fetch;
+export type ResolvedRemoteControlClientOptions = RemoteControlClientOptions;
 
-  constructor(options: RemoteControlClientOptions) {
-    this.#baseUrl = options.baseUrl;
-    this.#requestInit = options.requestInit;
-    this.#fetch = options.fetch ?? fetch;
+export class RemoteControlClient {
+  readonly #resolve: () => Promise<ResolvedRemoteControlClientOptions>;
+
+  constructor(
+    options:
+      | RemoteControlClientOptions
+      | { resolve: () => Promise<ResolvedRemoteControlClientOptions> },
+  ) {
+    this.#resolve =
+      "resolve" in options
+        ? options.resolve
+        : async () => ({
+            baseUrl: options.baseUrl,
+            requestInit: options.requestInit,
+            ...(options.fetch ? { fetch: options.fetch } : {}),
+          });
   }
 
   async request(command: RemoteCliCommand, args: RemoteCliRequest["arguments"]): Promise<unknown> {
-    const controlUrl = controlUrlForBase(this.#baseUrl);
+    const resolved = await this.#resolve();
+    const controlUrl = controlUrlForBase(resolved.baseUrl);
+    const requestInit = resolved.requestInit;
+    const fetchImpl = resolved.fetch ?? fetch;
     let response: Response;
     try {
-      response = await this.#fetch(controlUrl, {
-        ...this.#requestInit,
+      response = await fetchImpl(controlUrl, {
+        ...requestInit,
         method: "POST",
-        headers: mergeJsonHeaders(this.#requestInit.headers),
+        headers: mergeJsonHeaders(requestInit.headers),
         body: JSON.stringify({ command, arguments: args }),
       });
     } catch (error) {
       throw new CapletsError(
         "SERVER_UNAVAILABLE",
-        `Could not connect to Caplets server at ${safeBaseUrl(this.#baseUrl)}.`,
+        `Could not connect to Caplets server at ${safeBaseUrl(resolved.baseUrl)}.`,
         toSafeError(error, "SERVER_UNAVAILABLE"),
       );
     }
@@ -41,14 +53,14 @@ export class RemoteControlClient {
     if (response.status === 401 || response.status === 403) {
       throw new CapletsError(
         "AUTH_FAILED",
-        `Caplets remote authentication failed. Run caplets remote login ${safeBaseUrl(this.#baseUrl)}.`,
+        `Caplets remote authentication failed. Run caplets remote login ${safeBaseUrl(resolved.baseUrl)}.`,
       );
     }
 
     if (!response.ok) {
       throw new CapletsError(
         "SERVER_UNAVAILABLE",
-        `Caplets server at ${safeBaseUrl(this.#baseUrl)} returned HTTP ${response.status}.`,
+        `Caplets server at ${safeBaseUrl(resolved.baseUrl)} returned HTTP ${response.status}.`,
       );
     }
 

--- a/packages/core/src/remote-control/client.ts
+++ b/packages/core/src/remote-control/client.ts
@@ -41,7 +41,7 @@ export class RemoteControlClient {
     if (response.status === 401 || response.status === 403) {
       throw new CapletsError(
         "AUTH_FAILED",
-        "Caplets remote authentication failed. Check CAPLETS_REMOTE_USER and CAPLETS_REMOTE_PASSWORD.",
+        `Caplets remote authentication failed. Run caplets remote login ${safeBaseUrl(this.#baseUrl)}.`,
       );
     }
 

--- a/packages/core/src/remote/credential-store.ts
+++ b/packages/core/src/remote/credential-store.ts
@@ -29,7 +29,7 @@ export class FileRemoteCredentialStore {
   async load(key: string): Promise<RemoteProfileCredential | undefined> {
     const path = this.pathForKey(key);
     if (!existsSync(path)) return undefined;
-    return JSON.parse(readFileSync(path, "utf8")) as RemoteProfileCredential;
+    return parseRemoteProfileCredential(JSON.parse(readFileSync(path, "utf8")));
   }
 
   async save(key: string, credential: RemoteProfileCredential): Promise<void> {
@@ -56,4 +56,23 @@ export class FileRemoteCredentialStore {
     rmSync(path, { force: true });
     return true;
   }
+}
+
+function parseRemoteProfileCredential(value: unknown): RemoteProfileCredential | undefined {
+  if (!isRecord(value)) return undefined;
+  return {
+    ...(typeof value.accessToken === "string" ? { accessToken: value.accessToken } : {}),
+    ...(typeof value.refreshToken === "string" ? { refreshToken: value.refreshToken } : {}),
+    ...(typeof value.tokenType === "string" ? { tokenType: value.tokenType } : {}),
+    ...(typeof value.expiresAt === "string" ? { expiresAt: value.expiresAt } : {}),
+    ...(Array.isArray(value.scope)
+      ? { scope: value.scope.filter((entry): entry is string => typeof entry === "string") }
+      : {}),
+    ...(typeof value.clientSecret === "string" ? { clientSecret: value.clientSecret } : {}),
+    ...(typeof value.pairingCode === "string" ? { pairingCode: value.pairingCode } : {}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/core/src/remote/credential-store.ts
+++ b/packages/core/src/remote/credential-store.ts
@@ -1,0 +1,59 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { DEFAULT_AUTH_DIR } from "../config/paths";
+import type { RemoteProfileCredential } from "./profiles";
+
+export type RemoteCredentialStoreOptions = {
+  root?: string | undefined;
+};
+
+export class FileRemoteCredentialStore {
+  readonly root: string;
+
+  constructor(options: RemoteCredentialStoreOptions = {}) {
+    this.root = options.root ?? join(DEFAULT_AUTH_DIR, "remote-credentials");
+  }
+
+  pathForKey(key: string): string {
+    return join(this.root, `${encodeURIComponent(key)}.json`);
+  }
+
+  async load(key: string): Promise<RemoteProfileCredential | undefined> {
+    const path = this.pathForKey(key);
+    if (!existsSync(path)) return undefined;
+    return JSON.parse(readFileSync(path, "utf8")) as RemoteProfileCredential;
+  }
+
+  async save(key: string, credential: RemoteProfileCredential): Promise<void> {
+    mkdirSync(this.root, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(this.root, 0o700);
+    } catch {
+      // Best effort on platforms without POSIX permissions.
+    }
+    const path = this.pathForKey(key);
+    const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+    writeFileSync(tempPath, `${JSON.stringify(credential, null, 2)}\n`, { mode: 0o600 });
+    try {
+      chmodSync(tempPath, 0o600);
+    } catch {
+      // Best effort on platforms without POSIX permissions.
+    }
+    renameSync(tempPath, path);
+  }
+
+  async delete(key: string): Promise<boolean> {
+    const path = this.pathForKey(key);
+    if (!existsSync(path)) return false;
+    rmSync(path, { force: true });
+    return true;
+  }
+}

--- a/packages/core/src/remote/options.ts
+++ b/packages/core/src/remote/options.ts
@@ -1,17 +1,8 @@
-import { Buffer } from "node:buffer";
 import { CapletsError } from "../errors";
 import { appendBasePath, parseServerBaseUrl } from "../server/options";
 
 export type CapletsRemoteEnv = Partial<
-  Record<
-    | "CAPLETS_MODE"
-    | "CAPLETS_REMOTE_URL"
-    | "CAPLETS_REMOTE_USER"
-    | "CAPLETS_REMOTE_PASSWORD"
-    | "CAPLETS_REMOTE_TOKEN"
-    | "CAPLETS_REMOTE_WORKSPACE",
-    string
-  >
+  Record<"CAPLETS_MODE" | "CAPLETS_REMOTE_URL" | "CAPLETS_REMOTE_WORKSPACE", string>
 >;
 
 export type CapletsRemoteModeInput = {
@@ -23,17 +14,12 @@ export type CapletsRemoteMode = "local" | "remote" | "cloud";
 
 export type CapletsRemoteInput = {
   url?: string;
-  user?: string;
-  password?: string;
   token?: string;
   workspace?: string;
   fetch?: typeof fetch;
 };
 
-export type CapletsRemoteAuth =
-  | { type: "none"; user: string }
-  | { type: "basic"; user: string; password: string }
-  | { type: "bearer"; token: string };
+export type CapletsRemoteAuth = { type: "none"; user: string } | { type: "bearer"; token: string };
 
 export type ResolvedCapletsRemote = {
   baseUrl: URL;
@@ -98,45 +84,16 @@ export function resolveCapletsRemote(
   }
 
   const baseUrl = parseServerBaseUrl(rawUrl);
-  const token =
-    nonEmpty(input.token, "token") ?? nonEmpty(env.CAPLETS_REMOTE_TOKEN, "CAPLETS_REMOTE_TOKEN");
-  const userWasExplicit = input.user !== undefined || hasEnv(env.CAPLETS_REMOTE_USER);
-  const user =
-    nonEmpty(input.user, "user") ??
-    nonEmpty(env.CAPLETS_REMOTE_USER, "CAPLETS_REMOTE_USER") ??
-    DEFAULT_REMOTE_USER;
-  const password =
-    nonEmpty(input.password, "password") ??
-    nonEmpty(env.CAPLETS_REMOTE_PASSWORD, "CAPLETS_REMOTE_PASSWORD");
+  const token = nonEmpty(input.token, "token");
   const workspace =
     nonEmpty(input.workspace, "workspace") ??
     nonEmpty(env.CAPLETS_REMOTE_WORKSPACE, "CAPLETS_REMOTE_WORKSPACE");
 
-  if (token && password) {
-    throw new CapletsError(
-      "REQUEST_INVALID",
-      "Use either CAPLETS_REMOTE_TOKEN or CAPLETS_REMOTE_PASSWORD, not both.",
-    );
-  }
-
-  if (!token && userWasExplicit && password === undefined) {
-    throw new CapletsError(
-      "REQUEST_INVALID",
-      "Remote Caplets Basic Auth requires a password; set CAPLETS_REMOTE_PASSWORD or password.",
-    );
-  }
-
   const auth: CapletsRemoteAuth = token
     ? { type: "bearer", token }
-    : password === undefined
-      ? { type: "none", user }
-      : { type: "basic", user, password };
+    : { type: "none", user: DEFAULT_REMOTE_USER };
   const requestInit: RequestInit =
-    auth.type === "bearer"
-      ? { headers: { Authorization: `Bearer ${auth.token}` } }
-      : auth.type === "basic"
-        ? { headers: { Authorization: basicAuthHeader(auth.user, auth.password) } }
-        : {};
+    auth.type === "bearer" ? { headers: { Authorization: `Bearer ${auth.token}` } } : {};
 
   return {
     baseUrl,
@@ -174,8 +131,7 @@ export function resolveHostedCloudRemote(
     );
   }
 
-  const token =
-    nonEmpty(input.token, "token") ?? nonEmpty(env.CAPLETS_REMOTE_TOKEN, "CAPLETS_REMOTE_TOKEN");
+  const token = nonEmpty(input.token, "token");
   const auth: CapletsRemoteAuth = token
     ? { type: "bearer", token }
     : { type: "none", user: DEFAULT_REMOTE_USER };
@@ -273,17 +229,9 @@ function parseCapletsMode(value: string): "auto" | CapletsRemoteMode {
   );
 }
 
-function basicAuthHeader(user: string, password: string): string {
-  return `Basic ${Buffer.from(`${user}:${password}`).toString("base64")}`;
-}
-
 function nonEmpty(value: string | undefined, label: string): string | undefined {
   if (value === undefined) return undefined;
   const trimmed = value.trim();
   if (!trimmed) throw new CapletsError("REQUEST_INVALID", `${label} must not be empty`);
   return trimmed;
-}
-
-function hasEnv(value: string | undefined): boolean {
-  return value !== undefined && value.trim() !== "";
 }

--- a/packages/core/src/remote/options.ts
+++ b/packages/core/src/remote/options.ts
@@ -207,6 +207,14 @@ export function hostedCloudWorkspaceFromRemoteUrl(value: string): string | undef
   }
 }
 
+export function normalizeRemoteProfileHostUrl(value: string): string {
+  const url = parseServerBaseUrl(value);
+  if (isCapletsCloudUrl(url.toString())) {
+    return `${url.origin}/`;
+  }
+  return url.toString();
+}
+
 export function projectBindingWebSocketUrlForBase(baseUrl: URL): URL {
   return webSocketUrl(appendBasePath(baseUrl, "v1/attach/project-bindings/connect"));
 }

--- a/packages/core/src/remote/pairing.ts
+++ b/packages/core/src/remote/pairing.ts
@@ -1,0 +1,36 @@
+import { randomBytes } from "node:crypto";
+
+const PAIRING_CODE_PREFIX = "cap_pair";
+
+export type ParsedPairingCode = {
+  codeId: string;
+  secret: string;
+};
+
+export function createPairingCode(): { codeId: string; code: string; secret: string } {
+  const codeId = randomPairingPart(8);
+  const secret = randomPairingPart(24);
+  return { codeId, secret, code: createPairingCodeVerifier(codeId, secret) };
+}
+
+export function createPairingCodeVerifier(codeId: string, secret: string): string {
+  return `${PAIRING_CODE_PREFIX}_${codeId}_${secret}`;
+}
+
+export function parsePairingCode(value: string): ParsedPairingCode | undefined {
+  const match = value.match(/^cap_pair_([0-9A-Za-z_-]{8,})_([0-9A-Za-z_-]{24,})$/u);
+  if (!match?.[1] || !match[2]) return undefined;
+  return { codeId: match[1], secret: match[2] };
+}
+
+export function isPairingCodeFormat(value: string): boolean {
+  return parsePairingCode(value) !== undefined;
+}
+
+export function randomToken(bytes = 32): string {
+  return randomBytes(bytes).toString("base64url");
+}
+
+function randomPairingPart(bytes: number): string {
+  return randomToken(bytes).replaceAll("_", "-");
+}

--- a/packages/core/src/remote/profile-store.ts
+++ b/packages/core/src/remote/profile-store.ts
@@ -24,7 +24,7 @@ import {
 import { hostedCloudWorkspaceFromRemoteUrl, normalizeRemoteProfileHostUrl } from "./options";
 
 const PROFILE_LOCK_DIR = "remote-profiles.lock";
-const PROFILE_LOCK_TIMEOUT_MS = 2_000;
+const PROFILE_LOCK_TIMEOUT_MS = 20_000;
 
 type StoredRemoteProfile = {
   version: 1;
@@ -79,6 +79,14 @@ export type RefreshSelfHostedProfileInput = SelfHostedProfileLookup & {
     status: RemoteProfileStatus,
     credential: RemoteProfileCredential,
   ) => Promise<SaveSelfHostedProfileInput>;
+};
+
+export type RefreshCloudProfileInput = CloudProfileLookup & {
+  needsRefresh: (credential: RemoteProfileCredential) => boolean;
+  refresh: (
+    status: RemoteProfileStatus,
+    credential: RemoteProfileCredential,
+  ) => Promise<SaveCloudProfileInput>;
 };
 
 export type RemoteProfileStoreOptions = {
@@ -193,37 +201,39 @@ export class FileRemoteProfileStore {
     });
   }
 
-  async saveCloudProfile(input: SaveCloudProfileInput): Promise<RemoteProfileStatus> {
+  async refreshCloudProfileIfNeeded(
+    input: RefreshCloudProfileInput,
+  ): Promise<{ status: RemoteProfileStatus; credential: RemoteProfileCredential } | undefined> {
     return await this.withMutationLock(async () => {
       const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
-      const workspace = cloudWorkspace(input);
-      const key = remoteProfileKey({ kind: "cloud", hostUrl, workspace });
-      const now = (input.now ?? new Date()).toISOString();
-      const existing = this.readProfile(key);
-      const profile: StoredRemoteProfile = {
-        version: 1,
-        kind: "cloud",
-        key,
-        hostUrl,
-        workspaceId: input.workspaceId,
-        ...(input.workspaceSlug ? { workspaceSlug: input.workspaceSlug } : {}),
-        ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
-        createdAt: existing?.createdAt ?? now,
-        updatedAt: now,
-      };
-
-      await this.credentials.save(key, input.credentials);
-      this.writeJson(this.profilePath(key), profile);
-      this.writeJson(this.selectedWorkspacePath(hostUrl), {
-        version: 1,
-        hostUrl,
-        workspace,
-        profileKey: key,
-        selectedAt: now,
-      } satisfies SelectedCloudWorkspace);
-
-      return await this.statusFor(profile, input.credentials, true);
+      const workspace = input.workspace ?? hostedCloudWorkspaceFromRemoteUrl(input.hostUrl);
+      let status: RemoteProfileStatus | undefined;
+      if (workspace) {
+        status = await this.findCloudStatus(hostUrl, workspace);
+      } else {
+        const selected = this.readSelectedWorkspace(hostUrl);
+        if (selected) status = await this.statusByKey(selected.profileKey, true);
+        else if (this.listProfilesForHost(hostUrl).length > 0) {
+          throw new CapletsError(
+            "REQUEST_INVALID",
+            "Cloud Remote Profile requires a selected or explicit workspace.",
+          );
+        }
+      }
+      if (!status) return undefined;
+      const credential = await this.credentials.load(status.key);
+      if (!credential?.accessToken) return undefined;
+      if (!input.needsRefresh(credential)) return { status, credential };
+      const refreshed = await input.refresh(status, credential);
+      const refreshedStatus = await this.writeCloudProfile(refreshed);
+      const refreshedCredential = await this.credentials.load(refreshedStatus.key);
+      if (!refreshedCredential?.accessToken) return undefined;
+      return { status: refreshedStatus, credential: refreshedCredential };
     });
+  }
+
+  async saveCloudProfile(input: SaveCloudProfileInput): Promise<RemoteProfileStatus> {
+    return await this.withMutationLock(async () => await this.writeCloudProfile(input));
   }
 
   async getCloudProfileStatus(input: CloudProfileLookup): Promise<RemoteProfileStatus | undefined> {
@@ -424,6 +434,37 @@ export class FileRemoteProfileStore {
     await this.credentials.save(key, input.credentials);
     this.writeJson(this.profilePath(key), profile);
     return await this.statusFor(profile, input.credentials, false);
+  }
+
+  private async writeCloudProfile(input: SaveCloudProfileInput): Promise<RemoteProfileStatus> {
+    const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+    const workspace = cloudWorkspace(input);
+    const key = remoteProfileKey({ kind: "cloud", hostUrl, workspace });
+    const now = (input.now ?? new Date()).toISOString();
+    const existing = this.readProfile(key);
+    const profile: StoredRemoteProfile = {
+      version: 1,
+      kind: "cloud",
+      key,
+      hostUrl,
+      workspaceId: input.workspaceId,
+      ...(input.workspaceSlug ? { workspaceSlug: input.workspaceSlug } : {}),
+      ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    await this.credentials.save(key, input.credentials);
+    this.writeJson(this.profilePath(key), profile);
+    this.writeJson(this.selectedWorkspacePath(hostUrl), {
+      version: 1,
+      hostUrl,
+      workspace,
+      profileKey: key,
+      selectedAt: now,
+    } satisfies SelectedCloudWorkspace);
+
+    return await this.statusFor(profile, input.credentials, true);
   }
 
   private listProfilesForHost(hostUrl: string): StoredRemoteProfile[] {

--- a/packages/core/src/remote/profile-store.ts
+++ b/packages/core/src/remote/profile-store.ts
@@ -225,7 +225,9 @@ export class FileRemoteProfileStore {
       return await this.withMutationLock(async () => {
         const current = await this.cloudRefreshSnapshot(input);
         if (!current || !current.needsRefresh) return current?.result;
-        const refreshedStatus = await this.writeCloudProfile(refreshed);
+        const refreshedStatus = await this.writeCloudProfile(refreshed, {
+          select: current.result.status.selected,
+        });
         const refreshedCredential = await this.credentials.load(refreshedStatus.key);
         if (!refreshedCredential?.accessToken) return undefined;
         return { status: refreshedStatus, credential: refreshedCredential };
@@ -420,13 +422,14 @@ export class FileRemoteProfileStore {
     const legacy = await this.legacyCloudAuthStore?.load();
     if (!legacy) return;
     if (normalizeRemoteProfileHostUrl(legacy.cloudUrl) !== hostUrl) return;
-    if (
-      profile?.workspaceId &&
-      legacy.workspaceId !== profile.workspaceId &&
-      legacy.workspaceSlug !== profile.workspaceSlug
-    ) {
-      return;
-    }
+    if (!profile) return;
+    const workspaceIdMatches = legacy.workspaceId === profile.workspaceId;
+    const workspaceSlugMatches = Boolean(
+      legacy.workspaceSlug &&
+      profile.workspaceSlug &&
+      legacy.workspaceSlug === profile.workspaceSlug,
+    );
+    if (!workspaceIdMatches && !workspaceSlugMatches) return;
     await this.legacyCloudAuthStore?.clear();
   }
 
@@ -485,12 +488,16 @@ export class FileRemoteProfileStore {
     return await this.statusFor(profile, input.credentials, false);
   }
 
-  private async writeCloudProfile(input: SaveCloudProfileInput): Promise<RemoteProfileStatus> {
+  private async writeCloudProfile(
+    input: SaveCloudProfileInput,
+    options: { select?: boolean } = {},
+  ): Promise<RemoteProfileStatus> {
     const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
     const workspace = cloudWorkspace(input);
     const key = remoteProfileKey({ kind: "cloud", hostUrl, workspace });
     const now = (input.now ?? new Date()).toISOString();
     const existing = this.readProfile(key);
+    const select = options.select ?? true;
     const profile: StoredRemoteProfile = {
       version: 1,
       kind: "cloud",
@@ -505,15 +512,17 @@ export class FileRemoteProfileStore {
 
     await this.credentials.save(key, input.credentials);
     this.writeJson(this.profilePath(key), profile);
-    this.writeJson(this.selectedWorkspacePath(hostUrl), {
-      version: 1,
-      hostUrl,
-      workspace,
-      profileKey: key,
-      selectedAt: now,
-    } satisfies SelectedCloudWorkspace);
+    if (select) {
+      this.writeJson(this.selectedWorkspacePath(hostUrl), {
+        version: 1,
+        hostUrl,
+        workspace,
+        profileKey: key,
+        selectedAt: now,
+      } satisfies SelectedCloudWorkspace);
+    }
 
-    return await this.statusFor(profile, input.credentials, true);
+    return await this.statusFor(profile, input.credentials, select);
   }
 
   private listProfilesForHost(hostUrl: string): StoredRemoteProfile[] {

--- a/packages/core/src/remote/profile-store.ts
+++ b/packages/core/src/remote/profile-store.ts
@@ -6,6 +6,7 @@ import {
   readdirSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
@@ -24,6 +25,7 @@ import {
 import { hostedCloudWorkspaceFromRemoteUrl, normalizeRemoteProfileHostUrl } from "./options";
 
 const PROFILE_LOCK_DIR = "remote-profiles.lock";
+const PROFILE_REFRESH_LOCK_DIR = "remote-profile-refresh-locks";
 const PROFILE_LOCK_TIMEOUT_MS = 20_000;
 
 type StoredRemoteProfile = {
@@ -182,53 +184,52 @@ export class FileRemoteProfileStore {
   async refreshSelfHostedProfileIfNeeded(
     input: RefreshSelfHostedProfileInput,
   ): Promise<{ status: RemoteProfileStatus; credential: RemoteProfileCredential } | undefined> {
-    return await this.withMutationLock(async () => {
-      const key = remoteProfileKey({
-        kind: "self-hosted",
-        hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
+    const key = remoteProfileKey({
+      kind: "self-hosted",
+      hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
+    });
+    return await this.withRefreshLock(key, async () => {
+      const snapshot = await this.withMutationLock(async () =>
+        this.selfHostedRefreshSnapshot(key, input),
+      );
+      if (!snapshot || !snapshot.needsRefresh) return snapshot?.result;
+
+      const refreshed = await input.refresh(snapshot.result.status, snapshot.result.credential);
+      return await this.withMutationLock(async () => {
+        const current = await this.selfHostedRefreshSnapshot(key, input);
+        if (!current || !current.needsRefresh) return current?.result;
+        const refreshedStatus = await this.writeSelfHostedProfile(refreshed);
+        const refreshedCredential = await this.credentials.load(refreshedStatus.key);
+        if (!refreshedCredential?.accessToken) return undefined;
+        return { status: refreshedStatus, credential: refreshedCredential };
       });
-      const profile = this.readProfile(key);
-      if (!profile) return undefined;
-      const credential = await this.credentials.load(key);
-      if (!credential?.accessToken) return undefined;
-      const status = await this.statusFor(profile, credential, false);
-      if (!input.needsRefresh(credential)) return { status, credential };
-      const refreshed = await input.refresh(status, credential);
-      const refreshedStatus = await this.writeSelfHostedProfile(refreshed);
-      const refreshedCredential = await this.credentials.load(refreshedStatus.key);
-      if (!refreshedCredential?.accessToken) return undefined;
-      return { status: refreshedStatus, credential: refreshedCredential };
     });
   }
 
   async refreshCloudProfileIfNeeded(
     input: RefreshCloudProfileInput,
   ): Promise<{ status: RemoteProfileStatus; credential: RemoteProfileCredential } | undefined> {
-    return await this.withMutationLock(async () => {
-      const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
-      const workspace = input.workspace ?? hostedCloudWorkspaceFromRemoteUrl(input.hostUrl);
-      let status: RemoteProfileStatus | undefined;
-      if (workspace) {
-        status = await this.findCloudStatus(hostUrl, workspace);
-      } else {
-        const selected = this.readSelectedWorkspace(hostUrl);
-        if (selected) status = await this.statusByKey(selected.profileKey, true);
-        else if (this.listProfilesForHost(hostUrl).length > 0) {
-          throw new CapletsError(
-            "REQUEST_INVALID",
-            "Cloud Remote Profile requires a selected or explicit workspace.",
-          );
-        }
-      }
-      if (!status) return undefined;
-      const credential = await this.credentials.load(status.key);
-      if (!credential?.accessToken) return undefined;
-      if (!input.needsRefresh(credential)) return { status, credential };
-      const refreshed = await input.refresh(status, credential);
-      const refreshedStatus = await this.writeCloudProfile(refreshed);
-      const refreshedCredential = await this.credentials.load(refreshedStatus.key);
-      if (!refreshedCredential?.accessToken) return undefined;
-      return { status: refreshedStatus, credential: refreshedCredential };
+    const snapshot = await this.withMutationLock(async () => this.cloudRefreshSnapshot(input));
+    if (!snapshot || !snapshot.needsRefresh) return snapshot?.result;
+
+    return await this.withRefreshLock(snapshot.result.status.key, async () => {
+      const lockedSnapshot = await this.withMutationLock(async () =>
+        this.cloudRefreshSnapshot(input),
+      );
+      if (!lockedSnapshot || !lockedSnapshot.needsRefresh) return lockedSnapshot?.result;
+
+      const refreshed = await input.refresh(
+        lockedSnapshot.result.status,
+        lockedSnapshot.result.credential,
+      );
+      return await this.withMutationLock(async () => {
+        const current = await this.cloudRefreshSnapshot(input);
+        if (!current || !current.needsRefresh) return current?.result;
+        const refreshedStatus = await this.writeCloudProfile(refreshed);
+        const refreshedCredential = await this.credentials.load(refreshedStatus.key);
+        if (!refreshedCredential?.accessToken) return undefined;
+        return { status: refreshedStatus, credential: refreshedCredential };
+      });
     });
   }
 
@@ -326,10 +327,58 @@ export class FileRemoteProfileStore {
   }
 
   async clearSelectedCloudWorkspace(hostUrlInput: string): Promise<boolean> {
-    const path = this.selectedWorkspacePath(normalizeRemoteProfileHostUrl(hostUrlInput));
-    if (!existsSync(path)) return false;
-    rmSync(path, { force: true });
-    return true;
+    return await this.withMutationLock(async () => {
+      const path = this.selectedWorkspacePath(normalizeRemoteProfileHostUrl(hostUrlInput));
+      if (!existsSync(path)) return false;
+      rmSync(path, { force: true });
+      return true;
+    });
+  }
+
+  private async selfHostedRefreshSnapshot(
+    key: string,
+    input: RefreshSelfHostedProfileInput,
+  ): Promise<
+    | {
+        needsRefresh: boolean;
+        result: { status: RemoteProfileStatus; credential: RemoteProfileCredential };
+      }
+    | undefined
+  > {
+    const profile = this.readProfile(key);
+    if (!profile) return undefined;
+    const credential = await this.credentials.load(key);
+    if (!credential?.accessToken) return undefined;
+    const status = await this.statusFor(profile, credential, false);
+    return { needsRefresh: input.needsRefresh(credential), result: { status, credential } };
+  }
+
+  private async cloudRefreshSnapshot(input: RefreshCloudProfileInput): Promise<
+    | {
+        needsRefresh: boolean;
+        result: { status: RemoteProfileStatus; credential: RemoteProfileCredential };
+      }
+    | undefined
+  > {
+    const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+    const workspace = input.workspace ?? hostedCloudWorkspaceFromRemoteUrl(input.hostUrl);
+    let status: RemoteProfileStatus | undefined;
+    if (workspace) {
+      status = await this.findCloudStatus(hostUrl, workspace);
+    } else {
+      const selected = this.readSelectedWorkspace(hostUrl);
+      if (selected) status = await this.statusByKey(selected.profileKey, true);
+      else if (this.listProfilesForHost(hostUrl).length > 0) {
+        throw new CapletsError(
+          "REQUEST_INVALID",
+          "Cloud Remote Profile requires a selected or explicit workspace.",
+        );
+      }
+    }
+    if (!status) return undefined;
+    const credential = await this.credentials.load(status.key);
+    if (!credential?.accessToken) return undefined;
+    return { needsRefresh: input.needsRefresh(credential), result: { status, credential } };
   }
 
   private async findCloudStatus(
@@ -527,36 +576,64 @@ export class FileRemoteProfileStore {
   }
 
   private async withMutationLock<T>(operation: () => Promise<T>): Promise<T> {
-    await this.acquireMutationLock();
+    await this.acquireLock(this.lockPath(), "Remote Profile store is locked.");
     try {
       return await operation();
     } finally {
-      this.releaseMutationLock();
+      this.releaseLock(this.lockPath());
     }
   }
 
-  private async acquireMutationLock(): Promise<void> {
+  private async withRefreshLock<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    const lockPath = this.refreshLockPath(key);
+    await this.acquireLock(lockPath, "Remote Profile refresh is locked.");
+    try {
+      return await operation();
+    } finally {
+      this.releaseLock(lockPath);
+    }
+  }
+
+  private async acquireLock(lockPath: string, message: string): Promise<void> {
     mkdirSync(this.root, { recursive: true, mode: 0o700 });
+    mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
     const started = Date.now();
     while (true) {
       try {
-        mkdirSync(this.lockPath(), { mode: 0o700 });
+        mkdirSync(lockPath, { recursive: false, mode: 0o700 });
         return;
       } catch (error) {
+        if (isFileExistsError(error) && this.clearStaleLock(lockPath)) {
+          continue;
+        }
         if (!isFileExistsError(error) || Date.now() - started >= PROFILE_LOCK_TIMEOUT_MS) {
-          throw new CapletsError("SERVER_UNAVAILABLE", "Remote Profile store is locked.");
+          throw new CapletsError("SERVER_UNAVAILABLE", message);
         }
         await sleep(10);
       }
     }
   }
 
-  private releaseMutationLock(): void {
-    rmSync(this.lockPath(), { recursive: true, force: true });
+  private releaseLock(lockPath: string): void {
+    rmSync(lockPath, { recursive: true, force: true });
+  }
+
+  private clearStaleLock(lockPath: string): boolean {
+    try {
+      if (Date.now() - statSync(lockPath).mtimeMs < PROFILE_LOCK_TIMEOUT_MS) return false;
+      rmSync(lockPath, { recursive: true, force: true });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private lockPath(): string {
     return join(this.root, PROFILE_LOCK_DIR);
+  }
+
+  private refreshLockPath(key: string): string {
+    return join(this.root, PROFILE_REFRESH_LOCK_DIR, `${encodeURIComponent(key)}.lock`);
   }
 }
 

--- a/packages/core/src/remote/profile-store.ts
+++ b/packages/core/src/remote/profile-store.ts
@@ -23,6 +23,9 @@ import {
 } from "./profiles";
 import { hostedCloudWorkspaceFromRemoteUrl, normalizeRemoteProfileHostUrl } from "./options";
 
+const PROFILE_LOCK_DIR = "remote-profiles.lock";
+const PROFILE_LOCK_TIMEOUT_MS = 2_000;
+
 type StoredRemoteProfile = {
   version: 1;
   kind: "cloud" | "self-hosted";
@@ -70,11 +73,62 @@ export type SelfHostedProfileLookup = {
   hostUrl: string;
 };
 
+export type RefreshSelfHostedProfileInput = SelfHostedProfileLookup & {
+  needsRefresh: (credential: RemoteProfileCredential) => boolean;
+  refresh: (
+    status: RemoteProfileStatus,
+    credential: RemoteProfileCredential,
+  ) => Promise<SaveSelfHostedProfileInput>;
+};
+
 export type RemoteProfileStoreOptions = {
   root?: string | undefined;
   credentials?: FileRemoteCredentialStore | undefined;
   legacyCloudAuthStore?: CloudAuthStore | undefined;
 };
+
+export type CreateRemoteProfileStoreOptions = {
+  authDir?: string | undefined;
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined> | undefined;
+  legacyCloudAuthStore?: CloudAuthStore | undefined;
+};
+
+export function createRemoteProfileStore(
+  options: CreateRemoteProfileStoreOptions = {},
+): FileRemoteProfileStore {
+  const env = options.env ?? process.env;
+  const authRoot =
+    options.authDir ??
+    (env.CAPLETS_CLOUD_AUTH_PATH ? dirname(env.CAPLETS_CLOUD_AUTH_PATH) : undefined);
+  return new FileRemoteProfileStore({
+    root: join(authRoot ?? DEFAULT_AUTH_DIR, "remote-profiles"),
+    legacyCloudAuthStore:
+      options.legacyCloudAuthStore ??
+      new CloudAuthStore(
+        options.authDir ? { path: join(options.authDir, "cloud-auth.json") } : { env },
+      ),
+  });
+}
+
+export function cloudCredentialsFromRemoteProfile(
+  status: RemoteProfileStatus,
+  credential: RemoteProfileCredential,
+): CloudAuthCredentials {
+  return {
+    version: 2,
+    cloudUrl: status.hostUrl,
+    workspaceId: status.workspaceId ?? "",
+    ...(status.workspaceSlug ? { workspaceSlug: status.workspaceSlug } : {}),
+    accessToken: credential.accessToken ?? "",
+    refreshToken: credential.refreshToken ?? "",
+    expiresAt: credential.expiresAt ?? new Date(0).toISOString(),
+    scope: credential.scope,
+    tokenType: credential.tokenType,
+    deviceName: status.clientLabel,
+    createdAt: status.createdAt,
+    lastRefreshAt: status.updatedAt,
+  };
+}
 
 export class FileRemoteProfileStore {
   readonly root: string;
@@ -90,24 +144,7 @@ export class FileRemoteProfileStore {
   }
 
   async saveSelfHostedProfile(input: SaveSelfHostedProfileInput): Promise<RemoteProfileStatus> {
-    const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
-    const key = remoteProfileKey({ kind: "self-hosted", hostUrl });
-    const now = (input.now ?? new Date()).toISOString();
-    const existing = this.readProfile(key);
-    const profile: StoredRemoteProfile = {
-      version: 1,
-      kind: "self-hosted",
-      key,
-      hostUrl,
-      clientId: input.clientId,
-      ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
-      createdAt: existing?.createdAt ?? now,
-      updatedAt: now,
-    };
-
-    await this.credentials.save(key, input.credentials);
-    this.writeJson(this.profilePath(key), profile);
-    return await this.statusFor(profile, input.credentials, false);
+    return await this.withMutationLock(async () => await this.writeSelfHostedProfile(input));
   }
 
   async getSelfHostedProfileStatus(
@@ -121,46 +158,72 @@ export class FileRemoteProfileStore {
   }
 
   async logoutSelfHostedProfile(input: SelfHostedProfileLookup): Promise<boolean> {
-    const key = remoteProfileKey({
-      kind: "self-hosted",
-      hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
+    return await this.withMutationLock(async () => {
+      const key = remoteProfileKey({
+        kind: "self-hosted",
+        hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
+      });
+      const profile = this.readProfile(key);
+      if (!profile) return false;
+      await this.credentials.delete(key);
+      rmSync(this.profilePath(key), { force: true });
+      return true;
     });
-    const profile = this.readProfile(key);
-    if (!profile) return false;
-    await this.credentials.delete(key);
-    rmSync(this.profilePath(key), { force: true });
-    return true;
+  }
+
+  async refreshSelfHostedProfileIfNeeded(
+    input: RefreshSelfHostedProfileInput,
+  ): Promise<{ status: RemoteProfileStatus; credential: RemoteProfileCredential } | undefined> {
+    return await this.withMutationLock(async () => {
+      const key = remoteProfileKey({
+        kind: "self-hosted",
+        hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
+      });
+      const profile = this.readProfile(key);
+      if (!profile) return undefined;
+      const credential = await this.credentials.load(key);
+      if (!credential?.accessToken) return undefined;
+      const status = await this.statusFor(profile, credential, false);
+      if (!input.needsRefresh(credential)) return { status, credential };
+      const refreshed = await input.refresh(status, credential);
+      const refreshedStatus = await this.writeSelfHostedProfile(refreshed);
+      const refreshedCredential = await this.credentials.load(refreshedStatus.key);
+      if (!refreshedCredential?.accessToken) return undefined;
+      return { status: refreshedStatus, credential: refreshedCredential };
+    });
   }
 
   async saveCloudProfile(input: SaveCloudProfileInput): Promise<RemoteProfileStatus> {
-    const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
-    const workspace = cloudWorkspace(input);
-    const key = remoteProfileKey({ kind: "cloud", hostUrl, workspace });
-    const now = (input.now ?? new Date()).toISOString();
-    const existing = this.readProfile(key);
-    const profile: StoredRemoteProfile = {
-      version: 1,
-      kind: "cloud",
-      key,
-      hostUrl,
-      workspaceId: input.workspaceId,
-      ...(input.workspaceSlug ? { workspaceSlug: input.workspaceSlug } : {}),
-      ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
-      createdAt: existing?.createdAt ?? now,
-      updatedAt: now,
-    };
+    return await this.withMutationLock(async () => {
+      const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+      const workspace = cloudWorkspace(input);
+      const key = remoteProfileKey({ kind: "cloud", hostUrl, workspace });
+      const now = (input.now ?? new Date()).toISOString();
+      const existing = this.readProfile(key);
+      const profile: StoredRemoteProfile = {
+        version: 1,
+        kind: "cloud",
+        key,
+        hostUrl,
+        workspaceId: input.workspaceId,
+        ...(input.workspaceSlug ? { workspaceSlug: input.workspaceSlug } : {}),
+        ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+      };
 
-    await this.credentials.save(key, input.credentials);
-    this.writeJson(this.profilePath(key), profile);
-    this.writeJson(this.selectedWorkspacePath(hostUrl), {
-      version: 1,
-      hostUrl,
-      workspace,
-      profileKey: key,
-      selectedAt: now,
-    } satisfies SelectedCloudWorkspace);
+      await this.credentials.save(key, input.credentials);
+      this.writeJson(this.profilePath(key), profile);
+      this.writeJson(this.selectedWorkspacePath(hostUrl), {
+        version: 1,
+        hostUrl,
+        workspace,
+        profileKey: key,
+        selectedAt: now,
+      } satisfies SelectedCloudWorkspace);
 
-    return await this.statusFor(profile, input.credentials, true);
+      return await this.statusFor(profile, input.credentials, true);
+    });
   }
 
   async getCloudProfileStatus(input: CloudProfileLookup): Promise<RemoteProfileStatus | undefined> {
@@ -198,28 +261,58 @@ export class FileRemoteProfileStore {
     );
   }
 
-  async logoutCloudProfile(input: CloudProfileLookup): Promise<boolean> {
-    const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
-    const workspace = input.workspace ?? hostedCloudWorkspaceFromRemoteUrl(input.hostUrl);
-    const selected = this.readSelectedWorkspace(hostUrl);
-    let key: string | undefined;
-    if (workspace) {
-      key = this.listProfilesForHost(hostUrl).find((profile) =>
-        profileMatchesWorkspace(profile, workspace),
-      )?.key;
-    } else if (selected) {
-      key = selected.profileKey;
-    } else if (this.listProfilesForHost(hostUrl).length > 0) {
-      throw new CapletsError(
-        "REQUEST_INVALID",
-        "Cloud Remote Profile requires a selected or explicit workspace.",
+  async listProfileStatuses(): Promise<RemoteProfileStatus[]> {
+    const dir = this.profilesDir();
+    if (!existsSync(dir)) return [];
+    const statuses = await Promise.all(
+      readdirSync(dir, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+        .map((entry) => this.readProfileFile(join(dir, entry.name)))
+        .filter((profile): profile is StoredRemoteProfile => Boolean(profile))
+        .map(async (profile) => {
+          const selected =
+            profile.kind === "cloud"
+              ? this.readSelectedWorkspace(profile.hostUrl)?.profileKey === profile.key
+              : false;
+          return await this.statusFor(profile, undefined, selected);
+        }),
+    );
+    return statuses.sort((left, right) => {
+      const host = left.hostUrl.localeCompare(right.hostUrl);
+      if (host !== 0) return host;
+      return (left.workspaceSlug ?? left.workspaceId ?? "").localeCompare(
+        right.workspaceSlug ?? right.workspaceId ?? "",
       );
-    }
-    if (!key) return false;
-    await this.credentials.delete(key);
-    rmSync(this.profilePath(key), { force: true });
-    if (selected?.profileKey === key) rmSync(this.selectedWorkspacePath(hostUrl), { force: true });
-    return true;
+    });
+  }
+
+  async logoutCloudProfile(input: CloudProfileLookup): Promise<boolean> {
+    return await this.withMutationLock(async () => {
+      const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+      const workspace = input.workspace ?? hostedCloudWorkspaceFromRemoteUrl(input.hostUrl);
+      const selected = this.readSelectedWorkspace(hostUrl);
+      let key: string | undefined;
+      if (workspace) {
+        key = this.listProfilesForHost(hostUrl).find((profile) =>
+          profileMatchesWorkspace(profile, workspace),
+        )?.key;
+      } else if (selected) {
+        key = selected.profileKey;
+      } else if (this.listProfilesForHost(hostUrl).length > 0) {
+        throw new CapletsError(
+          "REQUEST_INVALID",
+          "Cloud Remote Profile requires a selected or explicit workspace.",
+        );
+      }
+      if (!key) return false;
+      const profile = this.readProfile(key);
+      await this.credentials.delete(key);
+      rmSync(this.profilePath(key), { force: true });
+      if (selected?.profileKey === key)
+        rmSync(this.selectedWorkspacePath(hostUrl), { force: true });
+      await this.clearMatchingLegacyCloudAuth(hostUrl, profile);
+      return true;
+    });
   }
 
   async clearSelectedCloudWorkspace(hostUrlInput: string): Promise<boolean> {
@@ -261,6 +354,23 @@ export class FileRemoteProfileStore {
     });
   }
 
+  private async clearMatchingLegacyCloudAuth(
+    hostUrl: string,
+    profile: StoredRemoteProfile | undefined,
+  ): Promise<void> {
+    const legacy = await this.legacyCloudAuthStore?.load();
+    if (!legacy) return;
+    if (normalizeRemoteProfileHostUrl(legacy.cloudUrl) !== hostUrl) return;
+    if (
+      profile?.workspaceId &&
+      legacy.workspaceId !== profile.workspaceId &&
+      legacy.workspaceSlug !== profile.workspaceSlug
+    ) {
+      return;
+    }
+    await this.legacyCloudAuthStore?.clear();
+  }
+
   private async statusByKey(
     key: string,
     selected: boolean,
@@ -291,6 +401,29 @@ export class FileRemoteProfileStore {
       });
     if (credential !== undefined) return build(credential);
     return build(await this.credentials.load(profile.key));
+  }
+
+  private async writeSelfHostedProfile(
+    input: SaveSelfHostedProfileInput,
+  ): Promise<RemoteProfileStatus> {
+    const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+    const key = remoteProfileKey({ kind: "self-hosted", hostUrl });
+    const now = (input.now ?? new Date()).toISOString();
+    const existing = this.readProfile(key);
+    const profile: StoredRemoteProfile = {
+      version: 1,
+      kind: "self-hosted",
+      key,
+      hostUrl,
+      clientId: input.clientId,
+      ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    await this.credentials.save(key, input.credentials);
+    this.writeJson(this.profilePath(key), profile);
+    return await this.statusFor(profile, input.credentials, false);
   }
 
   private listProfilesForHost(hostUrl: string): StoredRemoteProfile[] {
@@ -351,6 +484,52 @@ export class FileRemoteProfileStore {
     }
     renameSync(tempPath, path);
   }
+
+  private async withMutationLock<T>(operation: () => Promise<T>): Promise<T> {
+    await this.acquireMutationLock();
+    try {
+      return await operation();
+    } finally {
+      this.releaseMutationLock();
+    }
+  }
+
+  private async acquireMutationLock(): Promise<void> {
+    mkdirSync(this.root, { recursive: true, mode: 0o700 });
+    const started = Date.now();
+    while (true) {
+      try {
+        mkdirSync(this.lockPath(), { mode: 0o700 });
+        return;
+      } catch (error) {
+        if (!isFileExistsError(error) || Date.now() - started >= PROFILE_LOCK_TIMEOUT_MS) {
+          throw new CapletsError("SERVER_UNAVAILABLE", "Remote Profile store is locked.");
+        }
+        await sleep(10);
+      }
+    }
+  }
+
+  private releaseMutationLock(): void {
+    rmSync(this.lockPath(), { recursive: true, force: true });
+  }
+
+  private lockPath(): string {
+    return join(this.root, PROFILE_LOCK_DIR);
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isFileExistsError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "EEXIST"
+  );
 }
 
 function cloudWorkspace(input: SaveCloudProfileInput): string {

--- a/packages/core/src/remote/profile-store.ts
+++ b/packages/core/src/remote/profile-store.ts
@@ -1,0 +1,320 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { CloudAuthStore } from "../cloud-auth/store";
+import type { CloudAuthCredentials } from "../cloud-auth/store";
+import { DEFAULT_AUTH_DIR } from "../config/paths";
+import { CapletsError } from "../errors";
+import { FileRemoteCredentialStore } from "./credential-store";
+import {
+  remoteProfileKey,
+  remoteProfileStatus,
+  selectedWorkspaceKey,
+  type RemoteProfileCredential,
+  type RemoteProfileStatus,
+} from "./profiles";
+import { hostedCloudWorkspaceFromRemoteUrl, normalizeRemoteProfileHostUrl } from "./options";
+
+type StoredRemoteProfile = {
+  version: 1;
+  kind: "cloud";
+  key: string;
+  hostUrl: string;
+  workspaceId: string;
+  workspaceSlug?: string | undefined;
+  clientLabel?: string | undefined;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type SelectedCloudWorkspace = {
+  version: 1;
+  hostUrl: string;
+  workspace: string;
+  profileKey: string;
+  selectedAt: string;
+};
+
+export type SaveCloudProfileInput = {
+  hostUrl: string;
+  workspaceId: string;
+  workspaceSlug?: string | undefined;
+  clientLabel?: string | undefined;
+  credentials: RemoteProfileCredential;
+  now?: Date | undefined;
+};
+
+export type CloudProfileLookup = {
+  hostUrl: string;
+  workspace?: string | undefined;
+};
+
+export type RemoteProfileStoreOptions = {
+  root?: string | undefined;
+  credentials?: FileRemoteCredentialStore | undefined;
+  legacyCloudAuthStore?: CloudAuthStore | undefined;
+};
+
+export class FileRemoteProfileStore {
+  readonly root: string;
+  readonly credentials: FileRemoteCredentialStore;
+  readonly legacyCloudAuthStore?: CloudAuthStore | undefined;
+
+  constructor(options: RemoteProfileStoreOptions = {}) {
+    this.root = options.root ?? join(DEFAULT_AUTH_DIR, "remote-profiles");
+    this.credentials =
+      options.credentials ??
+      new FileRemoteCredentialStore({ root: join(this.root, "credentials") });
+    this.legacyCloudAuthStore = options.legacyCloudAuthStore;
+  }
+
+  async saveCloudProfile(input: SaveCloudProfileInput): Promise<RemoteProfileStatus> {
+    const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+    const workspace = cloudWorkspace(input);
+    const key = remoteProfileKey({ kind: "cloud", hostUrl, workspace });
+    const now = (input.now ?? new Date()).toISOString();
+    const existing = this.readProfile(key);
+    const profile: StoredRemoteProfile = {
+      version: 1,
+      kind: "cloud",
+      key,
+      hostUrl,
+      workspaceId: input.workspaceId,
+      ...(input.workspaceSlug ? { workspaceSlug: input.workspaceSlug } : {}),
+      ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    await this.credentials.save(key, input.credentials);
+    this.writeJson(this.profilePath(key), profile);
+    this.writeJson(this.selectedWorkspacePath(hostUrl), {
+      version: 1,
+      hostUrl,
+      workspace,
+      profileKey: key,
+      selectedAt: now,
+    } satisfies SelectedCloudWorkspace);
+
+    return await this.statusFor(profile, input.credentials, true);
+  }
+
+  async getCloudProfileStatus(input: CloudProfileLookup): Promise<RemoteProfileStatus | undefined> {
+    const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+    const workspace = input.workspace ?? hostedCloudWorkspaceFromRemoteUrl(input.hostUrl);
+    if (workspace) {
+      const found = await this.findCloudStatus(hostUrl, workspace);
+      if (found) return found;
+      return this.migrateLegacyCloudProfile(hostUrl, workspace);
+    }
+
+    const selected = this.readSelectedWorkspace(hostUrl);
+    if (selected) return this.statusByKey(selected.profileKey, true);
+    if (this.listProfilesForHost(hostUrl).length > 0) {
+      throw new CapletsError(
+        "REQUEST_INVALID",
+        "Cloud Remote Profile requires a selected or explicit workspace.",
+      );
+    }
+    return this.migrateLegacyCloudProfile(hostUrl);
+  }
+
+  async listCloudProfileStatuses(hostUrlInput: string): Promise<RemoteProfileStatus[]> {
+    const hostUrl = normalizeRemoteProfileHostUrl(hostUrlInput);
+    const selected = this.readSelectedWorkspace(hostUrl)?.profileKey;
+    const statuses = await Promise.all(
+      this.listProfilesForHost(hostUrl).map(async (profile) =>
+        this.statusFor(profile, undefined, profile.key === selected),
+      ),
+    );
+    return statuses.sort((left, right) =>
+      (left.workspaceSlug ?? left.workspaceId ?? "").localeCompare(
+        right.workspaceSlug ?? right.workspaceId ?? "",
+      ),
+    );
+  }
+
+  async logoutCloudProfile(input: CloudProfileLookup): Promise<boolean> {
+    const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+    const workspace = input.workspace ?? hostedCloudWorkspaceFromRemoteUrl(input.hostUrl);
+    const selected = this.readSelectedWorkspace(hostUrl);
+    let key: string | undefined;
+    if (workspace) {
+      key = this.listProfilesForHost(hostUrl).find((profile) =>
+        profileMatchesWorkspace(profile, workspace),
+      )?.key;
+    } else if (selected) {
+      key = selected.profileKey;
+    } else if (this.listProfilesForHost(hostUrl).length > 0) {
+      throw new CapletsError(
+        "REQUEST_INVALID",
+        "Cloud Remote Profile requires a selected or explicit workspace.",
+      );
+    }
+    if (!key) return false;
+    rmSync(this.profilePath(key), { force: true });
+    await this.credentials.delete(key);
+    if (selected?.profileKey === key) rmSync(this.selectedWorkspacePath(hostUrl), { force: true });
+    return true;
+  }
+
+  async clearSelectedCloudWorkspace(hostUrlInput: string): Promise<boolean> {
+    const path = this.selectedWorkspacePath(normalizeRemoteProfileHostUrl(hostUrlInput));
+    if (!existsSync(path)) return false;
+    rmSync(path, { force: true });
+    return true;
+  }
+
+  private async findCloudStatus(
+    hostUrl: string,
+    workspace: string,
+  ): Promise<RemoteProfileStatus | undefined> {
+    const selected = this.readSelectedWorkspace(hostUrl)?.profileKey;
+    const profile = this.listProfilesForHost(hostUrl).find((candidate) =>
+      profileMatchesWorkspace(candidate, workspace),
+    );
+    if (!profile) return undefined;
+    return this.statusFor(profile, undefined, profile.key === selected);
+  }
+
+  private async migrateLegacyCloudProfile(
+    hostUrl: string,
+    workspace?: string,
+  ): Promise<RemoteProfileStatus | undefined> {
+    const legacy = await this.legacyCloudAuthStore?.load();
+    if (!legacy) return undefined;
+    if (normalizeRemoteProfileHostUrl(legacy.cloudUrl) !== hostUrl) return undefined;
+    if (workspace && workspace !== legacy.workspaceSlug && workspace !== legacy.workspaceId) {
+      return undefined;
+    }
+    return this.saveCloudProfile({
+      hostUrl,
+      workspaceId: legacy.workspaceId,
+      ...(legacy.workspaceSlug ? { workspaceSlug: legacy.workspaceSlug } : {}),
+      clientLabel: legacy.deviceName,
+      credentials: legacyCredential(legacy),
+      now: legacy.createdAt ? new Date(legacy.createdAt) : undefined,
+    });
+  }
+
+  private async statusByKey(
+    key: string,
+    selected: boolean,
+  ): Promise<RemoteProfileStatus | undefined> {
+    const profile = this.readProfile(key);
+    if (!profile) return undefined;
+    return this.statusFor(profile, undefined, selected);
+  }
+
+  private async statusFor(
+    profile: StoredRemoteProfile,
+    credential: RemoteProfileCredential | undefined,
+    selected: boolean,
+  ): Promise<RemoteProfileStatus> {
+    const build = (loadedCredential: RemoteProfileCredential | undefined): RemoteProfileStatus =>
+      remoteProfileStatus({
+        kind: "cloud",
+        key: profile.key,
+        hostUrl: profile.hostUrl,
+        workspaceId: profile.workspaceId,
+        workspaceSlug: profile.workspaceSlug,
+        clientLabel: profile.clientLabel,
+        createdAt: profile.createdAt,
+        updatedAt: profile.updatedAt,
+        selected,
+        credential: loadedCredential,
+      });
+    if (credential !== undefined) return build(credential);
+    return build(await this.credentials.load(profile.key));
+  }
+
+  private listProfilesForHost(hostUrl: string): StoredRemoteProfile[] {
+    const dir = this.profilesDir();
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .map((entry) => this.readProfileFile(join(dir, entry.name)))
+      .filter((profile): profile is StoredRemoteProfile => Boolean(profile))
+      .filter((profile) => profile.kind === "cloud" && profile.hostUrl === hostUrl);
+  }
+
+  private readProfile(key: string): StoredRemoteProfile | undefined {
+    return this.readProfileFile(this.profilePath(key));
+  }
+
+  private readProfileFile(path: string): StoredRemoteProfile | undefined {
+    if (!existsSync(path)) return undefined;
+    return JSON.parse(readFileSync(path, "utf8")) as StoredRemoteProfile;
+  }
+
+  private readSelectedWorkspace(hostUrl: string): SelectedCloudWorkspace | undefined {
+    const path = this.selectedWorkspacePath(hostUrl);
+    if (!existsSync(path)) return undefined;
+    return JSON.parse(readFileSync(path, "utf8")) as SelectedCloudWorkspace;
+  }
+
+  private profilePath(key: string): string {
+    return join(this.profilesDir(), `${encodeURIComponent(key)}.json`);
+  }
+
+  private selectedWorkspacePath(hostUrl: string): string {
+    return join(this.selectionsDir(), `${encodeURIComponent(selectedWorkspaceKey(hostUrl))}.json`);
+  }
+
+  private profilesDir(): string {
+    return join(this.root, "profiles");
+  }
+
+  private selectionsDir(): string {
+    return join(this.root, "selections");
+  }
+
+  private writeJson(path: string, value: unknown): void {
+    const directory = dirname(path);
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(directory, 0o700);
+    } catch {
+      // Best effort on platforms without POSIX permissions.
+    }
+    const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+    writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+    try {
+      chmodSync(tempPath, 0o600);
+    } catch {
+      // Best effort on platforms without POSIX permissions.
+    }
+    renameSync(tempPath, path);
+  }
+}
+
+function cloudWorkspace(input: SaveCloudProfileInput): string {
+  return (
+    input.workspaceSlug ??
+    input.workspaceId ??
+    hostedCloudWorkspaceFromRemoteUrl(input.hostUrl) ??
+    ""
+  );
+}
+
+function profileMatchesWorkspace(profile: StoredRemoteProfile, workspace: string): boolean {
+  return profile.workspaceSlug === workspace || profile.workspaceId === workspace;
+}
+
+function legacyCredential(credentials: CloudAuthCredentials): RemoteProfileCredential {
+  return {
+    accessToken: credentials.accessToken,
+    refreshToken: credentials.refreshToken,
+    expiresAt: credentials.expiresAt,
+    ...(credentials.scope ? { scope: credentials.scope } : {}),
+    ...(credentials.tokenType ? { tokenType: credentials.tokenType } : {}),
+  };
+}

--- a/packages/core/src/remote/profile-store.ts
+++ b/packages/core/src/remote/profile-store.ts
@@ -25,11 +25,12 @@ import { hostedCloudWorkspaceFromRemoteUrl, normalizeRemoteProfileHostUrl } from
 
 type StoredRemoteProfile = {
   version: 1;
-  kind: "cloud";
+  kind: "cloud" | "self-hosted";
   key: string;
   hostUrl: string;
-  workspaceId: string;
+  workspaceId?: string | undefined;
   workspaceSlug?: string | undefined;
+  clientId?: string | undefined;
   clientLabel?: string | undefined;
   createdAt: string;
   updatedAt: string;
@@ -57,6 +58,18 @@ export type CloudProfileLookup = {
   workspace?: string | undefined;
 };
 
+export type SaveSelfHostedProfileInput = {
+  hostUrl: string;
+  clientId: string;
+  clientLabel?: string | undefined;
+  credentials: RemoteProfileCredential;
+  now?: Date | undefined;
+};
+
+export type SelfHostedProfileLookup = {
+  hostUrl: string;
+};
+
 export type RemoteProfileStoreOptions = {
   root?: string | undefined;
   credentials?: FileRemoteCredentialStore | undefined;
@@ -74,6 +87,49 @@ export class FileRemoteProfileStore {
       options.credentials ??
       new FileRemoteCredentialStore({ root: join(this.root, "credentials") });
     this.legacyCloudAuthStore = options.legacyCloudAuthStore;
+  }
+
+  async saveSelfHostedProfile(input: SaveSelfHostedProfileInput): Promise<RemoteProfileStatus> {
+    const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+    const key = remoteProfileKey({ kind: "self-hosted", hostUrl });
+    const now = (input.now ?? new Date()).toISOString();
+    const existing = this.readProfile(key);
+    const profile: StoredRemoteProfile = {
+      version: 1,
+      kind: "self-hosted",
+      key,
+      hostUrl,
+      clientId: input.clientId,
+      ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    await this.credentials.save(key, input.credentials);
+    this.writeJson(this.profilePath(key), profile);
+    return await this.statusFor(profile, input.credentials, false);
+  }
+
+  async getSelfHostedProfileStatus(
+    input: SelfHostedProfileLookup,
+  ): Promise<RemoteProfileStatus | undefined> {
+    const key = remoteProfileKey({
+      kind: "self-hosted",
+      hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
+    });
+    return this.statusByKey(key, false);
+  }
+
+  async logoutSelfHostedProfile(input: SelfHostedProfileLookup): Promise<boolean> {
+    const key = remoteProfileKey({
+      kind: "self-hosted",
+      hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
+    });
+    const profile = this.readProfile(key);
+    if (!profile) return false;
+    await this.credentials.delete(key);
+    rmSync(this.profilePath(key), { force: true });
+    return true;
   }
 
   async saveCloudProfile(input: SaveCloudProfileInput): Promise<RemoteProfileStatus> {
@@ -160,8 +216,8 @@ export class FileRemoteProfileStore {
       );
     }
     if (!key) return false;
-    rmSync(this.profilePath(key), { force: true });
     await this.credentials.delete(key);
+    rmSync(this.profilePath(key), { force: true });
     if (selected?.profileKey === key) rmSync(this.selectedWorkspacePath(hostUrl), { force: true });
     return true;
   }
@@ -221,11 +277,12 @@ export class FileRemoteProfileStore {
   ): Promise<RemoteProfileStatus> {
     const build = (loadedCredential: RemoteProfileCredential | undefined): RemoteProfileStatus =>
       remoteProfileStatus({
-        kind: "cloud",
+        kind: profile.kind,
         key: profile.key,
         hostUrl: profile.hostUrl,
         workspaceId: profile.workspaceId,
         workspaceSlug: profile.workspaceSlug,
+        clientId: profile.clientId,
         clientLabel: profile.clientLabel,
         createdAt: profile.createdAt,
         updatedAt: profile.updatedAt,
@@ -252,13 +309,13 @@ export class FileRemoteProfileStore {
 
   private readProfileFile(path: string): StoredRemoteProfile | undefined {
     if (!existsSync(path)) return undefined;
-    return JSON.parse(readFileSync(path, "utf8")) as StoredRemoteProfile;
+    return parseStoredRemoteProfile(JSON.parse(readFileSync(path, "utf8")));
   }
 
   private readSelectedWorkspace(hostUrl: string): SelectedCloudWorkspace | undefined {
     const path = this.selectedWorkspacePath(hostUrl);
     if (!existsSync(path)) return undefined;
-    return JSON.parse(readFileSync(path, "utf8")) as SelectedCloudWorkspace;
+    return parseSelectedCloudWorkspace(JSON.parse(readFileSync(path, "utf8")), hostUrl);
   }
 
   private profilePath(key: string): string {
@@ -317,4 +374,59 @@ function legacyCredential(credentials: CloudAuthCredentials): RemoteProfileCrede
     ...(credentials.scope ? { scope: credentials.scope } : {}),
     ...(credentials.tokenType ? { tokenType: credentials.tokenType } : {}),
   };
+}
+
+function parseStoredRemoteProfile(value: unknown): StoredRemoteProfile | undefined {
+  if (!isRecord(value)) return undefined;
+  if (value.version !== 1) return undefined;
+  if (value.kind !== "cloud" && value.kind !== "self-hosted") return undefined;
+  if (
+    typeof value.key !== "string" ||
+    typeof value.hostUrl !== "string" ||
+    typeof value.createdAt !== "string" ||
+    typeof value.updatedAt !== "string"
+  ) {
+    return undefined;
+  }
+  if (value.kind === "cloud" && typeof value.workspaceId !== "string") return undefined;
+  if (value.kind === "self-hosted" && typeof value.clientId !== "string") return undefined;
+  return {
+    version: 1,
+    kind: value.kind,
+    key: value.key,
+    hostUrl: value.hostUrl,
+    ...(typeof value.workspaceId === "string" ? { workspaceId: value.workspaceId } : {}),
+    ...(typeof value.workspaceSlug === "string" ? { workspaceSlug: value.workspaceSlug } : {}),
+    ...(typeof value.clientId === "string" ? { clientId: value.clientId } : {}),
+    ...(typeof value.clientLabel === "string" ? { clientLabel: value.clientLabel } : {}),
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+  };
+}
+
+function parseSelectedCloudWorkspace(
+  value: unknown,
+  expectedHostUrl: string,
+): SelectedCloudWorkspace | undefined {
+  if (!isRecord(value)) return undefined;
+  if (
+    value.version !== 1 ||
+    value.hostUrl !== expectedHostUrl ||
+    typeof value.workspace !== "string" ||
+    typeof value.profileKey !== "string" ||
+    typeof value.selectedAt !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    version: 1,
+    hostUrl: value.hostUrl,
+    workspace: value.workspace,
+    profileKey: value.profileKey,
+    selectedAt: value.selectedAt,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/core/src/remote/profiles.ts
+++ b/packages/core/src/remote/profiles.ts
@@ -79,8 +79,9 @@ export function remoteProfileStatus(input: RemoteProfileStatusInput): RemoteProf
   const expired = Number.isFinite(Date.parse(expiresAt ?? ""))
     ? Date.parse(expiresAt ?? "") <= Date.now()
     : false;
+  const hasAccessToken = Boolean(input.credential?.accessToken);
   return {
-    authenticated: Boolean(input.credential) && !expired,
+    authenticated: hasAccessToken && !expired,
     kind: input.kind,
     key,
     hostUrl,

--- a/packages/core/src/remote/profiles.ts
+++ b/packages/core/src/remote/profiles.ts
@@ -25,6 +25,7 @@ export type RemoteProfileStatusInput = {
   key?: string | undefined;
   workspaceId?: string | undefined;
   workspaceSlug?: string | undefined;
+  clientId?: string | undefined;
   selected?: boolean | undefined;
   clientLabel?: string | undefined;
   createdAt?: string | undefined;
@@ -39,6 +40,7 @@ export type RemoteProfileStatus = {
   hostUrl: string;
   workspaceId?: string | undefined;
   workspaceSlug?: string | undefined;
+  clientId?: string | undefined;
   selected: boolean;
   clientLabel?: string | undefined;
   createdAt?: string | undefined;
@@ -84,6 +86,7 @@ export function remoteProfileStatus(input: RemoteProfileStatusInput): RemoteProf
     hostUrl,
     ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
     ...(input.workspaceSlug ? { workspaceSlug: input.workspaceSlug } : {}),
+    ...(input.clientId ? { clientId: input.clientId } : {}),
     selected: Boolean(input.selected),
     ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
     ...(input.createdAt ? { createdAt: input.createdAt } : {}),

--- a/packages/core/src/remote/profiles.ts
+++ b/packages/core/src/remote/profiles.ts
@@ -1,0 +1,95 @@
+import { CapletsError } from "../errors";
+import { hostedCloudWorkspaceFromRemoteUrl, normalizeRemoteProfileHostUrl } from "./options";
+
+export type RemoteProfileKind = "cloud" | "self-hosted";
+
+export type RemoteProfileKeyInput = {
+  kind: RemoteProfileKind;
+  hostUrl: string;
+  workspace?: string | undefined;
+};
+
+export type RemoteProfileCredential = {
+  accessToken?: string | undefined;
+  refreshToken?: string | undefined;
+  tokenType?: string | undefined;
+  expiresAt?: string | undefined;
+  scope?: string[] | undefined;
+  clientSecret?: string | undefined;
+  pairingCode?: string | undefined;
+};
+
+export type RemoteProfileStatusInput = {
+  kind: RemoteProfileKind;
+  hostUrl: string;
+  key?: string | undefined;
+  workspaceId?: string | undefined;
+  workspaceSlug?: string | undefined;
+  selected?: boolean | undefined;
+  clientLabel?: string | undefined;
+  createdAt?: string | undefined;
+  updatedAt?: string | undefined;
+  credential?: RemoteProfileCredential | undefined;
+};
+
+export type RemoteProfileStatus = {
+  authenticated: boolean;
+  kind: RemoteProfileKind;
+  key: string;
+  hostUrl: string;
+  workspaceId?: string | undefined;
+  workspaceSlug?: string | undefined;
+  selected: boolean;
+  clientLabel?: string | undefined;
+  createdAt?: string | undefined;
+  updatedAt?: string | undefined;
+  expiresAt?: string | undefined;
+  scope?: string[] | undefined;
+  tokenType?: string | undefined;
+};
+
+export function remoteProfileKey(input: RemoteProfileKeyInput): string {
+  const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+  if (input.kind === "cloud") {
+    const workspace = input.workspace ?? hostedCloudWorkspaceFromRemoteUrl(input.hostUrl);
+    if (!workspace) {
+      throw new CapletsError("REQUEST_INVALID", "Cloud Remote Profile requires a workspace.");
+    }
+    return `cloud:${hostUrl}:${workspace}`;
+  }
+  return `self-hosted:${hostUrl}`;
+}
+
+export function selectedWorkspaceKey(hostUrl: string): string {
+  return `cloud:${normalizeRemoteProfileHostUrl(hostUrl)}:selected-workspace`;
+}
+
+export function remoteProfileStatus(input: RemoteProfileStatusInput): RemoteProfileStatus {
+  const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+  const key =
+    input.key ??
+    remoteProfileKey({
+      kind: input.kind,
+      hostUrl,
+      workspace: input.workspaceSlug ?? input.workspaceId,
+    });
+  const expiresAt = input.credential?.expiresAt;
+  const expired = Number.isFinite(Date.parse(expiresAt ?? ""))
+    ? Date.parse(expiresAt ?? "") <= Date.now()
+    : false;
+  return {
+    authenticated: Boolean(input.credential) && !expired,
+    kind: input.kind,
+    key,
+    hostUrl,
+    ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+    ...(input.workspaceSlug ? { workspaceSlug: input.workspaceSlug } : {}),
+    selected: Boolean(input.selected),
+    ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
+    ...(input.createdAt ? { createdAt: input.createdAt } : {}),
+    ...(input.updatedAt ? { updatedAt: input.updatedAt } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+    ...(input.credential?.scope ? { scope: input.credential.scope } : {}),
+    ...(input.credential?.tokenType ? { tokenType: input.credential.tokenType } : {}),
+  };
+}

--- a/packages/core/src/remote/selection.ts
+++ b/packages/core/src/remote/selection.ts
@@ -1,10 +1,9 @@
-import { dirname, join } from "node:path";
 import { CloudAuthClient } from "../cloud-auth/client";
-import { CloudAuthStore, type CloudAuthCredentials } from "../cloud-auth/store";
+import type { CloudAuthCredentials } from "../cloud-auth/store";
 import { HOSTED_CLOUD_AUTH_SCOPES } from "../cloud-auth/types";
-import { DEFAULT_AUTH_DIR } from "../config/paths";
 import { CapletsError } from "../errors";
 import { ProjectBindingError, projectBindingError } from "../project-binding/errors";
+import { appendBasePath } from "../server/options";
 import {
   hostedCloudWorkspaceFromRemoteUrl,
   normalizeRemoteProfileHostUrl,
@@ -13,8 +12,9 @@ import {
   resolveRemoteMode,
   type ResolvedCapletsRemote,
 } from "./options";
-import { FileRemoteProfileStore } from "./profile-store";
-import { remoteProfileKey } from "./profiles";
+import { cloudCredentialsFromRemoteProfile, createRemoteProfileStore } from "./profile-store";
+
+const SELF_HOSTED_REFRESH_TIMEOUT_MS = 15_000;
 
 export type RemoteSelectionInput = {
   mode?: string;
@@ -28,12 +28,14 @@ export type ResolvedRemoteSelection =
   | {
       kind: "self_hosted_remote";
       remote: ResolvedCapletsRemote;
+      credentialExpiresAt?: string | undefined;
     }
   | {
       kind: "hosted_cloud";
       remote: ResolvedCapletsRemote;
       selectedWorkspace: string;
       credentials: CloudAuthCredentials;
+      credentialExpiresAt?: string | undefined;
       cloudPresence: {
         url: URL;
         accessToken: string;
@@ -66,17 +68,44 @@ export async function resolveRemoteSelection(
     if (!remoteUrl) {
       throw new CapletsError("REQUEST_INVALID", "CAPLETS_REMOTE_URL or remoteUrl is required.");
     }
-    const store = remoteProfileStore(input.authDir, env);
-    const status = await store.getSelfHostedProfileStatus({ hostUrl: remoteUrl });
-    const credential = status
-      ? await store.credentials.load(
-          remoteProfileKey({
-            kind: "self-hosted",
-            hostUrl: normalizeRemoteProfileHostUrl(remoteUrl),
-          }),
-        )
-      : undefined;
-    if (!status || !credential?.accessToken) {
+    const store = createRemoteProfileStore({ authDir: input.authDir, env });
+    const refreshed = await store.refreshSelfHostedProfileIfNeeded({
+      hostUrl: remoteUrl,
+      needsRefresh: (credential) =>
+        credentialsNeedRefresh({ expiresAt: credential.expiresAt ?? "" }),
+      refresh: async (status, credential) => {
+        if (!credential.refreshToken || !status.clientId) {
+          throw remoteLoginRequired(remoteUrl);
+        }
+        const refreshed = await refreshSelfHostedCredentials(
+          remoteUrl,
+          credential.refreshToken,
+          input.fetch ? { fetch: input.fetch } : {},
+        );
+        return {
+          hostUrl: refreshed.hostUrl ?? remoteUrl,
+          clientId: refreshed.clientId,
+          clientLabel: refreshed.clientLabel ?? status.clientLabel,
+          credentials: {
+            accessToken: refreshed.accessToken,
+            refreshToken: refreshed.refreshToken,
+            expiresAt: refreshed.expiresAt,
+            tokenType: refreshed.tokenType,
+          },
+        };
+      },
+    });
+    const credential = refreshed?.credential;
+    if (!credential?.accessToken) {
+      const normalizedUrl = normalizeRemoteProfileHostUrl(remoteUrl);
+      throw new ProjectBindingError({
+        code: "remote_credentials_required",
+        message: `Remote Login required for ${normalizedUrl}.`,
+        recoveryCommand: `caplets remote login ${normalizedUrl}`,
+      });
+    }
+    const accessToken = credential.accessToken;
+    if (!accessToken) {
       const normalizedUrl = normalizeRemoteProfileHostUrl(remoteUrl);
       throw new ProjectBindingError({
         code: "remote_credentials_required",
@@ -89,16 +118,17 @@ export async function resolveRemoteSelection(
       remote: resolveCapletsRemote(
         {
           url: remoteUrl,
-          token: credential.accessToken,
+          token: accessToken,
           ...(input.workspace !== undefined ? { workspace: input.workspace } : {}),
           ...(input.fetch !== undefined ? { fetch: input.fetch } : {}),
         },
         {},
       ),
+      ...(credential.expiresAt ? { credentialExpiresAt: credential.expiresAt } : {}),
     };
   }
 
-  const store = remoteProfileStore(input.authDir, env);
+  const store = createRemoteProfileStore({ authDir: input.authDir, env });
   const remoteUrl = input.remoteUrl ?? env.CAPLETS_REMOTE_URL;
   if (!remoteUrl) {
     throw new CapletsError(
@@ -120,7 +150,7 @@ export async function resolveRemoteSelection(
   if (!status || !credential?.accessToken) {
     throw projectBindingError("cloud_auth_required");
   }
-  let credentials: CloudAuthCredentials = cloudCredentialsFromProfile(status, credential);
+  let credentials: CloudAuthCredentials = cloudCredentialsFromRemoteProfile(status, credential);
 
   if (credentialsNeedRefresh(credentials)) {
     if (!credentials.refreshToken) {
@@ -199,6 +229,7 @@ export async function resolveRemoteSelection(
     remote,
     selectedWorkspace,
     credentials,
+    credentialExpiresAt: credentials.expiresAt,
     cloudPresence: {
       url: remote.baseUrl,
       accessToken: credentials.accessToken,
@@ -207,53 +238,104 @@ export async function resolveRemoteSelection(
   };
 }
 
-function remoteProfileStore(
-  authDir: string | undefined,
-  env: Record<string, string | undefined>,
-): FileRemoteProfileStore {
-  const root = join(
-    authDir ??
-      (env.CAPLETS_CLOUD_AUTH_PATH ? dirname(env.CAPLETS_CLOUD_AUTH_PATH) : DEFAULT_AUTH_DIR),
-    "remote-profiles",
-  );
-  return new FileRemoteProfileStore({
-    root,
-    legacyCloudAuthStore: new CloudAuthStore({ env }),
-  });
-}
-
-function cloudCredentialsFromProfile(
-  status: {
-    hostUrl: string;
-    workspaceId?: string | undefined;
-    workspaceSlug?: string | undefined;
-    clientLabel?: string | undefined;
-  },
-  credential: {
-    accessToken?: string | undefined;
-    refreshToken?: string | undefined;
-    expiresAt?: string | undefined;
-    scope?: string[] | undefined;
-    tokenType?: string | undefined;
-  },
-): CloudAuthCredentials {
-  return {
-    version: 2,
-    cloudUrl: status.hostUrl,
-    workspaceId: status.workspaceId ?? "",
-    ...(status.workspaceSlug ? { workspaceSlug: status.workspaceSlug } : {}),
-    accessToken: credential.accessToken ?? "",
-    refreshToken: credential.refreshToken ?? "",
-    expiresAt: credential.expiresAt ?? new Date(0).toISOString(),
-    scope: credential.scope,
-    tokenType: credential.tokenType,
-    deviceName: status.clientLabel,
-  };
-}
-
 function credentialsNeedRefresh(credentials: { expiresAt: string }): boolean {
   const expiresAt = Date.parse(credentials.expiresAt);
   return Number.isFinite(expiresAt) && expiresAt <= Date.now() + 60_000;
+}
+
+type SelfHostedRefreshCredentials = {
+  hostUrl?: string | undefined;
+  clientId: string;
+  clientLabel?: string | undefined;
+  accessToken: string;
+  refreshToken: string;
+  tokenType?: string | undefined;
+  expiresAt?: string | undefined;
+};
+
+async function refreshSelfHostedCredentials(
+  remoteUrl: string,
+  refreshToken: string,
+  options: { fetch?: typeof fetch },
+): Promise<SelfHostedRefreshCredentials> {
+  const refreshUrl = appendBasePath(
+    new URL(normalizeRemoteProfileHostUrl(remoteUrl)),
+    "v1/remote/refresh",
+  );
+  const response = await fetchSelfHostedRefresh(refreshUrl, refreshToken, options);
+  if (!response.ok) {
+    throw remoteLoginRequired(remoteUrl);
+  }
+  return parseSelfHostedRefreshCredentials(response);
+}
+
+async function fetchSelfHostedRefresh(
+  refreshUrl: URL,
+  refreshToken: string,
+  options: { fetch?: typeof fetch },
+): Promise<Response> {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const refresh = (options.fetch ?? fetch)(refreshUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+      signal: controller.signal,
+    });
+    const timedOut = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(() => {
+        controller.abort();
+        reject(new CapletsError("SERVER_UNAVAILABLE", "Remote credential refresh timed out."));
+      }, SELF_HOSTED_REFRESH_TIMEOUT_MS);
+    });
+    return await Promise.race([refresh, timedOut]);
+  } catch (error) {
+    if (error instanceof CapletsError) throw error;
+    throw new CapletsError("SERVER_UNAVAILABLE", "Remote credential refresh failed.");
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function remoteLoginRequired(remoteUrl: string): ProjectBindingError {
+  return new ProjectBindingError({
+    code: "remote_credentials_required",
+    message: `Remote Login required for ${normalizeRemoteProfileHostUrl(remoteUrl)}.`,
+    recoveryCommand: `caplets remote login ${normalizeRemoteProfileHostUrl(remoteUrl)}`,
+  });
+}
+
+async function parseSelfHostedRefreshCredentials(
+  response: Response,
+): Promise<SelfHostedRefreshCredentials> {
+  const parsed = await response.json();
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new CapletsError(
+      "DOWNSTREAM_PROTOCOL_ERROR",
+      "Remote refresh response must be an object.",
+    );
+  }
+  const record = parsed as Record<string, unknown>;
+  if (
+    typeof record.clientId !== "string" ||
+    typeof record.accessToken !== "string" ||
+    typeof record.refreshToken !== "string"
+  ) {
+    throw new CapletsError(
+      "DOWNSTREAM_PROTOCOL_ERROR",
+      "Remote refresh response is missing credentials.",
+    );
+  }
+  return {
+    ...(typeof record.hostUrl === "string" ? { hostUrl: record.hostUrl } : {}),
+    clientId: record.clientId,
+    ...(typeof record.clientLabel === "string" ? { clientLabel: record.clientLabel } : {}),
+    accessToken: record.accessToken,
+    refreshToken: record.refreshToken,
+    ...(typeof record.tokenType === "string" ? { tokenType: record.tokenType } : {}),
+    ...(typeof record.expiresAt === "string" ? { expiresAt: record.expiresAt } : {}),
+  };
 }
 
 function requiredHostedCloudAttachScopes(): string[] {

--- a/packages/core/src/remote/selection.ts
+++ b/packages/core/src/remote/selection.ts
@@ -113,7 +113,7 @@ export async function resolveRemoteSelection(
           ...(input.workspace !== undefined ? { workspace: input.workspace } : {}),
           ...(input.fetch !== undefined ? { fetch: input.fetch } : {}),
         },
-        {},
+        env,
       ),
       ...(credential.expiresAt ? { credentialExpiresAt: credential.expiresAt } : {}),
     };
@@ -277,9 +277,43 @@ async function refreshSelfHostedCredentials(
   );
   const response = await fetchSelfHostedRefresh(refreshUrl, refreshToken, options);
   if (!response.ok) {
-    throw remoteLoginRequired(remoteUrl);
+    throw await selfHostedRefreshError(remoteUrl, response);
   }
   return parseSelfHostedRefreshCredentials(response);
+}
+
+async function selfHostedRefreshError(remoteUrl: string, response: Response): Promise<Error> {
+  const summary = await parseSelfHostedRefreshError(response);
+  if (response.status === 401 || summary?.code === "AUTH_FAILED") {
+    return remoteLoginRequired(remoteUrl);
+  }
+  if (response.status === 503 || summary?.code === "SERVER_UNAVAILABLE") {
+    return new CapletsError(
+      "SERVER_UNAVAILABLE",
+      summary?.message ?? "Remote credential refresh is temporarily unavailable.",
+    );
+  }
+  return new CapletsError(
+    "AUTH_REFRESH_FAILED",
+    summary?.message ?? `Remote credential refresh failed with HTTP ${response.status}.`,
+  );
+}
+
+async function parseSelfHostedRefreshError(
+  response: Response,
+): Promise<{ code?: string | undefined; message?: string | undefined } | undefined> {
+  const parsed = await response
+    .clone()
+    .json()
+    .catch(() => undefined);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  const error = (parsed as Record<string, unknown>).error;
+  if (!error || typeof error !== "object" || Array.isArray(error)) return undefined;
+  const record = error as Record<string, unknown>;
+  return {
+    ...(typeof record.code === "string" ? { code: record.code } : {}),
+    ...(typeof record.message === "string" ? { message: record.message } : {}),
+  };
 }
 
 async function fetchSelfHostedRefresh(

--- a/packages/core/src/remote/selection.ts
+++ b/packages/core/src/remote/selection.ts
@@ -1,15 +1,20 @@
+import { dirname, join } from "node:path";
 import { CloudAuthClient } from "../cloud-auth/client";
 import { CloudAuthStore, type CloudAuthCredentials } from "../cloud-auth/store";
 import { HOSTED_CLOUD_AUTH_SCOPES } from "../cloud-auth/types";
+import { DEFAULT_AUTH_DIR } from "../config/paths";
 import { CapletsError } from "../errors";
-import { projectBindingError } from "../project-binding/errors";
+import { ProjectBindingError, projectBindingError } from "../project-binding/errors";
 import {
   hostedCloudWorkspaceFromRemoteUrl,
+  normalizeRemoteProfileHostUrl,
   resolveCapletsRemote,
   resolveHostedCloudRemote,
   resolveRemoteMode,
   type ResolvedCapletsRemote,
 } from "./options";
+import { FileRemoteProfileStore } from "./profile-store";
+import { remoteProfileKey } from "./profiles";
 
 export type RemoteSelectionInput = {
   mode?: string;
@@ -19,6 +24,7 @@ export type RemoteSelectionInput = {
   token?: string;
   workspace?: string;
   fetch?: typeof fetch;
+  authDir?: string;
 };
 
 export type ResolvedRemoteSelection =
@@ -59,27 +65,65 @@ export async function resolveRemoteSelection(
   }
 
   if (mode.mode === "remote") {
+    const remoteUrl = input.remoteUrl ?? env.CAPLETS_REMOTE_URL;
+    if (!remoteUrl) {
+      throw new CapletsError("REQUEST_INVALID", "CAPLETS_REMOTE_URL or remoteUrl is required.");
+    }
+    const store = remoteProfileStore(input.authDir, env);
+    const status = await store.getSelfHostedProfileStatus({ hostUrl: remoteUrl });
+    const credential = status
+      ? await store.credentials.load(
+          remoteProfileKey({
+            kind: "self-hosted",
+            hostUrl: normalizeRemoteProfileHostUrl(remoteUrl),
+          }),
+        )
+      : undefined;
+    if (!status || !credential?.accessToken) {
+      const normalizedUrl = normalizeRemoteProfileHostUrl(remoteUrl);
+      throw new ProjectBindingError({
+        code: "remote_credentials_required",
+        message: `Remote Login required for ${normalizedUrl}.`,
+        recoveryCommand: `caplets remote login ${normalizedUrl}`,
+      });
+    }
     return {
       kind: "self_hosted_remote",
       remote: resolveCapletsRemote(
         {
-          ...(input.remoteUrl !== undefined ? { url: input.remoteUrl } : {}),
-          ...(input.user !== undefined ? { user: input.user } : {}),
-          ...(input.password !== undefined ? { password: input.password } : {}),
-          ...(input.token !== undefined ? { token: input.token } : {}),
+          url: remoteUrl,
+          token: credential.accessToken,
           ...(input.workspace !== undefined ? { workspace: input.workspace } : {}),
           ...(input.fetch !== undefined ? { fetch: input.fetch } : {}),
         },
-        env,
+        {},
       ),
     };
   }
 
-  const store = new CloudAuthStore({ env });
-  let credentials = await store.load();
-  if (!credentials?.accessToken) {
+  const store = remoteProfileStore(input.authDir, env);
+  const remoteUrl = input.remoteUrl ?? env.CAPLETS_REMOTE_URL;
+  if (!remoteUrl) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "CAPLETS_MODE=cloud requires CAPLETS_REMOTE_URL or remoteUrl.",
+    );
+  }
+  const workspaceFromRemoteUrl = hostedCloudWorkspaceFromRemoteUrl(remoteUrl);
+  let status = await store.getCloudProfileStatus({
+    hostUrl: normalizeRemoteProfileHostUrl(remoteUrl),
+    workspace: workspaceFromRemoteUrl,
+  });
+  if (!status && workspaceFromRemoteUrl) {
+    status = await store.getCloudProfileStatus({
+      hostUrl: normalizeRemoteProfileHostUrl(remoteUrl),
+    });
+  }
+  let credential = status ? await store.credentials.load(status.key) : undefined;
+  if (!status || !credential?.accessToken) {
     throw projectBindingError("cloud_auth_required");
   }
+  let credentials: CloudAuthCredentials = cloudCredentialsFromProfile(status, credential);
 
   if (credentialsNeedRefresh(credentials)) {
     if (!credentials.refreshToken) {
@@ -96,7 +140,20 @@ export async function resolveRemoteSelection(
       createdAt: credentials.createdAt,
       lastRefreshAt: new Date().toISOString(),
     };
-    await store.save(credentials);
+    status = await store.saveCloudProfile({
+      hostUrl: credentials.cloudUrl,
+      workspaceId: credentials.workspaceId,
+      ...(credentials.workspaceSlug ? { workspaceSlug: credentials.workspaceSlug } : {}),
+      clientLabel: credentials.deviceName,
+      credentials: {
+        accessToken: credentials.accessToken,
+        refreshToken: credentials.refreshToken,
+        expiresAt: credentials.expiresAt,
+        scope: credentials.scope,
+        tokenType: credentials.tokenType,
+      },
+    });
+    credential = await store.credentials.load(status.key);
   }
 
   const selectedWorkspace = credentials.workspaceSlug ?? credentials.workspaceId;
@@ -111,14 +168,6 @@ export async function resolveRemoteSelection(
     );
   }
 
-  const remoteUrl = input.remoteUrl ?? env.CAPLETS_REMOTE_URL;
-  if (!remoteUrl) {
-    throw new CapletsError(
-      "REQUEST_INVALID",
-      "CAPLETS_MODE=cloud requires CAPLETS_REMOTE_URL or remoteUrl.",
-    );
-  }
-  const workspaceFromRemoteUrl = hostedCloudWorkspaceFromRemoteUrl(remoteUrl);
   if (
     workspaceFromRemoteUrl &&
     workspaceFromRemoteUrl !== credentials.workspaceSlug &&
@@ -158,6 +207,50 @@ export async function resolveRemoteSelection(
       accessToken: credentials.accessToken,
       workspaceId: credentials.workspaceId,
     },
+  };
+}
+
+function remoteProfileStore(
+  authDir: string | undefined,
+  env: Record<string, string | undefined>,
+): FileRemoteProfileStore {
+  const root = join(
+    authDir ??
+      (env.CAPLETS_CLOUD_AUTH_PATH ? dirname(env.CAPLETS_CLOUD_AUTH_PATH) : DEFAULT_AUTH_DIR),
+    "remote-profiles",
+  );
+  return new FileRemoteProfileStore({
+    root,
+    legacyCloudAuthStore: new CloudAuthStore({ env }),
+  });
+}
+
+function cloudCredentialsFromProfile(
+  status: {
+    hostUrl: string;
+    workspaceId?: string | undefined;
+    workspaceSlug?: string | undefined;
+    clientLabel?: string | undefined;
+  },
+  credential: {
+    accessToken?: string | undefined;
+    refreshToken?: string | undefined;
+    expiresAt?: string | undefined;
+    scope?: string[] | undefined;
+    tokenType?: string | undefined;
+  },
+): CloudAuthCredentials {
+  return {
+    version: 2,
+    cloudUrl: status.hostUrl,
+    workspaceId: status.workspaceId ?? "",
+    ...(status.workspaceSlug ? { workspaceSlug: status.workspaceSlug } : {}),
+    accessToken: credential.accessToken ?? "",
+    refreshToken: credential.refreshToken ?? "",
+    expiresAt: credential.expiresAt ?? new Date(0).toISOString(),
+    scope: credential.scope,
+    tokenType: credential.tokenType,
+    deviceName: status.clientLabel,
   };
 }
 

--- a/packages/core/src/remote/selection.ts
+++ b/packages/core/src/remote/selection.ts
@@ -153,34 +153,52 @@ export async function resolveRemoteSelection(
   let credentials: CloudAuthCredentials = cloudCredentialsFromRemoteProfile(status, credential);
 
   if (credentialsNeedRefresh(credentials)) {
-    if (!credentials.refreshToken) {
-      throw projectBindingError("cloud_auth_required");
-    }
-    const refreshed = await new CloudAuthClient({
-      cloudUrl: credentials.cloudUrl,
-      ...(input.fetch !== undefined ? { fetch: input.fetch } : {}),
-    }).refresh({ refreshToken: credentials.refreshToken });
-    credentials = {
-      ...credentials,
-      ...refreshed,
-      refreshToken: refreshed.refreshToken ?? credentials.refreshToken,
-      createdAt: credentials.createdAt,
-      lastRefreshAt: new Date().toISOString(),
-    };
-    status = await store.saveCloudProfile({
-      hostUrl: credentials.cloudUrl,
-      workspaceId: credentials.workspaceId,
-      ...(credentials.workspaceSlug ? { workspaceSlug: credentials.workspaceSlug } : {}),
-      clientLabel: credentials.deviceName,
-      credentials: {
-        accessToken: credentials.accessToken,
-        refreshToken: credentials.refreshToken,
-        expiresAt: credentials.expiresAt,
-        scope: credentials.scope,
-        tokenType: credentials.tokenType,
+    const refreshed = await store.refreshCloudProfileIfNeeded({
+      hostUrl: normalizeRemoteProfileHostUrl(remoteUrl),
+      workspace: workspaceFromRemoteUrl,
+      needsRefresh: (candidate) => credentialsNeedRefresh({ expiresAt: candidate.expiresAt ?? "" }),
+      refresh: async (candidateStatus, candidateCredential) => {
+        const candidateCredentials = cloudCredentialsFromRemoteProfile(
+          candidateStatus,
+          candidateCredential,
+        );
+        if (!candidateCredentials.refreshToken) {
+          throw projectBindingError("cloud_auth_required");
+        }
+        const refreshedCredentials = await new CloudAuthClient({
+          cloudUrl: candidateCredentials.cloudUrl,
+          ...(input.fetch !== undefined ? { fetch: input.fetch } : {}),
+        }).refresh({ refreshToken: candidateCredentials.refreshToken });
+        const nextCredentials = {
+          ...candidateCredentials,
+          ...refreshedCredentials,
+          refreshToken: refreshedCredentials.refreshToken ?? candidateCredentials.refreshToken,
+          createdAt: candidateCredentials.createdAt,
+          lastRefreshAt: new Date().toISOString(),
+        };
+        return {
+          hostUrl: nextCredentials.cloudUrl,
+          workspaceId: nextCredentials.workspaceId,
+          ...(nextCredentials.workspaceSlug
+            ? { workspaceSlug: nextCredentials.workspaceSlug }
+            : {}),
+          clientLabel: nextCredentials.deviceName,
+          credentials: {
+            accessToken: nextCredentials.accessToken,
+            refreshToken: nextCredentials.refreshToken,
+            expiresAt: nextCredentials.expiresAt,
+            scope: nextCredentials.scope,
+            tokenType: nextCredentials.tokenType,
+          },
+        };
       },
     });
-    credential = await store.credentials.load(status.key);
+    if (!refreshed?.credential?.accessToken) {
+      throw projectBindingError("cloud_auth_required");
+    }
+    status = refreshed.status;
+    credential = refreshed.credential;
+    credentials = cloudCredentialsFromRemoteProfile(status, credential);
   }
 
   const selectedWorkspace = credentials.workspaceSlug ?? credentials.workspaceId;

--- a/packages/core/src/remote/selection.ts
+++ b/packages/core/src/remote/selection.ts
@@ -19,9 +19,6 @@ import { remoteProfileKey } from "./profiles";
 export type RemoteSelectionInput = {
   mode?: string;
   remoteUrl?: string;
-  user?: string;
-  password?: string;
-  token?: string;
   workspace?: string;
   fetch?: typeof fetch;
   authDir?: string;
@@ -184,7 +181,7 @@ export async function resolveRemoteSelection(
   if (missingScope) {
     throw projectBindingError(
       "cloud_auth_required",
-      `Hosted Cloud attach requires Cloud Auth scope ${missingScope}. Run caplets cloud auth login again.`,
+      `Hosted Cloud attach requires Cloud Auth scope ${missingScope}. Run caplets remote login ${credentials.cloudUrl} again.`,
     );
   }
   const remote = resolveHostedCloudRemote(

--- a/packages/core/src/remote/selection.ts
+++ b/packages/core/src/remote/selection.ts
@@ -104,21 +104,12 @@ export async function resolveRemoteSelection(
         recoveryCommand: `caplets remote login ${normalizedUrl}`,
       });
     }
-    const accessToken = credential.accessToken;
-    if (!accessToken) {
-      const normalizedUrl = normalizeRemoteProfileHostUrl(remoteUrl);
-      throw new ProjectBindingError({
-        code: "remote_credentials_required",
-        message: `Remote Login required for ${normalizedUrl}.`,
-        recoveryCommand: `caplets remote login ${normalizedUrl}`,
-      });
-    }
     return {
       kind: "self_hosted_remote",
       remote: resolveCapletsRemote(
         {
           url: remoteUrl,
-          token: accessToken,
+          token: credential.accessToken,
           ...(input.workspace !== undefined ? { workspace: input.workspace } : {}),
           ...(input.fetch !== undefined ? { fetch: input.fetch } : {}),
         },
@@ -137,13 +128,17 @@ export async function resolveRemoteSelection(
     );
   }
   const workspaceFromRemoteUrl = hostedCloudWorkspaceFromRemoteUrl(remoteUrl);
+  const explicitWorkspace =
+    input.workspace ?? (workspaceFromRemoteUrl ? undefined : env.CAPLETS_REMOTE_WORKSPACE);
+  const profileWorkspace = workspaceFromRemoteUrl ?? explicitWorkspace;
+  const normalizedRemoteUrl = normalizeRemoteProfileHostUrl(remoteUrl);
   let status = await store.getCloudProfileStatus({
-    hostUrl: normalizeRemoteProfileHostUrl(remoteUrl),
-    workspace: workspaceFromRemoteUrl,
+    hostUrl: normalizedRemoteUrl,
+    workspace: profileWorkspace,
   });
-  if (!status && workspaceFromRemoteUrl) {
+  if (!status && profileWorkspace) {
     status = await store.getCloudProfileStatus({
-      hostUrl: normalizeRemoteProfileHostUrl(remoteUrl),
+      hostUrl: normalizedRemoteUrl,
     });
   }
   let credential = status ? await store.credentials.load(status.key) : undefined;
@@ -154,8 +149,8 @@ export async function resolveRemoteSelection(
 
   if (credentialsNeedRefresh(credentials)) {
     const refreshed = await store.refreshCloudProfileIfNeeded({
-      hostUrl: normalizeRemoteProfileHostUrl(remoteUrl),
-      workspace: workspaceFromRemoteUrl,
+      hostUrl: normalizedRemoteUrl,
+      workspace: profileWorkspace,
       needsRefresh: (candidate) => credentialsNeedRefresh({ expiresAt: candidate.expiresAt ?? "" }),
       refresh: async (candidateStatus, candidateCredential) => {
         const candidateCredentials = cloudCredentialsFromRemoteProfile(
@@ -203,13 +198,13 @@ export async function resolveRemoteSelection(
 
   const selectedWorkspace = credentials.workspaceSlug ?? credentials.workspaceId;
   if (
-    input.workspace &&
-    input.workspace !== credentials.workspaceId &&
-    input.workspace !== credentials.workspaceSlug
+    explicitWorkspace &&
+    explicitWorkspace !== credentials.workspaceId &&
+    explicitWorkspace !== credentials.workspaceSlug
   ) {
     throw projectBindingError(
       "workspace_switch_required",
-      `Requested workspace ${input.workspace} differs from saved Selected Workspace ${selectedWorkspace}.`,
+      `Requested workspace ${explicitWorkspace} differs from saved Selected Workspace ${selectedWorkspace}.`,
     );
   }
 

--- a/packages/core/src/remote/server-credential-store.ts
+++ b/packages/core/src/remote/server-credential-store.ts
@@ -1,0 +1,331 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { Buffer } from "node:buffer";
+import { createHash, timingSafeEqual, randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { CapletsError } from "../errors";
+import { normalizeRemoteProfileHostUrl } from "./options";
+import { createPairingCode, parsePairingCode, randomToken } from "./pairing";
+import type {
+  IssuedRemoteClientCredentials,
+  RemoteClientStatus,
+  ValidatedRemoteClient,
+} from "./server-credentials";
+
+export type RemoteServerCredentialStoreOptions = {
+  dir: string;
+};
+
+export type CreatePairingCodeInput = {
+  hostUrl: string;
+  clientLabel?: string | undefined;
+  ttlMs?: number | undefined;
+  maxAttempts?: number | undefined;
+  now?: Date | undefined;
+};
+
+export type ExchangePairingCodeInput = {
+  hostUrl: string;
+  code: string;
+  clientLabel?: string | undefined;
+  now?: Date | undefined;
+};
+
+export type ValidateAccessTokenInput = {
+  hostUrl: string;
+  accessToken: string;
+  now?: Date | undefined;
+};
+
+export type RefreshClientCredentialsInput = {
+  hostUrl: string;
+  refreshToken: string;
+  now?: Date | undefined;
+};
+
+type StoredPairingCode = {
+  codeId: string;
+  hostUrl: string;
+  secretHash: string;
+  clientLabel?: string | undefined;
+  createdAt: string;
+  expiresAt: string;
+  attempts: number;
+  maxAttempts: number;
+  usedAt?: string | undefined;
+};
+
+type StoredRemoteClient = {
+  clientId: string;
+  clientLabel: string;
+  hostUrl: string;
+  accessTokenHash: string;
+  accessExpiresAt: string;
+  refreshTokenHash: string;
+  supersededRefreshTokenHashes: string[];
+  refreshFamilyId: string;
+  createdAt: string;
+  lastUsedAt?: string | undefined;
+  revokedAt?: string | undefined;
+};
+
+type RemoteServerCredentialState = {
+  version: 1;
+  pairingCodes: StoredPairingCode[];
+  clients: StoredRemoteClient[];
+};
+
+const DEFAULT_PAIRING_CODE_TTL_MS = 10 * 60_000;
+const DEFAULT_PAIRING_CODE_MAX_ATTEMPTS = 5;
+const DEFAULT_ACCESS_TOKEN_TTL_MS = 15 * 60_000;
+const STATE_FILE = "remote-server-credentials.json";
+
+export class RemoteServerCredentialStore {
+  readonly dir: string;
+
+  constructor(options: RemoteServerCredentialStoreOptions) {
+    this.dir = options.dir;
+  }
+
+  createPairingCode(input: CreatePairingCodeInput): {
+    codeId: string;
+    code: string;
+    expiresAt: string;
+  } {
+    const now = input.now ?? new Date();
+    const issued = createPairingCode();
+    const state = this.loadState();
+    state.pairingCodes.push({
+      codeId: issued.codeId,
+      hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
+      secretHash: hashSecret(issued.secret),
+      ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
+      createdAt: now.toISOString(),
+      expiresAt: new Date(
+        now.getTime() + (input.ttlMs ?? DEFAULT_PAIRING_CODE_TTL_MS),
+      ).toISOString(),
+      attempts: 0,
+      maxAttempts: input.maxAttempts ?? DEFAULT_PAIRING_CODE_MAX_ATTEMPTS,
+    });
+    this.saveState(state);
+    return {
+      codeId: issued.codeId,
+      code: issued.code,
+      expiresAt: state.pairingCodes.at(-1)!.expiresAt,
+    };
+  }
+
+  exchangePairingCode(input: ExchangePairingCodeInput): IssuedRemoteClientCredentials {
+    const now = input.now ?? new Date();
+    const parsed = parsePairingCode(input.code);
+    if (!parsed) {
+      throw new CapletsError("AUTH_FAILED", "Pairing Code format is invalid.");
+    }
+    const state = this.loadState();
+    const pairingCode = state.pairingCodes.find((candidate) => candidate.codeId === parsed.codeId);
+    if (!pairingCode) {
+      throw new CapletsError("AUTH_FAILED", "Pairing Code is unknown.");
+    }
+    const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+    if (pairingCode.hostUrl !== hostUrl) {
+      throw new CapletsError("AUTH_FAILED", "Pairing Code belongs to a different host.");
+    }
+    if (pairingCode.usedAt) {
+      throw new CapletsError("AUTH_FAILED", "Pairing Code has already been used.");
+    }
+    if (Date.parse(pairingCode.expiresAt) <= now.getTime()) {
+      throw new CapletsError("AUTH_FAILED", "Pairing Code has expired.");
+    }
+    if (pairingCode.attempts >= pairingCode.maxAttempts) {
+      throw new CapletsError("AUTH_FAILED", "Pairing Code attempts exhausted.");
+    }
+    if (!safeHashEqual(hashSecret(parsed.secret), pairingCode.secretHash)) {
+      pairingCode.attempts += 1;
+      this.saveState(state);
+      throw new CapletsError(
+        "AUTH_FAILED",
+        pairingCode.attempts >= pairingCode.maxAttempts
+          ? "Pairing Code attempts exhausted."
+          : "Pairing Code is invalid.",
+      );
+    }
+
+    pairingCode.usedAt = now.toISOString();
+    const clientId = `rcli_${randomToken(12)}`;
+    const accessToken = `cap_remote_access_${randomToken(32)}`;
+    const refreshToken = `cap_remote_refresh_${randomToken(32)}`;
+    const client: StoredRemoteClient = {
+      clientId,
+      clientLabel: input.clientLabel ?? pairingCode.clientLabel ?? "Caplets Remote Client",
+      hostUrl,
+      accessTokenHash: hashSecret(accessToken),
+      accessExpiresAt: new Date(now.getTime() + DEFAULT_ACCESS_TOKEN_TTL_MS).toISOString(),
+      refreshTokenHash: hashSecret(refreshToken),
+      supersededRefreshTokenHashes: [],
+      refreshFamilyId: randomUUID(),
+      createdAt: now.toISOString(),
+    };
+    state.clients.push(client);
+    this.saveState(state);
+    return credentialsFromClient(client, accessToken, refreshToken);
+  }
+
+  listClients(): RemoteClientStatus[] {
+    return this.loadState()
+      .clients.map(clientStatus)
+      .sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+  }
+
+  revokeClient(clientId: string, now = new Date()): boolean {
+    const state = this.loadState();
+    const client = state.clients.find((candidate) => candidate.clientId === clientId);
+    if (!client) return false;
+    client.revokedAt = client.revokedAt ?? now.toISOString();
+    this.saveState(state);
+    return true;
+  }
+
+  validateAccessToken(input: ValidateAccessTokenInput): ValidatedRemoteClient {
+    const now = input.now ?? new Date();
+    const state = this.loadState();
+    const client = state.clients.find((candidate) =>
+      safeHashEqual(hashSecret(input.accessToken), candidate.accessTokenHash),
+    );
+    if (!client) {
+      throw new CapletsError("AUTH_FAILED", "Remote client credential is invalid.");
+    }
+    validateClient(client, normalizeRemoteProfileHostUrl(input.hostUrl), now);
+    client.lastUsedAt = now.toISOString();
+    this.saveState(state);
+    return { ...clientStatus(client), tokenType: "Bearer" };
+  }
+
+  refreshClientCredentials(input: RefreshClientCredentialsInput): IssuedRemoteClientCredentials {
+    const now = input.now ?? new Date();
+    const state = this.loadState();
+    const refreshTokenHash = hashSecret(input.refreshToken);
+    const client = state.clients.find((candidate) =>
+      safeHashEqual(refreshTokenHash, candidate.refreshTokenHash),
+    );
+    if (!client) {
+      const replayedClient = state.clients.find((candidate) =>
+        candidate.supersededRefreshTokenHashes.some((supersededHash) =>
+          safeHashEqual(refreshTokenHash, supersededHash),
+        ),
+      );
+      if (replayedClient) {
+        replayedClient.revokedAt = now.toISOString();
+        this.saveState(state);
+        throw new CapletsError("AUTH_FAILED", "Remote refresh credential is stale.");
+      }
+      throw new CapletsError("AUTH_FAILED", "Remote refresh credential is invalid.");
+    }
+    validateClient(client, normalizeRemoteProfileHostUrl(input.hostUrl), now, {
+      allowExpiredAccess: true,
+    });
+
+    const accessToken = `cap_remote_access_${randomToken(32)}`;
+    const refreshToken = `cap_remote_refresh_${randomToken(32)}`;
+    client.accessTokenHash = hashSecret(accessToken);
+    client.accessExpiresAt = new Date(now.getTime() + DEFAULT_ACCESS_TOKEN_TTL_MS).toISOString();
+    client.supersededRefreshTokenHashes.push(client.refreshTokenHash);
+    client.refreshTokenHash = hashSecret(refreshToken);
+    client.lastUsedAt = now.toISOString();
+    this.saveState(state);
+    return credentialsFromClient(client, accessToken, refreshToken);
+  }
+
+  dumpForTest(): RemoteServerCredentialState {
+    return this.loadState();
+  }
+
+  private loadState(): RemoteServerCredentialState {
+    const path = this.statePath();
+    if (!existsSync(path)) return { version: 1, pairingCodes: [], clients: [] };
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<RemoteServerCredentialState>;
+    return {
+      version: 1,
+      pairingCodes: parsed.pairingCodes ?? [],
+      clients: (parsed.clients ?? []).map((client) => ({
+        ...client,
+        supersededRefreshTokenHashes: client.supersededRefreshTokenHashes ?? [],
+      })),
+    };
+  }
+
+  private saveState(state: RemoteServerCredentialState): void {
+    mkdirSync(this.dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(this.dir, 0o700);
+    } catch {
+      // Best effort on platforms without POSIX permissions.
+    }
+    const path = this.statePath();
+    const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+    writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+    try {
+      chmodSync(tempPath, 0o600);
+    } catch {
+      // Best effort on platforms without POSIX permissions.
+    }
+    renameSync(tempPath, path);
+  }
+
+  private statePath(): string {
+    return join(this.dir, STATE_FILE);
+  }
+}
+
+function validateClient(
+  client: StoredRemoteClient,
+  hostUrl: string,
+  now: Date,
+  options: { allowExpiredAccess?: boolean } = {},
+): void {
+  if (client.hostUrl !== hostUrl) {
+    throw new CapletsError("AUTH_FAILED", "Remote client credential is for a different host.");
+  }
+  if (client.revokedAt) {
+    throw new CapletsError("AUTH_FAILED", "Remote client credential has been revoked.");
+  }
+  if (!options.allowExpiredAccess && Date.parse(client.accessExpiresAt) <= now.getTime()) {
+    throw new CapletsError("AUTH_FAILED", "Remote client credential has expired.");
+  }
+}
+
+function credentialsFromClient(
+  client: StoredRemoteClient,
+  accessToken: string,
+  refreshToken: string,
+): IssuedRemoteClientCredentials {
+  return {
+    hostUrl: client.hostUrl,
+    clientId: client.clientId,
+    clientLabel: client.clientLabel,
+    accessToken,
+    refreshToken,
+    tokenType: "Bearer",
+    expiresAt: client.accessExpiresAt,
+    createdAt: client.createdAt,
+  };
+}
+
+function clientStatus(client: StoredRemoteClient): RemoteClientStatus {
+  return {
+    clientId: client.clientId,
+    clientLabel: client.clientLabel,
+    hostUrl: client.hostUrl,
+    createdAt: client.createdAt,
+    ...(client.lastUsedAt ? { lastUsedAt: client.lastUsedAt } : {}),
+    ...(client.revokedAt ? { revokedAt: client.revokedAt } : {}),
+  };
+}
+
+function hashSecret(secret: string): string {
+  return createHash("sha256").update(secret).digest("base64url");
+}
+
+function safeHashEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}

--- a/packages/core/src/remote/server-credential-store.ts
+++ b/packages/core/src/remote/server-credential-store.ts
@@ -1,4 +1,12 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { Buffer } from "node:buffer";
 import { createHash, timingSafeEqual, randomUUID } from "node:crypto";
 import { join } from "node:path";
@@ -78,6 +86,8 @@ const DEFAULT_PAIRING_CODE_TTL_MS = 10 * 60_000;
 const DEFAULT_PAIRING_CODE_MAX_ATTEMPTS = 5;
 const DEFAULT_ACCESS_TOKEN_TTL_MS = 15 * 60_000;
 const STATE_FILE = "remote-server-credentials.json";
+const LOCK_DIR = "remote-server-credentials.lock";
+const LOCK_TIMEOUT_MS = 2_000;
 
 export class RemoteServerCredentialStore {
   readonly dir: string;
@@ -91,82 +101,88 @@ export class RemoteServerCredentialStore {
     code: string;
     expiresAt: string;
   } {
-    const now = input.now ?? new Date();
-    const issued = createPairingCode();
-    const state = this.loadState();
-    state.pairingCodes.push({
-      codeId: issued.codeId,
-      hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
-      secretHash: hashSecret(issued.secret),
-      ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
-      createdAt: now.toISOString(),
-      expiresAt: new Date(
-        now.getTime() + (input.ttlMs ?? DEFAULT_PAIRING_CODE_TTL_MS),
-      ).toISOString(),
-      attempts: 0,
-      maxAttempts: input.maxAttempts ?? DEFAULT_PAIRING_CODE_MAX_ATTEMPTS,
+    return this.withStateLock(() => {
+      const now = input.now ?? new Date();
+      const issued = createPairingCode();
+      const state = this.loadState();
+      state.pairingCodes.push({
+        codeId: issued.codeId,
+        hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
+        secretHash: hashSecret(issued.secret),
+        ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
+        createdAt: now.toISOString(),
+        expiresAt: new Date(
+          now.getTime() + (input.ttlMs ?? DEFAULT_PAIRING_CODE_TTL_MS),
+        ).toISOString(),
+        attempts: 0,
+        maxAttempts: input.maxAttempts ?? DEFAULT_PAIRING_CODE_MAX_ATTEMPTS,
+      });
+      this.saveState(state);
+      return {
+        codeId: issued.codeId,
+        code: issued.code,
+        expiresAt: state.pairingCodes.at(-1)!.expiresAt,
+      };
     });
-    this.saveState(state);
-    return {
-      codeId: issued.codeId,
-      code: issued.code,
-      expiresAt: state.pairingCodes.at(-1)!.expiresAt,
-    };
   }
 
   exchangePairingCode(input: ExchangePairingCodeInput): IssuedRemoteClientCredentials {
-    const now = input.now ?? new Date();
-    const parsed = parsePairingCode(input.code);
-    if (!parsed) {
-      throw new CapletsError("AUTH_FAILED", "Pairing Code format is invalid.");
-    }
-    const state = this.loadState();
-    const pairingCode = state.pairingCodes.find((candidate) => candidate.codeId === parsed.codeId);
-    if (!pairingCode) {
-      throw new CapletsError("AUTH_FAILED", "Pairing Code is unknown.");
-    }
-    const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
-    if (pairingCode.hostUrl !== hostUrl) {
-      throw new CapletsError("AUTH_FAILED", "Pairing Code belongs to a different host.");
-    }
-    if (pairingCode.usedAt) {
-      throw new CapletsError("AUTH_FAILED", "Pairing Code has already been used.");
-    }
-    if (Date.parse(pairingCode.expiresAt) <= now.getTime()) {
-      throw new CapletsError("AUTH_FAILED", "Pairing Code has expired.");
-    }
-    if (pairingCode.attempts >= pairingCode.maxAttempts) {
-      throw new CapletsError("AUTH_FAILED", "Pairing Code attempts exhausted.");
-    }
-    if (!safeHashEqual(hashSecret(parsed.secret), pairingCode.secretHash)) {
-      pairingCode.attempts += 1;
-      this.saveState(state);
-      throw new CapletsError(
-        "AUTH_FAILED",
-        pairingCode.attempts >= pairingCode.maxAttempts
-          ? "Pairing Code attempts exhausted."
-          : "Pairing Code is invalid.",
+    return this.withStateLock(() => {
+      const now = input.now ?? new Date();
+      const parsed = parsePairingCode(input.code);
+      if (!parsed) {
+        throw new CapletsError("AUTH_FAILED", "Pairing Code format is invalid.");
+      }
+      const state = this.loadState();
+      const pairingCode = state.pairingCodes.find(
+        (candidate) => candidate.codeId === parsed.codeId,
       );
-    }
+      if (!pairingCode) {
+        throw new CapletsError("AUTH_FAILED", "Pairing Code is unknown.");
+      }
+      const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+      if (pairingCode.hostUrl !== hostUrl) {
+        throw new CapletsError("AUTH_FAILED", "Pairing Code belongs to a different host.");
+      }
+      if (pairingCode.usedAt) {
+        throw new CapletsError("AUTH_FAILED", "Pairing Code has already been used.");
+      }
+      if (Date.parse(pairingCode.expiresAt) <= now.getTime()) {
+        throw new CapletsError("AUTH_FAILED", "Pairing Code has expired.");
+      }
+      if (pairingCode.attempts >= pairingCode.maxAttempts) {
+        throw new CapletsError("AUTH_FAILED", "Pairing Code attempts exhausted.");
+      }
+      if (!safeHashEqual(hashSecret(parsed.secret), pairingCode.secretHash)) {
+        pairingCode.attempts += 1;
+        this.saveState(state);
+        throw new CapletsError(
+          "AUTH_FAILED",
+          pairingCode.attempts >= pairingCode.maxAttempts
+            ? "Pairing Code attempts exhausted."
+            : "Pairing Code is invalid.",
+        );
+      }
 
-    pairingCode.usedAt = now.toISOString();
-    const clientId = `rcli_${randomToken(12)}`;
-    const accessToken = `cap_remote_access_${randomToken(32)}`;
-    const refreshToken = `cap_remote_refresh_${randomToken(32)}`;
-    const client: StoredRemoteClient = {
-      clientId,
-      clientLabel: input.clientLabel ?? pairingCode.clientLabel ?? "Caplets Remote Client",
-      hostUrl,
-      accessTokenHash: hashSecret(accessToken),
-      accessExpiresAt: new Date(now.getTime() + DEFAULT_ACCESS_TOKEN_TTL_MS).toISOString(),
-      refreshTokenHash: hashSecret(refreshToken),
-      supersededRefreshTokenHashes: [],
-      refreshFamilyId: randomUUID(),
-      createdAt: now.toISOString(),
-    };
-    state.clients.push(client);
-    this.saveState(state);
-    return credentialsFromClient(client, accessToken, refreshToken);
+      pairingCode.usedAt = now.toISOString();
+      const clientId = `rcli_${randomToken(12)}`;
+      const accessToken = `cap_remote_access_${randomToken(32)}`;
+      const refreshToken = `cap_remote_refresh_${randomToken(32)}`;
+      const client: StoredRemoteClient = {
+        clientId,
+        clientLabel: input.clientLabel ?? pairingCode.clientLabel ?? "Caplets Remote Client",
+        hostUrl,
+        accessTokenHash: hashSecret(accessToken),
+        accessExpiresAt: new Date(now.getTime() + DEFAULT_ACCESS_TOKEN_TTL_MS).toISOString(),
+        refreshTokenHash: hashSecret(refreshToken),
+        supersededRefreshTokenHashes: [],
+        refreshFamilyId: randomUUID(),
+        createdAt: now.toISOString(),
+      };
+      state.clients.push(client);
+      this.saveState(state);
+      return credentialsFromClient(client, accessToken, refreshToken);
+    });
   }
 
   listClients(): RemoteClientStatus[] {
@@ -176,62 +192,65 @@ export class RemoteServerCredentialStore {
   }
 
   revokeClient(clientId: string, now = new Date()): boolean {
-    const state = this.loadState();
-    const client = state.clients.find((candidate) => candidate.clientId === clientId);
-    if (!client) return false;
-    client.revokedAt = client.revokedAt ?? now.toISOString();
-    this.saveState(state);
-    return true;
+    return this.withStateLock(() => {
+      const state = this.loadState();
+      const client = state.clients.find((candidate) => candidate.clientId === clientId);
+      if (!client) return false;
+      client.revokedAt = client.revokedAt ?? now.toISOString();
+      this.saveState(state);
+      return true;
+    });
   }
 
   validateAccessToken(input: ValidateAccessTokenInput): ValidatedRemoteClient {
     const now = input.now ?? new Date();
     const state = this.loadState();
+    const accessTokenHash = hashSecret(input.accessToken);
     const client = state.clients.find((candidate) =>
-      safeHashEqual(hashSecret(input.accessToken), candidate.accessTokenHash),
+      safeHashEqual(accessTokenHash, candidate.accessTokenHash),
     );
     if (!client) {
       throw new CapletsError("AUTH_FAILED", "Remote client credential is invalid.");
     }
     validateClient(client, normalizeRemoteProfileHostUrl(input.hostUrl), now);
-    client.lastUsedAt = now.toISOString();
-    this.saveState(state);
     return { ...clientStatus(client), tokenType: "Bearer" };
   }
 
   refreshClientCredentials(input: RefreshClientCredentialsInput): IssuedRemoteClientCredentials {
-    const now = input.now ?? new Date();
-    const state = this.loadState();
-    const refreshTokenHash = hashSecret(input.refreshToken);
-    const client = state.clients.find((candidate) =>
-      safeHashEqual(refreshTokenHash, candidate.refreshTokenHash),
-    );
-    if (!client) {
-      const replayedClient = state.clients.find((candidate) =>
-        candidate.supersededRefreshTokenHashes.some((supersededHash) =>
-          safeHashEqual(refreshTokenHash, supersededHash),
-        ),
+    return this.withStateLock(() => {
+      const now = input.now ?? new Date();
+      const state = this.loadState();
+      const refreshTokenHash = hashSecret(input.refreshToken);
+      const client = state.clients.find((candidate) =>
+        safeHashEqual(refreshTokenHash, candidate.refreshTokenHash),
       );
-      if (replayedClient) {
-        replayedClient.revokedAt = now.toISOString();
-        this.saveState(state);
-        throw new CapletsError("AUTH_FAILED", "Remote refresh credential is stale.");
+      if (!client) {
+        const replayedClient = state.clients.find((candidate) =>
+          candidate.supersededRefreshTokenHashes.some((supersededHash) =>
+            safeHashEqual(refreshTokenHash, supersededHash),
+          ),
+        );
+        if (replayedClient) {
+          replayedClient.revokedAt = now.toISOString();
+          this.saveState(state);
+          throw new CapletsError("AUTH_FAILED", "Remote refresh credential is stale.");
+        }
+        throw new CapletsError("AUTH_FAILED", "Remote refresh credential is invalid.");
       }
-      throw new CapletsError("AUTH_FAILED", "Remote refresh credential is invalid.");
-    }
-    validateClient(client, normalizeRemoteProfileHostUrl(input.hostUrl), now, {
-      allowExpiredAccess: true,
-    });
+      validateClient(client, normalizeRemoteProfileHostUrl(input.hostUrl), now, {
+        allowExpiredAccess: true,
+      });
 
-    const accessToken = `cap_remote_access_${randomToken(32)}`;
-    const refreshToken = `cap_remote_refresh_${randomToken(32)}`;
-    client.accessTokenHash = hashSecret(accessToken);
-    client.accessExpiresAt = new Date(now.getTime() + DEFAULT_ACCESS_TOKEN_TTL_MS).toISOString();
-    client.supersededRefreshTokenHashes.push(client.refreshTokenHash);
-    client.refreshTokenHash = hashSecret(refreshToken);
-    client.lastUsedAt = now.toISOString();
-    this.saveState(state);
-    return credentialsFromClient(client, accessToken, refreshToken);
+      const accessToken = `cap_remote_access_${randomToken(32)}`;
+      const refreshToken = `cap_remote_refresh_${randomToken(32)}`;
+      client.accessTokenHash = hashSecret(accessToken);
+      client.accessExpiresAt = new Date(now.getTime() + DEFAULT_ACCESS_TOKEN_TTL_MS).toISOString();
+      client.supersededRefreshTokenHashes.push(client.refreshTokenHash);
+      client.refreshTokenHash = hashSecret(refreshToken);
+      client.lastUsedAt = now.toISOString();
+      this.saveState(state);
+      return credentialsFromClient(client, accessToken, refreshToken);
+    });
   }
 
   dumpForTest(): RemoteServerCredentialState {
@@ -273,6 +292,52 @@ export class RemoteServerCredentialStore {
   private statePath(): string {
     return join(this.dir, STATE_FILE);
   }
+
+  private lockPath(): string {
+    return join(this.dir, LOCK_DIR);
+  }
+
+  private withStateLock<T>(operation: () => T): T {
+    this.acquireLock();
+    try {
+      return operation();
+    } finally {
+      this.releaseLock();
+    }
+  }
+
+  private acquireLock(): void {
+    mkdirSync(this.dir, { recursive: true, mode: 0o700 });
+    const started = Date.now();
+    while (true) {
+      try {
+        mkdirSync(this.lockPath(), { mode: 0o700 });
+        return;
+      } catch (error) {
+        if (!isFileExistsError(error) || Date.now() - started >= LOCK_TIMEOUT_MS) {
+          throw new CapletsError("SERVER_UNAVAILABLE", "Remote credential state is locked.");
+        }
+        sleepSync(10);
+      }
+    }
+  }
+
+  private releaseLock(): void {
+    rmSync(this.lockPath(), { recursive: true, force: true });
+  }
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function isFileExistsError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "EEXIST"
+  );
 }
 
 function validateClient(

--- a/packages/core/src/remote/server-credential-store.ts
+++ b/packages/core/src/remote/server-credential-store.ts
@@ -5,6 +5,7 @@ import {
   readFileSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { Buffer } from "node:buffer";
@@ -91,9 +92,11 @@ const DEFAULT_PAIRING_CODE_TTL_MS = 10 * 60_000;
 const DEFAULT_PAIRING_CODE_MAX_ATTEMPTS = 5;
 const DEFAULT_ACCESS_TOKEN_TTL_MS = 15 * 60_000;
 const STALE_REFRESH_REVOKE_GRACE_MS = 30_000;
+const SUPERSEDED_REFRESH_TOKEN_RETENTION_MS = 24 * 60 * 60_000;
 const STATE_FILE = "remote-server-credentials.json";
 const LOCK_DIR = "remote-server-credentials.lock";
 const LOCK_TIMEOUT_MS = 2_000;
+const LOCK_STALE_MS = 30_000;
 
 export class RemoteServerCredentialStore {
   readonly dir: string;
@@ -260,6 +263,10 @@ export class RemoteServerCredentialStore {
       const refreshToken = `cap_remote_refresh_${randomToken(32)}`;
       client.accessTokenHash = hashSecret(accessToken);
       client.accessExpiresAt = new Date(now.getTime() + DEFAULT_ACCESS_TOKEN_TTL_MS).toISOString();
+      client.supersededRefreshTokenHashes = pruneSupersededRefreshTokens(
+        client.supersededRefreshTokenHashes,
+        now,
+      );
       client.supersededRefreshTokenHashes.push({
         hash: client.refreshTokenHash,
         supersededAt: now.toISOString(),
@@ -334,6 +341,9 @@ export class RemoteServerCredentialStore {
         mkdirSync(this.lockPath(), { mode: 0o700 });
         return;
       } catch (error) {
+        if (isFileExistsError(error) && this.clearStaleLock()) {
+          continue;
+        }
         if (!isFileExistsError(error) || Date.now() - started >= LOCK_TIMEOUT_MS) {
           throw new CapletsError("SERVER_UNAVAILABLE", "Remote credential state is locked.");
         }
@@ -344,6 +354,16 @@ export class RemoteServerCredentialStore {
 
   private releaseLock(): void {
     rmSync(this.lockPath(), { recursive: true, force: true });
+  }
+
+  private clearStaleLock(): boolean {
+    try {
+      if (Date.now() - statSync(this.lockPath()).mtimeMs < LOCK_STALE_MS) return false;
+      rmSync(this.lockPath(), { recursive: true, force: true });
+      return true;
+    } catch {
+      return false;
+    }
   }
 }
 
@@ -358,6 +378,19 @@ function isFileExistsError(error: unknown): boolean {
     "code" in error &&
     (error as { code?: unknown }).code === "EEXIST"
   );
+}
+
+function pruneSupersededRefreshTokens(
+  entries: SupersededRefreshToken[],
+  now: Date,
+): SupersededRefreshToken[] {
+  return entries.filter((entry) => {
+    const supersededAt = Date.parse(entry.supersededAt);
+    return (
+      Number.isFinite(supersededAt) &&
+      now.getTime() - supersededAt < SUPERSEDED_REFRESH_TOKEN_RETENTION_MS
+    );
+  });
 }
 
 function validateClient(

--- a/packages/core/src/remote/server-credential-store.ts
+++ b/packages/core/src/remote/server-credential-store.ts
@@ -69,11 +69,16 @@ type StoredRemoteClient = {
   accessTokenHash: string;
   accessExpiresAt: string;
   refreshTokenHash: string;
-  supersededRefreshTokenHashes: string[];
+  supersededRefreshTokenHashes: SupersededRefreshToken[];
   refreshFamilyId: string;
   createdAt: string;
   lastUsedAt?: string | undefined;
   revokedAt?: string | undefined;
+};
+
+type SupersededRefreshToken = {
+  hash: string;
+  supersededAt: string;
 };
 
 type RemoteServerCredentialState = {
@@ -85,6 +90,7 @@ type RemoteServerCredentialState = {
 const DEFAULT_PAIRING_CODE_TTL_MS = 10 * 60_000;
 const DEFAULT_PAIRING_CODE_MAX_ATTEMPTS = 5;
 const DEFAULT_ACCESS_TOKEN_TTL_MS = 15 * 60_000;
+const STALE_REFRESH_REVOKE_GRACE_MS = 30_000;
 const STATE_FILE = "remote-server-credentials.json";
 const LOCK_DIR = "remote-server-credentials.lock";
 const LOCK_TIMEOUT_MS = 2_000;
@@ -226,12 +232,21 @@ export class RemoteServerCredentialStore {
       );
       if (!client) {
         const replayedClient = state.clients.find((candidate) =>
-          candidate.supersededRefreshTokenHashes.some((supersededHash) =>
-            safeHashEqual(refreshTokenHash, supersededHash),
+          candidate.supersededRefreshTokenHashes.some((superseded) =>
+            safeHashEqual(refreshTokenHash, superseded.hash),
           ),
         );
         if (replayedClient) {
-          replayedClient.revokedAt = now.toISOString();
+          const superseded = replayedClient.supersededRefreshTokenHashes.find((entry) =>
+            safeHashEqual(refreshTokenHash, entry.hash),
+          );
+          const supersededAt = superseded ? Date.parse(superseded.supersededAt) : Number.NaN;
+          if (
+            Number.isFinite(supersededAt) &&
+            now.getTime() - supersededAt >= STALE_REFRESH_REVOKE_GRACE_MS
+          ) {
+            replayedClient.revokedAt = now.toISOString();
+          }
           this.saveState(state);
           throw new CapletsError("AUTH_FAILED", "Remote refresh credential is stale.");
         }
@@ -245,7 +260,10 @@ export class RemoteServerCredentialStore {
       const refreshToken = `cap_remote_refresh_${randomToken(32)}`;
       client.accessTokenHash = hashSecret(accessToken);
       client.accessExpiresAt = new Date(now.getTime() + DEFAULT_ACCESS_TOKEN_TTL_MS).toISOString();
-      client.supersededRefreshTokenHashes.push(client.refreshTokenHash);
+      client.supersededRefreshTokenHashes.push({
+        hash: client.refreshTokenHash,
+        supersededAt: now.toISOString(),
+      });
       client.refreshTokenHash = hashSecret(refreshToken);
       client.lastUsedAt = now.toISOString();
       this.saveState(state);
@@ -266,7 +284,9 @@ export class RemoteServerCredentialStore {
       pairingCodes: parsed.pairingCodes ?? [],
       clients: (parsed.clients ?? []).map((client) => ({
         ...client,
-        supersededRefreshTokenHashes: client.supersededRefreshTokenHashes ?? [],
+        supersededRefreshTokenHashes: parseSupersededRefreshTokens(
+          client.supersededRefreshTokenHashes,
+        ),
       })),
     };
   }
@@ -393,4 +413,27 @@ function safeHashEqual(left: string, right: string): boolean {
   const leftBuffer = Buffer.from(left);
   const rightBuffer = Buffer.from(right);
   return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function parseSupersededRefreshTokens(value: unknown): SupersededRefreshToken[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (typeof entry === "string") {
+      return [{ hash: entry, supersededAt: new Date(0).toISOString() }];
+    }
+    if (
+      entry &&
+      typeof entry === "object" &&
+      typeof (entry as { hash?: unknown }).hash === "string" &&
+      typeof (entry as { supersededAt?: unknown }).supersededAt === "string"
+    ) {
+      return [
+        {
+          hash: (entry as { hash: string }).hash,
+          supersededAt: (entry as { supersededAt: string }).supersededAt,
+        },
+      ];
+    }
+    return [];
+  });
 }

--- a/packages/core/src/remote/server-credentials.ts
+++ b/packages/core/src/remote/server-credentials.ts
@@ -1,0 +1,23 @@
+export type IssuedRemoteClientCredentials = {
+  hostUrl: string;
+  clientId: string;
+  clientLabel: string;
+  accessToken: string;
+  refreshToken: string;
+  tokenType: "Bearer";
+  expiresAt: string;
+  createdAt: string;
+};
+
+export type RemoteClientStatus = {
+  clientId: string;
+  clientLabel: string;
+  hostUrl: string;
+  createdAt: string;
+  lastUsedAt?: string | undefined;
+  revokedAt?: string | undefined;
+};
+
+export type ValidatedRemoteClient = RemoteClientStatus & {
+  tokenType: "Bearer";
+};

--- a/packages/core/src/serve/http.ts
+++ b/packages/core/src/serve/http.ts
@@ -147,6 +147,25 @@ export function createHttpServeApp(
         return remoteCredentialErrorResponse(error);
       }
     });
+
+    app.delete(paths.remoteClient, protectedRouteAuth, (c) => {
+      try {
+        const client = validatedRemoteClient(
+          c.req.header("authorization") ?? "",
+          remoteCredentialStore,
+          c.req.url,
+          paths.base,
+          options,
+          (name) => c.req.header(name),
+        );
+        return c.json({
+          revoked: remoteCredentialStore.revokeClient(client.clientId),
+          clientId: client.clientId,
+        });
+      } catch (error) {
+        return remoteCredentialErrorResponse(error);
+      }
+    });
   }
 
   app.all(paths.mcp, protectedRouteAuth, async (c) => {
@@ -613,6 +632,7 @@ export function servicePaths(base: string): {
   projectBindings: string;
   pairingExchange: string;
   remoteRefresh: string;
+  remoteClient: string;
   health: string;
 } {
   const version = routePath(base, "v1");
@@ -629,6 +649,7 @@ export function servicePaths(base: string): {
     projectBindings: routePath(attach, "project-bindings"),
     pairingExchange: routePath(remote, "pairing/exchange"),
     remoteRefresh: routePath(remote, "refresh"),
+    remoteClient: routePath(remote, "client"),
     health: routePath(version, "healthz"),
   };
 }
@@ -687,6 +708,30 @@ function routeAuth(
     }
     await next();
   };
+}
+
+function validatedRemoteClient(
+  authorizationHeader: string,
+  remoteCredentialStore: RemoteServerCredentialStore,
+  requestUrl: string,
+  basePath: string,
+  options: HttpServeOptions,
+  header: (name: string) => string | undefined,
+) {
+  const token = bearerToken(authorizationHeader);
+  if (!token) {
+    throw new CapletsError("AUTH_FAILED", "Remote client credential is required.");
+  }
+  return remoteCredentialStore.validateAccessToken({
+    hostUrl: remoteCredentialHostUrl(
+      requestUrl,
+      basePath,
+      options.publicOrigin,
+      options.trustProxy,
+      header,
+    ),
+    accessToken: token,
+  });
 }
 
 function remoteCredentialStoreForOptions(

--- a/packages/core/src/serve/http.ts
+++ b/packages/core/src/serve/http.ts
@@ -792,7 +792,8 @@ function remoteCredentialErrorResponse(error: unknown): Response {
     error instanceof CapletsError
       ? toSafeError(error, error.code)
       : toSafeError(error, "AUTH_FAILED");
-  const status = safe.code === "REQUEST_INVALID" ? 400 : 401;
+  const status =
+    safe.code === "REQUEST_INVALID" ? 400 : safe.code === "SERVER_UNAVAILABLE" ? 503 : 401;
   return Response.json({ ok: false, error: safe }, { status });
 }
 

--- a/packages/core/src/serve/http.ts
+++ b/packages/core/src/serve/http.ts
@@ -19,6 +19,7 @@ import {
 } from "../remote-control/dispatch";
 import { RemoteAuthFlowStore } from "../remote-control/auth-flow";
 import type { RemoteCliRequest } from "../remote-control/types";
+import { RemoteServerCredentialStore } from "../remote/server-credential-store";
 import type { HttpBasicAuthOptions, HttpServeOptions } from "./options";
 import { CapletsMcpSession } from "./session";
 
@@ -28,6 +29,7 @@ type HttpServeIo = {
   authFlowStore?: RemoteAuthFlowStore;
   sessionFactory?: HttpMcpSessionFactory;
   exposeAttach?: boolean;
+  remoteCredentialStore?: RemoteServerCredentialStore;
 };
 
 type HttpMcpSession = {
@@ -62,6 +64,7 @@ export function createHttpServeApp(
   const paths = servicePaths(options.path);
   const authFlowStore = io.authFlowStore ?? new RemoteAuthFlowStore();
   const exposeAttach = io.exposeAttach ?? true;
+  const protectedRouteAuth = routeAuth(options, io.remoteCredentialStore, paths.base);
   app.use(
     "*",
     logger((message, ...rest) => {
@@ -75,7 +78,9 @@ export function createHttpServeApp(
       transport: "http",
       base: paths.base,
       versions: [versionDiscovery(paths, exposeAttach)],
-      auth: { type: "basic", enabled: options.auth.enabled },
+      auth: io.remoteCredentialStore
+        ? { type: "remote_credentials", enabled: true }
+        : { type: "basic", enabled: options.auth.enabled },
     }),
   );
 
@@ -87,7 +92,65 @@ export function createHttpServeApp(
     }),
   );
 
-  app.all(paths.mcp, basicAuth(options.auth), async (c) => {
+  if (io.remoteCredentialStore) {
+    app.post(paths.pairingExchange, async (c) => {
+      try {
+        const parsed = await parseJsonObject(c.req.json(), "Pairing exchange request");
+        const code = stringField(parsed, "code");
+        const clientLabel = optionalStringField(parsed, "clientLabel");
+        const credentials = io.remoteCredentialStore!.exchangePairingCode({
+          hostUrl: publicHostUrl(
+            c.req.url,
+            paths.base,
+            options.publicOrigin,
+            options.trustProxy,
+            (name) => c.req.header(name),
+          ),
+          code,
+          ...(clientLabel ? { clientLabel } : {}),
+        });
+        return c.json({
+          clientId: credentials.clientId,
+          clientLabel: credentials.clientLabel,
+          accessToken: credentials.accessToken,
+          refreshToken: credentials.refreshToken,
+          tokenType: credentials.tokenType,
+          expiresAt: credentials.expiresAt,
+        });
+      } catch (error) {
+        return remoteCredentialErrorResponse(error);
+      }
+    });
+
+    app.post(paths.remoteRefresh, async (c) => {
+      try {
+        const parsed = await parseJsonObject(c.req.json(), "Remote refresh request");
+        const refreshToken = stringField(parsed, "refreshToken");
+        const credentials = io.remoteCredentialStore!.refreshClientCredentials({
+          hostUrl: publicHostUrl(
+            c.req.url,
+            paths.base,
+            options.publicOrigin,
+            options.trustProxy,
+            (name) => c.req.header(name),
+          ),
+          refreshToken,
+        });
+        return c.json({
+          clientId: credentials.clientId,
+          clientLabel: credentials.clientLabel,
+          accessToken: credentials.accessToken,
+          refreshToken: credentials.refreshToken,
+          tokenType: credentials.tokenType,
+          expiresAt: credentials.expiresAt,
+        });
+      } catch (error) {
+        return remoteCredentialErrorResponse(error);
+      }
+    });
+  }
+
+  app.all(paths.mcp, protectedRouteAuth, async (c) => {
     const sessionId = c.req.header("mcp-session-id");
     if (sessionId) {
       const existing = sessions.get(sessionId);
@@ -135,16 +198,16 @@ export function createHttpServeApp(
   const attachHostProtection = dnsRebindingProtection(options);
 
   if (exposeAttach) {
-    app.get(paths.attachManifest, attachHostProtection, basicAuth(options.auth), async (c) => {
+    app.get(paths.attachManifest, attachHostProtection, protectedRouteAuth, async (c) => {
       const attachProjection = await buildAttachProjection(engine);
       return c.json(attachProjection.manifest);
     });
 
-    app.get(paths.attachEvents, attachHostProtection, basicAuth(options.auth), () =>
+    app.get(paths.attachEvents, attachHostProtection, protectedRouteAuth, () =>
       attachEventsResponse(engine, attachEventStreams),
     );
 
-    app.post(paths.attachInvoke, attachHostProtection, basicAuth(options.auth), async (c) => {
+    app.post(paths.attachInvoke, attachHostProtection, protectedRouteAuth, async (c) => {
       try {
         const request = await parseAttachInvokeRequest(c.req.json());
         const attachProjection = await buildAttachProjection(engine);
@@ -157,7 +220,7 @@ export function createHttpServeApp(
     });
   }
 
-  app.post(paths.control, basicAuth(options.auth), async (c) => {
+  app.post(paths.control, protectedRouteAuth, async (c) => {
     let request: RemoteCliRequest;
     try {
       const parsed = await c.req.json();
@@ -190,18 +253,18 @@ export function createHttpServeApp(
     );
   });
 
-  app.get(routePath(paths.projectBindings, "connect"), basicAuth(options.auth), (c) =>
+  app.get(routePath(paths.projectBindings, "connect"), protectedRouteAuth, (c) =>
     c.json({ error: "websocket_upgrade_required" }, 426),
   );
 
-  app.get(routePath(paths.projectBindings, ":bindingId/status"), basicAuth(options.auth), (c) =>
+  app.get(routePath(paths.projectBindings, ":bindingId/status"), protectedRouteAuth, (c) =>
     c.json({
       bindingId: c.req.param("bindingId"),
       state: "not_attached",
     }),
   );
 
-  app.post(routePath(paths.projectBindings, "sessions"), basicAuth(options.auth), (c) => {
+  app.post(routePath(paths.projectBindings, "sessions"), protectedRouteAuth, (c) => {
     const bindingId = randomUUID();
     return c.json(
       {
@@ -212,14 +275,14 @@ export function createHttpServeApp(
     );
   });
 
-  app.post(routePath(paths.projectBindings, ":bindingId/heartbeat"), basicAuth(options.auth), (c) =>
+  app.post(routePath(paths.projectBindings, ":bindingId/heartbeat"), protectedRouteAuth, (c) =>
     c.json({
       ok: true,
       binding: { bindingId: c.req.param("bindingId"), state: "ready" },
     }),
   );
 
-  app.delete(routePath(paths.projectBindings, ":bindingId/session"), basicAuth(options.auth), (c) =>
+  app.delete(routePath(paths.projectBindings, ":bindingId/session"), protectedRouteAuth, (c) =>
     c.json({
       ok: true,
       binding: { bindingId: c.req.param("bindingId"), state: "ended" },
@@ -288,7 +351,7 @@ function controlContext(
     authFlowStore,
     controlCallbackBaseUrl: new URL(
       controlPath,
-      publicOrigin ?? publicRequestOrigin(requestUrl, trustProxy, header),
+      publicOrigin ?? publicRequestOrigin(requestUrl, "/", trustProxy, header),
     ).toString(),
     writeErr,
   };
@@ -296,12 +359,13 @@ function controlContext(
 
 function publicRequestOrigin(
   requestUrl: string,
+  basePath: string,
   trustProxy: boolean,
   header: (name: string) => string | undefined,
 ): string {
   const url = new URL(requestUrl);
   if (!trustProxy) {
-    return `${url.protocol.slice(0, -1)}://${header("host") ?? url.host}`;
+    return `${url.protocol.slice(0, -1)}://${url.host}`;
   }
   const forwardedProto = firstForwardedValue(header("x-forwarded-proto"));
   const forwardedHost = firstForwardedValue(header("x-forwarded-host"));
@@ -311,6 +375,19 @@ function publicRequestOrigin(
       : url.protocol.slice(0, -1);
   const host = forwardedHost ?? header("host") ?? url.host;
   return `${proto}://${host}`;
+}
+
+function publicHostUrl(
+  requestUrl: string,
+  basePath: string,
+  publicOrigin: string | undefined,
+  trustProxy: boolean,
+  header: (name: string) => string | undefined,
+): string {
+  return new URL(
+    basePath,
+    publicOrigin ?? publicRequestOrigin(requestUrl, basePath, trustProxy, header),
+  ).toString();
 }
 
 function firstForwardedValue(value: string | undefined): string | undefined {
@@ -447,6 +524,13 @@ export async function serveHttp(
   const engine = new CapletsEngine(resolvedEngineOptions);
   const app = createHttpServeApp(options, engine, {
     writeErr,
+    ...(options.remoteCredentialStateDir
+      ? {
+          remoteCredentialStore: new RemoteServerCredentialStore({
+            dir: options.remoteCredentialStateDir,
+          }),
+        }
+      : {}),
     control: {
       ...resolvedEngineOptions,
       projectCapletsRoot: projectCapletsRootForEngineOptions(resolvedEngineOptions),
@@ -479,6 +563,13 @@ export async function serveHttpWithSessionFactory(
   const app = createHttpServeApp(options, engine, {
     writeErr,
     exposeAttach: false,
+    ...(options.remoteCredentialStateDir
+      ? {
+          remoteCredentialStore: new RemoteServerCredentialStore({
+            dir: options.remoteCredentialStateDir,
+          }),
+        }
+      : {}),
     sessionFactory: createSession,
     control: {
       ...resolvedEngineOptions,
@@ -524,10 +615,13 @@ export function servicePaths(base: string): {
   attachEvents: string;
   attachInvoke: string;
   projectBindings: string;
+  pairingExchange: string;
+  remoteRefresh: string;
   health: string;
 } {
   const version = routePath(base, "v1");
   const attach = routePath(version, "attach");
+  const remote = routePath(version, "remote");
   return {
     base,
     version,
@@ -537,6 +631,8 @@ export function servicePaths(base: string): {
     attachEvents: routePath(attach, "events"),
     attachInvoke: routePath(attach, "invoke"),
     projectBindings: routePath(attach, "project-bindings"),
+    pairingExchange: routePath(remote, "pairing/exchange"),
+    remoteRefresh: routePath(remote, "refresh"),
     health: routePath(version, "healthz"),
   };
 }
@@ -575,6 +671,83 @@ function basicAuth(auth: HttpBasicAuthOptions): MiddlewareHandler {
     }
     await next();
   };
+}
+
+function routeAuth(
+  options: HttpServeOptions,
+  remoteCredentialStore: RemoteServerCredentialStore | undefined,
+  basePath: string,
+): MiddlewareHandler {
+  if (!remoteCredentialStore) return basicAuth(options.auth);
+  return async (c, next) => {
+    const header = c.req.header("authorization") ?? "";
+    const token = bearerToken(header);
+    if (!token) {
+      return c.text("Unauthorized", 401);
+    }
+    try {
+      remoteCredentialStore.validateAccessToken({
+        hostUrl: publicHostUrl(
+          c.req.url,
+          basePath,
+          options.publicOrigin,
+          options.trustProxy,
+          (name) => c.req.header(name),
+        ),
+        accessToken: token,
+      });
+    } catch {
+      return c.text("Unauthorized", 401);
+    }
+    await next();
+  };
+}
+
+function bearerToken(header: string): string | undefined {
+  const [scheme, token] = header.split(" ");
+  return scheme?.toLowerCase() === "bearer" && token ? token : undefined;
+}
+
+async function parseJsonObject(
+  input: Promise<unknown>,
+  label: string,
+): Promise<Record<string, unknown>> {
+  let parsed: unknown;
+  try {
+    parsed = await input;
+  } catch (error) {
+    throw new CapletsError("REQUEST_INVALID", `${label} body must be valid JSON.`, error);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new CapletsError("REQUEST_INVALID", `${label} JSON must be an object.`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function stringField(input: Record<string, unknown>, key: string): string {
+  const value = input[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new CapletsError("REQUEST_INVALID", `${key} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function optionalStringField(input: Record<string, unknown>, key: string): string | undefined {
+  const value = input[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !value.trim()) {
+    throw new CapletsError("REQUEST_INVALID", `${key} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function remoteCredentialErrorResponse(error: unknown): Response {
+  const safe =
+    error instanceof CapletsError
+      ? toSafeError(error, error.code)
+      : toSafeError(error, "AUTH_FAILED");
+  const status = safe.code === "REQUEST_INVALID" ? 400 : 401;
+  return Response.json({ ok: false, error: safe }, { status });
 }
 
 function dnsRebindingProtection(options: HttpServeOptions): MiddlewareHandler {

--- a/packages/core/src/serve/http.ts
+++ b/packages/core/src/serve/http.ts
@@ -1,4 +1,4 @@
-import { randomUUID, timingSafeEqual } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { dirname } from "node:path";
 import { StreamableHTTPTransport } from "@hono/mcp";
 import { serve, type ServerType } from "@hono/node-server";
@@ -20,7 +20,7 @@ import {
 import { RemoteAuthFlowStore } from "../remote-control/auth-flow";
 import type { RemoteCliRequest } from "../remote-control/types";
 import { RemoteServerCredentialStore } from "../remote/server-credential-store";
-import type { HttpBasicAuthOptions, HttpServeOptions } from "./options";
+import type { HttpServeOptions } from "./options";
 import { CapletsMcpSession } from "./session";
 
 type HttpServeIo = {
@@ -64,7 +64,8 @@ export function createHttpServeApp(
   const paths = servicePaths(options.path);
   const authFlowStore = io.authFlowStore ?? new RemoteAuthFlowStore();
   const exposeAttach = io.exposeAttach ?? true;
-  const protectedRouteAuth = routeAuth(options, io.remoteCredentialStore, paths.base);
+  const remoteCredentialStore = remoteCredentialStoreForOptions(options, io.remoteCredentialStore);
+  const protectedRouteAuth = routeAuth(options, remoteCredentialStore, paths.base);
   app.use(
     "*",
     logger((message, ...rest) => {
@@ -78,9 +79,7 @@ export function createHttpServeApp(
       transport: "http",
       base: paths.base,
       versions: [versionDiscovery(paths, exposeAttach)],
-      auth: io.remoteCredentialStore
-        ? { type: "remote_credentials", enabled: true }
-        : { type: "basic", enabled: options.auth.enabled },
+      auth: { type: options.auth.type },
     }),
   );
 
@@ -92,13 +91,13 @@ export function createHttpServeApp(
     }),
   );
 
-  if (io.remoteCredentialStore) {
+  if (remoteCredentialStore) {
     app.post(paths.pairingExchange, async (c) => {
       try {
         const parsed = await parseJsonObject(c.req.json(), "Pairing exchange request");
         const code = stringField(parsed, "code");
         const clientLabel = optionalStringField(parsed, "clientLabel");
-        const credentials = io.remoteCredentialStore!.exchangePairingCode({
+        const credentials = remoteCredentialStore.exchangePairingCode({
           hostUrl: publicHostUrl(
             c.req.url,
             paths.base,
@@ -126,7 +125,7 @@ export function createHttpServeApp(
       try {
         const parsed = await parseJsonObject(c.req.json(), "Remote refresh request");
         const refreshToken = stringField(parsed, "refreshToken");
-        const credentials = io.remoteCredentialStore!.refreshClientCredentials({
+        const credentials = remoteCredentialStore.refreshClientCredentials({
           hostUrl: publicHostUrl(
             c.req.url,
             paths.base,
@@ -545,9 +544,7 @@ export async function serveHttp(
     writeErr(`Attach manifest: ${origin}${paths.attachManifest}\n`);
     writeErr(`Control endpoint: ${origin}${paths.control}\n`);
     writeErr(`Health check: ${origin}${paths.health}\n`);
-    writeErr(
-      `Basic Auth: ${options.auth.enabled ? `enabled (user: ${options.auth.user})` : "disabled"}\n`,
-    );
+    writeErr(`Auth: ${authDescription(options)}\n`);
   });
 
   installHttpSignalHandlers(server, app, engine, writeErr);
@@ -584,9 +581,7 @@ export async function serveHttpWithSessionFactory(
     writeErr(`MCP endpoint: ${origin}${paths.mcp}\n`);
     writeErr(`Control endpoint: ${origin}${paths.control}\n`);
     writeErr(`Health check: ${origin}${paths.health}\n`);
-    writeErr(
-      `Basic Auth: ${options.auth.enabled ? `enabled (user: ${options.auth.user})` : "disabled"}\n`,
-    );
+    writeErr(`Auth: ${authDescription(options)}\n`);
   });
 
   installHttpSignalHandlers(server, app, engine, writeErr);
@@ -653,32 +648,22 @@ async function createHttpSession(
   return { server, transport };
 }
 
-function basicAuth(auth: HttpBasicAuthOptions): MiddlewareHandler {
-  return async (c, next) => {
-    if (!auth.enabled) {
-      await next();
-      return;
-    }
-    const header = c.req.header("authorization") ?? "";
-    const credentials = parseBasicAuth(header);
-    if (
-      !credentials ||
-      !safeEqual(credentials.user, auth.user) ||
-      !safeEqual(credentials.password, auth.password)
-    ) {
-      c.header("www-authenticate", 'Basic realm="caplets"');
-      return c.text("Unauthorized", 401);
-    }
-    await next();
-  };
-}
-
 function routeAuth(
   options: HttpServeOptions,
   remoteCredentialStore: RemoteServerCredentialStore | undefined,
   basePath: string,
 ): MiddlewareHandler {
-  if (!remoteCredentialStore) return basicAuth(options.auth);
+  if (options.auth.type === "development_unauthenticated") {
+    return async (_c, next) => {
+      await next();
+    };
+  }
+  if (!remoteCredentialStore) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "Remote credential auth requires a server credential store.",
+    );
+  }
   return async (c, next) => {
     const header = c.req.header("authorization") ?? "";
     const token = bearerToken(header);
@@ -701,6 +686,21 @@ function routeAuth(
     }
     await next();
   };
+}
+
+function remoteCredentialStoreForOptions(
+  options: HttpServeOptions,
+  store: RemoteServerCredentialStore | undefined,
+): RemoteServerCredentialStore | undefined {
+  if (options.auth.type !== "remote_credentials") return undefined;
+  if (store) return store;
+  if (!options.remoteCredentialStateDir) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "Remote credential auth requires a server credential state directory.",
+    );
+  }
+  return new RemoteServerCredentialStore({ dir: options.remoteCredentialStateDir });
 }
 
 function bearerToken(header: string): string | undefined {
@@ -766,25 +766,6 @@ function dnsRebindingProtection(options: HttpServeOptions): MiddlewareHandler {
   };
 }
 
-function parseBasicAuth(header: string): { user: string; password: string } | undefined {
-  const [scheme, encoded] = header.split(" ");
-  if (scheme?.toLocaleLowerCase() !== "basic" || !encoded) {
-    return undefined;
-  }
-  const decoded = Buffer.from(encoded, "base64").toString("utf8");
-  const separator = decoded.indexOf(":");
-  if (separator < 0) {
-    return undefined;
-  }
-  return { user: decoded.slice(0, separator), password: decoded.slice(separator + 1) };
-}
-
-function safeEqual(left: string, right: string): boolean {
-  const leftBuffer = Buffer.from(left);
-  const rightBuffer = Buffer.from(right);
-  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
-}
-
 type DnsRebindingOptions = {
   enableDnsRebindingProtection: true;
   allowedHosts: string[];
@@ -794,7 +775,7 @@ function dnsRebindingOptions(options: HttpServeOptions): DnsRebindingOptions {
   const hostForHeader = options.host === "::1" ? "[::1]" : options.host;
   const publicUrl = options.publicOrigin ? new URL(options.publicOrigin) : undefined;
   const publicHosts =
-    publicUrl && (options.auth.enabled || options.allowUnauthenticatedHttp)
+    publicUrl && (options.auth.type === "remote_credentials" || options.allowUnauthenticatedHttp)
       ? [publicUrl.hostname, publicUrl.host]
       : [];
   return {
@@ -807,6 +788,12 @@ function dnsRebindingOptions(options: HttpServeOptions): DnsRebindingOptions {
       ...publicHosts,
     ],
   };
+}
+
+function authDescription(options: HttpServeOptions): string {
+  return options.auth.type === "remote_credentials"
+    ? "remote credentials"
+    : "development unauthenticated";
 }
 
 function installHttpSignalHandlers(

--- a/packages/core/src/serve/http.ts
+++ b/packages/core/src/serve/http.ts
@@ -65,6 +65,16 @@ export function createHttpServeApp(
   const authFlowStore = io.authFlowStore ?? new RemoteAuthFlowStore();
   const exposeAttach = io.exposeAttach ?? true;
   const remoteCredentialStore = remoteCredentialStoreForOptions(options, io.remoteCredentialStore);
+  if (
+    options.auth.type === "remote_credentials" &&
+    options.trustProxy === true &&
+    options.publicOrigin === undefined
+  ) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "Remote credential auth with --trust-proxy requires CAPLETS_SERVER_URL.",
+    );
+  }
   const protectedRouteAuth = routeAuth(options, remoteCredentialStore, paths.base);
   app.use(
     "*",

--- a/packages/core/src/serve/http.ts
+++ b/packages/core/src/serve/http.ts
@@ -98,7 +98,7 @@ export function createHttpServeApp(
         const code = stringField(parsed, "code");
         const clientLabel = optionalStringField(parsed, "clientLabel");
         const credentials = remoteCredentialStore.exchangePairingCode({
-          hostUrl: publicHostUrl(
+          hostUrl: remoteCredentialHostUrl(
             c.req.url,
             paths.base,
             options.publicOrigin,
@@ -126,7 +126,7 @@ export function createHttpServeApp(
         const parsed = await parseJsonObject(c.req.json(), "Remote refresh request");
         const refreshToken = stringField(parsed, "refreshToken");
         const credentials = remoteCredentialStore.refreshClientCredentials({
-          hostUrl: publicHostUrl(
+          hostUrl: remoteCredentialHostUrl(
             c.req.url,
             paths.base,
             options.publicOrigin,
@@ -350,7 +350,7 @@ function controlContext(
     authFlowStore,
     controlCallbackBaseUrl: new URL(
       controlPath,
-      publicOrigin ?? publicRequestOrigin(requestUrl, "/", trustProxy, header),
+      publicOrigin ?? publicRequestOrigin(requestUrl, trustProxy, header),
     ).toString(),
     writeErr,
   };
@@ -358,7 +358,6 @@ function controlContext(
 
 function publicRequestOrigin(
   requestUrl: string,
-  basePath: string,
   trustProxy: boolean,
   header: (name: string) => string | undefined,
 ): string {
@@ -385,8 +384,24 @@ function publicHostUrl(
 ): string {
   return new URL(
     basePath,
-    publicOrigin ?? publicRequestOrigin(requestUrl, basePath, trustProxy, header),
+    publicOrigin ?? publicRequestOrigin(requestUrl, trustProxy, header),
   ).toString();
+}
+
+function remoteCredentialHostUrl(
+  requestUrl: string,
+  basePath: string,
+  publicOrigin: string | undefined,
+  trustProxy: boolean,
+  header: (name: string) => string | undefined,
+): string {
+  if (trustProxy && !publicOrigin) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "Remote credential auth with --trust-proxy requires CAPLETS_SERVER_URL.",
+    );
+  }
+  return publicHostUrl(requestUrl, basePath, publicOrigin, trustProxy, header);
 }
 
 function firstForwardedValue(value: string | undefined): string | undefined {
@@ -523,13 +538,6 @@ export async function serveHttp(
   const engine = new CapletsEngine(resolvedEngineOptions);
   const app = createHttpServeApp(options, engine, {
     writeErr,
-    ...(options.remoteCredentialStateDir
-      ? {
-          remoteCredentialStore: new RemoteServerCredentialStore({
-            dir: options.remoteCredentialStateDir,
-          }),
-        }
-      : {}),
     control: {
       ...resolvedEngineOptions,
       projectCapletsRoot: projectCapletsRootForEngineOptions(resolvedEngineOptions),
@@ -560,13 +568,6 @@ export async function serveHttpWithSessionFactory(
   const app = createHttpServeApp(options, engine, {
     writeErr,
     exposeAttach: false,
-    ...(options.remoteCredentialStateDir
-      ? {
-          remoteCredentialStore: new RemoteServerCredentialStore({
-            dir: options.remoteCredentialStateDir,
-          }),
-        }
-      : {}),
     sessionFactory: createSession,
     control: {
       ...resolvedEngineOptions,
@@ -672,7 +673,7 @@ function routeAuth(
     }
     try {
       remoteCredentialStore.validateAccessToken({
-        hostUrl: publicHostUrl(
+        hostUrl: remoteCredentialHostUrl(
           c.req.url,
           basePath,
           options.publicOrigin,

--- a/packages/core/src/serve/options.ts
+++ b/packages/core/src/serve/options.ts
@@ -10,8 +10,6 @@ export type RawServeOptions = {
   host?: string;
   port?: string | number;
   path?: string;
-  user?: string;
-  password?: string;
   remoteStatePath?: string;
   allowUnauthenticatedHttp?: boolean;
   trustProxy?: boolean;
@@ -27,7 +25,7 @@ export type HttpServeOptions = {
   port: number;
   path: string;
   publicOrigin?: string | undefined;
-  auth: HttpBasicAuthOptions;
+  auth: HttpServeAuthOptions;
   remoteCredentialStateDir?: string | undefined;
   allowUnauthenticatedHttp: boolean;
   warnUnauthenticatedNetwork: boolean;
@@ -35,28 +33,20 @@ export type HttpServeOptions = {
   trustProxy: boolean;
 };
 
-export type HttpBasicAuthOptions =
-  | { enabled: false; user: string }
-  | { enabled: true; user: string; password: string };
+export type HttpServeAuthOptions =
+  | { type: "remote_credentials" }
+  | { type: "development_unauthenticated" };
 
 export type ServeOptions = StdioServeOptions | HttpServeOptions;
 
 export type ServeEnv = Partial<
-  Record<
-    | "CAPLETS_SERVER_URL"
-    | "CAPLETS_SERVER_USER"
-    | "CAPLETS_SERVER_PASSWORD"
-    | "CAPLETS_REMOTE_SERVER_STATE_DIR",
-    string
-  >
+  Record<"CAPLETS_SERVER_URL" | "CAPLETS_REMOTE_SERVER_STATE_DIR", string>
 >;
 
 const HTTP_ONLY_OPTIONS = [
   "host",
   "port",
   "path",
-  "user",
-  "password",
   "remoteStatePath",
   "allowUnauthenticatedHttp",
   "trustProxy",
@@ -84,32 +74,21 @@ export function resolveServeOptions(
   const host = nonEmpty(raw.host, "--host") ?? serverUrlHost(serverUrl) ?? "127.0.0.1";
   const port = parsePort(raw.port ?? (serverUrl?.port ? Number(serverUrl.port) : 5387));
   const path = normalizeHttpPath(raw.path ?? serverUrl?.pathname ?? "/");
-  const userWasExplicit = raw.user !== undefined || hasEnv(env.CAPLETS_SERVER_USER);
-  const user =
-    nonEmpty(raw.user, "--user") ??
-    nonEmpty(env.CAPLETS_SERVER_USER, "CAPLETS_SERVER_USER") ??
-    "caplets";
-  const password =
-    nonEmpty(raw.password, "--password") ??
-    nonEmpty(env.CAPLETS_SERVER_PASSWORD, "CAPLETS_SERVER_PASSWORD");
   const remoteCredentialStateDir =
     nonEmpty(raw.remoteStatePath, "--remote-state-path") ??
     nonEmpty(env.CAPLETS_REMOTE_SERVER_STATE_DIR, "CAPLETS_REMOTE_SERVER_STATE_DIR") ??
     join(DEFAULT_AUTH_DIR, "remote-server");
 
-  if (userWasExplicit && password === undefined) {
-    throw new CapletsError(
-      "REQUEST_INVALID",
-      "HTTP Basic Auth requires a password; pass --password or set CAPLETS_SERVER_PASSWORD.",
-    );
-  }
-
   const loopback = isLoopbackHost(host);
-  const auth =
-    password === undefined
-      ? { enabled: false as const, user }
-      : { enabled: true as const, user, password };
-  if (!loopback && !auth.enabled && raw.allowUnauthenticatedHttp !== true) {
+  const auth: HttpServeAuthOptions =
+    raw.allowUnauthenticatedHttp === true
+      ? { type: "development_unauthenticated" }
+      : { type: "remote_credentials" };
+  if (
+    !loopback &&
+    auth.type === "development_unauthenticated" &&
+    raw.allowUnauthenticatedHttp !== true
+  ) {
     throw new CapletsError(
       "REQUEST_INVALID",
       "Unauthenticated HTTP serving on non-loopback hosts requires --allow-unauthenticated-http.",
@@ -122,9 +101,9 @@ export function resolveServeOptions(
     path,
     ...(serverUrl ? { publicOrigin: serverUrl.origin } : {}),
     auth,
-    remoteCredentialStateDir,
+    ...(auth.type === "remote_credentials" ? { remoteCredentialStateDir } : {}),
     allowUnauthenticatedHttp: raw.allowUnauthenticatedHttp === true,
-    warnUnauthenticatedNetwork: !loopback && !auth.enabled,
+    warnUnauthenticatedNetwork: !loopback && auth.type === "development_unauthenticated",
     loopback,
     trustProxy: raw.trustProxy === true,
   };
@@ -199,8 +178,4 @@ function nonEmpty(value: string | undefined, label: string): string | undefined 
     throw new CapletsError("REQUEST_INVALID", `${label} must not be empty`);
   }
   return trimmed;
-}
-
-function hasEnv(value: string | undefined): boolean {
-  return value !== undefined && value.trim() !== "";
 }

--- a/packages/core/src/serve/options.ts
+++ b/packages/core/src/serve/options.ts
@@ -1,5 +1,7 @@
 import { CapletsError } from "../errors";
 import { parseServerBaseUrl } from "../server/options";
+import { DEFAULT_AUTH_DIR } from "../config/paths";
+import { join } from "node:path";
 
 export type ServeTransport = "stdio" | "http";
 
@@ -10,6 +12,7 @@ export type RawServeOptions = {
   path?: string;
   user?: string;
   password?: string;
+  remoteStatePath?: string;
   allowUnauthenticatedHttp?: boolean;
   trustProxy?: boolean;
 };
@@ -25,6 +28,7 @@ export type HttpServeOptions = {
   path: string;
   publicOrigin?: string | undefined;
   auth: HttpBasicAuthOptions;
+  remoteCredentialStateDir?: string | undefined;
   allowUnauthenticatedHttp: boolean;
   warnUnauthenticatedNetwork: boolean;
   loopback: boolean;
@@ -38,7 +42,13 @@ export type HttpBasicAuthOptions =
 export type ServeOptions = StdioServeOptions | HttpServeOptions;
 
 export type ServeEnv = Partial<
-  Record<"CAPLETS_SERVER_URL" | "CAPLETS_SERVER_USER" | "CAPLETS_SERVER_PASSWORD", string>
+  Record<
+    | "CAPLETS_SERVER_URL"
+    | "CAPLETS_SERVER_USER"
+    | "CAPLETS_SERVER_PASSWORD"
+    | "CAPLETS_REMOTE_SERVER_STATE_DIR",
+    string
+  >
 >;
 
 const HTTP_ONLY_OPTIONS = [
@@ -47,6 +57,7 @@ const HTTP_ONLY_OPTIONS = [
   "path",
   "user",
   "password",
+  "remoteStatePath",
   "allowUnauthenticatedHttp",
   "trustProxy",
 ] as const;
@@ -81,6 +92,10 @@ export function resolveServeOptions(
   const password =
     nonEmpty(raw.password, "--password") ??
     nonEmpty(env.CAPLETS_SERVER_PASSWORD, "CAPLETS_SERVER_PASSWORD");
+  const remoteCredentialStateDir =
+    nonEmpty(raw.remoteStatePath, "--remote-state-path") ??
+    nonEmpty(env.CAPLETS_REMOTE_SERVER_STATE_DIR, "CAPLETS_REMOTE_SERVER_STATE_DIR") ??
+    join(DEFAULT_AUTH_DIR, "remote-server");
 
   if (userWasExplicit && password === undefined) {
     throw new CapletsError(
@@ -107,6 +122,7 @@ export function resolveServeOptions(
     path,
     ...(serverUrl ? { publicOrigin: serverUrl.origin } : {}),
     auth,
+    remoteCredentialStateDir,
     allowUnauthenticatedHttp: raw.allowUnauthenticatedHttp === true,
     warnUnauthenticatedNetwork: !loopback && !auth.enabled,
     loopback,

--- a/packages/core/src/serve/options.ts
+++ b/packages/core/src/serve/options.ts
@@ -1,5 +1,5 @@
 import { CapletsError } from "../errors";
-import { parseServerBaseUrl } from "../server/options";
+import { isLoopbackHost, parseServerBaseUrl } from "../server/options";
 import { DEFAULT_AUTH_DIR } from "../config/paths";
 import { join } from "node:path";
 
@@ -84,16 +84,6 @@ export function resolveServeOptions(
     raw.allowUnauthenticatedHttp === true
       ? { type: "development_unauthenticated" }
       : { type: "remote_credentials" };
-  if (
-    !loopback &&
-    auth.type === "development_unauthenticated" &&
-    raw.allowUnauthenticatedHttp !== true
-  ) {
-    throw new CapletsError(
-      "REQUEST_INVALID",
-      "Unauthenticated HTTP serving on non-loopback hosts requires --allow-unauthenticated-http.",
-    );
-  }
   return {
     transport,
     host,
@@ -107,11 +97,6 @@ export function resolveServeOptions(
     loopback,
     trustProxy: raw.trustProxy === true,
   };
-}
-
-export function isLoopbackHost(host: string): boolean {
-  const normalized = host.toLocaleLowerCase();
-  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
 }
 
 function parseServeServerUrl(value: string): URL {

--- a/packages/core/src/server/options.ts
+++ b/packages/core/src/server/options.ts
@@ -1,5 +1,3 @@
-import { Buffer } from "node:buffer";
-
 import { CapletsError } from "../errors";
 
 export type CapletsMode = "auto" | "local" | "remote";
@@ -8,8 +6,6 @@ export type CapletsServerEnv = Partial<
   Record<
     | "CAPLETS_MODE"
     | "CAPLETS_SERVER_URL"
-    | "CAPLETS_SERVER_USER"
-    | "CAPLETS_SERVER_PASSWORD"
     | "CAPLETS_CLOUD_URL"
     | "CAPLETS_CLOUD_TOKEN"
     | "CAPLETS_CLOUD_WORKSPACE_ID"
@@ -25,14 +21,10 @@ export type CapletsModeInput = {
 
 export type CapletsServerInput = {
   url?: string;
-  user?: string;
-  password?: string;
   fetch?: typeof fetch;
 };
 
-export type CapletsServerAuth =
-  | { enabled: false; user: string }
-  | { enabled: true; user: string; password: string };
+export type CapletsServerAuth = { type: "none" };
 
 export type ResolvedCapletsServer = {
   baseUrl: URL;
@@ -44,8 +36,6 @@ export type ResolvedCapletsServer = {
   requestInit: RequestInit;
   fetch?: typeof fetch;
 };
-
-const DEFAULT_SERVER_USER = "caplets";
 
 export function resolveCapletsMode(
   input: CapletsModeInput = {},
@@ -83,27 +73,7 @@ export function resolveCapletsServer(
   }
 
   const baseUrl = parseServerBaseUrl(rawUrl);
-  const userWasExplicit = input.user !== undefined || hasEnv(env.CAPLETS_SERVER_USER);
-  const user =
-    nonEmpty(input.user, "user") ??
-    nonEmpty(env.CAPLETS_SERVER_USER, "CAPLETS_SERVER_USER") ??
-    DEFAULT_SERVER_USER;
-  const password =
-    nonEmpty(input.password, "password") ??
-    nonEmpty(env.CAPLETS_SERVER_PASSWORD, "CAPLETS_SERVER_PASSWORD");
-
-  if (userWasExplicit && password === undefined) {
-    throw new CapletsError(
-      "REQUEST_INVALID",
-      "Caplets server Basic Auth requires a password; set CAPLETS_SERVER_PASSWORD or password.",
-    );
-  }
-
-  const auth: CapletsServerAuth =
-    password === undefined ? { enabled: false, user } : { enabled: true, user, password };
-  const requestInit: RequestInit = auth.enabled
-    ? { headers: { Authorization: basicAuthHeader(auth.user, auth.password) } }
-    : {};
+  const auth: CapletsServerAuth = { type: "none" };
 
   return {
     baseUrl,
@@ -112,7 +82,7 @@ export function resolveCapletsServer(
     controlUrl: controlUrlForBase(baseUrl),
     healthUrl: healthUrlForBase(baseUrl),
     auth,
-    requestInit,
+    requestInit: {},
     ...(input.fetch ? { fetch: input.fetch } : {}),
   };
 }
@@ -185,10 +155,6 @@ function parseCapletsMode(value: string): CapletsMode {
   );
 }
 
-function basicAuthHeader(user: string, password: string): string {
-  return `Basic ${Buffer.from(`${user}:${password}`).toString("base64")}`;
-}
-
 function nonEmpty(value: string | undefined, label: string): string | undefined {
   if (value === undefined) {
     return undefined;
@@ -198,8 +164,4 @@ function nonEmpty(value: string | undefined, label: string): string | undefined 
     throw new CapletsError("REQUEST_INVALID", `${label} must not be empty`);
   }
   return trimmed;
-}
-
-function hasEnv(value: string | undefined): boolean {
-  return value !== undefined && value.trim() !== "";
 }

--- a/packages/core/test/agent-plugins.test.ts
+++ b/packages/core/test/agent-plugins.test.ts
@@ -35,9 +35,9 @@ describe("Codex and Claude manual MCP setup", () => {
     const readme = await readFile(path.join(repoRoot, "README.md"), "utf8");
     expect(readme).toContain("caplets serve");
     expect(readme).toContain("caplets attach");
+    expect(readme).toContain("caplets remote login https://caplets.example.com/caplets");
     expect(readme).toContain("CAPLETS_MODE=cloud");
     expect(readme).toContain("CAPLETS_REMOTE_URL=https://cloud.caplets.dev");
-    expect(readme).toContain("CAPLETS_MODE=remote");
   });
 
   it("does not keep version-package plugin sync wiring", async () => {

--- a/packages/core/test/attach-cli.test.ts
+++ b/packages/core/test/attach-cli.test.ts
@@ -2,10 +2,18 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { attachProjectOnce, resolveAttachOptions } from "../src/project-binding/attach";
+import {
+  attachProjectOnce,
+  attachProjectSession,
+  resolveAttachOptions,
+} from "../src/project-binding/attach";
 import { runCli } from "../src/cli";
 import { CloudAuthStore } from "../src/cloud-auth/store";
 import { FileRemoteProfileStore } from "../src/remote/profile-store";
+import type {
+  ProjectBindingSocketEvent,
+  ProjectBindingWebSocket,
+} from "../src/project-binding/transport";
 import { hostedCredentials, tempCloudAuthPath } from "./fixtures/cloud-auth";
 
 const tempDirs: string[] = [];
@@ -237,6 +245,80 @@ describe("caplets attach CLI", () => {
     );
   });
 
+  it("pins the selected Cloud workspace for active attach session refreshes", async () => {
+    const authDir = tempAuthDir();
+    const store = new FileRemoteProfileStore({ root: join(authDir, "remote-profiles") });
+    await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "workspace_team",
+      workspaceSlug: "team",
+      credentials: {
+        accessToken: "team-access",
+        refreshToken: "team-refresh",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        scope: ["project_binding:read", "project_binding:write", "mcp:tools"],
+        tokenType: "Bearer",
+      },
+    });
+    const controller = new AbortController();
+    const requests: Array<{ path: string; body?: unknown }> = [];
+    let switchedSelection = false;
+
+    await attachProjectSession(
+      {
+        authDir,
+        remoteUrl: "https://cloud.caplets.dev",
+        projectRoot: "/repo",
+        fetch: async (url, init) => {
+          const path = new URL(String(url)).pathname;
+          requests.push({
+            path,
+            ...(init?.body ? { body: JSON.parse(String(init.body)) } : {}),
+          });
+          if (path.endsWith("/project-bindings/sessions")) {
+            if (!switchedSelection) {
+              switchedSelection = true;
+              await store.saveCloudProfile({
+                hostUrl: "https://cloud.caplets.dev",
+                workspaceId: "workspace_personal",
+                workspaceSlug: "personal",
+                credentials: {
+                  accessToken: "personal-access",
+                  refreshToken: "personal-refresh",
+                  expiresAt: "2999-01-01T00:00:00.000Z",
+                  scope: ["project_binding:read", "project_binding:write", "mcp:tools"],
+                  tokenType: "Bearer",
+                },
+              });
+            }
+            return Response.json(
+              { binding: { bindingId: "binding_1" }, sessionId: "session_1" },
+              { status: 201 },
+            );
+          }
+          return Response.json({ ok: true });
+        },
+      },
+      { CAPLETS_MODE: "cloud" },
+      {
+        signal: controller.signal,
+        heartbeatIntervalMs: 60_000,
+        webSocketFactory: () => new OpenProjectBindingSocket(),
+        onEvent: (event) => {
+          if (event.type === "heartbeat") controller.abort();
+        },
+      },
+    );
+
+    expect(requests.map((request) => request.path)).toEqual(
+      expect.arrayContaining([
+        "/v1/ws/team/attach/project-bindings/sessions",
+        "/v1/ws/team/attach/project-bindings/binding_1/heartbeat",
+      ]),
+    );
+    expect(requests.map((request) => request.path).join("\n")).not.toContain("/ws/personal/");
+  });
+
   it("runs once from the CLI and reports WebSocket availability", async () => {
     const out: string[] = [];
     const cwd = process.cwd();
@@ -406,4 +488,16 @@ async function saveSelfHostedProfile(
       expiresAt: "2999-01-01T00:00:00.000Z",
     },
   });
+}
+
+class OpenProjectBindingSocket implements ProjectBindingWebSocket {
+  readonly readyState = 1;
+  onopen: ((event: ProjectBindingSocketEvent) => void) | null = null;
+  onmessage: ((event: ProjectBindingSocketEvent) => void) | null = null;
+  onclose: ((event: ProjectBindingSocketEvent) => void) | null = null;
+  onerror: ((event: ProjectBindingSocketEvent) => void) | null = null;
+
+  send(): void {}
+
+  close(): void {}
 }

--- a/packages/core/test/attach-cli.test.ts
+++ b/packages/core/test/attach-cli.test.ts
@@ -27,6 +27,9 @@ describe("caplets attach CLI", () => {
     expect(out.join("")).toContain("--remote-url <url>");
     expect(out.join("")).toContain("--workspace <workspace>");
     expect(out.join("")).toContain("--once");
+    expect(out.join("")).not.toContain("--user");
+    expect(out.join("")).not.toContain("--password");
+    expect(out.join("")).not.toContain("--token");
   });
 
   it("runs attach as a stdio MCP server by default", async () => {
@@ -51,38 +54,13 @@ describe("caplets attach CLI", () => {
     });
   });
 
-  it("ignores legacy attach Basic Auth flags and uses the stored Remote Profile", async () => {
-    const served: unknown[] = [];
-    const authDir = tempAuthDir();
-    await saveSelfHostedProfile(authDir, "https://caplets.example.com/caplets", "profile-token");
-    await runCli(
-      [
-        "attach",
-        "--remote-url",
-        "https://caplets.example.com/caplets",
-        "--user",
-        "alice",
-        "--password",
-        "secret",
-      ],
-      {
-        authDir,
+  it("rejects removed attach credential flags", async () => {
+    await expect(
+      runCli(["attach", "--remote-url", "https://caplets.example.com/caplets", "--user", "alice"], {
         env: { CAPLETS_MODE: "remote" },
-        attachServe: async (options: unknown) => {
-          served.push(options);
-        },
-      } as never,
-    );
-
-    expect(served).toHaveLength(1);
-    expect(served[0]).toMatchObject({
-      transport: "stdio",
-      selection: {
-        remote: {
-          auth: { type: "bearer", token: "profile-token" },
-        },
-      },
-    });
+        attachServe: async () => undefined,
+      } as never),
+    ).rejects.toThrow(/unknown option '--user'/u);
   });
 
   it("passes local overlay config paths into attach serving", async () => {
@@ -346,7 +324,7 @@ describe("caplets attach CLI", () => {
     expect(JSON.parse(out.join(""))).toMatchObject({
       error: {
         code: "cloud_auth_required",
-        recoveryCommand: "caplets cloud auth login",
+        recoveryCommand: "caplets remote login <cloud-url>",
       },
     });
   });
@@ -373,7 +351,7 @@ describe("caplets attach CLI", () => {
     expect(JSON.parse(out[0] ?? "{}")).toMatchObject({
       error: {
         code: "workspace_switch_required",
-        recoveryCommand: "caplets cloud auth switch <workspace>",
+        recoveryCommand: "caplets remote login <cloud-url> --workspace <workspace>",
       },
     });
   });

--- a/packages/core/test/attach-cli.test.ts
+++ b/packages/core/test/attach-cli.test.ts
@@ -50,6 +50,7 @@ describe("caplets attach CLI", () => {
     expect(served).toHaveLength(1);
     expect(served[0]).toMatchObject({
       transport: "stdio",
+      authDir,
       selection: { kind: "self_hosted_remote" },
     });
   });

--- a/packages/core/test/attach-cli.test.ts
+++ b/packages/core/test/attach-cli.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { attachProjectOnce, resolveAttachOptions } from "../src/project-binding/attach";
 import { runCli } from "../src/cli";
 import { CloudAuthStore } from "../src/cloud-auth/store";
+import { FileRemoteProfileStore } from "../src/remote/profile-store";
 import { hostedCredentials, tempCloudAuthPath } from "./fixtures/cloud-auth";
 
 const tempDirs: string[] = [];
@@ -30,7 +31,10 @@ describe("caplets attach CLI", () => {
 
   it("runs attach as a stdio MCP server by default", async () => {
     const served: unknown[] = [];
+    const authDir = tempAuthDir();
+    await saveSelfHostedProfile(authDir, "https://caplets.example.com/caplets");
     await runCli(["attach"], {
+      authDir,
       env: {
         CAPLETS_MODE: "remote",
         CAPLETS_REMOTE_URL: "https://caplets.example.com/caplets",
@@ -47,8 +51,10 @@ describe("caplets attach CLI", () => {
     });
   });
 
-  it("treats attach --user and --password as remote Basic Auth for stdio serving", async () => {
+  it("ignores legacy attach Basic Auth flags and uses the stored Remote Profile", async () => {
     const served: unknown[] = [];
+    const authDir = tempAuthDir();
+    await saveSelfHostedProfile(authDir, "https://caplets.example.com/caplets", "profile-token");
     await runCli(
       [
         "attach",
@@ -60,6 +66,7 @@ describe("caplets attach CLI", () => {
         "secret",
       ],
       {
+        authDir,
         env: { CAPLETS_MODE: "remote" },
         attachServe: async (options: unknown) => {
           served.push(options);
@@ -72,7 +79,7 @@ describe("caplets attach CLI", () => {
       transport: "stdio",
       selection: {
         remote: {
-          auth: { type: "basic", user: "alice", password: "secret" },
+          auth: { type: "bearer", token: "profile-token" },
         },
       },
     });
@@ -84,8 +91,11 @@ describe("caplets attach CLI", () => {
     const configPath = join(dir, "local.json");
     const projectConfigPath = join(dir, "project.json");
     const served: unknown[] = [];
+    const authDir = tempAuthDir();
+    await saveSelfHostedProfile(authDir, "https://caplets.example.com/caplets");
 
     await runCli(["attach", "--remote-url", "https://caplets.example.com/caplets"], {
+      authDir,
       env: {
         CAPLETS_MODE: "remote",
         CAPLETS_CONFIG: configPath,
@@ -109,6 +119,8 @@ describe("caplets attach CLI", () => {
     const projectRoot = join(dir, "checkout");
     const configPath = join(dir, "local.json");
     const served: unknown[] = [];
+    const authDir = tempAuthDir();
+    await saveSelfHostedProfile(authDir, "https://caplets.example.com/caplets");
 
     await runCli(
       [
@@ -119,6 +131,7 @@ describe("caplets attach CLI", () => {
         projectRoot,
       ],
       {
+        authDir,
         env: {
           CAPLETS_MODE: "remote",
           CAPLETS_CONFIG: configPath,
@@ -147,13 +160,15 @@ describe("caplets attach CLI", () => {
   });
 
   it("resolves attach options from flags, env, and the caller cwd", async () => {
+    const authDir = tempAuthDir();
+    await saveSelfHostedProfile(authDir, "https://caplets.example.com/caplets", "profile-token");
     const resolved = await resolveAttachOptions(
       {
         remoteUrl: "https://caplets.example.com/caplets",
-        token: "token",
         workspace: "workspace",
         once: true,
         projectRoot: "/repo",
+        authDir,
       },
       { CAPLETS_REMOTE_URL: "https://env.example.com" },
     );
@@ -164,16 +179,19 @@ describe("caplets attach CLI", () => {
       remote: {
         baseUrl: new URL("https://caplets.example.com/caplets"),
         workspace: "workspace",
-        auth: { type: "bearer", token: "token" },
+        auth: { type: "bearer", token: "profile-token" },
       },
     });
   });
 
   it("reports WebSocket upgrade failures clearly in once mode", async () => {
+    const authDir = tempAuthDir();
+    await saveSelfHostedProfile(authDir, "https://caplets.example.com/caplets");
     await expect(
       attachProjectOnce({
         projectRoot: "/repo",
         remoteUrl: "https://caplets.example.com/caplets",
+        authDir,
         fetch: async () => new Response("upgrade blocked", { status: 426 }),
       }),
     ).rejects.toMatchObject({
@@ -184,11 +202,14 @@ describe("caplets attach CLI", () => {
 
   it("probes the HTTP equivalent of the Project Binding WebSocket URL", async () => {
     let requestedUrl: string | undefined;
+    const authDir = tempAuthDir();
+    await saveSelfHostedProfile(authDir, "http://127.0.0.1:8787/caplets");
 
     await expect(
       attachProjectOnce({
         projectRoot: "/repo",
         remoteUrl: "http://127.0.0.1:8787/caplets",
+        authDir,
         fetch: async (url) => {
           requestedUrl = String(url);
           return Response.json({ error: "websocket_upgrade_required" }, { status: 426 });
@@ -244,8 +265,11 @@ describe("caplets attach CLI", () => {
 
     try {
       process.chdir(projectRoot);
+      const authDir = tempAuthDir();
+      await saveSelfHostedProfile(authDir, "https://caplets.example.com/caplets");
 
       await runCli(["attach", "--remote-url", "https://caplets.example.com/caplets", "--once"], {
+        authDir,
         fetch: async () => Response.json({ error: "websocket_upgrade_required" }, { status: 426 }),
         writeOut: (value) => out.push(value),
       });
@@ -260,7 +284,10 @@ describe("caplets attach CLI", () => {
 
   it("keeps attach --once as the finite Project Binding smoke path", async () => {
     const out: string[] = [];
+    const authDir = tempAuthDir();
+    await saveSelfHostedProfile(authDir, "https://caplets.example.com/caplets");
     await runCli(["attach", "--once", "--remote-url", "https://caplets.example.com/caplets"], {
+      authDir,
       fetch: async () => Response.json({ error: "websocket_upgrade_required" }, { status: 426 }),
       writeOut: (value) => out.push(value),
     });
@@ -275,10 +302,13 @@ describe("caplets attach CLI", () => {
 
     try {
       process.chdir(projectRoot);
+      const authDir = tempAuthDir();
+      await saveSelfHostedProfile(authDir, "https://caplets.example.com/caplets");
 
       await runCli(
         ["attach", "--remote-url", "https://caplets.example.com/caplets", "--once", "--json"],
         {
+          authDir,
           fetch: async () => new Response("upgrade blocked", { status: 426 }),
           writeOut: (value) => out.push(value),
           setExitCode: (code) => {
@@ -371,4 +401,30 @@ function tempProjectRoot(): string {
   const root = mkdtempSync(join(tmpdir(), "caplets-attach-cli-"));
   tempDirs.push(root);
   return root;
+}
+
+function tempAuthDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "caplets-attach-auth-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function saveSelfHostedProfile(
+  authDir: string,
+  hostUrl: string,
+  accessToken = "profile-access-token",
+): Promise<void> {
+  await new FileRemoteProfileStore({
+    root: join(authDir, "remote-profiles"),
+  }).saveSelfHostedProfile({
+    hostUrl,
+    clientId: "rcli_123",
+    clientLabel: "Test Device",
+    credentials: {
+      accessToken,
+      refreshToken: "profile-refresh-token",
+      tokenType: "Bearer",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+    },
+  });
 }

--- a/packages/core/test/attach-service-wiring.test.ts
+++ b/packages/core/test/attach-service-wiring.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AttachServeOptions } from "../src/attach/options";
+import type { ResolvedRemoteSelection } from "../src/remote/selection";
+
+const { createNativeCapletsService } = vi.hoisted(() => ({
+  createNativeCapletsService: vi.fn((options: unknown) => ({ options })),
+}));
+
+vi.mock("../src/native/service", () => ({
+  createNativeCapletsService,
+}));
+
+describe("attach native service wiring", () => {
+  it("forwards the resolved Cloud workspace into profile-backed native remotes", async () => {
+    const { createAttachNativeServiceForTests } = await import("../src/attach/server");
+    const selection: ResolvedRemoteSelection = {
+      kind: "hosted_cloud",
+      remote: {
+        baseUrl: new URL("https://cloud.caplets.dev/"),
+        mcpUrl: new URL("https://cloud.caplets.dev/v1/ws/team/mcp"),
+        attachUrl: new URL("https://cloud.caplets.dev/v1/ws/team/attach"),
+        controlUrl: new URL("https://cloud.caplets.dev/v1/admin"),
+        healthUrl: new URL("https://cloud.caplets.dev/v1/healthz"),
+        projectBindingWebSocketUrl: new URL(
+          "wss://cloud.caplets.dev/v1/ws/team/attach/project-bindings/connect",
+        ),
+        auth: { type: "bearer", token: "cloud-access" },
+        requestInit: { headers: { Authorization: "Bearer cloud-access" } },
+        workspace: "team",
+      },
+      selectedWorkspace: "team",
+      credentials: {
+        cloudUrl: "https://cloud.caplets.dev",
+        workspaceId: "workspace_team",
+        workspaceSlug: "team",
+        accessToken: "cloud-access",
+        refreshToken: "cloud-refresh",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        scope: ["project_binding:read", "project_binding:write", "mcp:tools"],
+        tokenType: "Bearer",
+        createdAt: "2026-06-19T00:00:00.000Z",
+      },
+      credentialExpiresAt: "2999-01-01T00:00:00.000Z",
+      cloudPresence: {
+        url: new URL("https://cloud.caplets.dev/"),
+        accessToken: "cloud-access",
+        workspaceId: "workspace_team",
+      },
+    };
+
+    createAttachNativeServiceForTests(
+      {
+        transport: "stdio",
+        configPath: "/repo/caplets.json",
+        projectRoot: "/repo",
+        projectConfigPath: "/repo/.caplets/config.json",
+        selection,
+      } as AttachServeOptions,
+      {},
+    );
+
+    expect(createNativeCapletsService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "cloud",
+        remote: expect.objectContaining({
+          url: "https://cloud.caplets.dev/",
+          workspace: "team",
+        }),
+      }),
+    );
+  });
+});

--- a/packages/core/test/cli-completion.test.ts
+++ b/packages/core/test/cli-completion.test.ts
@@ -85,6 +85,17 @@ describe("CLI completion resolver", () => {
       "status",
       "logs",
     ]);
+    await expect(completeCliWords(["remote", ""])).resolves.toEqual([
+      "login",
+      "status",
+      "logout",
+      "host",
+    ]);
+    await expect(completeCliWords(["remote", "host", ""])).resolves.toEqual([
+      "pair",
+      "clients",
+      "revoke",
+    ]);
     await expect(completeCliWords(["completion", ""])).resolves.toEqual([
       "bash",
       "zsh",

--- a/packages/core/test/cli-remote.test.ts
+++ b/packages/core/test/cli-remote.test.ts
@@ -4,6 +4,8 @@ import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runCli } from "../src/cli";
 import { CapletsEngine } from "../src/engine";
+import { normalizeRemoteProfileHostUrl } from "../src/remote/options";
+import { remoteProfileKey } from "../src/remote/profiles";
 import { createHttpServeApp, type CapletsHttpApp } from "../src/serve/http";
 import type { HttpServeOptions } from "../src/serve/options";
 
@@ -29,10 +31,8 @@ describe("remote CLI routing", () => {
 
     await runCli(["__complete", "--shell", "bash", "--", "inspect", ""], {
       env: {
-        CAPLETS_MODE: "remote",
-        CAPLETS_REMOTE_URL: "http://127.0.0.1:5387/caplets",
+        ...remoteEnv(context),
         CAPLETS_CONFIG: join(dirname(context.configPath), "missing-config.json"),
-        CAPLETS_PROJECT_CONFIG: context.projectConfigPath,
       },
       fetch,
       writeOut: (value) => out.push(value),
@@ -149,15 +149,13 @@ describe("remote CLI routing", () => {
   });
 
   it("keeps hidden remote completion quiet when remote control fails", async () => {
+    const context = testContext("caplets-cli-remote-complete-fail-quiet-");
     const out: string[] = [];
     const err: string[] = [];
     const fetch = vi.fn(async () => Response.json({ ok: false, error: "server unavailable" }));
 
     await runCli(["__complete", "--shell", "bash", "--", "inspect", ""], {
-      env: {
-        CAPLETS_MODE: "remote",
-        CAPLETS_REMOTE_URL: "http://127.0.0.1:5387/caplets",
-      },
+      env: remoteEnv(context),
       fetch,
       writeOut: (value) => out.push(value),
       writeErr: (value) => err.push(value),
@@ -190,7 +188,11 @@ describe("remote CLI routing", () => {
     const requests: unknown[] = [];
     const out: string[] = [];
     const fetch = vi.fn(async (url: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
-      requests.push({ url: String(url), body: init?.body });
+      requests.push({
+        url: String(url),
+        authorization: new Headers(init?.headers).get("authorization"),
+        body: init?.body,
+      });
       return Response.json({
         ok: true,
         result: [
@@ -211,10 +213,8 @@ describe("remote CLI routing", () => {
 
     await runCli(["list", "--json"], {
       env: {
-        CAPLETS_MODE: "remote",
-        CAPLETS_REMOTE_URL: "http://127.0.0.1:5387/caplets",
+        ...remoteEnv(context),
         CAPLETS_CONFIG: join(dirname(context.configPath), "missing-config.json"),
-        CAPLETS_PROJECT_CONFIG: context.projectConfigPath,
       },
       fetch,
       writeOut: (value) => out.push(value),
@@ -223,6 +223,7 @@ describe("remote CLI routing", () => {
     expect(requests).toEqual([
       {
         url: "http://127.0.0.1:5387/caplets/v1/admin",
+        authorization: "Bearer remote-profile-access-token",
         body: JSON.stringify({ command: "list", arguments: { includeDisabled: false } }),
       },
     ]);
@@ -411,10 +412,8 @@ describe("remote CLI routing", () => {
       ["call-tool", "github.search", "--args", '{"query":"caplets"}', "--format", "json"],
       {
         env: {
-          CAPLETS_MODE: "remote",
-          CAPLETS_REMOTE_URL: "http://127.0.0.1:5387/caplets",
+          ...remoteEnv(context),
           CAPLETS_CONFIG: join(dirname(context.configPath), "missing-config.json"),
-          CAPLETS_PROJECT_CONFIG: context.projectConfigPath,
         },
         fetch,
         writeOut: (value) => out.push(value),
@@ -600,8 +599,9 @@ describe("remote CLI routing", () => {
       });
     });
 
+    const context = testContext("caplets-cli-remote-resources-");
     const io = {
-      env: { CAPLETS_MODE: "remote", CAPLETS_REMOTE_URL: "http://127.0.0.1:5387/caplets" },
+      env: remoteEnv(context),
       fetch,
       writeOut: (value: string) => out.push(value),
     };
@@ -729,6 +729,7 @@ describe("remote CLI routing", () => {
   });
 
   it("routes add mcp through remote control with --remote and labels the remote path", async () => {
+    const context = testContext("caplets-cli-remote-add-control-");
     const out: string[] = [];
     const fetchMock = vi.fn(
       async () =>
@@ -759,7 +760,7 @@ describe("remote CLI routing", () => {
       ],
       {
         env: {
-          CAPLETS_MODE: "remote",
+          ...remoteEnv(context),
           CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
         },
         fetch: fetchMock as typeof fetch,
@@ -799,8 +800,7 @@ describe("remote CLI routing", () => {
         ["add", "mcp", "remote-tools", "--url", "https://mcp.example.com/mcp", "--remote"],
         {
           env: {
-            CAPLETS_MODE: "remote",
-            CAPLETS_REMOTE_URL: "http://127.0.0.1:5387/caplets",
+            ...remoteEnv(local),
             CAPLETS_CONFIG: local.configPath,
           },
           fetch: async (input, init) => remote.app.fetch(new Request(input, init)),
@@ -1004,6 +1004,7 @@ describe("remote CLI routing", () => {
   });
 
   it("routes install through remote control with --remote", async () => {
+    const context = testContext("caplets-cli-remote-install-control-");
     const out: string[] = [];
     const fetchMock = vi.fn(
       async () =>
@@ -1028,7 +1029,7 @@ describe("remote CLI routing", () => {
 
     await runCli(["install", "spiritledsoftware/caplets", "github", "--remote"], {
       env: {
-        CAPLETS_MODE: "remote",
+        ...remoteEnv(context),
         CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
       },
       fetch: fetchMock as typeof fetch,
@@ -1104,6 +1105,7 @@ describe("remote CLI routing", () => {
   });
 
   it("routes init through remote control with --remote", async () => {
+    const context = testContext("caplets-cli-remote-init-control-");
     const out: string[] = [];
     const fetchMock = vi.fn(
       async () =>
@@ -1115,7 +1117,7 @@ describe("remote CLI routing", () => {
 
     await runCli(["init", "--force", "--remote"], {
       env: {
-        CAPLETS_MODE: "remote",
+        ...remoteEnv(context),
         CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
       },
       fetch: fetchMock as typeof fetch,
@@ -1160,6 +1162,7 @@ describe("remote CLI routing", () => {
   });
 
   it("routes auth list and logout through remote control", async () => {
+    const context = testContext("caplets-cli-remote-auth-list-control-");
     const out: string[] = [];
     const fetchMock = vi
       .fn()
@@ -1190,7 +1193,7 @@ describe("remote CLI routing", () => {
 
     const io = {
       env: {
-        CAPLETS_MODE: "remote",
+        ...remoteEnv(context),
         CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
       },
       fetch: fetchMock as typeof fetch,
@@ -1284,6 +1287,7 @@ describe("remote CLI routing", () => {
   });
 
   it("uses explicit --remote for auth login, refresh, and logout remote requests", async () => {
+    const context = testContext("caplets-cli-remote-auth-control-");
     const out: string[] = [];
     const fetchMock = vi
       .fn()
@@ -1297,7 +1301,7 @@ describe("remote CLI routing", () => {
 
     const io = {
       env: {
-        CAPLETS_MODE: "remote",
+        ...remoteEnv(context),
         CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
       },
       fetch: fetchMock as typeof fetch,
@@ -1333,6 +1337,7 @@ describe("remote CLI routing", () => {
   });
 
   it("does not print or open an auth URL when remote auth is already complete", async () => {
+    const context = testContext("caplets-cli-remote-auth-complete-");
     const out: string[] = [];
     const fetchMock = vi.fn(async () =>
       Response.json({ ok: true, result: { server: "remote", authenticated: true } }),
@@ -1340,7 +1345,7 @@ describe("remote CLI routing", () => {
 
     await runCli(["auth", "login", "remote"], {
       env: {
-        CAPLETS_MODE: "remote",
+        ...remoteEnv(context),
         CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
       },
       fetch: fetchMock as typeof fetch,
@@ -1351,6 +1356,7 @@ describe("remote CLI routing", () => {
   });
 
   it("prints pending instructions instead of authenticated when remote auth needs browser completion", async () => {
+    const context = testContext("caplets-cli-remote-auth-pending-");
     const out: string[] = [];
     const fetchMock = vi.fn(async () =>
       Response.json({
@@ -1365,7 +1371,7 @@ describe("remote CLI routing", () => {
 
     await runCli(["auth", "login", "remote", "--no-open"], {
       env: {
-        CAPLETS_MODE: "remote",
+        ...remoteEnv(context),
         CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
       },
       fetch: fetchMock as typeof fetch,
@@ -1381,6 +1387,7 @@ describe("remote CLI routing", () => {
 });
 
 async function runRemoteAdd(args: string[]): Promise<unknown> {
+  const context = testContext("caplets-cli-remote-add-request-");
   const requests: unknown[] = [];
   const fetchMock = vi.fn(
     async (url: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
@@ -1398,7 +1405,7 @@ async function runRemoteAdd(args: string[]): Promise<unknown> {
 
   await runCli(["add", ...args], {
     env: {
-      CAPLETS_MODE: "remote",
+      ...remoteEnv(context),
       CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
     },
     fetch: fetchMock as typeof fetch,
@@ -1443,20 +1450,34 @@ function remoteServerFixture(): {
   return { app, engine, projectCapletsRoot: context.projectCapletsRoot };
 }
 
-function clientFixture(): { configPath: string; projectCapletsRoot: string } {
+function clientFixture(): {
+  configPath: string;
+  projectConfigPath: string;
+  projectCapletsRoot: string;
+  authDir: string;
+} {
   const context = testContext("caplets-cli-remote-client-");
-  return { configPath: context.configPath, projectCapletsRoot: context.projectCapletsRoot };
+  return {
+    configPath: context.configPath,
+    projectConfigPath: context.projectConfigPath,
+    projectCapletsRoot: context.projectCapletsRoot,
+    authDir: context.authDir,
+  };
 }
 
 function remoteEnv(context: {
   configPath: string;
   projectConfigPath: string;
+  authDir?: string;
 }): Record<string, string> {
   return {
     CAPLETS_MODE: "remote",
     CAPLETS_REMOTE_URL: "http://127.0.0.1:5387/caplets",
     CAPLETS_CONFIG: context.configPath,
     CAPLETS_PROJECT_CONFIG: context.projectConfigPath,
+    ...(context.authDir
+      ? { CAPLETS_CLOUD_AUTH_PATH: join(context.authDir, "cloud-auth.json") }
+      : {}),
   };
 }
 
@@ -1579,11 +1600,13 @@ function testContext(prefix: string): {
   configPath: string;
   projectConfigPath: string;
   projectCapletsRoot: string;
+  authDir: string;
   watch: false;
 } {
   const dir = mkdtempSync(join(tmpdir(), prefix));
   dirs.push(dir);
   const userRoot = join(dir, "user");
+  const authDir = join(dir, "auth");
   const projectCapletsRoot = join(dir, "project", ".caplets");
   mkdirSync(userRoot, { recursive: true });
   mkdirSync(projectCapletsRoot, { recursive: true });
@@ -1603,5 +1626,49 @@ function testContext(prefix: string): {
       },
     }),
   );
-  return { configPath, projectConfigPath, projectCapletsRoot, watch: false };
+  writeSelfHostedRemoteProfile(authDir);
+  return { configPath, projectConfigPath, projectCapletsRoot, authDir, watch: false };
+}
+
+function writeSelfHostedRemoteProfile(authDir: string): void {
+  writeSelfHostedRemoteProfileForHost(authDir, "http://127.0.0.1:5387");
+  writeSelfHostedRemoteProfileForHost(authDir, "http://127.0.0.1:5387/caplets");
+}
+
+function writeSelfHostedRemoteProfileForHost(authDir: string, inputHostUrl: string): void {
+  const hostUrl = normalizeRemoteProfileHostUrl(inputHostUrl);
+  const key = remoteProfileKey({ kind: "self-hosted", hostUrl });
+  const root = join(authDir, "remote-profiles");
+  mkdirSync(join(root, "profiles"), { recursive: true });
+  mkdirSync(join(root, "credentials"), { recursive: true });
+  writeFileSync(
+    join(root, "profiles", `${encodeURIComponent(key)}.json`),
+    `${JSON.stringify(
+      {
+        version: 1,
+        kind: "self-hosted",
+        key,
+        hostUrl,
+        clientId: "rcli_test",
+        clientLabel: "Remote CLI Test",
+        createdAt: "2026-06-19T12:00:00.000Z",
+        updatedAt: "2026-06-19T12:00:00.000Z",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(
+    join(root, "credentials", `${encodeURIComponent(key)}.json`),
+    `${JSON.stringify(
+      {
+        accessToken: "remote-profile-access-token",
+        refreshToken: "remote-profile-refresh-token",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        tokenType: "Bearer",
+      },
+      null,
+      2,
+    )}\n`,
+  );
 }

--- a/packages/core/test/cli-remote.test.ts
+++ b/packages/core/test/cli-remote.test.ts
@@ -1416,7 +1416,7 @@ function httpOptions(overrides: Partial<HttpServeOptions> = {}): HttpServeOption
     host: "127.0.0.1",
     port: 5387,
     path: "/caplets",
-    auth: { enabled: false, user: "caplets" },
+    auth: { type: "development_unauthenticated" },
     allowUnauthenticatedHttp: false,
     warnUnauthenticatedNetwork: false,
     loopback: true,

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -170,6 +170,57 @@ describe("cli init", () => {
     expect(fetchStub).not.toHaveBeenCalled();
   });
 
+  it("uses the workspace from a copied Cloud MCP URL when logging in", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-cloud-login-url-workspace-"));
+    const authDir = join(dir, "auth");
+    const startRequests: unknown[] = [];
+    const fetchStub: typeof fetch = vi.fn(async (input, init) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/cloud-client/login/start") {
+        startRequests.push(JSON.parse(String(init?.body ?? "{}")));
+        return Response.json({
+          loginId: "login_123",
+          loginUrl: "https://cloud.caplets.dev/login/login_123",
+          userCode: "ABCD-EFGH",
+          expiresAt: "2999-06-19T12:00:00.000Z",
+        });
+      }
+      if (url.pathname === "/api/cloud-client/login/login_123") {
+        return Response.json({ status: "completed", oneTimeCode: "one_time_code" });
+      }
+      if (url.pathname === "/api/cloud-client/token") {
+        return Response.json({
+          cloudUrl: "https://cloud.caplets.dev",
+          workspaceId: "workspace_team",
+          workspaceSlug: "team",
+          accessToken: "access-token",
+          refreshToken: "refresh-token",
+          expiresAt: "2999-06-19T12:00:00.000Z",
+        });
+      }
+      return Response.json({ error: "not_found" }, { status: 404 });
+    });
+    try {
+      await runCli(
+        ["remote", "login", "https://cloud.caplets.dev/ws/team/mcp", "--no-open", "--json"],
+        {
+          authDir,
+          fetch: fetchStub,
+          writeOut: () => {},
+        },
+      );
+
+      expect(startRequests).toEqual([
+        expect.objectContaining({
+          requestedWorkspace: "team",
+          deviceName: "Caplets CLI",
+        }),
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("prints parent command help without throwing", async () => {
     const out: string[] = [];
 

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -2766,7 +2766,7 @@ describe("cli setup", () => {
     );
   });
 
-  it("writes the versioned URL for remote generic MCP client setup", async () => {
+  it("writes attach command config for remote generic MCP client setup", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-setup-"));
     const output = join(dir, "caplets.remote.json");
 
@@ -2785,7 +2785,10 @@ describe("cli setup", () => {
 
       expect(JSON.parse(readFileSync(output, "utf8"))).toEqual({
         mcpServers: {
-          caplets: { url: "https://caplets.example.test/caplets/v1/mcp" },
+          caplets: {
+            command: "caplets",
+            args: ["attach", "--remote-url", "https://caplets.example.test/caplets"],
+          },
         },
       });
     } finally {
@@ -2831,10 +2834,12 @@ describe("cli setup", () => {
         },
       ],
       nextSteps: [
+        "Run caplets remote login https://caplets.example.test/caplets before starting OpenCode.",
         "Run OpenCode with CAPLETS_MODE=remote and CAPLETS_REMOTE_URL=https://caplets.example.test/caplets.",
-        "Keep CAPLETS_REMOTE_TOKEN or CAPLETS_REMOTE_PASSWORD in your shell or secret manager.",
       ],
     });
+    expect(out.join("")).not.toContain("CAPLETS_REMOTE_TOKEN");
+    expect(out.join("")).not.toContain("CAPLETS_REMOTE_PASSWORD");
   });
 
   it("adds remote-backed Caplets to Codex MCP config", async () => {
@@ -2886,7 +2891,13 @@ describe("cli setup", () => {
           status: "completed",
         },
       ],
+      nextSteps: [
+        "Run caplets remote login https://caplets.example.test/caplets before using this MCP config.",
+        "In Codex, run /mcp to confirm the caplets server is connected.",
+      ],
     });
+    expect(out.join("")).not.toContain("CAPLETS_REMOTE_TOKEN");
+    expect(out.join("")).not.toContain("CAPLETS_REMOTE_PASSWORD");
   });
 
   it("adds remote-backed Caplets to Claude Code MCP config", async () => {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -16,6 +16,7 @@ import { initConfig, installCaplets, normalizeGitRepo, runCli } from "../src/cli
 import { loadConfig, parseConfig } from "../src/config";
 import type { CapletsError } from "../src/errors";
 import { readTokenBundle, writeTokenBundle } from "../src/auth";
+import { FileRemoteProfileStore } from "../src/remote/profile-store";
 
 describe("cli init", () => {
   const originalMode = process.env.CAPLETS_MODE;
@@ -711,6 +712,7 @@ describe("cli init", () => {
 
   it("gets an MCP prompt with split caplet and prompt arguments", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-remote-prompt-"));
+    const authDir = join(dir, "auth");
     const requests: unknown[] = [];
     const out: string[] = [];
     const fetchMock = vi.fn(
@@ -730,6 +732,19 @@ describe("cli init", () => {
     );
 
     try {
+      await new FileRemoteProfileStore({
+        root: join(authDir, "remote-profiles"),
+      }).saveSelfHostedProfile({
+        hostUrl: "http://127.0.0.1:5387",
+        clientId: "rcli_test",
+        clientLabel: "Remote Prompt Test",
+        credentials: {
+          accessToken: "remote-profile-access-token",
+          refreshToken: "remote-profile-refresh-token",
+          tokenType: "Bearer",
+          expiresAt: "2999-01-01T00:00:00.000Z",
+        },
+      });
       await runCli(
         [
           "get-prompt",
@@ -747,6 +762,7 @@ describe("cli init", () => {
             CAPLETS_CONFIG: join(dir, "missing-user-config.json"),
             CAPLETS_PROJECT_CONFIG: join(dir, "project", ".caplets", "config.json"),
           },
+          authDir,
           fetch: fetchMock,
           writeOut: (value) => out.push(value),
         },
@@ -2840,6 +2856,36 @@ describe("cli setup", () => {
     });
     expect(out.join("")).not.toContain("CAPLETS_REMOTE_TOKEN");
     expect(out.join("")).not.toContain("CAPLETS_REMOTE_PASSWORD");
+  });
+
+  it("uses cloud mode for Cloud OpenCode and Pi setup", async () => {
+    const openCodeOut: string[] = [];
+    const piOut: string[] = [];
+
+    await runCli(
+      ["setup", "opencode", "--remote-url", "https://cloud.caplets.dev", "--format", "json"],
+      {
+        writeOut: (value) => openCodeOut.push(value),
+        runSetupCommand: async () => ({ stdout: "", stderr: "" }),
+      },
+    );
+    await runCli(["setup", "pi", "--remote-url", "https://cloud.caplets.dev", "--format", "json"], {
+      writeOut: (value) => piOut.push(value),
+      runSetupCommand: async () => ({ stdout: "", stderr: "" }),
+    });
+
+    expect(JSON.parse(openCodeOut.join(""))).toMatchObject({
+      nextSteps: [
+        "Run caplets remote login https://cloud.caplets.dev before starting OpenCode.",
+        "Run OpenCode with CAPLETS_MODE=cloud and CAPLETS_REMOTE_URL=https://cloud.caplets.dev.",
+      ],
+    });
+    expect(JSON.parse(piOut.join(""))).toMatchObject({
+      nextSteps: [
+        "Run caplets remote login https://cloud.caplets.dev before starting Pi.",
+        "Start Pi with CAPLETS_MODE=cloud and CAPLETS_REMOTE_URL=https://cloud.caplets.dev.",
+      ],
+    });
   });
 
   it("adds remote-backed Caplets to Codex MCP config", async () => {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -234,7 +234,8 @@ describe("cli init", () => {
         host: "127.0.0.1",
         port: 5387,
         path: "/",
-        auth: { enabled: false, user: "caplets" },
+        auth: { type: "remote_credentials" },
+        remoteCredentialStateDir: expect.stringContaining("remote-server"),
       }),
     ]);
   });

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -154,6 +154,22 @@ describe("cli init", () => {
     );
   });
 
+  it("rejects empty self-hosted remote login code from stdin", async () => {
+    const fetchStub = vi.fn();
+
+    await expect(
+      runCli(["remote", "login", "https://caplets.example.com/caplets", "--code-stdin"], {
+        readStdin: async () => " \n\t",
+        fetch: fetchStub as unknown as typeof fetch,
+        writeErr: () => {},
+      }),
+    ).rejects.toMatchObject({
+      code: "REQUEST_INVALID",
+      message: "Pairing Code is required when --code-stdin is used.",
+    } satisfies Partial<CapletsError>);
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
   it("prints parent command help without throwing", async () => {
     const out: string[] = [];
 

--- a/packages/core/test/cloud-auth-login-cli.test.ts
+++ b/packages/core/test/cloud-auth-login-cli.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import { runCli } from "../src/cli";
@@ -59,13 +59,25 @@ describe("caplets cloud auth login", () => {
 
     expect(JSON.parse(out.join(""))).toMatchObject({
       authenticated: true,
-      status: "authenticated",
-      cloudUrl: "https://cloud.caplets.dev",
+      kind: "cloud",
+      hostUrl: "https://cloud.caplets.dev/",
       workspaceId: "workspace_team",
       workspaceSlug: "team",
+      selected: true,
     });
     assertNoSecrets(out.join(""));
-    expect(readFileSync(path, "utf8")).toContain("cap_refresh_secret");
+    expect(existsSync(path)).toBe(false);
+
+    const statusOut: string[] = [];
+    await runCli(["remote", "status", "https://cloud.caplets.dev", "--json"], {
+      env: { CAPLETS_CLOUD_AUTH_PATH: path },
+      writeOut: (value) => statusOut.push(value),
+    });
+    expect(JSON.parse(statusOut.join(""))).toMatchObject({
+      authenticated: true,
+      kind: "cloud",
+      workspaceSlug: "team",
+    });
   });
 
   it("continues polling while browser workspace selection is required", async () => {
@@ -120,6 +132,16 @@ describe("caplets cloud auth login", () => {
     expect(
       requests.filter((url) => url.endsWith("/api/cloud-client/login/login_123")),
     ).toHaveLength(2);
-    expect(readFileSync(path, "utf8")).toContain("workspace_team");
+    expect(existsSync(path)).toBe(false);
+
+    const statusOut: string[] = [];
+    await runCli(["remote", "status", "https://cloud.caplets.dev", "--json"], {
+      env: { CAPLETS_CLOUD_AUTH_PATH: path },
+      writeOut: (value) => statusOut.push(value),
+    });
+    expect(JSON.parse(statusOut.join(""))).toMatchObject({
+      authenticated: true,
+      workspaceId: "workspace_team",
+    });
   });
 });

--- a/packages/core/test/cloud-auth-refresh-attach.test.ts
+++ b/packages/core/test/cloud-auth-refresh-attach.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { dirname, join } from "node:path";
 import { CloudAuthStore } from "../src/cloud-auth/store";
 import { attachProjectOnce } from "../src/project-binding/attach";
+import { FileRemoteProfileStore } from "../src/remote/profile-store";
 import { hostedCredentials, tempCloudAuthPath } from "./fixtures/cloud-auth";
 
 describe("hosted Cloud Auth refresh before attach", () => {
@@ -49,6 +51,21 @@ describe("hosted Cloud Auth refresh before attach", () => {
     ).resolves.toMatchObject({ ok: true });
 
     await expect(store.load()).resolves.toMatchObject({
+      accessToken: "old_access",
+      refreshToken: "old_refresh",
+      expiresAt: "2026-06-03T00:00:00.000Z",
+    });
+    const profileStore = new FileRemoteProfileStore({
+      root: join(dirname(path), "remote-profiles"),
+    });
+    const status = await profileStore.getCloudProfileStatus({
+      hostUrl: "https://cloud.caplets.dev",
+    });
+    expect(status).toMatchObject({
+      hostUrl: "https://cloud.caplets.dev/",
+      workspaceSlug: "personal",
+    });
+    await expect(profileStore.credentials.load(status?.key ?? "")).resolves.toMatchObject({
       accessToken: "new_access",
       refreshToken: "new_refresh",
       expiresAt: "2999-01-01T00:00:00.000Z",

--- a/packages/core/test/cloud-auth.test.ts
+++ b/packages/core/test/cloud-auth.test.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   CloudAuthStore,
@@ -9,6 +9,7 @@ import {
   type CloudAuthCredentials,
 } from "../src/cloud-auth/store";
 import { runCli } from "../src/cli";
+import { FileRemoteProfileStore } from "../src/remote/profile-store";
 
 const tempDirs: string[] = [];
 const credentials: CloudAuthCredentials = {
@@ -55,12 +56,14 @@ describe("caplets cloud auth CLI", () => {
     expect(JSON.parse(out.join(""))).toEqual({
       authenticated: false,
       status: "unauthenticated",
+      hostUrl: "https://cloud.caplets.dev/",
+      kind: "cloud",
     });
   });
 
   it("prints authenticated status and stored workspace as JSON", async () => {
     const path = tempAuthPath();
-    await new CloudAuthStore({ path }).save(credentials);
+    await saveRemoteProfile(path);
     const out: string[] = [];
 
     await runCli(["cloud", "auth", "status", "--json"], {
@@ -68,25 +71,25 @@ describe("caplets cloud auth CLI", () => {
       writeOut: (value) => out.push(value),
     });
 
-    expect(JSON.parse(out.join(""))).toEqual({
+    expect(JSON.parse(out.join(""))).toMatchObject({
       authenticated: true,
-      status: "authenticated",
-      cloudUrl: "https://cloud.caplets.dev",
+      kind: "cloud",
+      hostUrl: "https://cloud.caplets.dev/",
       workspaceId: "ws_123",
       workspaceSlug: "team",
+      selected: true,
+      clientLabel: "Test Device",
       expiresAt: "2099-06-02T12:00:00.000Z",
       scope: ["project_binding:read", "project_binding:write", "mcp:tools"],
       tokenType: "Bearer",
-      credentialFamilyId: "family_123",
-      deviceName: "Test Device",
       createdAt: "2026-06-03T12:00:00.000Z",
-      lastRefreshAt: "2026-06-03T12:00:00.000Z",
+      updatedAt: "2026-06-03T12:00:00.000Z",
     });
   });
 
   it("lists the stored workspace as JSON", async () => {
     const path = tempAuthPath();
-    await new CloudAuthStore({ path }).save(credentials);
+    await saveRemoteProfile(path);
     const out: string[] = [];
 
     await runCli(["cloud", "auth", "workspaces", "--json"], {
@@ -99,21 +102,26 @@ describe("caplets cloud auth CLI", () => {
     });
   });
 
-  it("logs out by deleting stored Cloud Auth credentials", async () => {
+  it("logs out by deleting stored Remote Profile credentials", async () => {
     const path = tempAuthPath();
-    await new CloudAuthStore({ path }).save(credentials);
+    await saveRemoteProfile(path);
 
     await runCli(["cloud", "auth", "logout"], {
       env: { CAPLETS_CLOUD_AUTH_PATH: path },
       writeOut: () => undefined,
     });
 
-    expect(existsSync(path)).toBe(false);
+    const out: string[] = [];
+    await runCli(["cloud", "auth", "status", "--json"], {
+      env: { CAPLETS_CLOUD_AUTH_PATH: path },
+      writeOut: (value) => out.push(value),
+    });
+    expect(JSON.parse(out.join(""))).toMatchObject({ authenticated: false });
   });
 
   it("uploads local caplet-files to the selected Cloud workspace", async () => {
     const authPath = tempAuthPath();
-    await new CloudAuthStore({ path: authPath }).save(credentials);
+    await saveRemoteProfile(authPath);
     const root = tempDir("caplets-cloud-add-");
     mkdirSync(join(root, "search"), { recursive: true });
     writeFileSync(
@@ -223,6 +231,25 @@ describe("CloudAuthStore", () => {
 
 function tempAuthPath(): string {
   return join(tempDir("caplets-cloud-auth-"), "cloud-auth.json");
+}
+
+async function saveRemoteProfile(cloudAuthPath: string): Promise<void> {
+  await new FileRemoteProfileStore({
+    root: join(dirname(cloudAuthPath), "remote-profiles"),
+  }).saveCloudProfile({
+    hostUrl: credentials.cloudUrl,
+    workspaceId: credentials.workspaceId,
+    ...(credentials.workspaceSlug ? { workspaceSlug: credentials.workspaceSlug } : {}),
+    clientLabel: credentials.deviceName,
+    credentials: {
+      accessToken: credentials.accessToken,
+      refreshToken: credentials.refreshToken,
+      expiresAt: credentials.expiresAt,
+      scope: credentials.scope,
+      tokenType: credentials.tokenType,
+    },
+    now: new Date(credentials.createdAt ?? "2026-06-03T12:00:00.000Z"),
+  });
 }
 
 function tempDir(prefix: string): string {

--- a/packages/core/test/doctor-cli.test.ts
+++ b/packages/core/test/doctor-cli.test.ts
@@ -18,19 +18,18 @@ describe("caplets doctor", () => {
     expect(report).toContain("Project Binding");
     expect(report).toContain("Project sync");
     expect(report).toContain("Daemon");
-    expect(report).toContain("Cloud Auth");
+    expect(report).toContain("Remote Login");
     expect(report).toContain("Exposure");
     expect(report).toContain("Code Mode");
     expect(report).not.toContain("local presence");
   });
 
-  it("shows remote client derived URLs and auth state", async () => {
+  it("shows remote client derived URLs without env-token auth", async () => {
     const out: string[] = [];
 
     await runCli(["doctor"], {
       env: {
         CAPLETS_REMOTE_URL: "https://cloud.caplets.dev/ws/ian",
-        CAPLETS_REMOTE_TOKEN: "secret",
         CAPLETS_REMOTE_WORKSPACE: "ws_1",
       },
       writeOut: (value) => out.push(value),
@@ -43,8 +42,8 @@ describe("caplets doctor", () => {
     expect(report).toContain(
       "WebSocket URL: wss://cloud.caplets.dev/v1/ws/ian/attach/project-bindings/connect",
     );
-    expect(report).toContain("Auth: bearer");
-    expect(report).not.toContain("secret");
+    expect(report).toContain("Auth: none");
+    expect(report).toContain("Remote Login");
   });
 
   it("uses saved Cloud Auth workspace for bare hosted Cloud remote URLs", async () => {
@@ -76,6 +75,13 @@ describe("caplets doctor", () => {
         tokenPresent: true,
         workspace: "personal-c9b49d",
       },
+      remoteLogin: {
+        configured: true,
+        authenticated: true,
+        kind: "cloud",
+        hostUrl: "https://cloud.caplets.dev/",
+        workspaceSlug: "personal-c9b49d",
+      },
     });
   });
 
@@ -97,7 +103,7 @@ describe("caplets doctor", () => {
       projectBinding: { state: "not_attached" },
       sync: { state: "idle" },
       daemon: { running: false },
-      cloudAuth: { authenticated: false },
+      remoteLogin: { configured: true, authenticated: false },
       exposure: { ok: true },
       codeMode: {
         typesGeneration: { ok: true },

--- a/packages/core/test/doctor-cli.test.ts
+++ b/packages/core/test/doctor-cli.test.ts
@@ -127,6 +127,27 @@ describe("caplets doctor", () => {
     });
   });
 
+  it("reports malformed Remote Login URLs instead of throwing", async () => {
+    const out: string[] = [];
+
+    await runCli(["doctor", "--json"], {
+      env: {
+        CAPLETS_MODE: "remote",
+        CAPLETS_REMOTE_URL: "http://example.com",
+      },
+      writeOut: (value) => out.push(value),
+    });
+
+    expect(JSON.parse(out.join(""))).toMatchObject({
+      remoteLogin: {
+        configured: true,
+        authenticated: false,
+        kind: "self-hosted",
+        error: expect.any(String),
+      },
+    });
+  });
+
   it("emits JSON diagnostics with separate server, remote, binding, sync, daemon, and auth sections", async () => {
     const out: string[] = [];
 

--- a/packages/core/test/doctor-cli.test.ts
+++ b/packages/core/test/doctor-cli.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { dirname } from "node:path";
 import { CloudAuthStore } from "../src/cloud-auth/store";
 import { runCli } from "../src/cli";
 import { hostedCredentials, tempCloudAuthPath } from "./fixtures/cloud-auth";
+import { FileRemoteProfileStore } from "../src/remote/profile-store";
 
 describe("caplets doctor", () => {
   it("shows sectioned local diagnostics without stale presence wording", async () => {
@@ -81,6 +83,46 @@ describe("caplets doctor", () => {
         kind: "cloud",
         hostUrl: "https://cloud.caplets.dev/",
         workspaceSlug: "personal-c9b49d",
+      },
+    });
+  });
+
+  it("reports ambiguous Cloud Remote Profiles instead of throwing", async () => {
+    const path = tempCloudAuthPath();
+    const authDir = dirname(path);
+    const store = new FileRemoteProfileStore({ root: `${authDir}/remote-profiles` });
+    await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "workspace_team",
+      workspaceSlug: "team",
+      credentials: {
+        accessToken: "cloud-access",
+        refreshToken: "cloud-refresh",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+      },
+    });
+    await store.clearSelectedCloudWorkspace("https://cloud.caplets.dev");
+    const out: string[] = [];
+
+    await runCli(["doctor", "--json"], {
+      env: {
+        CAPLETS_MODE: "cloud",
+        CAPLETS_REMOTE_URL: "https://cloud.caplets.dev",
+        CAPLETS_CLOUD_AUTH_PATH: path,
+      },
+      writeOut: (value) => out.push(value),
+    });
+
+    expect(JSON.parse(out.join(""))).toMatchObject({
+      remoteLogin: {
+        configured: true,
+        authenticated: false,
+        kind: "cloud",
+        hostUrl: "https://cloud.caplets.dev/",
+        error: "Cloud Remote Profile requires a selected or explicit workspace.",
+      },
+      projectBinding: {
+        authMode: "remote_login_required",
       },
     });
   });

--- a/packages/core/test/native-options.test.ts
+++ b/packages/core/test/native-options.test.ts
@@ -40,15 +40,20 @@ describe("resolveNativeCapletsServiceOptions", () => {
     });
   });
 
-  it("rejects cloud mode without a workspace", () => {
-    expect(() =>
+  it("allows cloud mode without a workspace because Remote Profiles select it", () => {
+    expect(
       resolveNativeCapletsServiceOptions(
         {},
         {
           CAPLETS_REMOTE_URL: "https://cloud.caplets.dev",
         },
       ),
-    ).toThrow(/workspace/u);
+    ).toMatchObject({
+      mode: "cloud",
+      remote: {
+        url: new URL("https://cloud.caplets.dev/v1/attach"),
+      },
+    });
   });
 
   it("uses cloud mode when CAPLETS_MODE=cloud is explicit", () => {

--- a/packages/core/test/native-options.test.ts
+++ b/packages/core/test/native-options.test.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import { describe, expect, it } from "vitest";
 
 import type { CapletsError } from "../src/errors";
@@ -125,64 +124,57 @@ describe("resolveNativeCapletsServiceOptions", () => {
     }
   });
 
-  it("lets config override env vars", () => {
-    const configPassword = ["config", "password"].join("-");
+  it("uses the configured remote URL without reading legacy credential env vars", () => {
     expect(
       resolveNativeCapletsServiceOptions(
         {
           remote: {
             url: "https://configured.example.com/caplets",
-            user: "configured",
-            password: configPassword,
           },
         },
         {
           CAPLETS_REMOTE_URL: "https://env.example.com",
           CAPLETS_REMOTE_USER: "env-user",
           CAPLETS_REMOTE_PASSWORD: ["env", "password"].join("-"),
-        },
+          CAPLETS_REMOTE_TOKEN: "env-token",
+        } as Record<string, string>,
       ),
     ).toMatchObject({
       mode: "remote",
       remote: {
         url: new URL("https://configured.example.com/caplets/v1/attach"),
-        auth: { enabled: true, user: "configured", password: configPassword },
+        auth: { enabled: false, user: "caplets" },
       },
     });
   });
 
-  it("defaults Basic Auth user when password exists", () => {
-    const password = ["remote", "password"].join("-");
+  it("ignores removed Basic Auth fields in remote config objects", () => {
     expect(
       resolveNativeCapletsServiceOptions(
-        { remote: { url: "https://caplets.example.com", password } },
+        {
+          remote: {
+            url: "https://caplets.example.com",
+            user: "caplets",
+            password: ["remote", "password"].join("-"),
+          },
+        } as never,
         {},
       ),
     ).toMatchObject({
-      remote: { auth: { enabled: true, user: "caplets", password } },
+      remote: { auth: { enabled: false, user: "caplets" } },
     });
   });
 
-  it("rejects user without password", () => {
-    expect(() =>
-      resolveNativeCapletsServiceOptions(
-        { remote: { url: "https://caplets.example.com", user: "caplets" } },
-        {},
-      ),
-    ).toThrow(/requires a password/u);
-  });
-
-  it("builds request headers without logging credentials", () => {
-    const password = ["remote", "password"].join("-");
+  it("does not build Basic Auth request headers from removed credential fields", () => {
     const resolved = resolveNativeCapletsServiceOptions(
       {
         remote: {
           pollIntervalMs: 5_000,
           url: "https://caplets.example.com/caplets",
           user: "caplets",
-          password,
+          password: ["remote", "password"].join("-"),
         },
-      },
+      } as never,
       {},
     );
     expect(resolved.mode).toBe("remote");
@@ -190,9 +182,9 @@ describe("resolveNativeCapletsServiceOptions", () => {
       new URL("https://caplets.example.com/caplets/v1/attach"),
     );
     expect(resolved.mode === "remote" ? resolved.remote.pollIntervalMs : undefined).toBe(5_000);
-    expect(resolved.mode === "remote" ? resolved.remote.requestInit.headers : undefined).toEqual({
-      Authorization: `Basic ${Buffer.from(`caplets:${password}`).toString("base64")}`,
-    });
+    expect(
+      resolved.mode === "remote" ? resolved.remote.requestInit.headers : undefined,
+    ).toBeUndefined();
   });
 
   it("rejects invalid poll intervals", () => {

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -17,6 +17,7 @@ import {
   type NativeCapletsService,
   resetNativeProjectBindingFallbackWarningForTests,
 } from "../src/native/service";
+import { FileRemoteProfileStore } from "../src/remote/profile-store";
 import { createHttpServeApp } from "../src/serve/http";
 import type { HttpServeOptions } from "../src/serve/options";
 import { hostedCredentials, tempCloudAuthPath } from "./fixtures/cloud-auth";
@@ -1361,6 +1362,41 @@ describe("createNativeCapletsService remote mode", () => {
     await service.close();
   });
 
+  it("loads self-hosted native remote credentials from a saved Remote Profile", async () => {
+    const authDir = mkdtempSync(join(tmpdir(), "caplets-native-remote-auth-"));
+    dirs.push(authDir);
+    await new FileRemoteProfileStore({
+      root: join(authDir, "remote-profiles"),
+    }).saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "client_123",
+      clientLabel: "Native Test",
+      credentials: {
+        accessToken: "profile-access-token",
+        refreshToken: "profile-refresh-token",
+        expiresAt: "2099-06-19T12:00:00.000Z",
+      },
+    });
+    const authorizationHeaders: Array<string | null> = [];
+    const service = createNativeCapletsService({
+      mode: "remote",
+      authDir,
+      remote: {
+        url: "https://caplets.example.com/caplets",
+        fetch: (async (_input, init) => {
+          authorizationHeaders.push(new Headers(init?.headers).get("authorization"));
+          return Response.json(attachManifest("rev-1", "export-1"));
+        }) as typeof fetch,
+      },
+    });
+
+    await service.reload();
+
+    expect(authorizationHeaders).toContain("Bearer profile-access-token");
+    expect(configuredCapletIds(service.listTools())).toContain("remote");
+    await service.close();
+  });
+
   it("does not create the remote service when local overlay construction fails", () => {
     const fixture = client();
     const remoteClientFactory = vi.fn(() => fixture.api);
@@ -2074,8 +2110,23 @@ describe("createNativeCapletsService remote mode", () => {
       headers.set("host", new URL(request.url).host);
       return app.fetch(new Request(request, { headers }));
     };
+    const authDir = mkdtempSync(join(tmpdir(), "caplets-native-code-mode-auth-"));
+    dirs.push(authDir);
+    await new FileRemoteProfileStore({
+      root: join(authDir, "remote-profiles"),
+    }).saveSelfHostedProfile({
+      hostUrl: "http://127.0.0.1:5387",
+      clientId: "client_123",
+      clientLabel: "Native Code Mode Test",
+      credentials: {
+        accessToken: "profile-access-token",
+        refreshToken: "profile-refresh-token",
+        expiresAt: "2099-06-19T12:00:00.000Z",
+      },
+    });
     const service = createNativeCapletsService({
       mode: "remote",
+      authDir,
       remote: { url: "http://127.0.0.1:5387", fetch: fetchFromApp },
       configPath: localConfig.configPath,
       projectConfigPath: localConfig.projectConfigPath,

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -523,6 +523,39 @@ describe("RemoteNativeCapletsService", () => {
     }
   });
 
+  it("does not reconnect attach events after permanent runtime credential failures", async () => {
+    vi.useFakeTimers();
+    try {
+      const writeErr = vi.fn();
+      const resolveRuntimeOptions = vi.fn(async () => {
+        const error = new Error("Remote Login required.");
+        Object.assign(error, { projectBindingCode: "remote_credentials_required" });
+        throw error;
+      });
+      const remote = createSdkRemoteCapletsClient({
+        url: new URL("https://caplets.example.com/v1/attach"),
+        requestInit: {},
+        fetch: vi.fn(async () => Response.json(attachManifest("rev-1", "export-1"))),
+        auth: { enabled: false, user: "caplets" },
+        pollIntervalMs: 60_000,
+        resolveRuntimeOptions,
+        writeErr,
+      });
+
+      remote.onToolsChanged(vi.fn());
+      await vi.waitFor(() => expect(resolveRuntimeOptions).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(resolveRuntimeOptions).toHaveBeenCalledTimes(1);
+      expect(writeErr).toHaveBeenCalledWith(
+        "Remote Caplets authentication failed; run caplets remote login <url>.\n",
+      );
+      await remote.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not reconnect the attach events stream after an HTTP error response", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -1397,6 +1397,195 @@ describe("createNativeCapletsService remote mode", () => {
     await service.close();
   });
 
+  it("refreshes saved self-hosted native remote credentials before reloading", async () => {
+    const authDir = mkdtempSync(join(tmpdir(), "caplets-native-remote-auth-"));
+    dirs.push(authDir);
+    const store = new FileRemoteProfileStore({ root: join(authDir, "remote-profiles") });
+    await store.saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "client_123",
+      clientLabel: "Native Test",
+      credentials: {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2999-06-19T12:00:00.000Z",
+      },
+    });
+    const authorizationHeaders: Array<string | null> = [];
+    const service = createNativeCapletsService({
+      mode: "remote",
+      authDir,
+      remote: {
+        url: "https://caplets.example.com/caplets",
+        fetch: (async (input, init) => {
+          if (String(input).endsWith("/v1/remote/refresh")) {
+            return Response.json({
+              clientId: "client_123",
+              clientLabel: "Native Test",
+              accessToken: "new-access-token",
+              refreshToken: "new-refresh-token",
+              expiresAt: "2999-06-19T12:00:00.000Z",
+            });
+          }
+          authorizationHeaders.push(new Headers(init?.headers).get("authorization"));
+          return Response.json(attachManifest("rev-1", "export-1"));
+        }) as typeof fetch,
+      },
+    });
+
+    await service.reload();
+    await store.saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "client_123",
+      clientLabel: "Native Test",
+      credentials: {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2026-06-19T00:00:00.000Z",
+      },
+    });
+    await service.reload();
+
+    expect(authorizationHeaders[0]).toBe("Bearer old-access-token");
+    expect(authorizationHeaders.at(-1)).toBe("Bearer new-access-token");
+    await service.close();
+  });
+
+  it("refreshes saved self-hosted native remote credentials before executing", async () => {
+    const authDir = mkdtempSync(join(tmpdir(), "caplets-native-remote-auth-"));
+    dirs.push(authDir);
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-19T12:00:00.000Z"));
+    const store = new FileRemoteProfileStore({ root: join(authDir, "remote-profiles") });
+    await store.saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "client_123",
+      clientLabel: "Native Test",
+      credentials: {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2026-06-19T12:02:00.000Z",
+      },
+    });
+    const authorizationHeaders: Array<string | null> = [];
+    let refreshCalls = 0;
+    const service = createNativeCapletsService({
+      mode: "remote",
+      authDir,
+      remote: {
+        url: "https://caplets.example.com/caplets",
+        fetch: (async (input, init) => {
+          const url = String(input);
+          if (url.endsWith("/v1/remote/refresh")) {
+            refreshCalls += 1;
+            return Response.json({
+              clientId: "client_123",
+              clientLabel: "Native Test",
+              accessToken: "new-access-token",
+              refreshToken: "new-refresh-token",
+              expiresAt: "2999-06-19T12:00:00.000Z",
+            });
+          }
+          authorizationHeaders.push(new Headers(init?.headers).get("authorization"));
+          if (url.endsWith("/manifest")) return Response.json(attachManifest("rev-1", "export-1"));
+          return Response.json({ ok: true, data: { invoked: true } });
+        }) as typeof fetch,
+      },
+    });
+
+    try {
+      await service.reload();
+      vi.setSystemTime(new Date("2026-06-19T12:01:30.000Z"));
+
+      await expect(service.execute("remote", { ok: true })).resolves.toEqual({ invoked: true });
+
+      expect(refreshCalls).toBe(1);
+      expect(authorizationHeaders[0]).toBe("Bearer old-access-token");
+      expect(authorizationHeaders.at(-1)).toBe("Bearer new-access-token");
+    } finally {
+      vi.useRealTimers();
+      await service.close();
+    }
+  });
+
+  it("closes the local overlay when explicit profile-backed remote reload fails", async () => {
+    const authDir = mkdtempSync(join(tmpdir(), "caplets-native-remote-auth-"));
+    dirs.push(authDir);
+    const localClose = vi.fn(async () => undefined);
+    const localService = {
+      listTools: vi.fn(() => []),
+      execute: vi.fn(async () => undefined),
+      reload: vi.fn(async () => true),
+      onToolsChanged: vi.fn(() => () => undefined),
+      close: localClose,
+    };
+    const service = createNativeCapletsService({
+      mode: "remote",
+      authDir,
+      remote: { url: "https://caplets.example.com/caplets" },
+      localServiceFactory: vi.fn(() => localService),
+    });
+
+    await expect(service.reload()).rejects.toThrow(/Remote Login required/u);
+
+    expect(localClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an existing explicit profile-backed remote service open after refresh failure", async () => {
+    const authDir = mkdtempSync(join(tmpdir(), "caplets-native-remote-auth-"));
+    dirs.push(authDir);
+    const store = new FileRemoteProfileStore({ root: join(authDir, "remote-profiles") });
+    await store.saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "client_123",
+      clientLabel: "Native Test",
+      credentials: {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2999-06-19T12:00:00.000Z",
+      },
+    });
+    const localClose = vi.fn(async () => undefined);
+    const localService = {
+      listTools: vi.fn(() => []),
+      execute: vi.fn(async () => undefined),
+      reload: vi.fn(async () => true),
+      onToolsChanged: vi.fn(() => () => undefined),
+      close: localClose,
+    };
+    const service = createNativeCapletsService({
+      mode: "remote",
+      authDir,
+      remote: {
+        url: "https://caplets.example.com/caplets",
+        fetch: (async (input) => {
+          if (String(input).endsWith("/v1/remote/refresh")) {
+            return Response.json({ ok: false }, { status: 401 });
+          }
+          return Response.json(attachManifest("rev-1", "export-1"));
+        }) as typeof fetch,
+      },
+      localServiceFactory: vi.fn(() => localService),
+    });
+    await service.reload();
+    await store.saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "client_123",
+      clientLabel: "Native Test",
+      credentials: {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2026-06-19T00:00:00.000Z",
+      },
+    });
+
+    await expect(service.reload()).rejects.toThrow(/Remote Login required/u);
+
+    expect(localClose).not.toHaveBeenCalled();
+    expect(configuredCapletIds(service.listTools())).toContain("remote");
+    await service.close();
+  });
+
   it("does not create the remote service when local overlay construction fails", () => {
     const fixture = client();
     const remoteClientFactory = vi.fn(() => fixture.api);

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -474,6 +474,54 @@ describe("RemoteNativeCapletsService", () => {
     }
   });
 
+  it("uses refreshed runtime options when reconnecting the attach events stream", async () => {
+    vi.useFakeTimers();
+    try {
+      const controllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+      const eventAuthHeaders: Array<string | null> = [];
+      let token = "token-1";
+      const fetchStub: typeof fetch = vi.fn(async (input, init) => {
+        const url = String(input);
+        if (url.endsWith("/manifest")) return Response.json(attachManifest("rev-1", "export-1"));
+        if (url.endsWith("/events")) {
+          eventAuthHeaders.push(new Headers(init?.headers).get("authorization"));
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controllers.push(controller);
+              },
+            }),
+            { headers: { "content-type": "text/event-stream" } },
+          );
+        }
+        return Response.json({ ok: true });
+      });
+      const remoteOptions = () => ({
+        url: new URL("https://caplets.example.com/v1/attach"),
+        requestInit: { headers: { authorization: `Bearer ${token}` } },
+        fetch: fetchStub,
+        auth: { enabled: false, user: "caplets" } as const,
+        pollIntervalMs: 60_000,
+      });
+      const remote = createSdkRemoteCapletsClient({
+        ...remoteOptions(),
+        resolveRuntimeOptions: async () => remoteOptions(),
+      });
+
+      remote.onToolsChanged(vi.fn());
+      await vi.waitFor(() => expect(controllers).toHaveLength(1));
+      token = "token-2";
+      controllers[0]!.close();
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await vi.waitFor(() => expect(controllers).toHaveLength(2));
+      expect(eventAuthHeaders).toEqual(["Bearer token-1", "Bearer token-2"]);
+      await remote.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not reconnect the attach events stream after an HTTP error response", async () => {
     vi.useFakeTimers();
     try {
@@ -1320,6 +1368,43 @@ describe("RemoteNativeCapletsService", () => {
 
     await service.close();
     vi.useRealTimers();
+  });
+
+  it("uses refreshed runtime options when fallback polling the remote service", async () => {
+    vi.useFakeTimers();
+    try {
+      const manifestAuthHeaders: Array<string | null> = [];
+      let token = "token-1";
+      const fetchStub: typeof fetch = vi.fn(async (input, init) => {
+        if (String(input).endsWith("/manifest")) {
+          manifestAuthHeaders.push(new Headers(init?.headers).get("authorization"));
+          return Response.json(attachManifest("rev-1", "export-1"));
+        }
+        return Response.json({ ok: true });
+      });
+      const remoteOptions = () => ({
+        url: new URL("https://caplets.example.com/v1/attach"),
+        requestInit: { headers: { authorization: `Bearer ${token}` } },
+        fetch: fetchStub,
+        auth: { enabled: false, user: "caplets" } as const,
+        pollIntervalMs: 60_000,
+      });
+      const remote = createSdkRemoteCapletsClient({
+        ...remoteOptions(),
+        resolveRuntimeOptions: async () => remoteOptions(),
+      });
+      const service = new RemoteNativeCapletsService({ client: remote, pollIntervalMs: 1_000 });
+
+      await service.reload();
+      token = "token-2";
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await vi.waitFor(() => expect(manifestAuthHeaders).toContain("Bearer token-2"));
+      expect(manifestAuthHeaders[0]).toBe("Bearer token-1");
+      await service.close();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("cleans up subscriptions, polling, listeners, and client close idempotently", async () => {

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { ProjectBindingSessionManager } from "../src/cloud/presence";
 import type { CapletsError } from "../src/errors";
 import { CloudAuthStore } from "../src/cloud-auth/store";
 import { CapletsEngine } from "../src/engine";
@@ -1637,6 +1638,55 @@ describe("createNativeCapletsService remote mode", () => {
 
     expect(emitted).toEqual([[["remote", "Remote Updated"]]]);
     await service.close();
+  });
+
+  it("does not start replacement presence when closed during remote replacement", async () => {
+    const fixture = client([{ name: "alpha", title: "Alpha" }]);
+    const previousCloseStarted = deferred();
+    const releasePreviousClose = deferred();
+    fixture.api.close = vi.fn(async () => {
+      previousCloseStarted.resolve();
+      await releasePreviousClose.promise;
+    });
+    const localService = {
+      listTools: vi.fn(() => []),
+      execute: vi.fn(async () => undefined),
+      reload: vi.fn(async () => true),
+      onToolsChanged: vi.fn(() => () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const service = createNativeCapletsService({
+      mode: "remote",
+      remote: { url: "http://127.0.0.1:5387" },
+      remoteClientFactory: vi.fn(() => fixture.api),
+      localServiceFactory: vi.fn(() => localService),
+    }) as NativeCapletsService & {
+      replaceRemote(
+        remote: NativeCapletsService,
+        presence?: ProjectBindingSessionManager,
+      ): Promise<void>;
+    };
+    const replacement = {
+      listTools: vi.fn(() => []),
+      execute: vi.fn(async () => undefined),
+      reload: vi.fn(async () => true),
+      onToolsChanged: vi.fn(() => () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const replacementPresence = {
+      start: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+      updateAllowedCapletIds: vi.fn(async () => undefined),
+    } as unknown as ProjectBindingSessionManager;
+
+    const replacing = service.replaceRemote(replacement, replacementPresence);
+    await previousCloseStarted.promise;
+    const closing = service.close();
+    releasePreviousClose.resolve();
+    await Promise.all([replacing, closing]);
+
+    expect(replacementPresence.close).toHaveBeenCalledTimes(1);
+    expect(replacementPresence.start).not.toHaveBeenCalled();
   });
 
   it("refreshes saved self-hosted native remote credentials before executing", async () => {

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -1689,6 +1689,66 @@ describe("createNativeCapletsService remote mode", () => {
     expect(replacementPresence.start).not.toHaveBeenCalled();
   });
 
+  it("does not create a profile-backed delegate when closed while resolving credentials", async () => {
+    const authDir = mkdtempSync(join(tmpdir(), "caplets-native-remote-auth-"));
+    dirs.push(authDir);
+    const store = new FileRemoteProfileStore({ root: join(authDir, "remote-profiles") });
+    await store.saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "client_123",
+      clientLabel: "Native Test",
+      credentials: {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2026-06-19T00:00:00.000Z",
+      },
+    });
+    const refreshStarted = deferred();
+    const releaseRefresh = deferred();
+    const manifestRequests: string[] = [];
+    const localClose = vi.fn(async () => undefined);
+    const localService = {
+      listTools: vi.fn(() => []),
+      execute: vi.fn(async () => undefined),
+      reload: vi.fn(async () => true),
+      onToolsChanged: vi.fn(() => () => undefined),
+      close: localClose,
+    };
+    const service = createNativeCapletsService({
+      mode: "remote",
+      authDir,
+      remote: {
+        url: "https://caplets.example.com/caplets",
+        fetch: (async (input) => {
+          const url = String(input);
+          if (url.endsWith("/v1/remote/refresh")) {
+            refreshStarted.resolve();
+            await releaseRefresh.promise;
+            return Response.json({
+              clientId: "client_123",
+              clientLabel: "Native Test",
+              accessToken: "new-access-token",
+              refreshToken: "new-refresh-token",
+              expiresAt: "2999-06-19T12:00:00.000Z",
+            });
+          }
+          manifestRequests.push(url);
+          return Response.json(attachManifest("rev-1", "export-1"));
+        }) as typeof fetch,
+      },
+      localServiceFactory: vi.fn(() => localService),
+    });
+
+    const reload = service.reload();
+    await refreshStarted.promise;
+    const closing = service.close();
+    releaseRefresh.resolve();
+    await Promise.all([reload, closing]);
+
+    expect(localClose).toHaveBeenCalledTimes(1);
+    expect(manifestRequests).toEqual([]);
+  });
+
   it("refreshes saved self-hosted native remote credentials before executing", async () => {
     const authDir = mkdtempSync(join(tmpdir(), "caplets-native-remote-auth-"));
     dirs.push(authDir);

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -1042,7 +1042,7 @@ describe("RemoteNativeCapletsService", () => {
 
     await expect(service.execute("remote", {})).rejects.toMatchObject({
       code: "AUTH_FAILED",
-      message: "Caplets Cloud authentication failed; run caplets cloud auth login.",
+      message: "Caplets Cloud authentication failed; run caplets remote login <cloud-url>.",
     });
     await service.close();
   });
@@ -1303,7 +1303,7 @@ describe("RemoteNativeCapletsService", () => {
 
     await expect(service.execute("alpha", {})).rejects.toMatchObject({
       code: "AUTH_FAILED",
-      message: expect.stringContaining("CAPLETS_REMOTE_TOKEN"),
+      message: "Remote Caplets authentication failed; run caplets remote login <url>.",
     } satisfies Partial<CapletsError>);
 
     await service.close();

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -1482,6 +1482,48 @@ describe("createNativeCapletsService remote mode", () => {
     await service.close();
   });
 
+  it("preserves configured Cloud workspace when resolving profile-backed native remotes", async () => {
+    const authDir = mkdtempSync(join(tmpdir(), "caplets-native-cloud-auth-"));
+    dirs.push(authDir);
+    const store = new FileRemoteProfileStore({ root: join(authDir, "remote-profiles") });
+    await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "workspace_team",
+      workspaceSlug: "team",
+      credentials: {
+        accessToken: "cloud-access-token",
+        refreshToken: "cloud-refresh-token",
+        expiresAt: "2099-06-19T12:00:00.000Z",
+        scope: ["project_binding:read", "project_binding:write", "mcp:tools"],
+        tokenType: "Bearer",
+      },
+    });
+    await store.clearSelectedCloudWorkspace("https://cloud.caplets.dev");
+    const manifestUrls: string[] = [];
+    const service = createNativeCapletsService({
+      mode: "cloud",
+      authDir,
+      remote: {
+        url: "https://cloud.caplets.dev",
+        workspace: "team",
+        fetch: (async (input, init) => {
+          manifestUrls.push(String(input));
+          expect(new Headers(init?.headers).get("authorization")).toBe("Bearer cloud-access-token");
+          return Response.json(attachManifest("rev-1", "export-1"));
+        }) as typeof fetch,
+      },
+    });
+
+    try {
+      await service.reload();
+
+      expect(manifestUrls).toContain("https://cloud.caplets.dev/v1/ws/team/attach/manifest");
+      expect(configuredCapletIds(service.listTools())).toContain("remote");
+    } finally {
+      await service.close();
+    }
+  });
+
   it("refreshes saved self-hosted native remote credentials before reloading", async () => {
     const authDir = mkdtempSync(join(tmpdir(), "caplets-native-remote-auth-"));
     dirs.push(authDir);

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -1578,6 +1578,67 @@ describe("createNativeCapletsService remote mode", () => {
     await service.close();
   });
 
+  it("loads refreshed profile-backed remote tools before replacing the active delegate", async () => {
+    const authDir = mkdtempSync(join(tmpdir(), "caplets-native-remote-auth-"));
+    dirs.push(authDir);
+    const store = new FileRemoteProfileStore({ root: join(authDir, "remote-profiles") });
+    await store.saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "client_123",
+      clientLabel: "Native Test",
+      credentials: {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2999-06-19T12:00:00.000Z",
+      },
+    });
+    const service = createNativeCapletsService({
+      mode: "remote",
+      authDir,
+      remote: {
+        url: "https://caplets.example.com/caplets",
+        fetch: (async (input, init) => {
+          const url = String(input);
+          if (url.endsWith("/v1/remote/refresh")) {
+            return Response.json({
+              clientId: "client_123",
+              clientLabel: "Native Test",
+              accessToken: "new-access-token",
+              refreshToken: "new-refresh-token",
+              expiresAt: "2999-06-19T12:00:00.000Z",
+            });
+          }
+          const auth = new Headers(init?.headers).get("authorization");
+          const manifest = attachManifest(
+            auth === "Bearer new-access-token" ? "rev-2" : "rev-1",
+            auth === "Bearer new-access-token" ? "export-2" : "export-1",
+          );
+          manifest.caplets[0]!.title =
+            auth === "Bearer new-access-token" ? "Remote Updated" : "Remote";
+          return Response.json(manifest);
+        }) as typeof fetch,
+      },
+    });
+    await service.reload();
+    const emitted = new Array<string[][]>();
+    service.onToolsChanged((tools) => emitted.push(configuredCapletTitles(tools)));
+    await store.saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "client_123",
+      clientLabel: "Native Test",
+      credentials: {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2026-06-19T00:00:00.000Z",
+      },
+    });
+
+    await service.reload();
+
+    expect(emitted).toEqual([[["remote", "Remote Updated"]]]);
+    await service.close();
+  });
+
   it("refreshes saved self-hosted native remote credentials before executing", async () => {
     const authDir = mkdtempSync(join(tmpdir(), "caplets-native-remote-auth-"));
     dirs.push(authDir);

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -2670,7 +2670,7 @@ function httpOptions(overrides: Partial<HttpServeOptions> = {}): HttpServeOption
     port: 5387,
     path: "/",
     publicOrigin: undefined,
-    auth: { enabled: false, user: "caplets" },
+    auth: { type: "development_unauthenticated" },
     allowUnauthenticatedHttp: false,
     warnUnauthenticatedNetwork: false,
     loopback: true,

--- a/packages/core/test/project-binding-gitignore.test.ts
+++ b/packages/core/test/project-binding-gitignore.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { attachProjectOnce } from "../src/project-binding/attach";
 import { bootstrapProjectBindingGitignore } from "../src/project-binding/gitignore";
+import { FileRemoteProfileStore } from "../src/remote/profile-store";
 
 const tempDirs: string[] = [];
 
@@ -39,10 +40,13 @@ describe("Project Binding gitignore bootstrap", () => {
 
   it("bootstraps .caplets/.gitignore during attach once", async () => {
     const projectRoot = tempProjectRoot();
+    const authDir = tempAuthDir();
+    await saveSelfHostedProfile(authDir, "http://127.0.0.1:8787/caplets");
 
     await attachProjectOnce({
       projectRoot,
       remoteUrl: "http://127.0.0.1:8787/caplets",
+      authDir,
       fetch: async () => Response.json({ error: "websocket_upgrade_required" }, { status: 426 }),
     });
 
@@ -58,4 +62,26 @@ function tempProjectRoot(): string {
   const root = mkdtempSync(join(tmpdir(), "caplets-project-binding-"));
   tempDirs.push(root);
   return root;
+}
+
+function tempAuthDir(): string {
+  const root = mkdtempSync(join(tmpdir(), "caplets-project-binding-auth-"));
+  tempDirs.push(root);
+  return root;
+}
+
+async function saveSelfHostedProfile(authDir: string, hostUrl: string): Promise<void> {
+  await new FileRemoteProfileStore({
+    root: join(authDir, "remote-profiles"),
+  }).saveSelfHostedProfile({
+    hostUrl,
+    clientId: "rcli_123",
+    clientLabel: "Test Device",
+    credentials: {
+      accessToken: "profile-access-token",
+      refreshToken: "profile-refresh-token",
+      tokenType: "Bearer",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+    },
+  });
 }

--- a/packages/core/test/project-binding-session.test.ts
+++ b/packages/core/test/project-binding-session.test.ts
@@ -109,6 +109,51 @@ describe("runProjectBindingSession", () => {
     expect(events).toContainEqual(expect.objectContaining({ type: "reconnecting", attempt: 1 }));
   });
 
+  it("resolves fresh remote credentials for heartbeats", async () => {
+    const controller = new AbortController();
+    const authorizationByPath: Array<{ path: string; authorization: string | null }> = [];
+    let token = "token-session";
+
+    await runProjectBindingSession({
+      projectRoot: "/repo",
+      remote: resolveCapletsRemote({ url: "https://cloud.caplets.dev", token: "token-start" }),
+      remoteResolver: async () => resolveCapletsRemote({ url: "https://cloud.caplets.dev", token }),
+      fetch: async (url, init) => {
+        authorizationByPath.push({
+          path: new URL(String(url)).pathname,
+          authorization: new Headers(init?.headers).get("authorization"),
+        });
+        if (String(url).endsWith("/sessions")) {
+          token = "token-heartbeat";
+          return Response.json(
+            { binding: { bindingId: "binding_1" }, sessionId: "binding_session_1" },
+            { status: 201 },
+          );
+        }
+        return Response.json({ ok: true });
+      },
+      webSocketFactory: () => new FakeProjectBindingSocket([]),
+      signal: controller.signal,
+      heartbeatIntervalMs: 60_000,
+      onEvent: (event) => {
+        if (event.type === "heartbeat") controller.abort();
+      },
+    });
+
+    expect(authorizationByPath).toEqual(
+      expect.arrayContaining([
+        {
+          path: "/v1/attach/project-bindings/sessions",
+          authorization: "Bearer token-session",
+        },
+        {
+          path: "/v1/attach/project-bindings/binding_1/heartbeat",
+          authorization: "Bearer token-heartbeat",
+        },
+      ]),
+    );
+  });
+
   it("cleans up once listeners in the on-event WebSocket fallback path", async () => {
     const controller = new AbortController();
     const socket = new FallbackProjectBindingSocket();

--- a/packages/core/test/remote-control-client.test.ts
+++ b/packages/core/test/remote-control-client.test.ts
@@ -67,7 +67,8 @@ describe("RemoteControlClient", () => {
 
     await expect(client.request("list", {})).rejects.toMatchObject({
       code: "AUTH_FAILED",
-      message: expect.stringContaining("CAPLETS_REMOTE_USER"),
+      message:
+        "Caplets remote authentication failed. Run caplets remote login https://example.com/caplets.",
     });
 
     try {

--- a/packages/core/test/remote-login-cli.test.ts
+++ b/packages/core/test/remote-login-cli.test.ts
@@ -84,25 +84,45 @@ describe("caplets remote CLI", () => {
     const authDir = tempDir("caplets-remote-cli-auth-");
     const server = new RemoteServerCredentialStore({ dir: tempDir("caplets-remote-cli-server-") });
     const issued = server.createPairingCode({ hostUrl: "https://caplets.example.com" });
+    let accessToken = "";
 
     await runCli(["remote", "login", "https://caplets.example.com", "--code", issued.code], {
       authDir,
-      fetch: async (_input, init) =>
-        Response.json(
-          server.exchangePairingCode({
-            hostUrl: "https://caplets.example.com/",
-            code: String(JSON.parse(String(init?.body)).code),
-          }),
-        ),
+      fetch: async (_input, init) => {
+        const credentials = server.exchangePairingCode({
+          hostUrl: "https://caplets.example.com/",
+          code: String(JSON.parse(String(init?.body)).code),
+        });
+        accessToken = credentials.accessToken;
+        return Response.json(credentials);
+      },
       writeOut: () => undefined,
     });
 
     const out: string[] = [];
     await runCli(["remote", "logout", "https://caplets.example.com"], {
       authDir,
+      fetch: async (input, init) => {
+        expect(String(input)).toBe("https://caplets.example.com/v1/remote/client");
+        expect(init?.method).toBe("DELETE");
+        expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${accessToken}`);
+        const revoked = server.revokeClient(
+          server.validateAccessToken({
+            hostUrl: "https://caplets.example.com/",
+            accessToken,
+          }).clientId,
+        );
+        return Response.json({ revoked });
+      },
       writeOut: (value) => out.push(value),
     });
     expect(out.join("")).toContain("Logged out");
+    expect(() =>
+      server.validateAccessToken({
+        hostUrl: "https://caplets.example.com/",
+        accessToken,
+      }),
+    ).toThrow(/revoked/u);
 
     const statusOut: string[] = [];
     await runCli(["remote", "status", "https://caplets.example.com", "--json"], {
@@ -115,6 +135,42 @@ describe("caplets remote CLI", () => {
       hostUrl: "https://caplets.example.com/",
       kind: "self-hosted",
     });
+  });
+
+  it("logs out a stored Cloud Remote Profile through Cloud logout", async () => {
+    const authDir = tempDir("caplets-remote-cli-auth-");
+    await new FileRemoteProfileStore({
+      root: join(authDir, "remote-profiles"),
+    }).saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "workspace_team",
+      workspaceSlug: "team",
+      credentials: {
+        accessToken: "cloud-access",
+        refreshToken: "cloud-refresh",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+      },
+    });
+    const requests: Array<{ url: string; body: unknown }> = [];
+
+    await runCli(["remote", "logout", "https://cloud.caplets.dev", "--json"], {
+      authDir,
+      fetch: async (input, init) => {
+        requests.push({
+          url: String(input),
+          body: JSON.parse(String(init?.body)),
+        });
+        return Response.json({});
+      },
+      writeOut: () => undefined,
+    });
+
+    expect(requests).toEqual([
+      {
+        url: "https://cloud.caplets.dev/api/cloud-client/logout",
+        body: { refreshToken: "cloud-refresh" },
+      },
+    ]);
   });
 
   it("prints paired self-hosted client labels without terminal control bytes", async () => {

--- a/packages/core/test/remote-login-cli.test.ts
+++ b/packages/core/test/remote-login-cli.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { runCli } from "../src/cli";
+import { FileRemoteProfileStore } from "../src/remote/profile-store";
 import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
 
 const dirs: string[] = [];
@@ -19,6 +20,7 @@ describe("caplets remote CLI", () => {
     const issued = server.createPairingCode({ hostUrl: "https://caplets.example.com/caplets" });
     const requests: Array<{ url: string; body: unknown }> = [];
     const out: string[] = [];
+    const err: string[] = [];
 
     await runCli(
       [
@@ -44,6 +46,7 @@ describe("caplets remote CLI", () => {
           return Response.json(credentials);
         },
         writeOut: (value) => out.push(value),
+        writeErr: (value) => err.push(value),
       },
     );
 
@@ -61,6 +64,8 @@ describe("caplets remote CLI", () => {
       clientLabel: "Test Device",
     });
     expect(out.join("")).not.toContain(issued.code);
+    expect(err.join("")).toContain("--code may store the Pairing Code in shell history");
+    expect(err.join("")).not.toContain(issued.code);
 
     const statusOut: string[] = [];
     await runCli(["remote", "status", "https://caplets.example.com/caplets", "--json"], {
@@ -110,6 +115,26 @@ describe("caplets remote CLI", () => {
       hostUrl: "https://caplets.example.com/",
       kind: "self-hosted",
     });
+  });
+
+  it("prints paired self-hosted client labels without terminal control bytes", async () => {
+    const serverStateDir = tempDir("caplets-remote-cli-server-");
+    const server = new RemoteServerCredentialStore({ dir: serverStateDir });
+    const issued = server.createPairingCode({ hostUrl: "https://caplets.example.com" });
+    server.exchangePairingCode({
+      hostUrl: "https://caplets.example.com",
+      code: issued.code,
+      clientLabel: `Bad${String.fromCharCode(0x1b)}[31mName${String.fromCharCode(0x07)}`,
+    });
+    const out: string[] = [];
+
+    await runCli(["remote", "host", "clients", "--state-path", serverStateDir], {
+      writeOut: (value) => out.push(value),
+    });
+
+    expect(out.join("")).not.toContain(String.fromCharCode(0x1b));
+    expect(out.join("")).not.toContain(String.fromCharCode(0x07));
+    expect(out.join("")).toContain("Bad?[31mName?");
   });
 
   it("routes Cloud login through Remote Profiles instead of legacy Cloud Auth", async () => {
@@ -181,6 +206,41 @@ describe("caplets remote CLI", () => {
       kind: "cloud",
       workspaceSlug: "team",
     });
+  });
+
+  it("lists saved Remote Profiles without requiring a host URL", async () => {
+    const authDir = tempDir("caplets-remote-cli-auth-");
+    await new FileRemoteProfileStore({
+      root: join(authDir, "remote-profiles"),
+    }).saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "rcli_123",
+      clientLabel: "Test Device",
+      credentials: {
+        accessToken: "self-hosted-access",
+        refreshToken: "self-hosted-refresh",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+      },
+    });
+    const out: string[] = [];
+
+    await runCli(["remote", "status", "--json"], {
+      authDir,
+      writeOut: (value) => out.push(value),
+    });
+
+    expect(JSON.parse(out.join(""))).toMatchObject({
+      profiles: [
+        {
+          authenticated: true,
+          kind: "self-hosted",
+          hostUrl: "https://caplets.example.com/caplets",
+          clientLabel: "Test Device",
+        },
+      ],
+    });
+    expect(out.join("")).not.toContain("self-hosted-access");
+    expect(out.join("")).not.toContain("self-hosted-refresh");
   });
 });
 

--- a/packages/core/test/remote-login-cli.test.ts
+++ b/packages/core/test/remote-login-cli.test.ts
@@ -137,6 +137,66 @@ describe("caplets remote CLI", () => {
     });
   });
 
+  it("refreshes expired self-hosted credentials before logout revoke", async () => {
+    const authDir = tempDir("caplets-remote-cli-auth-");
+    const server = new RemoteServerCredentialStore({ dir: tempDir("caplets-remote-cli-server-") });
+    const issued = server.createPairingCode({ hostUrl: "https://caplets.example.com" });
+    const credentials = server.exchangePairingCode({
+      hostUrl: "https://caplets.example.com/",
+      code: issued.code,
+    });
+    await new FileRemoteProfileStore({
+      root: join(authDir, "remote-profiles"),
+    }).saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com",
+      clientId: credentials.clientId,
+      clientLabel: credentials.clientLabel,
+      credentials: {
+        accessToken: "expired-access-token",
+        refreshToken: credentials.refreshToken,
+        expiresAt: "2026-06-19T00:00:00.000Z",
+      },
+    });
+    const requests: Array<{ path: string; authorization?: string | null }> = [];
+
+    await runCli(["remote", "logout", "https://caplets.example.com"], {
+      authDir,
+      fetch: async (input, init) => {
+        const url = new URL(String(input));
+        requests.push({
+          path: url.pathname,
+          authorization: new Headers(init?.headers).get("authorization"),
+        });
+        if (url.pathname.endsWith("/v1/remote/refresh")) {
+          const body = JSON.parse(String(init?.body)) as { refreshToken: string };
+          return Response.json(
+            server.refreshClientCredentials({
+              hostUrl: "https://caplets.example.com/",
+              refreshToken: body.refreshToken,
+            }),
+          );
+        }
+        const accessToken = new Headers(init?.headers)
+          .get("authorization")
+          ?.replace(/^Bearer /u, "");
+        const clientId = server.validateAccessToken({
+          hostUrl: "https://caplets.example.com/",
+          accessToken: accessToken ?? "",
+        }).clientId;
+        return Response.json({ revoked: server.revokeClient(clientId) });
+      },
+      writeOut: () => undefined,
+    });
+
+    expect(requests).toEqual([
+      { path: "/v1/remote/refresh", authorization: null },
+      {
+        path: "/v1/remote/client",
+        authorization: expect.stringMatching(/^Bearer (?!expired-access-token)/u),
+      },
+    ]);
+  });
+
   it("logs out a stored Cloud Remote Profile through Cloud logout", async () => {
     const authDir = tempDir("caplets-remote-cli-auth-");
     await new FileRemoteProfileStore({

--- a/packages/core/test/remote-login-cli.test.ts
+++ b/packages/core/test/remote-login-cli.test.ts
@@ -1,0 +1,191 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCli } from "../src/cli";
+import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("caplets remote CLI", () => {
+  it("logs into a self-hosted remote with a Pairing Code without storing the copied code", async () => {
+    const authDir = tempDir("caplets-remote-cli-auth-");
+    const serverStateDir = tempDir("caplets-remote-cli-server-");
+    const server = new RemoteServerCredentialStore({ dir: serverStateDir });
+    const issued = server.createPairingCode({ hostUrl: "https://caplets.example.com/caplets" });
+    const requests: Array<{ url: string; body: unknown }> = [];
+    const out: string[] = [];
+
+    await runCli(
+      [
+        "remote",
+        "login",
+        "https://caplets.example.com/caplets",
+        "--code",
+        issued.code,
+        "--client-label",
+        "Test Device",
+        "--json",
+      ],
+      {
+        authDir,
+        fetch: async (input, init) => {
+          const body = JSON.parse(String(init?.body)) as { code: string };
+          requests.push({ url: String(input), body });
+          const credentials = server.exchangePairingCode({
+            hostUrl: "https://caplets.example.com/caplets",
+            code: body.code,
+            clientLabel: "Test Device",
+          });
+          return Response.json(credentials);
+        },
+        writeOut: (value) => out.push(value),
+      },
+    );
+
+    expect(requests).toEqual([
+      {
+        url: "https://caplets.example.com/caplets/v1/remote/pairing/exchange",
+        body: { code: issued.code, clientLabel: "Test Device" },
+      },
+    ]);
+    expect(JSON.parse(out.join(""))).toMatchObject({
+      authenticated: true,
+      kind: "self-hosted",
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: expect.any(String),
+      clientLabel: "Test Device",
+    });
+    expect(out.join("")).not.toContain(issued.code);
+
+    const statusOut: string[] = [];
+    await runCli(["remote", "status", "https://caplets.example.com/caplets", "--json"], {
+      authDir,
+      writeOut: (value) => statusOut.push(value),
+    });
+    expect(JSON.parse(statusOut.join(""))).toMatchObject({
+      authenticated: true,
+      kind: "self-hosted",
+      clientLabel: "Test Device",
+    });
+    expect(statusOut.join("")).not.toContain(issued.code);
+  });
+
+  it("logs out a stored self-hosted remote profile", async () => {
+    const authDir = tempDir("caplets-remote-cli-auth-");
+    const server = new RemoteServerCredentialStore({ dir: tempDir("caplets-remote-cli-server-") });
+    const issued = server.createPairingCode({ hostUrl: "https://caplets.example.com" });
+
+    await runCli(["remote", "login", "https://caplets.example.com", "--code", issued.code], {
+      authDir,
+      fetch: async (_input, init) =>
+        Response.json(
+          server.exchangePairingCode({
+            hostUrl: "https://caplets.example.com/",
+            code: String(JSON.parse(String(init?.body)).code),
+          }),
+        ),
+      writeOut: () => undefined,
+    });
+
+    const out: string[] = [];
+    await runCli(["remote", "logout", "https://caplets.example.com"], {
+      authDir,
+      writeOut: (value) => out.push(value),
+    });
+    expect(out.join("")).toContain("Logged out");
+
+    const statusOut: string[] = [];
+    await runCli(["remote", "status", "https://caplets.example.com", "--json"], {
+      authDir,
+      writeOut: (value) => statusOut.push(value),
+    });
+    expect(JSON.parse(statusOut.join(""))).toEqual({
+      authenticated: false,
+      status: "unauthenticated",
+      hostUrl: "https://caplets.example.com/",
+      kind: "self-hosted",
+    });
+  });
+
+  it("routes Cloud login through Remote Profiles instead of legacy Cloud Auth", async () => {
+    const authDir = tempDir("caplets-remote-cli-auth-");
+    const responses = [
+      Response.json({
+        loginId: "login_123",
+        loginUrl: "https://cloud.caplets.dev/cli-login/login_123",
+        userCode: "ABCD-EFGH",
+        expiresAt: "2026-06-19T12:10:00.000Z",
+      }),
+      Response.json({
+        status: "completed",
+        selectedWorkspace: { workspaceId: "workspace_team", slug: "team" },
+        oneTimeCode: "one_time_code_secret",
+      }),
+      Response.json({
+        status: "authenticated",
+        cloudUrl: "https://cloud.caplets.dev",
+        workspaceId: "workspace_team",
+        workspaceSlug: "team",
+        accessToken: "cap_access_secret",
+        refreshToken: "cap_refresh_secret",
+        expiresAt: "2099-06-19T13:00:00.000Z",
+        scope: ["project_binding:read", "project_binding:write", "mcp:tools"],
+        tokenType: "Bearer",
+        credentialFamilyId: "family_123",
+        deviceName: "Test Device",
+      }),
+    ];
+    const out: string[] = [];
+
+    await runCli(
+      [
+        "remote",
+        "login",
+        "https://cloud.caplets.dev",
+        "--workspace",
+        "team",
+        "--no-open",
+        "--json",
+      ],
+      {
+        authDir,
+        env: { CAPLETS_CLOUD_AUTH_POLL_INTERVAL_MS: "0" },
+        fetch: async () => responses.shift() ?? Response.json({}, { status: 500 }),
+        writeOut: (value) => out.push(value),
+      },
+    );
+
+    expect(JSON.parse(out.join(""))).toMatchObject({
+      authenticated: true,
+      kind: "cloud",
+      hostUrl: "https://cloud.caplets.dev/",
+      workspaceId: "workspace_team",
+      workspaceSlug: "team",
+      selected: true,
+    });
+    expect(out.join("")).not.toContain("cap_access_secret");
+    expect(out.join("")).not.toContain("cap_refresh_secret");
+
+    const statusOut: string[] = [];
+    await runCli(["remote", "status", "https://cloud.caplets.dev", "--json"], {
+      authDir,
+      writeOut: (value) => statusOut.push(value),
+    });
+    expect(JSON.parse(statusOut.join(""))).toMatchObject({
+      authenticated: true,
+      kind: "cloud",
+      workspaceSlug: "team",
+    });
+  });
+});
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  dirs.push(dir);
+  return dir;
+}

--- a/packages/core/test/remote-options.test.ts
+++ b/packages/core/test/remote-options.test.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import { describe, expect, it } from "vitest";
 import type { CapletsError } from "../src/errors";
 import {
@@ -84,16 +83,13 @@ describe("resolveRemoteMode", () => {
 });
 
 describe("resolveCapletsRemote", () => {
-  it("derives remote service URLs and Basic Auth from CAPLETS_REMOTE variables", () => {
-    const password = "remote-password";
-    const resolved = resolveCapletsRemote(
-      {},
-      {
-        CAPLETS_REMOTE_URL: "https://example.com/caplets/",
-        CAPLETS_REMOTE_USER: "env-user",
-        CAPLETS_REMOTE_PASSWORD: password,
-      },
-    );
+  it("derives remote service URLs without reading legacy credential env vars", () => {
+    const resolved = resolveCapletsRemote({}, {
+      CAPLETS_REMOTE_URL: "https://example.com/caplets/",
+      CAPLETS_REMOTE_USER: "env-user",
+      CAPLETS_REMOTE_PASSWORD: "remote-password",
+      CAPLETS_REMOTE_TOKEN: "remote-token",
+    } as Record<string, string>);
 
     expect(resolved).toMatchObject({
       baseUrl: new URL("https://example.com/caplets"),
@@ -104,12 +100,10 @@ describe("resolveCapletsRemote", () => {
       projectBindingWebSocketUrl: new URL(
         "wss://example.com/caplets/v1/attach/project-bindings/connect",
       ),
-      auth: { type: "basic", user: "env-user", password },
+      auth: { type: "none", user: "caplets" },
     });
     expect(resolved.workspace).toBeUndefined();
-    expect(new Headers(resolved.requestInit.headers).get("authorization")).toBe(
-      `Basic ${Buffer.from(`env-user:${password}`).toString("base64")}`,
-    );
+    expect(new Headers(resolved.requestInit.headers).get("authorization")).toBeNull();
   });
 
   it("derives attach URL from self-hosted remote base paths", () => {
@@ -118,7 +112,7 @@ describe("resolveCapletsRemote", () => {
     ).toEqual(new URL("https://host.example/base/v1/attach"));
   });
 
-  it("supports bearer token and workspace settings", () => {
+  it("supports issued bearer token and workspace settings from trusted callers", () => {
     const resolved = resolveCapletsRemote(
       { token: "input-token", workspace: "team" },
       { CAPLETS_REMOTE_URL: "https://example.com" },
@@ -129,15 +123,6 @@ describe("resolveCapletsRemote", () => {
     expect(new Headers(resolved.requestInit.headers).get("authorization")).toBe(
       "Bearer input-token",
     );
-  });
-
-  it("references CAPLETS_REMOTE_TOKEN or Basic Auth vars for self-hosted auth failures", () => {
-    expect(() =>
-      resolveCapletsRemote(
-        { user: "caplets" },
-        { CAPLETS_REMOTE_URL: "https://caplets.example.com/caplets" },
-      ),
-    ).toThrow(/CAPLETS_REMOTE_PASSWORD/u);
   });
 });
 

--- a/packages/core/test/remote-pairing.test.ts
+++ b/packages/core/test/remote-pairing.test.ts
@@ -84,13 +84,18 @@ describe("self-hosted remote pairing", () => {
     );
     for (let attempt = 0; attempt < 2; attempt += 1) {
       expect(() =>
-        store.exchangePairingCode({ hostUrl: "https://caplets.example.com", code: badCode }),
+        store.exchangePairingCode({
+          hostUrl: "https://caplets.example.com",
+          code: badCode,
+          now: new Date("2026-06-19T12:00:00.000Z"),
+        }),
       ).toThrow(CapletsError);
     }
     expect(() =>
       store.exchangePairingCode({
         hostUrl: "https://caplets.example.com",
         code: exhausted.code,
+        now: new Date("2026-06-19T12:00:00.000Z"),
       }),
     ).toThrow(/attempts/u);
   });

--- a/packages/core/test/remote-pairing.test.ts
+++ b/packages/core/test/remote-pairing.test.ts
@@ -139,7 +139,7 @@ describe("self-hosted remote pairing", () => {
     ).toThrow(/revoked/u);
   });
 
-  it("rotates refresh tokens once and invalidates the family on stale reuse", () => {
+  it("rotates refresh tokens once and invalidates the family on delayed stale reuse", () => {
     const store = new RemoteServerCredentialStore({ dir: tempDir() });
     const issued = store.createPairingCode({
       hostUrl: "https://caplets.example.com",
@@ -172,6 +172,40 @@ describe("self-hosted remote pairing", () => {
         now: new Date("2026-06-19T12:04:00.000Z"),
       }),
     ).toThrow(/revoked/u);
+  });
+
+  it("does not revoke a client on immediate stale refresh retry", () => {
+    const store = new RemoteServerCredentialStore({ dir: tempDir() });
+    const issued = store.createPairingCode({
+      hostUrl: "https://caplets.example.com",
+      now: new Date("2026-06-19T12:00:00.000Z"),
+    });
+    const credentials = store.exchangePairingCode({
+      hostUrl: "https://caplets.example.com",
+      code: issued.code,
+      now: new Date("2026-06-19T12:01:00.000Z"),
+    });
+
+    const refreshed = store.refreshClientCredentials({
+      hostUrl: "https://caplets.example.com",
+      refreshToken: credentials.refreshToken,
+      now: new Date("2026-06-19T12:02:00.000Z"),
+    });
+
+    expect(() =>
+      store.refreshClientCredentials({
+        hostUrl: "https://caplets.example.com",
+        refreshToken: credentials.refreshToken,
+        now: new Date("2026-06-19T12:02:05.000Z"),
+      }),
+    ).toThrow(/stale/u);
+    expect(
+      store.validateAccessToken({
+        hostUrl: "https://caplets.example.com",
+        accessToken: refreshed.accessToken,
+        now: new Date("2026-06-19T12:02:10.000Z"),
+      }),
+    ).toMatchObject({ clientId: credentials.clientId });
   });
 
   it("validates access tokens without rewriting server credential state", () => {

--- a/packages/core/test/remote-pairing.test.ts
+++ b/packages/core/test/remote-pairing.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -235,6 +235,48 @@ describe("self-hosted remote pairing", () => {
     });
 
     expect(readFileSync(statePath, "utf8")).toBe(before);
+  });
+
+  it("prunes superseded refresh token hashes after the retention window", () => {
+    const store = new RemoteServerCredentialStore({ dir: tempDir() });
+    const issued = store.createPairingCode({
+      hostUrl: "https://caplets.example.com",
+      now: new Date("2026-06-19T12:00:00.000Z"),
+    });
+    const credentials = store.exchangePairingCode({
+      hostUrl: "https://caplets.example.com",
+      code: issued.code,
+      now: new Date("2026-06-19T12:01:00.000Z"),
+    });
+    const firstRefresh = store.refreshClientCredentials({
+      hostUrl: "https://caplets.example.com",
+      refreshToken: credentials.refreshToken,
+      now: new Date("2026-06-19T12:02:00.000Z"),
+    });
+
+    store.refreshClientCredentials({
+      hostUrl: "https://caplets.example.com",
+      refreshToken: firstRefresh.refreshToken,
+      now: new Date("2026-06-20T13:02:00.000Z"),
+    });
+
+    const client = store.dumpForTest().clients[0] as {
+      supersededRefreshTokenHashes: unknown[];
+    };
+    expect(client.supersededRefreshTokenHashes).toHaveLength(1);
+  });
+
+  it("recovers stale server credential locks left by crashed processes", () => {
+    const dir = tempDir();
+    const lockPath = join(dir, "remote-server-credentials.lock");
+    mkdirSync(lockPath, { recursive: true });
+    const staleTime = new Date(Date.now() - 60_000);
+    utimesSync(lockPath, staleTime, staleTime);
+    const store = new RemoteServerCredentialStore({ dir });
+
+    expect(store.createPairingCode({ hostUrl: "https://caplets.example.com" })).toMatchObject({
+      codeId: expect.any(String),
+    });
   });
 
   it("creates private server-owned state files where supported", () => {

--- a/packages/core/test/remote-pairing.test.ts
+++ b/packages/core/test/remote-pairing.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -87,7 +87,7 @@ describe("self-hosted remote pairing", () => {
         store.exchangePairingCode({
           hostUrl: "https://caplets.example.com",
           code: badCode,
-          now: new Date("2026-06-19T12:00:00.000Z"),
+          now: new Date("2026-06-19T12:01:00.000Z"),
         }),
       ).toThrow(CapletsError);
     }
@@ -95,7 +95,7 @@ describe("self-hosted remote pairing", () => {
       store.exchangePairingCode({
         hostUrl: "https://caplets.example.com",
         code: exhausted.code,
-        now: new Date("2026-06-19T12:00:00.000Z"),
+        now: new Date("2026-06-19T12:01:00.000Z"),
       }),
     ).toThrow(/attempts/u);
   });
@@ -172,6 +172,35 @@ describe("self-hosted remote pairing", () => {
         now: new Date("2026-06-19T12:04:00.000Z"),
       }),
     ).toThrow(/revoked/u);
+  });
+
+  it("validates access tokens without rewriting server credential state", () => {
+    const dir = tempDir();
+    const store = new RemoteServerCredentialStore({ dir });
+    const issued = store.createPairingCode({
+      hostUrl: "https://caplets.example.com",
+      now: new Date("2026-06-19T12:00:00.000Z"),
+    });
+    const credentials = store.exchangePairingCode({
+      hostUrl: "https://caplets.example.com",
+      code: issued.code,
+      now: new Date("2026-06-19T12:01:00.000Z"),
+    });
+    const statePath = join(dir, "remote-server-credentials.json");
+    const before = readFileSync(statePath, "utf8");
+
+    expect(
+      store.validateAccessToken({
+        hostUrl: "https://caplets.example.com",
+        accessToken: credentials.accessToken,
+        now: new Date("2026-06-19T12:02:00.000Z"),
+      }),
+    ).toMatchObject({
+      clientId: credentials.clientId,
+      tokenType: "Bearer",
+    });
+
+    expect(readFileSync(statePath, "utf8")).toBe(before);
   });
 
   it("creates private server-owned state files where supported", () => {

--- a/packages/core/test/remote-pairing.test.ts
+++ b/packages/core/test/remote-pairing.test.ts
@@ -1,0 +1,188 @@
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CapletsError } from "../src/errors";
+import { createPairingCodeVerifier, isPairingCodeFormat } from "../src/remote/pairing";
+import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("self-hosted remote pairing", () => {
+  it("issues one-time Pairing Codes that exchange for client credentials", () => {
+    const store = new RemoteServerCredentialStore({ dir: tempDir() });
+    const issued = store.createPairingCode({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientLabel: "MacBook Pro",
+      now: new Date("2026-06-19T12:00:00.000Z"),
+    });
+
+    expect(isPairingCodeFormat(issued.code)).toBe(true);
+    expect(JSON.stringify(store.dumpForTest())).not.toContain(issued.code);
+
+    const exchanged = store.exchangePairingCode({
+      hostUrl: "https://caplets.example.com/caplets",
+      code: issued.code,
+      clientLabel: "MacBook Pro",
+      now: new Date("2026-06-19T12:01:00.000Z"),
+    });
+
+    expect(exchanged).toMatchObject({
+      clientLabel: "MacBook Pro",
+      hostUrl: "https://caplets.example.com/caplets",
+      tokenType: "Bearer",
+    });
+    expect(exchanged.accessToken).not.toBe(issued.code);
+    expect(exchanged.refreshToken).not.toBe(issued.code);
+
+    expect(() =>
+      store.exchangePairingCode({
+        hostUrl: "https://caplets.example.com/caplets",
+        code: issued.code,
+      }),
+    ).toThrow(/used/u);
+  });
+
+  it("rejects expired, wrong-host, and attempt-exhausted Pairing Codes", () => {
+    const store = new RemoteServerCredentialStore({ dir: tempDir() });
+    const expired = store.createPairingCode({
+      hostUrl: "https://caplets.example.com",
+      ttlMs: 1_000,
+      now: new Date("2026-06-19T12:00:00.000Z"),
+    });
+    expect(() =>
+      store.exchangePairingCode({
+        hostUrl: "https://caplets.example.com",
+        code: expired.code,
+        now: new Date("2026-06-19T12:00:02.000Z"),
+      }),
+    ).toThrow(/expired/u);
+
+    const wrongHost = store.createPairingCode({
+      hostUrl: "https://caplets.example.com",
+      now: new Date("2026-06-19T12:00:00.000Z"),
+    });
+    expect(() =>
+      store.exchangePairingCode({
+        hostUrl: "https://other.example.com",
+        code: wrongHost.code,
+      }),
+    ).toThrow(/host/u);
+
+    const exhausted = store.createPairingCode({
+      hostUrl: "https://caplets.example.com",
+      maxAttempts: 2,
+      now: new Date("2026-06-19T12:00:00.000Z"),
+    });
+    const badCode = createPairingCodeVerifier(
+      exhausted.codeId,
+      "wrong-secret-value-that-is-long-enough",
+    );
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      expect(() =>
+        store.exchangePairingCode({ hostUrl: "https://caplets.example.com", code: badCode }),
+      ).toThrow(CapletsError);
+    }
+    expect(() =>
+      store.exchangePairingCode({
+        hostUrl: "https://caplets.example.com",
+        code: exhausted.code,
+      }),
+    ).toThrow(/attempts/u);
+  });
+
+  it("lists, persists, and revokes paired clients without exposing secrets", () => {
+    const dir = tempDir();
+    const store = new RemoteServerCredentialStore({ dir });
+    const issued = store.createPairingCode({
+      hostUrl: "https://caplets.example.com",
+      now: new Date("2026-06-19T12:00:00.000Z"),
+    });
+    const credentials = store.exchangePairingCode({
+      hostUrl: "https://caplets.example.com",
+      code: issued.code,
+      clientLabel: "CI Runner",
+      now: new Date("2026-06-19T12:00:00.000Z"),
+    });
+
+    const restarted = new RemoteServerCredentialStore({ dir });
+    expect(restarted.listClients()).toEqual([
+      expect.objectContaining({
+        clientId: credentials.clientId,
+        clientLabel: "CI Runner",
+      }),
+    ]);
+    expect(restarted.listClients()[0]).not.toHaveProperty("revokedAt");
+    expect(JSON.stringify(restarted.listClients())).not.toContain(credentials.accessToken);
+    expect(JSON.stringify(restarted.listClients())).not.toContain(credentials.refreshToken);
+
+    restarted.validateAccessToken({
+      hostUrl: "https://caplets.example.com",
+      accessToken: credentials.accessToken,
+      now: new Date("2026-06-19T12:01:00.000Z"),
+    });
+    restarted.revokeClient(credentials.clientId, new Date("2026-06-19T12:02:00.000Z"));
+    expect(() =>
+      restarted.validateAccessToken({
+        hostUrl: "https://caplets.example.com",
+        accessToken: credentials.accessToken,
+      }),
+    ).toThrow(/revoked/u);
+  });
+
+  it("rotates refresh tokens once and invalidates the family on stale reuse", () => {
+    const store = new RemoteServerCredentialStore({ dir: tempDir() });
+    const issued = store.createPairingCode({
+      hostUrl: "https://caplets.example.com",
+      now: new Date("2026-06-19T12:00:00.000Z"),
+    });
+    const credentials = store.exchangePairingCode({
+      hostUrl: "https://caplets.example.com",
+      code: issued.code,
+      now: new Date("2026-06-19T12:01:00.000Z"),
+    });
+
+    const refreshed = store.refreshClientCredentials({
+      hostUrl: "https://caplets.example.com",
+      refreshToken: credentials.refreshToken,
+      now: new Date("2026-06-19T12:02:00.000Z"),
+    });
+
+    expect(refreshed.refreshToken).not.toBe(credentials.refreshToken);
+    expect(() =>
+      store.refreshClientCredentials({
+        hostUrl: "https://caplets.example.com",
+        refreshToken: credentials.refreshToken,
+        now: new Date("2026-06-19T12:03:00.000Z"),
+      }),
+    ).toThrow(/stale/u);
+    expect(() =>
+      store.validateAccessToken({
+        hostUrl: "https://caplets.example.com",
+        accessToken: refreshed.accessToken,
+        now: new Date("2026-06-19T12:04:00.000Z"),
+      }),
+    ).toThrow(/revoked/u);
+  });
+
+  it("creates private server-owned state files where supported", () => {
+    const dir = tempDir();
+    const store = new RemoteServerCredentialStore({ dir });
+    store.createPairingCode({ hostUrl: "https://caplets.example.com" });
+
+    if (process.platform !== "win32") {
+      expect(statSync(dir).mode & 0o777).toBe(0o700);
+      expect(statSync(join(dir, "remote-server-credentials.json")).mode & 0o777).toBe(0o600);
+    }
+  });
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "caplets-remote-pairing-"));
+  dirs.push(dir);
+  return dir;
+}

--- a/packages/core/test/remote-profiles.test.ts
+++ b/packages/core/test/remote-profiles.test.ts
@@ -263,6 +263,54 @@ describe("Remote Profile storage", () => {
       ),
     ).resolves.toMatchObject({ accessToken: "legacy_access", refreshToken: "legacy_refresh" });
   });
+
+  it("clears matching legacy Cloud Auth when logging out a migrated Cloud Remote Profile", async () => {
+    const legacyPath = join(tempDir("caplets-cloud-auth-"), "cloud-auth.json");
+    const legacy = new CloudAuthStore({ path: legacyPath });
+    await legacy.save({
+      ...legacyCloudCredentials,
+      cloudUrl: "https://cloud.caplets.dev",
+      workspaceSlug: "team",
+    });
+    const store = tempRemoteProfileStore({ legacyCloudAuthStore: legacy });
+    await store.getCloudProfileStatus({
+      hostUrl: "https://cloud.caplets.dev",
+      workspace: "team",
+    });
+
+    await expect(
+      store.logoutCloudProfile({ hostUrl: "https://cloud.caplets.dev", workspace: "team" }),
+    ).resolves.toBe(true);
+
+    expect(existsSync(legacyPath)).toBe(false);
+    await expect(
+      store.getCloudProfileStatus({ hostUrl: "https://cloud.caplets.dev", workspace: "team" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps mismatched legacy Cloud Auth when logging out a different workspace profile", async () => {
+    const legacyPath = join(tempDir("caplets-cloud-auth-"), "cloud-auth.json");
+    const legacy = new CloudAuthStore({ path: legacyPath });
+    await legacy.save({
+      ...legacyCloudCredentials,
+      cloudUrl: "https://cloud.caplets.dev",
+      workspaceId: "ws_other",
+      workspaceSlug: "other",
+    });
+    const store = tempRemoteProfileStore({ legacyCloudAuthStore: legacy });
+    await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "ws_123",
+      workspaceSlug: "team",
+      credentials: cloudCredentials,
+    });
+
+    await expect(
+      store.logoutCloudProfile({ hostUrl: "https://cloud.caplets.dev", workspace: "team" }),
+    ).resolves.toBe(true);
+
+    expect(existsSync(legacyPath)).toBe(true);
+  });
 });
 
 describe("Remote Profile helpers", () => {

--- a/packages/core/test/remote-profiles.test.ts
+++ b/packages/core/test/remote-profiles.test.ts
@@ -29,6 +29,83 @@ afterEach(() => {
 });
 
 describe("Remote Profile storage", () => {
+  it("saves a self-hosted profile with redacted status and credential storage", async () => {
+    const store = tempRemoteProfileStore();
+
+    const status = await store.saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets/",
+      clientId: "rcli_123",
+      clientLabel: "Ian's MacBook",
+      credentials: {
+        accessToken: "self_hosted_access_secret",
+        refreshToken: "self_hosted_refresh_secret",
+        tokenType: "Bearer",
+        expiresAt: "2099-06-19T12:00:00.000Z",
+      },
+      now: new Date("2026-06-19T10:00:00.000Z"),
+    });
+
+    expect(status).toEqual({
+      authenticated: true,
+      kind: "self-hosted",
+      key: remoteProfileKey({
+        kind: "self-hosted",
+        hostUrl: "https://caplets.example.com/caplets",
+      }),
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "rcli_123",
+      selected: false,
+      clientLabel: "Ian's MacBook",
+      createdAt: "2026-06-19T10:00:00.000Z",
+      updatedAt: "2026-06-19T10:00:00.000Z",
+      expiresAt: "2099-06-19T12:00:00.000Z",
+      tokenType: "Bearer",
+    });
+    expect(JSON.stringify(status)).not.toContain("self_hosted_access_secret");
+    expect(JSON.stringify(status)).not.toContain("self_hosted_refresh_secret");
+
+    await expect(
+      store.getSelfHostedProfileStatus({ hostUrl: "https://caplets.example.com/caplets" }),
+    ).resolves.toMatchObject({ clientId: "rcli_123", clientLabel: "Ian's MacBook" });
+    await expect(
+      store.credentials.load(
+        remoteProfileKey({
+          kind: "self-hosted",
+          hostUrl: "https://caplets.example.com/caplets",
+        }),
+      ),
+    ).resolves.toMatchObject({ accessToken: "self_hosted_access_secret" });
+  });
+
+  it("logs out a self-hosted profile without touching Cloud profiles", async () => {
+    const store = tempRemoteProfileStore();
+    await store.saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com",
+      clientId: "rcli_123",
+      credentials: {
+        accessToken: "self_hosted_access_secret",
+        refreshToken: "self_hosted_refresh_secret",
+      },
+    });
+    await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "ws_123",
+      workspaceSlug: "team",
+      credentials: cloudCredentials,
+    });
+
+    await expect(
+      store.logoutSelfHostedProfile({ hostUrl: "https://caplets.example.com" }),
+    ).resolves.toBe(true);
+
+    await expect(
+      store.getSelfHostedProfileStatus({ hostUrl: "https://caplets.example.com" }),
+    ).resolves.toBeUndefined();
+    await expect(
+      store.getCloudProfileStatus({ hostUrl: "https://cloud.caplets.dev" }),
+    ).resolves.toMatchObject({ workspaceSlug: "team" });
+  });
+
   it("saves a Cloud profile with redacted status and selected workspace pointer", async () => {
     const store = tempRemoteProfileStore();
 

--- a/packages/core/test/remote-profiles.test.ts
+++ b/packages/core/test/remote-profiles.test.ts
@@ -208,6 +208,47 @@ describe("Remote Profile storage", () => {
     ).rejects.toThrow(expect.objectContaining({ code: "REQUEST_INVALID" }) as CapletsError);
   });
 
+  it("refreshes explicit Cloud workspaces without changing the selected workspace", async () => {
+    const store = tempRemoteProfileStore();
+    await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "ws_alpha",
+      workspaceSlug: "alpha",
+      credentials: { ...cloudCredentials, accessToken: "alpha_access" },
+    });
+    await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "ws_beta",
+      workspaceSlug: "beta",
+      credentials: { ...cloudCredentials, accessToken: "beta_access" },
+    });
+
+    const refreshed = await store.refreshCloudProfileIfNeeded({
+      hostUrl: "https://cloud.caplets.dev/v1/ws/alpha/mcp",
+      needsRefresh: () => true,
+      refresh: async (status) => ({
+        hostUrl: status.hostUrl,
+        workspaceId: status.workspaceId ?? "",
+        ...(status.workspaceSlug ? { workspaceSlug: status.workspaceSlug } : {}),
+        credentials: { ...cloudCredentials, accessToken: "alpha_refreshed" },
+      }),
+    });
+
+    expect(refreshed?.status).toMatchObject({ workspaceSlug: "alpha", selected: false });
+    await expect(
+      store.getCloudProfileStatus({ hostUrl: "https://cloud.caplets.dev" }),
+    ).resolves.toMatchObject({ workspaceSlug: "beta", selected: true });
+    await expect(
+      store.credentials.load(
+        remoteProfileKey({
+          kind: "cloud",
+          hostUrl: "https://cloud.caplets.dev/",
+          workspace: "alpha",
+        }),
+      ),
+    ).resolves.toMatchObject({ accessToken: "alpha_refreshed" });
+  });
+
   it("recovers stale mutation locks left by crashed processes", async () => {
     const root = tempDir("caplets-remote-profiles-");
     const lockPath = join(root, "remote-profiles.lock");
@@ -333,6 +374,29 @@ describe("Remote Profile storage", () => {
 
     await expect(
       store.logoutCloudProfile({ hostUrl: "https://cloud.caplets.dev", workspace: "team" }),
+    ).resolves.toBe(true);
+
+    expect(existsSync(legacyPath)).toBe(true);
+  });
+
+  it("keeps no-slug legacy Cloud Auth when logging out a different no-slug workspace", async () => {
+    const legacyPath = join(tempDir("caplets-cloud-auth-"), "cloud-auth.json");
+    const legacy = new CloudAuthStore({ path: legacyPath });
+    const { workspaceSlug: _workspaceSlug, ...legacyWithoutSlug } = legacyCloudCredentials;
+    await legacy.save({
+      ...legacyWithoutSlug,
+      cloudUrl: "https://cloud.caplets.dev",
+      workspaceId: "ws_legacy",
+    });
+    const store = tempRemoteProfileStore({ legacyCloudAuthStore: legacy });
+    await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "ws_profile",
+      credentials: cloudCredentials,
+    });
+
+    await expect(
+      store.logoutCloudProfile({ hostUrl: "https://cloud.caplets.dev", workspace: "ws_profile" }),
     ).resolves.toBe(true);
 
     expect(existsSync(legacyPath)).toBe(true);

--- a/packages/core/test/remote-profiles.test.ts
+++ b/packages/core/test/remote-profiles.test.ts
@@ -1,0 +1,251 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CloudAuthStore, type CloudAuthCredentials } from "../src/cloud-auth/store";
+import { CapletsError } from "../src/errors";
+import { FileRemoteCredentialStore } from "../src/remote/credential-store";
+import { FileRemoteProfileStore } from "../src/remote/profile-store";
+import {
+  remoteProfileKey,
+  remoteProfileStatus,
+  selectedWorkspaceKey,
+} from "../src/remote/profiles";
+
+const tempDirs: string[] = [];
+
+const cloudCredentials = {
+  accessToken: "access_secret",
+  refreshToken: "refresh_secret",
+  expiresAt: "2099-06-19T12:00:00.000Z",
+  scope: ["mcp:tools"],
+  tokenType: "Bearer",
+  clientSecret: "client_secret",
+  pairingCode: "pairing_code",
+};
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("Remote Profile storage", () => {
+  it("saves a Cloud profile with redacted status and selected workspace pointer", async () => {
+    const store = tempRemoteProfileStore();
+
+    const status = await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev/v1/ws/team/mcp",
+      workspaceId: "ws_123",
+      workspaceSlug: "team",
+      clientLabel: "Ian's MacBook",
+      credentials: cloudCredentials,
+      now: new Date("2026-06-19T10:00:00.000Z"),
+    });
+
+    expect(status).toEqual({
+      authenticated: true,
+      kind: "cloud",
+      key: remoteProfileKey({
+        kind: "cloud",
+        hostUrl: "https://cloud.caplets.dev/",
+        workspace: "team",
+      }),
+      hostUrl: "https://cloud.caplets.dev/",
+      workspaceId: "ws_123",
+      workspaceSlug: "team",
+      selected: true,
+      clientLabel: "Ian's MacBook",
+      createdAt: "2026-06-19T10:00:00.000Z",
+      updatedAt: "2026-06-19T10:00:00.000Z",
+      expiresAt: "2099-06-19T12:00:00.000Z",
+      scope: ["mcp:tools"],
+      tokenType: "Bearer",
+    });
+    expect(JSON.stringify(status)).not.toContain("access_secret");
+    expect(JSON.stringify(status)).not.toContain("refresh_secret");
+    expect(JSON.stringify(status)).not.toContain("client_secret");
+    expect(JSON.stringify(status)).not.toContain("pairing_code");
+    await expect(
+      store.getCloudProfileStatus({ hostUrl: "https://cloud.caplets.dev" }),
+    ).resolves.toMatchObject({ workspaceSlug: "team", selected: true });
+  });
+
+  it("keeps Cloud workspaces distinct under one host and only logs out the selected profile", async () => {
+    const store = tempRemoteProfileStore();
+    await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "ws_a",
+      workspaceSlug: "alpha",
+      credentials: { ...cloudCredentials, accessToken: "alpha_access" },
+    });
+    await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "ws_b",
+      workspaceSlug: "beta",
+      credentials: { ...cloudCredentials, accessToken: "beta_access" },
+    });
+
+    expect(await store.listCloudProfileStatuses("https://cloud.caplets.dev")).toEqual([
+      expect.objectContaining({ workspaceSlug: "alpha", selected: false }),
+      expect.objectContaining({ workspaceSlug: "beta", selected: true }),
+    ]);
+
+    await store.logoutCloudProfile({ hostUrl: "https://cloud.caplets.dev" });
+
+    expect(await store.listCloudProfileStatuses("https://cloud.caplets.dev")).toEqual([
+      expect.objectContaining({ workspaceSlug: "alpha", selected: false }),
+    ]);
+    await expect(
+      store.credentials.load(
+        remoteProfileKey({
+          kind: "cloud",
+          hostUrl: "https://cloud.caplets.dev/",
+          workspace: "alpha",
+        }),
+      ),
+    ).resolves.toMatchObject({ accessToken: "alpha_access" });
+  });
+
+  it("requires an explicit workspace before mutating a bare Cloud host with no selected workspace", async () => {
+    const store = tempRemoteProfileStore();
+    await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "ws_a",
+      workspaceSlug: "alpha",
+      credentials: cloudCredentials,
+    });
+    await store.clearSelectedCloudWorkspace("https://cloud.caplets.dev");
+
+    await expect(
+      store.getCloudProfileStatus({ hostUrl: "https://cloud.caplets.dev" }),
+    ).rejects.toThrow(expect.objectContaining({ code: "REQUEST_INVALID" }) as CapletsError);
+    await expect(
+      store.logoutCloudProfile({ hostUrl: "https://cloud.caplets.dev" }),
+    ).rejects.toThrow(expect.objectContaining({ code: "REQUEST_INVALID" }) as CapletsError);
+  });
+
+  it("rejects credential-bearing remote URLs before persisting profile data", async () => {
+    const root = tempDir("caplets-remote-profiles-");
+    const store = new FileRemoteProfileStore({ root });
+
+    await expect(
+      store.saveCloudProfile({
+        hostUrl: "https://user:pass@cloud.caplets.dev/v1/ws/team/mcp?token=query#refresh",
+        workspaceId: "ws_123",
+        workspaceSlug: "team",
+        credentials: cloudCredentials,
+      }),
+    ).rejects.toThrow(expect.objectContaining({ code: "REQUEST_INVALID" }) as CapletsError);
+    expect(readdirSync(root)).toEqual([]);
+  });
+
+  it("creates private directories and credential files with restrictive permissions", async () => {
+    const root = tempDir("caplets-remote-credentials-");
+    const credentials = new FileRemoteCredentialStore({ root });
+
+    await credentials.save("profile-key", cloudCredentials);
+
+    expect(await credentials.load("profile-key")).toEqual(cloudCredentials);
+    if (process.platform !== "win32") {
+      expect(statSync(root).mode & 0o777).toBe(0o700);
+      expect(statSync(credentials.pathForKey("profile-key")).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("migrates legacy Cloud Auth through the remote profile store without deleting legacy state", async () => {
+    const legacyPath = join(tempDir("caplets-cloud-auth-"), "cloud-auth.json");
+    const legacy = new CloudAuthStore({ path: legacyPath });
+    await legacy.save({
+      ...legacyCloudCredentials,
+      cloudUrl: "https://cloud.caplets.dev",
+      workspaceSlug: "team",
+    });
+    const store = tempRemoteProfileStore({ legacyCloudAuthStore: legacy });
+
+    const status = await store.getCloudProfileStatus({
+      hostUrl: "https://cloud.caplets.dev",
+      workspace: "team",
+    });
+
+    expect(status).toMatchObject({
+      authenticated: true,
+      kind: "cloud",
+      hostUrl: "https://cloud.caplets.dev/",
+      workspaceId: "ws_123",
+      workspaceSlug: "team",
+      selected: true,
+    });
+    expect(existsSync(legacyPath)).toBe(true);
+    expect(JSON.stringify(status)).not.toContain("legacy_access");
+    await expect(
+      store.credentials.load(
+        remoteProfileKey({
+          kind: "cloud",
+          hostUrl: "https://cloud.caplets.dev/",
+          workspace: "team",
+        }),
+      ),
+    ).resolves.toMatchObject({ accessToken: "legacy_access", refreshToken: "legacy_refresh" });
+  });
+});
+
+describe("Remote Profile helpers", () => {
+  it("derives normalized profile and selected workspace keys", () => {
+    expect(
+      remoteProfileKey({
+        kind: "cloud",
+        hostUrl: "https://cloud.caplets.dev/v1/ws/team/mcp",
+        workspace: "team",
+      }),
+    ).toBe("cloud:https://cloud.caplets.dev/:team");
+    expect(selectedWorkspaceKey("https://cloud.caplets.dev/v1/ws/team/mcp")).toBe(
+      "cloud:https://cloud.caplets.dev/:selected-workspace",
+    );
+  });
+
+  it("redacts raw credential-shaped fields from profile status helpers", () => {
+    expect(
+      JSON.stringify(
+        remoteProfileStatus({
+          kind: "cloud",
+          hostUrl: "https://cloud.caplets.dev",
+          workspaceId: "ws_123",
+          workspaceSlug: "team",
+          clientLabel: "Test",
+          credential: cloudCredentials,
+        }),
+      ),
+    ).not.toMatch(/access_secret|refresh_secret|client_secret|pairing_code/u);
+  });
+});
+
+const legacyCloudCredentials: CloudAuthCredentials = {
+  version: 2,
+  cloudUrl: "https://cloud.caplets.dev",
+  workspaceId: "ws_123",
+  workspaceSlug: "team",
+  accessToken: "legacy_access",
+  refreshToken: "legacy_refresh",
+  expiresAt: "2099-06-19T12:00:00.000Z",
+  scope: ["mcp:tools"],
+  tokenType: "Bearer",
+  credentialFamilyId: "family_123",
+  deviceName: "Legacy CLI",
+  createdAt: "2026-06-19T09:00:00.000Z",
+  lastRefreshAt: "2026-06-19T09:00:00.000Z",
+};
+
+function tempRemoteProfileStore(
+  options: { legacyCloudAuthStore?: CloudAuthStore } = {},
+): FileRemoteProfileStore {
+  return new FileRemoteProfileStore({
+    root: tempDir("caplets-remote-profiles-"),
+    credentials: new FileRemoteCredentialStore({ root: tempDir("caplets-remote-credentials-") }),
+    legacyCloudAuthStore: options.legacyCloudAuthStore,
+  });
+}
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}

--- a/packages/core/test/remote-profiles.test.ts
+++ b/packages/core/test/remote-profiles.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -200,6 +208,24 @@ describe("Remote Profile storage", () => {
     ).rejects.toThrow(expect.objectContaining({ code: "REQUEST_INVALID" }) as CapletsError);
   });
 
+  it("recovers stale mutation locks left by crashed processes", async () => {
+    const root = tempDir("caplets-remote-profiles-");
+    const lockPath = join(root, "remote-profiles.lock");
+    mkdirSync(lockPath, { recursive: true });
+    const staleTime = new Date(Date.now() - 60_000);
+    utimesSync(lockPath, staleTime, staleTime);
+    const store = new FileRemoteProfileStore({ root });
+
+    await expect(
+      store.saveSelfHostedProfile({
+        hostUrl: "https://caplets.example.com",
+        clientId: "rcli_123",
+        credentials: { accessToken: "access", refreshToken: "refresh" },
+      }),
+    ).resolves.toMatchObject({ authenticated: true });
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
   it("rejects credential-bearing remote URLs before persisting profile data", async () => {
     const root = tempDir("caplets-remote-profiles-");
     const store = new FileRemoteProfileStore({ root });
@@ -340,6 +366,17 @@ describe("Remote Profile helpers", () => {
         }),
       ),
     ).not.toMatch(/access_secret|refresh_secret|client_secret|pairing_code/u);
+  });
+
+  it("does not report partial credentials without access tokens as authenticated", () => {
+    expect(
+      remoteProfileStatus({
+        kind: "self-hosted",
+        hostUrl: "https://caplets.example.com",
+        clientId: "rcli_123",
+        credential: { refreshToken: "refresh_secret" },
+      }),
+    ).toMatchObject({ authenticated: false });
   });
 });
 

--- a/packages/core/test/remote-selection.test.ts
+++ b/packages/core/test/remote-selection.test.ts
@@ -57,6 +57,113 @@ describe("resolveRemoteSelection", () => {
     });
   });
 
+  it("refreshes expired self-hosted credentials before returning the upstream", async () => {
+    const authDir = tempDir("caplets-remote-selection-auth-");
+    await new FileRemoteProfileStore({
+      root: join(authDir, "remote-profiles"),
+    }).saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "rcli_123",
+      clientLabel: "Test Device",
+      credentials: {
+        accessToken: "old-access",
+        refreshToken: "old-refresh",
+        tokenType: "Bearer",
+        expiresAt: "2026-06-19T00:00:00.000Z",
+      },
+    });
+
+    const resolved = await resolveRemoteSelection(
+      {
+        authDir,
+        fetch: async (url, init) => {
+          expect(String(url)).toBe("https://caplets.example.com/caplets/v1/remote/refresh");
+          expect(JSON.parse(String(init?.body))).toEqual({ refreshToken: "old-refresh" });
+          return Response.json({
+            clientId: "rcli_123",
+            clientLabel: "Test Device",
+            accessToken: "new-access",
+            refreshToken: "new-refresh",
+            tokenType: "Bearer",
+            expiresAt: "2999-01-01T00:00:00.000Z",
+          });
+        },
+      },
+      {
+        CAPLETS_MODE: "remote",
+        CAPLETS_REMOTE_URL: "https://caplets.example.com/caplets",
+      },
+    );
+
+    expect(resolved).toMatchObject({
+      kind: "self_hosted_remote",
+      remote: { auth: { type: "bearer", token: "new-access" } },
+    });
+    const store = new FileRemoteProfileStore({ root: join(authDir, "remote-profiles") });
+    const status = await store.getSelfHostedProfileStatus({
+      hostUrl: "https://caplets.example.com/caplets",
+    });
+    expect(status).toMatchObject({
+      clientLabel: "Test Device",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+    });
+    await expect(store.credentials.load(status!.key)).resolves.toMatchObject({
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+    });
+  });
+
+  it("serializes concurrent expired self-hosted credential refreshes", async () => {
+    const authDir = tempDir("caplets-remote-selection-auth-");
+    await new FileRemoteProfileStore({
+      root: join(authDir, "remote-profiles"),
+    }).saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "rcli_123",
+      clientLabel: "Test Device",
+      credentials: {
+        accessToken: "old-access",
+        refreshToken: "old-refresh",
+        expiresAt: "2026-06-19T00:00:00.000Z",
+      },
+    });
+    let refreshCalls = 0;
+    const fetchRefresh: typeof fetch = async (_url, init) => {
+      refreshCalls += 1;
+      expect(JSON.parse(String(init?.body))).toEqual({ refreshToken: "old-refresh" });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return Response.json({
+        clientId: "rcli_123",
+        clientLabel: "Test Device",
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+      });
+    };
+
+    const [left, right] = await Promise.all([
+      resolveRemoteSelection(
+        { authDir, fetch: fetchRefresh },
+        {
+          CAPLETS_MODE: "remote",
+          CAPLETS_REMOTE_URL: "https://caplets.example.com/caplets",
+        },
+      ),
+      resolveRemoteSelection(
+        { authDir, fetch: fetchRefresh },
+        {
+          CAPLETS_MODE: "remote",
+          CAPLETS_REMOTE_URL: "https://caplets.example.com/caplets",
+        },
+      ),
+    ]);
+
+    expect(refreshCalls).toBe(1);
+    expect(left).toMatchObject({ remote: { auth: { type: "bearer", token: "new-access" } } });
+    expect(right).toMatchObject({ remote: { auth: { type: "bearer", token: "new-access" } } });
+  });
+
   it("fails closed when self-hosted attach has only legacy env-token state", async () => {
     await expect(
       resolveRemoteSelection(

--- a/packages/core/test/remote-selection.test.ts
+++ b/packages/core/test/remote-selection.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { CloudAuthStore } from "../src/cloud-auth/store";
+import { FileRemoteProfileStore } from "../src/remote/profile-store";
 import { resolveRemoteSelection } from "../src/remote/selection";
 import { hostedCredentials, tempCloudAuthPath } from "./fixtures/cloud-auth";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
 
 describe("resolveRemoteSelection", () => {
   it("rejects attach selection in local mode", async () => {
@@ -14,7 +24,40 @@ describe("resolveRemoteSelection", () => {
     await expect(resolveRemoteSelection({}, {})).rejects.toThrow(/CAPLETS_REMOTE_URL/u);
   });
 
-  it("resolves self-hosted remote auth from CAPLETS_REMOTE variables", async () => {
+  it("resolves self-hosted remote auth from a stored Remote Profile", async () => {
+    const authDir = tempDir("caplets-remote-selection-auth-");
+    await new FileRemoteProfileStore({
+      root: join(authDir, "remote-profiles"),
+    }).saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "rcli_123",
+      clientLabel: "Test Device",
+      credentials: {
+        accessToken: "profile-access-token",
+        refreshToken: "profile-refresh-token",
+        tokenType: "Bearer",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+      },
+    });
+
+    await expect(
+      resolveRemoteSelection(
+        { authDir },
+        {
+          CAPLETS_MODE: "remote",
+          CAPLETS_REMOTE_URL: "https://caplets.example.com/caplets",
+        },
+      ),
+    ).resolves.toMatchObject({
+      kind: "self_hosted_remote",
+      remote: {
+        baseUrl: new URL("https://caplets.example.com/caplets"),
+        auth: { type: "bearer", token: "profile-access-token" },
+      },
+    });
+  });
+
+  it("fails closed when self-hosted attach has only legacy env-token state", async () => {
     await expect(
       resolveRemoteSelection(
         {},
@@ -24,26 +67,33 @@ describe("resolveRemoteSelection", () => {
           CAPLETS_REMOTE_TOKEN: "remote-token",
         },
       ),
-    ).resolves.toMatchObject({
-      kind: "self_hosted_remote",
-      remote: {
-        baseUrl: new URL("https://caplets.example.com/caplets"),
-        auth: { type: "bearer", token: "remote-token" },
-      },
+    ).rejects.toMatchObject({
+      projectBindingCode: "remote_credentials_required",
+      recoveryCommand: "caplets remote login https://caplets.example.com/caplets",
     });
   });
 
-  it("uses saved Cloud Auth in cloud mode and ignores self-hosted token vars", async () => {
-    const path = tempCloudAuthPath();
-    await new CloudAuthStore({ path }).save(hostedCredentials({ accessToken: "cloud-access" }));
+  it("uses saved Cloud Remote Profiles in cloud mode and ignores self-hosted token vars", async () => {
+    const authDir = tempDir("caplets-remote-selection-auth-");
+    await new FileRemoteProfileStore({ root: join(authDir, "remote-profiles") }).saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "workspace_personal",
+      workspaceSlug: "personal",
+      credentials: {
+        accessToken: "cloud-access",
+        refreshToken: "cloud-refresh",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        scope: ["project_binding:read", "project_binding:write", "mcp:tools"],
+        tokenType: "Bearer",
+      },
+    });
 
     const resolved = await resolveRemoteSelection(
-      {},
+      { authDir },
       {
         CAPLETS_MODE: "cloud",
         CAPLETS_REMOTE_URL: "https://cloud.caplets.dev",
         CAPLETS_REMOTE_TOKEN: "self-hosted-token",
-        CAPLETS_CLOUD_AUTH_PATH: path,
       },
     );
 
@@ -251,3 +301,9 @@ describe("resolveRemoteSelection", () => {
     });
   });
 });
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}

--- a/packages/core/test/remote-selection.test.ts
+++ b/packages/core/test/remote-selection.test.ts
@@ -214,6 +214,59 @@ describe("resolveRemoteSelection", () => {
     });
   });
 
+  it("honors an explicit Cloud workspace with a bare Cloud URL", async () => {
+    const authDir = tempDir("caplets-remote-selection-auth-");
+    const store = new FileRemoteProfileStore({ root: join(authDir, "remote-profiles") });
+    await store.saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "workspace_team",
+      workspaceSlug: "team",
+      credentials: {
+        accessToken: "old-cloud-access",
+        refreshToken: "old-cloud-refresh",
+        expiresAt: "2026-06-03T00:00:00.000Z",
+        scope: ["project_binding:read", "project_binding:write", "mcp:tools"],
+        tokenType: "Bearer",
+      },
+    });
+    await store.clearSelectedCloudWorkspace("https://cloud.caplets.dev");
+
+    const resolved = await resolveRemoteSelection(
+      {
+        authDir,
+        remoteUrl: "https://cloud.caplets.dev",
+        workspace: "team",
+        fetch: async (url, init) => {
+          expect(String(url)).toBe("https://cloud.caplets.dev/api/cloud-client/refresh");
+          expect(JSON.parse(String(init?.body))).toEqual({ refreshToken: "old-cloud-refresh" });
+          return Response.json({
+            status: "authenticated",
+            cloudUrl: "https://cloud.caplets.dev",
+            workspaceId: "workspace_team",
+            workspaceSlug: "team",
+            accessToken: "new-cloud-access",
+            refreshToken: "new-cloud-refresh",
+            expiresAt: "2999-01-01T00:00:00.000Z",
+            scope: ["project_binding:read", "project_binding:write", "mcp:tools"],
+            tokenType: "Bearer",
+          });
+        },
+      },
+      {
+        CAPLETS_MODE: "cloud",
+      },
+    );
+
+    expect(resolved).toMatchObject({
+      kind: "hosted_cloud",
+      selectedWorkspace: "team",
+      remote: {
+        mcpUrl: new URL("https://cloud.caplets.dev/v1/ws/team/mcp"),
+        auth: { type: "bearer", token: "new-cloud-access" },
+      },
+    });
+  });
+
   it("derives Cloud MCP and Project Binding URLs from the selected workspace", async () => {
     const path = tempCloudAuthPath();
     await new CloudAuthStore({ path }).save(

--- a/packages/core/test/remote-selection.test.ts
+++ b/packages/core/test/remote-selection.test.ts
@@ -114,6 +114,80 @@ describe("resolveRemoteSelection", () => {
     });
   });
 
+  it("surfaces transient self-hosted refresh failures without requiring login", async () => {
+    const authDir = tempDir("caplets-remote-selection-auth-");
+    await new FileRemoteProfileStore({
+      root: join(authDir, "remote-profiles"),
+    }).saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "rcli_123",
+      clientLabel: "Test Device",
+      credentials: {
+        accessToken: "old-access",
+        refreshToken: "old-refresh",
+        tokenType: "Bearer",
+        expiresAt: "2026-06-19T00:00:00.000Z",
+      },
+    });
+
+    await expect(
+      resolveRemoteSelection(
+        {
+          authDir,
+          fetch: async () =>
+            Response.json(
+              {
+                ok: false,
+                error: {
+                  code: "SERVER_UNAVAILABLE",
+                  message: "Remote credential state is locked.",
+                },
+              },
+              { status: 503 },
+            ),
+        },
+        {
+          CAPLETS_MODE: "remote",
+          CAPLETS_REMOTE_URL: "https://caplets.example.com/caplets",
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "SERVER_UNAVAILABLE",
+      message: "Remote credential state is locked.",
+    });
+  });
+
+  it("preserves CAPLETS_REMOTE_WORKSPACE for self-hosted remotes", async () => {
+    const authDir = tempDir("caplets-remote-selection-auth-");
+    await new FileRemoteProfileStore({
+      root: join(authDir, "remote-profiles"),
+    }).saveSelfHostedProfile({
+      hostUrl: "https://caplets.example.com/caplets",
+      clientId: "rcli_123",
+      clientLabel: "Test Device",
+      credentials: {
+        accessToken: "profile-access-token",
+        refreshToken: "profile-refresh-token",
+        tokenType: "Bearer",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+      },
+    });
+
+    const resolved = await resolveRemoteSelection(
+      { authDir },
+      {
+        CAPLETS_MODE: "remote",
+        CAPLETS_REMOTE_URL: "https://caplets.example.com/caplets",
+        CAPLETS_REMOTE_WORKSPACE: "tenant-a",
+      },
+    );
+
+    expect(resolved).toMatchObject({
+      kind: "self_hosted_remote",
+      remote: { workspace: "tenant-a" },
+    });
+  });
+
   it("serializes concurrent expired self-hosted credential refreshes", async () => {
     const authDir = tempDir("caplets-remote-selection-auth-");
     await new FileRemoteProfileStore({

--- a/packages/core/test/remote-selection.test.ts
+++ b/packages/core/test/remote-selection.test.ts
@@ -219,7 +219,7 @@ describe("resolveRemoteSelection", () => {
       ),
     ).rejects.toMatchObject({
       projectBindingCode: "cloud_auth_required",
-      recoveryCommand: "caplets cloud auth login",
+      recoveryCommand: "caplets remote login <cloud-url>",
     });
   });
 

--- a/packages/core/test/remote-selection.test.ts
+++ b/packages/core/test/remote-selection.test.ts
@@ -393,6 +393,61 @@ describe("resolveRemoteSelection", () => {
     expect(resolved.remote.auth).toEqual({ type: "bearer", token: "new-access" });
   });
 
+  it("serializes concurrent expired Cloud Remote Profile refreshes", async () => {
+    const authDir = tempDir("caplets-remote-selection-auth-");
+    await new FileRemoteProfileStore({ root: join(authDir, "remote-profiles") }).saveCloudProfile({
+      hostUrl: "https://cloud.caplets.dev",
+      workspaceId: "workspace_personal",
+      workspaceSlug: "personal",
+      credentials: {
+        accessToken: "old-access",
+        refreshToken: "old-refresh",
+        expiresAt: "2026-06-03T00:00:00.000Z",
+        scope: ["project_binding:read", "project_binding:write", "mcp:tools"],
+        tokenType: "Bearer",
+      },
+    });
+    let refreshCalls = 0;
+    const fetchRefresh: typeof fetch = async (_url, init) => {
+      refreshCalls += 1;
+      expect(JSON.parse(String(init?.body))).toEqual({ refreshToken: "old-refresh" });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return Response.json({
+        status: "authenticated",
+        cloudUrl: "https://cloud.caplets.dev",
+        workspaceId: "workspace_personal",
+        workspaceSlug: "personal",
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        scope: ["project_binding:read", "project_binding:write", "mcp:tools"],
+        tokenType: "Bearer",
+        credentialFamilyId: "family_123",
+      });
+    };
+
+    const [left, right] = await Promise.all([
+      resolveRemoteSelection(
+        { authDir, fetch: fetchRefresh },
+        {
+          CAPLETS_MODE: "cloud",
+          CAPLETS_REMOTE_URL: "https://cloud.caplets.dev",
+        },
+      ),
+      resolveRemoteSelection(
+        { authDir, fetch: fetchRefresh },
+        {
+          CAPLETS_MODE: "cloud",
+          CAPLETS_REMOTE_URL: "https://cloud.caplets.dev",
+        },
+      ),
+    ]);
+
+    expect(refreshCalls).toBe(1);
+    expect(left.remote.auth).toEqual({ type: "bearer", token: "new-access" });
+    expect(right.remote.auth).toEqual({ type: "bearer", token: "new-access" });
+  });
+
   it("requires Cloud Auth when cloud mode is selected", async () => {
     await expect(
       resolveRemoteSelection(

--- a/packages/core/test/serve-daemon.test.ts
+++ b/packages/core/test/serve-daemon.test.ts
@@ -421,11 +421,14 @@ describe("daemon paths and config", () => {
     }
   });
 
-  it("does not emit auth flags for default unauthenticated loopback serve", () => {
+  it("emits remote credential state and no Basic Auth flags for default daemon serve", () => {
     const serve = resolveDaemonHttpServeOptions({});
 
-    expect(daemonServeArgs(serve)).not.toContain("--user");
-    expect(daemonServeArgs(serve)).not.toContain("--password");
+    const args = daemonServeArgs(serve);
+    expect(args).toContain("--remote-state-path");
+    expect(args).toContain(serve.remoteCredentialStateDir);
+    expect(args).not.toContain("--user");
+    expect(args).not.toContain("--password");
   });
 
   it("validates updates to running daemons on a temporary loopback port", async () => {

--- a/packages/core/test/serve-daemon.test.ts
+++ b/packages/core/test/serve-daemon.test.ts
@@ -163,6 +163,45 @@ describe("caplets daemon CLI", () => {
     }
   });
 
+  it("redacts legacy daemon Basic Auth passwords from JSON status", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-cli-legacy-auth-redaction-"));
+    try {
+      const runner = fakeRunner();
+      const options = {
+        env: testEnv(dir),
+        platform: "linux" as const,
+        commandRunner: runner,
+      };
+      await installDaemon({ validate: false }, options);
+      const paths = resolveDaemonPaths(options);
+      const config = JSON.parse(readFileSync(paths.configFile, "utf8")) as {
+        serve: { auth: unknown };
+      };
+      config.serve.auth = {
+        enabled: true,
+        user: "caplets",
+        password: "legacy-password-secret",
+      };
+      writeFileSync(paths.configFile, `${JSON.stringify(config, null, 2)}\n`);
+      const out: string[] = [];
+
+      await runCli(["daemon", "status", "--json"], {
+        env: testEnv(dir),
+        writeOut: (value) => out.push(value),
+        daemon: options,
+      });
+
+      const serialized = out.join("");
+      const status = JSON.parse(serialized) as {
+        config: { serve: { auth: { password?: string } } };
+      };
+      expect(status.config.serve.auth.password).toBe("[redacted]");
+      expect(serialized).not.toContain("legacy-password-secret");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("reports daemon start as a restart when the service is already running", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-cli-start-restart-"));
     try {

--- a/packages/core/test/serve-daemon.test.ts
+++ b/packages/core/test/serve-daemon.test.ts
@@ -132,6 +132,37 @@ describe("caplets daemon CLI", () => {
     }
   });
 
+  it("prints JSON status with remote credential auth config", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-cli-"));
+    const out: string[] = [];
+    try {
+      const runner = fakeRunner();
+      await installDaemon(
+        { remoteStatePath: join(dir, "remote-state"), validate: false },
+        {
+          env: testEnv(dir),
+          platform: "linux",
+          commandRunner: runner,
+        },
+      );
+
+      await runCli(["daemon", "status", "--json"], {
+        env: testEnv(dir),
+        writeOut: (value) => out.push(value),
+        daemon: { platform: "linux", commandRunner: runner },
+      });
+
+      const status = JSON.parse(out.join("")) as {
+        config: { serve: { auth: { type: string }; remoteCredentialStateDir: string } };
+      };
+      expect(status.config.serve.auth.type).toBe("remote_credentials");
+      expect(status.config.serve.remoteCredentialStateDir).toBe("[REDACTED]");
+      expect(out.join("")).not.toContain(join(dir, "remote-state"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("reports daemon start as a restart when the service is already running", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-cli-start-restart-"));
     try {
@@ -175,10 +206,8 @@ describe("caplets daemon CLI", () => {
           "install",
           "--json",
           "--dry-run",
-          "--user",
-          "alice",
-          "--password",
-          'pa"$USER',
+          "--remote-state-path",
+          join(dir, 'remote "state'),
           "--env",
           'TOKEN=a&b"c',
           "--env",
@@ -198,9 +227,9 @@ describe("caplets daemon CLI", () => {
         descriptor?: { contents?: string };
       };
       expect(serialized).toContain("[redacted]");
-      expect(serialized).not.toContain('pa"$USER');
+      expect(serialized).not.toContain(join(dir, 'remote "state'));
       expect(serialized).not.toContain('a&b"c');
-      expect(parsed.descriptor?.contents).not.toContain('pa\\"$$USER');
+      expect(parsed.descriptor?.contents).not.toContain('remote \\"state');
       expect(parsed.descriptor?.contents).not.toContain('a&b\\"c');
       expect(parsed.descriptor?.contents).not.toContain("a'\\\\''b");
     } finally {
@@ -563,8 +592,7 @@ describe("daemon paths and config", () => {
       const systemdWithDollar = await installDaemon(
         {
           ...common,
-          password: "pa$USER",
-          allowUnauthenticatedHttp: false,
+          remoteStatePath: join(dir, "pa$USER"),
           env: ["TOKEN=pa$USER"],
         },
         {
@@ -602,7 +630,7 @@ describe("daemon paths and config", () => {
       expect(windows.descriptor.wrapper.contents).toContain("2>> ");
 
       const escapedWindows = await installDaemon(
-        { ...common, password: "pa%USERNAME%ss", allowUnauthenticatedHttp: false },
+        { ...common, remoteStatePath: join(dir, "pa%USERNAME%ss") },
         {
           env: {
             APPDATA: join(dir, "Escaped", "Roaming"),
@@ -696,8 +724,7 @@ describe("daemon paths and config", () => {
       await expect(
         installDaemon(
           {
-            password: "secret\r\nwhoami",
-            allowUnauthenticatedHttp: false,
+            remoteStatePath: `secret\r\nwhoami`,
             validate: false,
             dryRun: true,
           },
@@ -721,7 +748,7 @@ describe("daemon paths and config", () => {
     const cmd = serviceCommand({
       command: {
         executable: "C:\\Program Files\\Caplets\\cli.js",
-        args: ["serve", "--password", "pa ss"],
+        args: ["serve", "--remote-state-path", "pa ss"],
         env: { PATH: "C:\\Tools" },
         shell: { executable: "cmd.exe", args: ["/d", "/s", "/c"] },
       },
@@ -734,7 +761,7 @@ describe("daemon paths and config", () => {
     const powerShell = serviceCommand({
       command: {
         executable: "C:\\Program Files\\Caplets\\cli.js",
-        args: ["serve", "--password", "pa ss"],
+        args: ["serve", "--remote-state-path", "pa ss"],
         env: { PATH: "C:\\Tools" },
         shell: {
           executable: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
@@ -760,7 +787,7 @@ describe("daemon paths and config", () => {
     const shellWithSlashC = serviceCommand({
       command: {
         executable: "/usr/local/bin/caplets",
-        args: ["serve", "--password", "pa ss"],
+        args: ["serve", "--remote-state-path", "pa ss"],
         env: { TOKEN: "value" },
         shell: { executable: "/usr/bin/custom-shell", args: ["/c"] },
       },
@@ -853,7 +880,7 @@ describe("daemon paths and config", () => {
     }
   });
 
-  it("preserves disabled auth across daemon config updates", async () => {
+  it("preserves unauthenticated auth across daemon config updates", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-update-no-auth-"));
     try {
       const options = {
@@ -862,7 +889,7 @@ describe("daemon paths and config", () => {
         platform: "linux" as const,
         commandRunner: fakeRunner(),
       };
-      await installDaemon({ validate: false }, options);
+      await installDaemon({ validate: false, allowUnauthenticatedHttp: true }, options);
 
       const updated = await installDaemon(
         { validate: false, env: ["FOO=bar"], noRestart: true },
@@ -870,14 +897,13 @@ describe("daemon paths and config", () => {
           ...options,
           env: {
             ...testEnv(dir),
-            CAPLETS_SERVER_USER: "alice",
-            CAPLETS_SERVER_PASSWORD: "secret",
+            CAPLETS_REMOTE_SERVER_STATE_DIR: join(dir, "remote-state"),
           },
         },
       );
 
-      expect(updated.config.serve.auth.enabled).toBe(false);
-      expect(updated.config.command.args).not.toContain("--password");
+      expect(updated.config.serve.auth.type).toBe("development_unauthenticated");
+      expect(updated.config.command.args).not.toContain("--remote-state-path");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -2147,7 +2173,7 @@ describe("daemon lifecycle and logs", () => {
     }
   });
 
-  it("redacts daemon auth secrets from status config", async () => {
+  it("redacts daemon remote credential state from status config", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-status-redaction-"));
     try {
       const runner: DaemonCommandRunner = {
@@ -2155,7 +2181,7 @@ describe("daemon lifecycle and logs", () => {
           if (command === "systemctl" && args.includes("show")) {
             return {
               stdout:
-                "ExecStart={ path=/node ; argv[]=/node /cli serve --password secret ; }\nEnvironment=TOKEN=abc123\n",
+                "ExecStart={ path=/node ; argv[]=/node /cli serve --remote-state-path /secret/state ; }\nEnvironment=TOKEN=abc123\n",
               stderr: "",
               code: 0,
             };
@@ -2173,9 +2199,7 @@ describe("daemon lifecycle and logs", () => {
       };
       await installDaemon(
         {
-          user: "alice",
-          password: "secret",
-          allowUnauthenticatedHttp: false,
+          remoteStatePath: "/secret/state",
           env: ["TOKEN=abc123"],
           validate: false,
         },
@@ -2185,13 +2209,12 @@ describe("daemon lifecycle and logs", () => {
       const status = await daemonStatus(options);
       const serialized = JSON.stringify(status);
 
-      expect(status.config?.serve.auth.enabled).toBe(true);
-      if (!status.config?.serve.auth.enabled) throw new Error("expected daemon auth");
-      expect(status.config.serve.auth.password).toBe("[redacted]");
+      expect(status.config?.serve.auth.type).toBe("remote_credentials");
+      expect(status.config?.serve.remoteCredentialStateDir).toBe("[REDACTED]");
       expect(status.config.env.values.TOKEN).toBe("[redacted]");
       expect(status.config.command.env.TOKEN).toBe("[redacted]");
-      expect(status.config?.command.args).toContain("--password");
-      expect(status.config?.command.args).not.toContain("secret");
+      expect(status.config?.command.args).toContain("--remote-state-path");
+      expect(status.config?.command.args).not.toContain("/secret/state");
       expect(serialized).not.toContain("secret");
       expect(serialized).not.toContain("abc123");
     } finally {
@@ -2199,14 +2222,15 @@ describe("daemon lifecycle and logs", () => {
     }
   });
 
-  it("redacts password arguments from native status when config is missing", async () => {
+  it("redacts remote state path arguments from native status when config is missing", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-status-stale-redaction-"));
     try {
       const runner: DaemonCommandRunner = {
         async exec(command, args) {
           if (command === "systemctl" && args.includes("show")) {
             return {
-              stdout: "ExecStart={ path=/node ; argv[]=/node /cli serve --password secret ; }\n",
+              stdout:
+                "ExecStart={ path=/node ; argv[]=/node /cli serve --remote-state-path /secret/state ; }\n",
               stderr: "",
               code: 0,
             };
@@ -2224,9 +2248,7 @@ describe("daemon lifecycle and logs", () => {
       };
       const installed = await installDaemon(
         {
-          user: "alice",
-          password: "secret",
-          allowUnauthenticatedHttp: false,
+          remoteStatePath: "/secret/state",
           validate: false,
         },
         options,
@@ -2238,7 +2260,7 @@ describe("daemon lifecycle and logs", () => {
 
       expect(status.config).toBeUndefined();
       expect(serialized).toContain("[redacted]");
-      expect(serialized).not.toContain("--password secret");
+      expect(serialized).not.toContain("--remote-state-path /secret/state");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/core/test/serve-daemon.test.ts
+++ b/packages/core/test/serve-daemon.test.ts
@@ -2212,12 +2212,13 @@ describe("daemon lifecycle and logs", () => {
       const status = await daemonStatus(options);
       const serialized = JSON.stringify(status);
 
-      expect(status.config?.serve.auth.type).toBe("remote_credentials");
-      expect(status.config?.serve.remoteCredentialStateDir).toBe("[REDACTED]");
+      if (!status.config) throw new Error("expected daemon config");
+      expect(status.config.serve.auth.type).toBe("remote_credentials");
+      expect(status.config.serve.remoteCredentialStateDir).toBe("[REDACTED]");
       expect(status.config.env.values.TOKEN).toBe("[redacted]");
       expect(status.config.command.env.TOKEN).toBe("[redacted]");
-      expect(status.config?.command.args).toContain("--remote-state-path");
-      expect(status.config?.command.args).not.toContain("/secret/state");
+      expect(status.config.command.args).toContain("--remote-state-path");
+      expect(status.config.command.args).not.toContain("/secret/state");
       expect(serialized).not.toContain("secret");
       expect(serialized).not.toContain("abc123");
     } finally {

--- a/packages/core/test/serve-daemon.test.ts
+++ b/packages/core/test/serve-daemon.test.ts
@@ -2312,8 +2312,8 @@ describe("daemon validation", () => {
         ...result.config,
         command: {
           ...result.config.command,
-          executable: process.execPath,
-          args: [candidate],
+          executable: candidate,
+          args: [],
         },
       };
 

--- a/packages/core/test/serve-http.test.ts
+++ b/packages/core/test/serve-http.test.ts
@@ -234,6 +234,104 @@ describe("createHttpServeApp", () => {
     await engine.close();
   });
 
+  it("requires explicit public origin before trusted proxy headers select remote credential audiences", async () => {
+    const { engine } = testEngine();
+    const store = remoteCredentialStore();
+    const issued = store.createPairingCode({ hostUrl: "https://caplets.example.com/" });
+    const app = createHttpServeApp(
+      httpOptions({ auth: { type: "remote_credentials" }, trustProxy: true }),
+      engine,
+      {
+        writeErr: () => {},
+        remoteCredentialStore: store,
+      },
+    );
+
+    const exchanged = await app.request("http://10.0.0.5:5387/v1/remote/pairing/exchange", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "caplets.example.com",
+      },
+      body: JSON.stringify({ code: issued.code }),
+    });
+
+    expect(exchanged.status).toBe(400);
+    await expect(exchanged.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "REQUEST_INVALID" },
+    });
+
+    const refreshed = await app.request("http://10.0.0.5:5387/v1/remote/refresh", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "caplets.example.com",
+      },
+      body: JSON.stringify({ refreshToken: "unused-refresh-token" }),
+    });
+    expect(refreshed.status).toBe(400);
+    await expect(refreshed.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "REQUEST_INVALID" },
+    });
+    await engine.close();
+  });
+
+  it("uses explicit public origin for remote credential audiences behind trusted proxies", async () => {
+    const { engine } = testEngine();
+    const store = remoteCredentialStore();
+    const issued = store.createPairingCode({ hostUrl: "https://caplets.example.com/" });
+    const app = createHttpServeApp(
+      httpOptions({
+        auth: { type: "remote_credentials" },
+        publicOrigin: "https://caplets.example.com",
+        trustProxy: true,
+      }),
+      engine,
+      {
+        writeErr: () => {},
+        remoteCredentialStore: store,
+      },
+    );
+
+    const exchanged = await app.request("http://10.0.0.5:5387/v1/remote/pairing/exchange", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "attacker.example.com",
+      },
+      body: JSON.stringify({ code: issued.code }),
+    });
+    expect(exchanged.status).toBe(200);
+    const credentials = (await exchanged.json()) as { accessToken: string; refreshToken: string };
+
+    const refreshed = await app.request("http://10.0.0.5:5387/v1/remote/refresh", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "attacker.example.com",
+      },
+      body: JSON.stringify({ refreshToken: credentials.refreshToken }),
+    });
+    expect(refreshed.status).toBe(200);
+    const nextCredentials = (await refreshed.json()) as { accessToken: string };
+
+    const attach = await app.request("http://10.0.0.5:5387/v1/attach/manifest", {
+      headers: {
+        authorization: `Bearer ${nextCredentials.accessToken}`,
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "attacker.example.com",
+      },
+    });
+    expect(attach.status).toBe(200);
+    await engine.close();
+  });
+
   it("rejects Basic Auth on attach manifest when remote credentials are required", async () => {
     const { engine } = testEngine();
     const app = createHttpServeApp(

--- a/packages/core/test/serve-http.test.ts
+++ b/packages/core/test/serve-http.test.ts
@@ -41,7 +41,7 @@ describe("createHttpServeApp", () => {
           },
         },
       ],
-      auth: { type: "basic", enabled: false },
+      auth: { type: "development_unauthenticated" },
     });
 
     const v1 = await app.request("http://127.0.0.1:5387/v1");
@@ -85,23 +85,25 @@ describe("createHttpServeApp", () => {
     await engine.close();
   });
 
-  it("requires Basic Auth on MCP path when password is configured", async () => {
+  it("rejects Basic Auth on MCP path when remote credentials are required", async () => {
     const { engine } = testEngine();
-    const testPassword = ["test", "password"].join("-");
     const app = createHttpServeApp(
-      httpOptions({ auth: { enabled: true, user: "caplets", password: testPassword } }),
+      httpOptions({
+        auth: { type: "remote_credentials" },
+        remoteCredentialStateDir: tempDir("caplets-http-remote-credentials-"),
+      }),
       engine,
       { writeErr: () => {} },
     );
 
     const missing = await app.request("http://127.0.0.1:5387/v1/mcp", { method: "POST" });
     expect(missing.status).toBe(401);
-    expect(missing.headers.get("www-authenticate")).toContain("Basic");
+    expect(missing.headers.get("www-authenticate")).toBeNull();
 
     const wrong = await app.request("http://127.0.0.1:5387/v1/mcp", {
       method: "POST",
       headers: {
-        authorization: `Basic ${Buffer.from(`caplets:not-the-${testPassword}`).toString("base64")}`,
+        authorization: `Basic ${Buffer.from("caplets:password").toString("base64")}`,
       },
     });
     expect(wrong.status).toBe(401);
@@ -113,7 +115,7 @@ describe("createHttpServeApp", () => {
     const { engine } = testEngine();
     const store = remoteCredentialStore();
     const credentials = pairedClient(store);
-    const app = createHttpServeApp(httpOptions(), engine, {
+    const app = createHttpServeApp(httpOptions({ auth: { type: "remote_credentials" } }), engine, {
       writeErr: () => {},
       remoteCredentialStore: store,
     });
@@ -121,7 +123,7 @@ describe("createHttpServeApp", () => {
     const root = await app.request("http://127.0.0.1:5387/");
     expect(root.status).toBe(200);
     await expect(root.json()).resolves.toMatchObject({
-      auth: { type: "remote_credentials", enabled: true },
+      auth: { type: "remote_credentials" },
     });
 
     const basic = await app.request("http://127.0.0.1:5387/v1/attach/manifest", {
@@ -182,7 +184,7 @@ describe("createHttpServeApp", () => {
     const { engine } = testEngine();
     const store = remoteCredentialStore();
     const issued = store.createPairingCode({ hostUrl: "http://127.0.0.1:5387/" });
-    const app = createHttpServeApp(httpOptions(), engine, {
+    const app = createHttpServeApp(httpOptions({ auth: { type: "remote_credentials" } }), engine, {
       writeErr: () => {},
       remoteCredentialStore: store,
     });
@@ -232,44 +234,47 @@ describe("createHttpServeApp", () => {
     await engine.close();
   });
 
-  it("requires Basic Auth on attach manifest when password is configured", async () => {
+  it("rejects Basic Auth on attach manifest when remote credentials are required", async () => {
     const { engine } = testEngine();
-    const testPassword = ["test", "password"].join("-");
     const app = createHttpServeApp(
-      httpOptions({ auth: { enabled: true, user: "caplets", password: testPassword } }),
+      httpOptions({
+        auth: { type: "remote_credentials" },
+        remoteCredentialStateDir: tempDir("caplets-http-remote-credentials-"),
+      }),
       engine,
       { writeErr: () => {} },
     );
 
     const missing = await app.request("http://127.0.0.1:5387/v1/attach/manifest");
     expect(missing.status).toBe(401);
-    expect(missing.headers.get("www-authenticate")).toContain("Basic");
+    expect(missing.headers.get("www-authenticate")).toBeNull();
 
     await engine.close();
   });
 
-  it("requires Basic Auth on control path and dispatches authenticated list requests", async () => {
+  it("requires remote credentials on control path and dispatches authenticated list requests", async () => {
     const context = testContext();
     const engine = new CapletsEngine({
       configPath: context.configPath,
       projectConfigPath: context.projectConfigPath,
       watch: false,
     });
-    const testPassword = ["test", "password"].join("-");
-    const app = createHttpServeApp(
-      httpOptions({ auth: { enabled: true, user: "caplets", password: testPassword } }),
-      engine,
-      { writeErr: () => {}, control: context },
-    );
+    const store = remoteCredentialStore();
+    const credentials = pairedClient(store);
+    const app = createHttpServeApp(httpOptions({ auth: { type: "remote_credentials" } }), engine, {
+      writeErr: () => {},
+      control: context,
+      remoteCredentialStore: store,
+    });
 
     const missing = await app.request("http://127.0.0.1:5387/v1/admin", { method: "POST" });
     expect(missing.status).toBe(401);
-    expect(missing.headers.get("www-authenticate")).toContain("Basic");
+    expect(missing.headers.get("www-authenticate")).toBeNull();
 
     const listed = await app.request("http://127.0.0.1:5387/v1/admin", {
       method: "POST",
       headers: {
-        authorization: `Basic ${Buffer.from(`caplets:${testPassword}`).toString("base64")}`,
+        authorization: `Bearer ${credentials.accessToken}`,
         "content-type": "application/json",
       },
       body: JSON.stringify({ command: "list", arguments: {} }),
@@ -282,12 +287,12 @@ describe("createHttpServeApp", () => {
 
   it("exposes authenticated Project Binding status under the attach namespace", async () => {
     const { engine } = testEngine();
-    const testPassword = ["test", "password"].join("-");
-    const app = createHttpServeApp(
-      httpOptions({ auth: { enabled: true, user: "caplets", password: testPassword } }),
-      engine,
-      { writeErr: () => {} },
-    );
+    const store = remoteCredentialStore();
+    const credentials = pairedClient(store);
+    const app = createHttpServeApp(httpOptions({ auth: { type: "remote_credentials" } }), engine, {
+      writeErr: () => {},
+      remoteCredentialStore: store,
+    });
 
     const missing = await app.request(
       "http://127.0.0.1:5387/v1/attach/project-bindings/bind_123/status",
@@ -298,7 +303,7 @@ describe("createHttpServeApp", () => {
       "http://127.0.0.1:5387/v1/attach/project-bindings/bind_123/status",
       {
         headers: {
-          authorization: `Basic ${Buffer.from(`caplets:${testPassword}`).toString("base64")}`,
+          authorization: `Bearer ${credentials.accessToken}`,
         },
       },
     );
@@ -386,14 +391,12 @@ describe("createHttpServeApp", () => {
       projectConfigPath: context.projectConfigPath,
       watch: false,
     });
-    const testPassword = ["test", "password"].join("-");
+    const store = remoteCredentialStore();
+    const credentials = pairedClient(store, "http://127.0.0.1:5387/caplets");
     const app = createHttpServeApp(
-      httpOptions({
-        path: "/caplets",
-        auth: { enabled: true, user: "caplets", password: testPassword },
-      }),
+      httpOptions({ path: "/caplets", auth: { type: "remote_credentials" } }),
       engine,
-      { writeErr: () => {}, control: context },
+      { writeErr: () => {}, control: context, remoteCredentialStore: store },
     );
 
     const rootControl = await app.request("http://127.0.0.1:5387/control", { method: "POST" });
@@ -407,7 +410,7 @@ describe("createHttpServeApp", () => {
     const listed = await app.request("http://127.0.0.1:5387/caplets/v1/admin", {
       method: "POST",
       headers: {
-        authorization: `Basic ${Buffer.from(`caplets:${testPassword}`).toString("base64")}`,
+        authorization: `Bearer ${credentials.accessToken}`,
         "content-type": "application/json",
       },
       body: JSON.stringify({ command: "list", arguments: {} }),
@@ -925,20 +928,21 @@ describe("createHttpServeApp", () => {
 
   it("allows authenticated attach requests through the configured public origin host", async () => {
     const { engine } = testEngine();
-    const password = "test-password";
+    const store = remoteCredentialStore();
+    const credentials = pairedClient(store, "https://caplets.tail7ff085.ts.net/");
     const app = createHttpServeApp(
       httpOptions({
         publicOrigin: "https://caplets.tail7ff085.ts.net",
-        auth: { enabled: true, user: "caplets", password },
+        auth: { type: "remote_credentials" },
       }),
       engine,
-      { writeErr: () => {} },
+      { writeErr: () => {}, remoteCredentialStore: store },
     );
 
     const response = await app.request("http://127.0.0.1:5387/v1/attach/manifest", {
       headers: {
         host: "caplets.tail7ff085.ts.net",
-        authorization: `Basic ${Buffer.from(`caplets:${password}`).toString("base64")}`,
+        authorization: `Bearer ${credentials.accessToken}`,
       },
     });
 
@@ -992,21 +996,22 @@ describe("createHttpServeApp", () => {
 
   it("allows authenticated MCP requests through the configured public origin host", async () => {
     const { engine } = testEngine();
-    const password = "test-password";
+    const store = remoteCredentialStore();
+    const credentials = pairedClient(store, "https://caplets.tail7ff085.ts.net/");
     const app = createHttpServeApp(
       httpOptions({
         publicOrigin: "https://caplets.tail7ff085.ts.net",
-        auth: { enabled: true, user: "caplets", password },
+        auth: { type: "remote_credentials" },
       }),
       engine,
-      { writeErr: () => {} },
+      { writeErr: () => {}, remoteCredentialStore: store },
     );
 
     const init = await app.request("http://127.0.0.1:5387/v1/mcp", {
       method: "POST",
       headers: {
         host: "caplets.tail7ff085.ts.net",
-        authorization: `Basic ${Buffer.from(`caplets:${password}`).toString("base64")}`,
+        authorization: `Bearer ${credentials.accessToken}`,
         accept: "application/json, text/event-stream",
         "content-type": "application/json",
       },
@@ -1156,7 +1161,7 @@ function httpOptions(overrides: Partial<HttpServeOptions> = {}): HttpServeOption
     port: 5387,
     path: "/",
     publicOrigin: undefined,
-    auth: { enabled: false, user: "caplets" },
+    auth: { type: "development_unauthenticated" },
     allowUnauthenticatedHttp: false,
     warnUnauthenticatedNetwork: false,
     loopback: true,
@@ -1169,13 +1174,16 @@ function remoteCredentialStore(): RemoteServerCredentialStore {
   return new RemoteServerCredentialStore({ dir: tempDir("caplets-http-remote-credentials-") });
 }
 
-function pairedClient(store: RemoteServerCredentialStore): {
+function pairedClient(
+  store: RemoteServerCredentialStore,
+  hostUrl = "http://127.0.0.1:5387/",
+): {
   accessToken: string;
   refreshToken: string;
 } {
-  const issued = store.createPairingCode({ hostUrl: "http://127.0.0.1:5387/" });
+  const issued = store.createPairingCode({ hostUrl });
   return store.exchangePairingCode({
-    hostUrl: "http://127.0.0.1:5387/",
+    hostUrl,
     code: issued.code,
   });
 }

--- a/packages/core/test/serve-http.test.ts
+++ b/packages/core/test/serve-http.test.ts
@@ -112,11 +112,17 @@ describe("createHttpServeApp", () => {
   });
 
   it("uses issued remote credentials for protected self-hosted route classes", async () => {
-    const { engine } = testEngine();
+    const context = testContext();
+    const engine = new CapletsEngine({
+      configPath: context.configPath,
+      projectConfigPath: context.projectConfigPath,
+      watch: false,
+    });
     const store = remoteCredentialStore();
     const credentials = pairedClient(store);
     const app = createHttpServeApp(httpOptions({ auth: { type: "remote_credentials" } }), engine, {
       writeErr: () => {},
+      control: context,
       remoteCredentialStore: store,
     });
 

--- a/packages/core/test/serve-http.test.ts
+++ b/packages/core/test/serve-http.test.ts
@@ -297,47 +297,25 @@ describe("createHttpServeApp", () => {
   it("requires explicit public origin before trusted proxy headers select remote credential audiences", async () => {
     const { engine } = testEngine();
     const store = remoteCredentialStore();
-    const issued = store.createPairingCode({ hostUrl: "https://caplets.example.com/" });
-    const app = createHttpServeApp(
-      httpOptions({ auth: { type: "remote_credentials" }, trustProxy: true }),
-      engine,
-      {
-        writeErr: () => {},
-        remoteCredentialStore: store,
-      },
-    );
-
-    const exchanged = await app.request("http://10.0.0.5:5387/v1/remote/pairing/exchange", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-forwarded-proto": "https",
-        "x-forwarded-host": "caplets.example.com",
-      },
-      body: JSON.stringify({ code: issued.code }),
-    });
-
-    expect(exchanged.status).toBe(400);
-    await expect(exchanged.json()).resolves.toMatchObject({
-      ok: false,
-      error: { code: "REQUEST_INVALID" },
-    });
-
-    const refreshed = await app.request("http://10.0.0.5:5387/v1/remote/refresh", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-forwarded-proto": "https",
-        "x-forwarded-host": "caplets.example.com",
-      },
-      body: JSON.stringify({ refreshToken: "unused-refresh-token" }),
-    });
-    expect(refreshed.status).toBe(400);
-    await expect(refreshed.json()).resolves.toMatchObject({
-      ok: false,
-      error: { code: "REQUEST_INVALID" },
-    });
-    await engine.close();
+    try {
+      expect(() =>
+        createHttpServeApp(
+          httpOptions({ auth: { type: "remote_credentials" }, trustProxy: true }),
+          engine,
+          {
+            writeErr: () => {},
+            remoteCredentialStore: store,
+          },
+        ),
+      ).toThrow(
+        expect.objectContaining({
+          code: "REQUEST_INVALID",
+          message: "Remote credential auth with --trust-proxy requires CAPLETS_SERVER_URL.",
+        }) as CapletsError,
+      );
+    } finally {
+      await engine.close();
+    }
   });
 
   it("uses explicit public origin for remote credential audiences behind trusted proxies", async () => {

--- a/packages/core/test/serve-http.test.ts
+++ b/packages/core/test/serve-http.test.ts
@@ -229,7 +229,34 @@ describe("createHttpServeApp", () => {
     const revokedByReplay = await app.request("http://127.0.0.1:5387/v1/attach/manifest", {
       headers: { authorization: `Bearer ${nextCredentials.accessToken}` },
     });
-    expect(revokedByReplay.status).toBe(401);
+    expect(revokedByReplay.status).toBe(200);
+
+    await engine.close();
+  });
+
+  it("revokes the authenticated self-hosted remote client", async () => {
+    const { engine } = testEngine();
+    const store = remoteCredentialStore();
+    const credentials = pairedClient(store);
+    const app = createHttpServeApp(httpOptions({ auth: { type: "remote_credentials" } }), engine, {
+      writeErr: () => {},
+      remoteCredentialStore: store,
+    });
+
+    const revoked = await app.request("http://127.0.0.1:5387/v1/remote/client", {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${credentials.accessToken}` },
+    });
+
+    expect(revoked.status).toBe(200);
+    await expect(revoked.json()).resolves.toMatchObject({
+      revoked: true,
+      clientId: credentials.clientId,
+    });
+    const attach = await app.request("http://127.0.0.1:5387/v1/attach/manifest", {
+      headers: { authorization: `Bearer ${credentials.accessToken}` },
+    });
+    expect(attach.status).toBe(401);
 
     await engine.close();
   });
@@ -1276,6 +1303,7 @@ function pairedClient(
   store: RemoteServerCredentialStore,
   hostUrl = "http://127.0.0.1:5387/",
 ): {
+  clientId: string;
   accessToken: string;
   refreshToken: string;
 } {

--- a/packages/core/test/serve-http.test.ts
+++ b/packages/core/test/serve-http.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { CapletsEngine } from "../src/engine";
 import { RemoteAuthFlowStore } from "../src/remote-control/auth-flow";
+import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
 import { createHttpServeApp } from "../src/serve/http";
 import type { HttpServeOptions } from "../src/serve/options";
 
@@ -104,6 +105,129 @@ describe("createHttpServeApp", () => {
       },
     });
     expect(wrong.status).toBe(401);
+
+    await engine.close();
+  });
+
+  it("uses issued remote credentials for protected self-hosted route classes", async () => {
+    const { engine } = testEngine();
+    const store = remoteCredentialStore();
+    const credentials = pairedClient(store);
+    const app = createHttpServeApp(httpOptions(), engine, {
+      writeErr: () => {},
+      remoteCredentialStore: store,
+    });
+
+    const root = await app.request("http://127.0.0.1:5387/");
+    expect(root.status).toBe(200);
+    await expect(root.json()).resolves.toMatchObject({
+      auth: { type: "remote_credentials", enabled: true },
+    });
+
+    const basic = await app.request("http://127.0.0.1:5387/v1/attach/manifest", {
+      headers: {
+        authorization: `Basic ${Buffer.from("caplets:password").toString("base64")}`,
+      },
+    });
+    expect(basic.status).toBe(401);
+    expect(basic.headers.get("www-authenticate")).toBeNull();
+
+    const attach = await app.request("http://127.0.0.1:5387/v1/attach/manifest", {
+      headers: { authorization: `Bearer ${credentials.accessToken}` },
+    });
+    expect(attach.status).toBe(200);
+
+    const project = await app.request(
+      "http://127.0.0.1:5387/v1/attach/project-bindings/bind_123/status",
+      { headers: { authorization: `Bearer ${credentials.accessToken}` } },
+    );
+    expect(project.status).toBe(200);
+
+    const control = await app.request("http://127.0.0.1:5387/v1/admin", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${credentials.accessToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ command: "list", arguments: {} }),
+    });
+    expect(control.status).toBe(200);
+    await expect(control.json()).resolves.toMatchObject({ ok: true });
+
+    const mcp = await app.request("http://127.0.0.1:5387/v1/mcp", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${credentials.accessToken}`,
+        host: "127.0.0.1:5387",
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      }),
+    });
+    expect(mcp.status).toBe(200);
+
+    await engine.close();
+  });
+
+  it("exchanges Pairing Codes and rotates refresh credentials without accepting the copied code", async () => {
+    const { engine } = testEngine();
+    const store = remoteCredentialStore();
+    const issued = store.createPairingCode({ hostUrl: "http://127.0.0.1:5387/" });
+    const app = createHttpServeApp(httpOptions(), engine, {
+      writeErr: () => {},
+      remoteCredentialStore: store,
+    });
+
+    const exchanged = await app.request("http://127.0.0.1:5387/v1/remote/pairing/exchange", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: issued.code, clientLabel: "Test Client" }),
+    });
+    expect(exchanged.status).toBe(200);
+    const credentials = (await exchanged.json()) as {
+      accessToken: string;
+      refreshToken: string;
+    };
+    expect(credentials.accessToken).not.toBe(issued.code);
+    expect(credentials.refreshToken).not.toBe(issued.code);
+
+    const copiedCodeAttach = await app.request("http://127.0.0.1:5387/v1/attach/manifest", {
+      headers: { authorization: `Bearer ${issued.code}` },
+    });
+    expect(copiedCodeAttach.status).toBe(401);
+
+    const refreshed = await app.request("http://127.0.0.1:5387/v1/remote/refresh", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: credentials.refreshToken }),
+    });
+    expect(refreshed.status).toBe(200);
+    const nextCredentials = (await refreshed.json()) as {
+      accessToken: string;
+      refreshToken: string;
+    };
+    expect(nextCredentials.refreshToken).not.toBe(credentials.refreshToken);
+
+    const stale = await app.request("http://127.0.0.1:5387/v1/remote/refresh", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: credentials.refreshToken }),
+    });
+    expect(stale.status).toBe(401);
+
+    const revokedByReplay = await app.request("http://127.0.0.1:5387/v1/attach/manifest", {
+      headers: { authorization: `Bearer ${nextCredentials.accessToken}` },
+    });
+    expect(revokedByReplay.status).toBe(401);
 
     await engine.close();
   });
@@ -470,6 +594,39 @@ describe("createHttpServeApp", () => {
         "content-type": "application/json",
         "x-forwarded-proto": "https",
         "x-forwarded-host": "caplets.example.com",
+      },
+      body: JSON.stringify({ command: "auth_login_start", arguments: { server: "remote" } }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual(expect.objectContaining({ ok: true }));
+    const result = (body as { result: { authorizationUrl: string } }).result;
+    const authorizationUrl = new URL(result.authorizationUrl);
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toMatch(
+      /^http:\/\/10\.0\.0\.5:5387\/caplets\/v1\/admin\/auth\/callback\//u,
+    );
+
+    await engine.close();
+  });
+
+  it("ignores spoofed host headers for remote auth callback URLs by default", async () => {
+    const context = testContext({ oauth: true });
+    const engine = new CapletsEngine({
+      configPath: context.configPath,
+      projectConfigPath: context.projectConfigPath,
+      watch: false,
+    });
+    const app = createHttpServeApp(httpOptions({ path: "/caplets" }), engine, {
+      writeErr: () => {},
+      control: context,
+    });
+
+    const response = await app.request("http://10.0.0.5:5387/caplets/v1/admin", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        host: "attacker.example.com",
       },
       body: JSON.stringify({ command: "auth_login_start", arguments: { server: "remote" } }),
     });
@@ -1006,6 +1163,27 @@ function httpOptions(overrides: Partial<HttpServeOptions> = {}): HttpServeOption
     trustProxy: false,
     ...overrides,
   };
+}
+
+function remoteCredentialStore(): RemoteServerCredentialStore {
+  return new RemoteServerCredentialStore({ dir: tempDir("caplets-http-remote-credentials-") });
+}
+
+function pairedClient(store: RemoteServerCredentialStore): {
+  accessToken: string;
+  refreshToken: string;
+} {
+  const issued = store.createPairingCode({ hostUrl: "http://127.0.0.1:5387/" });
+  return store.exchangePairingCode({
+    hostUrl: "http://127.0.0.1:5387/",
+    code: issued.code,
+  });
+}
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  dirs.push(dir);
+  return dir;
 }
 
 function testEngine(config: Record<string, unknown> = {}): { engine: CapletsEngine } {

--- a/packages/core/test/serve-http.test.ts
+++ b/packages/core/test/serve-http.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { CapletsEngine } from "../src/engine";
+import { CapletsError } from "../src/errors";
 import { RemoteAuthFlowStore } from "../src/remote-control/auth-flow";
 import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
 import { createHttpServeApp } from "../src/serve/http";
@@ -236,6 +237,32 @@ describe("createHttpServeApp", () => {
       headers: { authorization: `Bearer ${nextCredentials.accessToken}` },
     });
     expect(revokedByReplay.status).toBe(200);
+
+    await engine.close();
+  });
+
+  it("returns a retryable status when remote credential refresh state is unavailable", async () => {
+    const { engine } = testEngine();
+    const app = createHttpServeApp(httpOptions({ auth: { type: "remote_credentials" } }), engine, {
+      writeErr: () => {},
+      remoteCredentialStore: {
+        refreshClientCredentials: () => {
+          throw new CapletsError("SERVER_UNAVAILABLE", "Remote credential state is locked.");
+        },
+      } as unknown as RemoteServerCredentialStore,
+    });
+
+    const response = await app.request("http://127.0.0.1:5387/v1/remote/refresh", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: "refresh-token" }),
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "SERVER_UNAVAILABLE" },
+    });
 
     await engine.close();
   });

--- a/packages/core/test/serve-options.test.ts
+++ b/packages/core/test/serve-options.test.ts
@@ -13,20 +13,18 @@ describe("resolveServeOptions", () => {
       host: "127.0.0.1",
       port: 5387,
       path: "/",
-      auth: { enabled: false, user: "caplets" },
+      auth: { type: "remote_credentials" },
+      remoteCredentialStateDir: expect.stringContaining("remote-server"),
       trustProxy: false,
     });
   });
 
   it("uses CAPLETS_SERVER_URL as HTTP serve defaults", () => {
-    const testPassword = ["test", "env", "password"].join("-");
-
     expect(
       resolveServeOptions(
         { transport: "http" },
         {
           CAPLETS_SERVER_URL: "http://localhost:7890/caplets/",
-          CAPLETS_SERVER_PASSWORD: testPassword,
         },
       ),
     ).toMatchObject({
@@ -34,7 +32,7 @@ describe("resolveServeOptions", () => {
       host: "localhost",
       port: 7890,
       path: "/caplets",
-      auth: { enabled: true, user: "caplets", password: testPassword },
+      auth: { type: "remote_credentials" },
       publicOrigin: "http://localhost:7890",
     });
   });
@@ -79,7 +77,7 @@ describe("resolveServeOptions", () => {
       host: "::1",
       port: 5387,
       path: "/caplets",
-      auth: { enabled: false, user: "caplets" },
+      auth: { type: "remote_credentials" },
       loopback: true,
       warnUnauthenticatedNetwork: false,
     });
@@ -115,39 +113,25 @@ describe("resolveServeOptions", () => {
     });
   });
 
-  it("resolves Basic Auth from password with default user", () => {
-    const testPassword = ["test", "password"].join("-");
-
-    expect(resolveServeOptions({ transport: "http", password: testPassword }, {})).toMatchObject({
-      transport: "http",
-      auth: { enabled: true, user: "caplets", password: testPassword },
-    });
-  });
-
-  it("resolves Basic Auth from env and lets flags win", () => {
-    const envPassword = ["test", "env", "password"].join("-");
-
+  it("ignores removed Basic Auth env vars and keeps remote credential auth", () => {
     expect(
-      resolveServeOptions(
-        { transport: "http", user: "cli-user" },
-        { CAPLETS_SERVER_USER: "env-user", CAPLETS_SERVER_PASSWORD: envPassword },
-      ),
+      resolveServeOptions({ transport: "http" }, {
+        CAPLETS_SERVER_USER: "env-user",
+        CAPLETS_SERVER_PASSWORD: "env-password",
+      } as Record<string, string>),
     ).toMatchObject({
       transport: "http",
-      auth: { enabled: true, user: "cli-user", password: envPassword },
+      auth: { type: "remote_credentials" },
     });
   });
 
-  it("rejects explicit user without password", () => {
-    expect(() => resolveServeOptions({ transport: "http", user: "alice" }, {})).toThrow(
-      /requires a password/u,
-    );
-  });
-
-  it("requires explicit opt-in for unauthenticated non-loopback HTTP serving", () => {
-    expect(() => resolveServeOptions({ transport: "http", host: "0.0.0.0" }, {})).toThrow(
-      /requires --allow-unauthenticated-http/u,
-    );
+  it("allows non-loopback HTTP serving when protected by remote credentials", () => {
+    expect(resolveServeOptions({ transport: "http", host: "0.0.0.0" }, {})).toMatchObject({
+      transport: "http",
+      host: "0.0.0.0",
+      auth: { type: "remote_credentials" },
+      warnUnauthenticatedNetwork: false,
+    });
   });
 
   it("enables proxy trust only with explicit HTTP opt-in", () => {
@@ -180,17 +164,17 @@ describe("resolveServeOptions", () => {
   });
 
   it("allows unauthenticated non-loopback HTTP serving with explicit opt-in", () => {
-    expect(
-      resolveServeOptions(
-        { transport: "http", host: "0.0.0.0", allowUnauthenticatedHttp: true },
-        {},
-      ),
-    ).toMatchObject({
+    const resolved = resolveServeOptions(
+      { transport: "http", host: "0.0.0.0", allowUnauthenticatedHttp: true },
+      {},
+    );
+    expect(resolved).toMatchObject({
       transport: "http",
       host: "0.0.0.0",
-      auth: { enabled: false, user: "caplets" },
+      auth: { type: "development_unauthenticated" },
       warnUnauthenticatedNetwork: true,
     });
+    expect("remoteCredentialStateDir" in resolved).toBe(false);
   });
 
   it("rejects HTTP-only options for stdio", () => {

--- a/packages/core/test/serve-options.test.ts
+++ b/packages/core/test/serve-options.test.ts
@@ -157,6 +157,28 @@ describe("resolveServeOptions", () => {
     });
   });
 
+  it("resolves the server-owned remote credential state directory", () => {
+    expect(resolveServeOptions({ transport: "http" }, {})).toMatchObject({
+      remoteCredentialStateDir: expect.stringContaining("remote-server"),
+    });
+    expect(
+      resolveServeOptions(
+        { transport: "http", remoteStatePath: "/var/lib/caplets/remote-auth" },
+        { CAPLETS_REMOTE_SERVER_STATE_DIR: "/env/remote-auth" },
+      ),
+    ).toMatchObject({
+      remoteCredentialStateDir: "/var/lib/caplets/remote-auth",
+    });
+    expect(
+      resolveServeOptions(
+        { transport: "http" },
+        { CAPLETS_REMOTE_SERVER_STATE_DIR: "/env/remote-auth" },
+      ),
+    ).toMatchObject({
+      remoteCredentialStateDir: "/env/remote-auth",
+    });
+  });
+
   it("allows unauthenticated non-loopback HTTP serving with explicit opt-in", () => {
     expect(
       resolveServeOptions(

--- a/packages/core/test/server-options.test.ts
+++ b/packages/core/test/server-options.test.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import { describe, expect, it } from "vitest";
 
 import type { CapletsError } from "../src/errors";
@@ -54,9 +53,14 @@ describe("resolveCapletsMode", () => {
 });
 
 describe("resolveCapletsServer", () => {
-  it("normalizes a base path URL and derives service URLs with Basic Auth", () => {
-    const password = ["server", "password"].join("-");
-    const resolved = resolveCapletsServer({ url: "https://example.com/caplets/", password }, {});
+  it("normalizes a base path URL and derives service URLs without legacy server auth", () => {
+    const resolved = resolveCapletsServer(
+      { url: "https://example.com/caplets/" } as never,
+      {
+        CAPLETS_SERVER_USER: "env-user",
+        CAPLETS_SERVER_PASSWORD: ["server", "password"].join("-"),
+      } as Record<string, string>,
+    );
 
     expect(resolved).toMatchObject({
       baseUrl: new URL("https://example.com/caplets"),
@@ -64,12 +68,8 @@ describe("resolveCapletsServer", () => {
       attachUrl: new URL("https://example.com/caplets/v1/attach"),
       controlUrl: new URL("https://example.com/caplets/v1/admin"),
       healthUrl: new URL("https://example.com/caplets/v1/healthz"),
-      auth: { enabled: true, user: "caplets", password },
-      requestInit: {
-        headers: {
-          Authorization: `Basic ${Buffer.from(`caplets:${password}`).toString("base64")}`,
-        },
-      },
+      auth: { type: "none" },
+      requestInit: {},
     });
   });
 
@@ -110,31 +110,24 @@ describe("resolveCapletsServer", () => {
     }
   });
 
-  it("requires a password when user is explicit", () => {
-    expect(() =>
-      resolveCapletsServer({ url: "https://example.com/caplets", user: "alice" }, {}),
-    ).toThrow(/requires a password/u);
-  });
-
-  it("resolves Basic Auth from CAPLETS_SERVER_USER and CAPLETS_SERVER_PASSWORD", () => {
-    const password = ["env", "password"].join("-");
-
+  it("ignores removed server Basic Auth fields", () => {
     expect(
       resolveCapletsServer(
-        {},
+        {
+          url: "https://input.example.com/caplets",
+          user: "input-user",
+          password: "input-password",
+        } as never,
         {
           CAPLETS_SERVER_URL: "https://example.com/caplets",
           CAPLETS_SERVER_USER: "env-user",
-          CAPLETS_SERVER_PASSWORD: password,
-        },
+          CAPLETS_SERVER_PASSWORD: "env-password",
+        } as Record<string, string>,
       ),
     ).toMatchObject({
-      auth: { enabled: true, user: "env-user", password },
-      requestInit: {
-        headers: {
-          Authorization: `Basic ${Buffer.from(`env-user:${password}`).toString("base64")}`,
-        },
-      },
+      baseUrl: new URL("https://input.example.com/caplets"),
+      auth: { type: "none" },
+      requestInit: {},
     });
   });
 });

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -32,12 +32,12 @@ CAPLETS_MODE=remote CAPLETS_REMOTE_URL=https://caplets.example.com/caplets openc
 CAPLETS_MODE=cloud CAPLETS_REMOTE_URL=https://cloud.caplets.dev opencode
 ```
 
-Run `caplets cloud auth login` before Cloud mode. For authenticated self-hosted remotes, keep credentials in the environment:
+Run `caplets remote login <url>` before remote or Cloud mode. Native integrations use the saved Remote Profile, so remote credentials do not belong in the environment:
 
 ```sh
+caplets remote login https://caplets.example.com/caplets
 CAPLETS_MODE=remote \
 CAPLETS_REMOTE_URL=https://caplets.example.com/caplets \
-CAPLETS_REMOTE_TOKEN=... \
 opencode
 ```
 
@@ -52,7 +52,6 @@ export default {
         mode: "remote",
         remote: {
           url: "https://caplets.example.com/caplets",
-          user: "caplets",
           pollIntervalMs: 5_000,
         },
       },
@@ -61,4 +60,4 @@ export default {
 };
 ```
 
-Plugin config overrides environment variables. The explicit config shape is `{ mode, remote: { url, user, pollIntervalMs } }`. Prefer `CAPLETS_REMOTE_TOKEN` or `CAPLETS_REMOTE_PASSWORD` for self-hosted credentials unless your OpenCode setup provides secure secret storage.
+Plugin config overrides environment variables. The explicit config shape is `{ mode, remote: { url, pollIntervalMs } }`; credentials come from `caplets remote login <url>`.

--- a/packages/opencode/test/opencode.test.ts
+++ b/packages/opencode/test/opencode.test.ts
@@ -305,7 +305,6 @@ describe("@caplets/opencode", () => {
         mode: "remote",
         remote: {
           url: "https://caplets.example.com",
-          user: "caplets",
           pollIntervalMs: 5_000,
         },
       } as never,
@@ -315,7 +314,6 @@ describe("@caplets/opencode", () => {
       mode: "remote",
       remote: {
         url: "https://caplets.example.com",
-        user: "caplets",
         pollIntervalMs: 5_000,
       },
     });

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -45,7 +45,7 @@ CAPLETS_MODE=remote CAPLETS_REMOTE_URL=https://caplets.example.com/caplets pi
 CAPLETS_MODE=cloud CAPLETS_REMOTE_URL=https://cloud.caplets.dev pi
 ```
 
-Run `caplets cloud auth login` before Cloud mode. For authenticated self-hosted remotes, prefer `CAPLETS_REMOTE_TOKEN`, or `CAPLETS_REMOTE_USER` plus `CAPLETS_REMOTE_PASSWORD`, from your shell or secret manager.
+Run `caplets remote login <url>` before remote or Cloud mode. Native integrations use the saved Remote Profile, so remote credentials do not belong in environment variables or Pi settings.
 
 Pi currently calls extension factories with the Pi API only, so this extension reads its remote
 settings from the top-level `caplets` key in `~/.pi/agent/settings.json` when no programmatic
@@ -58,7 +58,6 @@ options are supplied:
     "mode": "remote",
     "remote": {
       "url": "https://caplets.example.com/caplets",
-      "user": "caplets",
       "pollIntervalMs": 5000
     },
     "statusWidget": true,
@@ -84,13 +83,11 @@ export default createCapletsPiExtension({
     mode: "remote",
     remote: {
       url: "https://caplets.example.com/caplets",
-      user: "caplets",
       pollIntervalMs: 5_000,
     },
   },
 });
 ```
 
-The explicit config shape is `{ mode, remote: { url, user, pollIntervalMs } }`.
-Prefer environment variables for `CAPLETS_REMOTE_TOKEN` or `CAPLETS_REMOTE_PASSWORD` rather than storing passwords in
-settings files or source code.
+The explicit config shape is `{ mode, remote: { url, pollIntervalMs } }`. Credentials come from
+`caplets remote login <url>`, not settings files or source code.

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -289,7 +289,7 @@ function parsePiNativeOptions(
   }
   if (remote) {
     const parsedRemote: NonNullable<PiNativeCapletsOptions["remote"]> = {};
-    for (const key of ["url", "user", "password", "token", "workspace"] as const) {
+    for (const key of ["url", "workspace"] as const) {
       const field = remote[key];
       if (field !== undefined) {
         if (typeof field !== "string") return undefined;

--- a/packages/pi/test/pi.test.ts
+++ b/packages/pi/test/pi.test.ts
@@ -728,7 +728,7 @@ describe("@caplets/pi", () => {
     const service = mockService([]);
     const args = {
       mode: "remote",
-      remote: { url: "https://caplets.example.com", user: "pi-user" },
+      remote: { url: "https://caplets.example.com" },
     } satisfies Pick<NativeCapletsServiceOptions, "mode" | "remote">;
     nativeMocks.createNativeCapletsService.mockReturnValueOnce(service);
 
@@ -1051,7 +1051,7 @@ describe("@caplets/pi", () => {
     });
   });
 
-  it("loads remote URL fields from Pi settings", async () => {
+  it("loads non-secret remote URL fields from Pi settings", async () => {
     const writeWarning = vi.fn();
     fsMocks.readFile.mockResolvedValueOnce(
       JSON.stringify({
@@ -1060,8 +1060,6 @@ describe("@caplets/pi", () => {
           mode: "remote",
           remote: {
             url: "https://caplets.example.com",
-            user: "ian",
-            password: "test-password",
             pollIntervalMs: 1_000,
           },
         },
@@ -1075,8 +1073,6 @@ describe("@caplets/pi", () => {
       mode: "remote",
       remote: {
         url: "https://caplets.example.com",
-        user: "ian",
-        password: "test-password",
         pollIntervalMs: 1_000,
       },
     });
@@ -1148,7 +1144,6 @@ describe("@caplets/pi", () => {
           mode: "remote",
           remote: {
             url: "https://caplets.example.com",
-            user: "ian",
             pollIntervalMs: 1_000,
           },
         },
@@ -1163,7 +1158,6 @@ describe("@caplets/pi", () => {
       mode: "remote",
       remote: {
         url: "https://caplets.example.com",
-        user: "ian",
         pollIntervalMs: 1_000,
       },
     });

--- a/scripts/check-public-docs.ts
+++ b/scripts/check-public-docs.ts
@@ -47,7 +47,7 @@ const requiredContent = new Map<string, string[]>([
   ],
   ["capabilities.mdx", ["CAPLET.md", "OpenAPI", "GraphQL", "MCP"]],
   ["agent-integrations.mdx", ["Codex", "Claude", "OpenCode", "Pi"]],
-  ["remote-attach.mdx", ["caplets attach", "CAPLETS_MODE=remote"]],
+  ["remote-attach.mdx", ["caplets attach", "caplets remote login"]],
   ["troubleshooting.mdx", ["caplets doctor", "CAPLETS_CONFIG"]],
   ["changelog.mdx", ["Changelog", "GitHub releases"]],
   ["reference/config.mdx", ["https://caplets.dev/config.schema.json", "Required"]],


### PR DESCRIPTION
## Summary

Remote attach no longer depends on agent-owned env secrets or one-off startup credentials. Users can trust a Caplets host once with `caplets remote login <url>`, then `caplets attach`, hosted Cloud, OpenCode, and Pi resolve Caplets-owned Remote Profiles as the credential source of truth.

The self-hosted path now uses pairing codes and stored remote profiles instead of legacy Basic Auth/env-token setup. Long-running native clients also refresh runtime auth before polling, tool invocation, stale-manifest retry, and attach event reconnects, so background traffic does not keep using expired authorization headers.

## Design Notes

- Remote Profiles are host-scoped and stored by Caplets, keeping remote secrets out of agent config.
- `CAPLETS_REMOTE_URL` remains a non-secret selector for native integrations.
- Setup, doctor, docs, and native integration guidance now steer through Remote Login rather than compatibility auth paths.
- The branch includes durable requirements, implementation plan, Changesets, `CONCEPTS.md` vocabulary, and a solution note for the stale background-auth issue.

## Validation

- `pnpm changeset status --since=origin/main`
- `python3 /Users/ianpascoe/.codex/.tmp/marketplaces/compound-engineering-plugin/plugins/compound-engineering/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/integration-issues/stale-remote-profile-credentials-refresh.md`
- `pnpm docs:check`
- `pnpm verify`
- `git push -u origin HEAD` pre-push hook reran `pnpm verify` successfully

## Post-Deploy Monitoring & Validation

Validation window: first 24 hours after release. Owner: release owner.

Healthy signals:
- Users can run `caplets remote login <url>` and then attach without adding remote secrets to agent config.
- `caplets doctor` reports clear Remote Profile status for Cloud and self-hosted hosts.
- Long-running native integrations continue to list and call remote tools after credential refresh windows.

Failure signals:
- Reports of `AUTH_FAILED`, `SERVER_UNAVAILABLE`, or repeated attach event reconnect failures after successful Remote Login.
- Support/debug logs showing stale `Authorization` headers after Remote Profile refresh.
- Setup or doctor output steering Cloud users into self-hosted remote mode.

Suggested checks:
- Search issue/support reports for `remote login`, `Remote Profile`, `AUTH_FAILED`, `attach event`, `pairing code`, and `CAPLETS_REMOTE_URL`.
- Re-run a smoke flow against self-hosted and Cloud remotes: login, attach, list tools, wait through a refresh interval or force refreshed credentials, then list/call again.

Rollback/mitigation trigger:
- If Remote Login blocks attach for existing users, hold release promotion and patch the affected resolver/setup path. Avoid reintroducing agent-config secrets as the primary path; use a targeted resolver fix or explicit migration note instead.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added unified Remote Login with saved Remote Profiles (self-hosted and cloud).
  * Introduced the `caplets remote` command group (login/status/logout and host/client management).
  * Added file-backed profile/credential storage used automatically by `caplets attach --remote-url <url>`.

* **Improvements**
  * Remote authorization is refreshed for reconnects, background polling, and stale-manifest retries to prevent expired-token reuse.
  * Removed basic-auth/remote-token secret patterns from remote attach setup flows.

* **Documentation**
  * Updated remote-mode, troubleshooting, and extension guides to the new workflow.

* **Tests**
  * Expanded coverage for remote login flows, refreshed auth behavior, and updated diagnostics output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->