### PR TITLE
fix(cli): respect remote caplet shadowing policy

### DIFF
--- a/.changeset/friendly-windows-heal.md
+++ b/.changeset/friendly-windows-heal.md
@@ -1,0 +1,6 @@
+---
+"@caplets/core": patch
+"caplets": patch
+---
+
+Respect remote Caplet shadowing policy when merging local overlays into remote CLI list output.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -4068,6 +4068,12 @@ function mergeRemoteAndLocalRows(
       if (row.disabled) {
         continue;
       }
+      if (remote.shadowing !== "allow") {
+        options.writeErr(
+          `Local Caplet '${row.server}' is suppressed because the remote Caplet forbids shadowing that Caplet ID.\n`,
+        );
+        continue;
+      }
       options.writeErr(
         `Warning: ${formatOverlaySource(row.source)} Caplet ${row.server} shadows remote Caplet\n`,
       );

--- a/packages/core/src/cli/inspection.ts
+++ b/packages/core/src/cli/inspection.ts
@@ -5,6 +5,7 @@ import {
   resolveConfigPath,
   resolveProjectConfigPath,
   type CapletConfig,
+  type CapletShadowingPolicy,
   type CapletsConfig,
   type ConfigSource,
   type ConfigWithSources,
@@ -21,6 +22,7 @@ type CapletListRow = {
   source: ConfigSource["kind"] | "remote" | "unknown";
   path: string | null;
   shadows: ConfigSource[];
+  shadowing?: CapletShadowingPolicy | undefined;
 };
 
 type ConfigPaths = {
@@ -50,6 +52,7 @@ export function listCaplets(
       source: sources[server.server]?.kind ?? "unknown",
       path: sources[server.server]?.path ?? null,
       shadows: shadows[server.server] ?? [],
+      shadowing: server.shadowing,
     }));
   return rows.sort((left, right) => left.server.localeCompare(right.server));
 }

--- a/packages/core/test/cli-remote.test.ts
+++ b/packages/core/test/cli-remote.test.ts
@@ -493,7 +493,10 @@ describe("remote CLI routing", () => {
     const err: string[] = [];
     writeCliCapletConfig(context.configPath, "shared", "Disabled Shared", { disabled: true });
     const fetch = vi.fn(async () =>
-      Response.json({ ok: true, result: [remoteListRow("shared", "Remote Shared")] }),
+      Response.json({
+        ok: true,
+        result: [{ ...remoteListRow("shared", "Remote Shared"), shadowing: "allow" }],
+      }),
     );
 
     await runCli(["list", "--json"], {
@@ -509,13 +512,44 @@ describe("remote CLI routing", () => {
     expect(err.join("")).not.toContain("shadows remote Caplet");
   });
 
+  it("keeps remote list rows when the remote Caplet forbids local shadowing", async () => {
+    const context = testContext("caplets-cli-remote-list-forbid-shadow-");
+    const out: string[] = [];
+    const err: string[] = [];
+    writeCliCapletConfig(context.configPath, "shared", "Local Shared");
+    const fetch = vi.fn(async () =>
+      Response.json({
+        ok: true,
+        result: [{ ...remoteListRow("shared", "Remote Shared"), shadowing: "forbid" }],
+      }),
+    );
+
+    await runCli(["list", "--json"], {
+      env: remoteEnv(context),
+      fetch,
+      writeOut: (value) => out.push(value),
+      writeErr: (value) => err.push(value),
+    });
+
+    expect(JSON.parse(out.join(""))).toEqual([
+      expect.objectContaining({ server: "shared", name: "Remote Shared", source: "remote" }),
+    ]);
+    expect(err.join("")).toContain(
+      "Local Caplet 'shared' is suppressed because the remote Caplet forbids shadowing that Caplet ID.",
+    );
+    expect(err.join("")).not.toContain("global Caplet shared shadows remote Caplet");
+  });
+
   it("lets project list rows shadow remote rows and warns on stderr", async () => {
     const context = testContext("caplets-cli-remote-list-project-shadow-");
     const out: string[] = [];
     const err: string[] = [];
     writeProjectMcpCaplet(context.projectCapletsRoot, "shared", "Project Shared");
     const fetch = vi.fn(async () =>
-      Response.json({ ok: true, result: [remoteListRow("shared", "Remote Shared")] }),
+      Response.json({
+        ok: true,
+        result: [{ ...remoteListRow("shared", "Remote Shared"), shadowing: "allow" }],
+      }),
     );
 
     await runCli(["list", "--json"], {
@@ -537,7 +571,10 @@ describe("remote CLI routing", () => {
     const err: string[] = [];
     writeCliCapletConfig(context.configPath, "shared", "Global Shared");
     const fetch = vi.fn(async () =>
-      Response.json({ ok: true, result: [remoteListRow("shared", "Remote Shared")] }),
+      Response.json({
+        ok: true,
+        result: [{ ...remoteListRow("shared", "Remote Shared"), shadowing: "allow" }],
+      }),
     );
 
     await runCli(["list", "--json"], {

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -3140,6 +3140,23 @@ describe("config", () => {
     ]);
   });
 
+  it("includes Caplet shadowing policy in inspection list rows", () => {
+    const config = parseConfig({
+      mcpServers: {
+        browser: {
+          name: "Browser",
+          description: "Local browser tools.",
+          command: "browser-mcp",
+          shadowing: "allow",
+        },
+      },
+    });
+
+    expect(listCaplets({ config, sources: {}, shadows: {} }, { includeDisabled: false })).toEqual([
+      expect.objectContaining({ server: "browser", shadowing: "allow" }),
+    ]);
+  });
+
   it("rejects invalid Caplet set sources and duplicate IDs", () => {
     expect(() =>
       parseConfig({


### PR DESCRIPTION
## Summary

Remote CLI list output now respects the remote Caplet's shadowing policy instead of letting every matching local overlay replace the remote row. Users with mirrored local/remote configs should now see remote rows for default-forbid Caplets, while intentionally shadowable Caplets such as local browser/computer overlays can still appear locally when the remote config allows it.

This also carries the configured `shadowing` policy through list rows so self-hosted remote list responses expose the policy needed by clients.

## Validation

- `pnpm --filter @caplets/core test -- test/cli-remote.test.ts test/config.test.ts`
- `pnpm --filter @caplets/core typecheck`
- `pnpm --filter @caplets/core build && pnpm --filter caplets build`
- `pnpm format:check && pnpm lint`
- pre-push hook: `pnpm verify` (`104` test files, `1608` tests passed, full build passed)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* CLI now properly respects remote Caplet shadowing policies when merging local overlays with remote lists. Local overlays are suppressed when the remote Caplet's shadowing policy forbids it, with a notification displayed.
* Caplet list output now includes shadowing policy information to support proper enforcement of shadowing policies during merge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->