### PR TITLE
fix(release): run publish through package script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
   changeset:
     name: Changeset
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, '[no changeset]') == false
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'no changeset') == false
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm version-packages
-          publish: pnpm telemetry:prepare-release-env && pnpm release
+          publish: pnpm release:publish
           commit: "chore: version packages"
           title: "chore: version packages"
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@
 
 ## PR And Release Checks
 
-- CI runs `pnpm verify` plus `pnpm changeset status --since=origin/main` on PRs unless the PR has the `[no changeset]` label.
+- CI runs `pnpm verify` plus `pnpm changeset status --since=origin/main` on PRs unless the PR has the `no changeset` label.
 - User-facing package changes usually need a changeset; current versioning is handled by Changesets and `pnpm version-packages`/`pnpm release`.
 - Pre-commit only runs `pnpm lint-staged` (`oxfmt --check` and `oxlint` on staged JS/TS/config/docs files); pre-push runs the full `pnpm verify`.
 - Alchemy deploy workflows are in `.github/workflows/deploy.yml` and `.github/workflows/pr-preview-deploy.yml`; check `alchemy.run.ts` and `infra/` before changing deploy behavior.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint:staged": "lint-staged",
     "prepare": "husky",
     "release": "turbo build && changeset publish",
+    "release:publish": "pnpm telemetry:prepare-release-env && pnpm release",
     "schema:check": "tsx ./scripts/generate-config-schema.ts --check",
     "schema:generate": "tsx ./scripts/generate-config-schema.ts",
     "test": "vitest run",

--- a/packages/core/test/telemetry-release.test.ts
+++ b/packages/core/test/telemetry-release.test.ts
@@ -37,9 +37,13 @@ describe("telemetry release environment", () => {
   });
 
   it("wires telemetry secrets into the release workflow", () => {
+    const packageJson = read("package.json");
     const workflow = read(".github/workflows/release.yml");
 
-    expect(workflow).toContain("publish: pnpm telemetry:prepare-release-env && pnpm release");
+    expect(packageJson).toContain(
+      '"release:publish": "pnpm telemetry:prepare-release-env && pnpm release"',
+    );
+    expect(workflow).toContain("publish: pnpm release:publish");
     expect(workflow).toContain("CAPLETS_POSTHOG_TOKEN: ${{ secrets.CAPLETS_POSTHOG_TOKEN }}");
     expect(workflow).toContain("CAPLETS_SENTRY_DSN: ${{ secrets.CAPLETS_SENTRY_DSN }}");
   });


### PR DESCRIPTION
## Summary
The release workflow now publishes through a single `pnpm release:publish` script, so Changesets no longer hands `&& pnpm release` to `pnpm telemetry:prepare-release-env` as inert script arguments.

This fixes the June 24 release run that reached Changesets publish mode, wrote bundled telemetry intake identifiers, and then exited before running `pnpm release`. The already-versioned packages on `main` are still unpublished on npm, so merging this should let the next release workflow publish `caplets@0.22.0`, `@caplets/core@0.28.0`, `@caplets/opencode@0.8.0`, and `@caplets/pi@0.9.0`.

## Validation
- Confirmed failed run: https://github.com/spiritledsoftware/caplets/actions/runs/28105672351
- Confirmed npm still reports prior versions for all four public packages.
- Ran `pnpm --filter @caplets/core test -- test/telemetry-release.test.ts`.
- Ran `pnpm verify` locally.
- `git push` pre-push hook ran `pnpm verify` again and passed.

No local publish command was run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
