### PR TITLE
fix(core): add upstream URL to daemon install

### DIFF
--- a/.changeset/stacked-daemon-upstream-url.md
+++ b/.changeset/stacked-daemon-upstream-url.md
@@ -1,0 +1,5 @@
+---
+"@caplets/core": patch
+---
+
+Add `--upstream-url` to `caplets daemon install` so managed HTTP daemons can run stacked Caplets runtimes.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -246,6 +246,7 @@ type DaemonInstallCommandOptions = {
   port?: string;
   path?: string;
   remoteStatePath?: string;
+  upstreamUrl?: string;
   allowUnauthenticatedHttp?: boolean;
   trustProxy?: boolean;
   json?: boolean;
@@ -280,6 +281,10 @@ function addDaemonInstallOptions(command: Command): Command {
     .option("--port <port>", "HTTP bind port")
     .option("--path <path>", "HTTP service base path")
     .option("--remote-state-path <path>", "server-owned remote credential state directory")
+    .option(
+      "--upstream-url <url>",
+      "upstream Caplets runtime URL to compose with this HTTP service",
+    )
     .option(
       "--allow-unauthenticated-http",
       "allow unauthenticated HTTP serving on non-loopback hosts",
@@ -684,6 +689,7 @@ function daemonInstallOptions(options: DaemonInstallCommandOptions): DaemonInsta
     ...(options.port !== undefined ? { port: options.port } : {}),
     ...(options.path !== undefined ? { path: options.path } : {}),
     ...(options.remoteStatePath !== undefined ? { remoteStatePath: options.remoteStatePath } : {}),
+    ...(options.upstreamUrl !== undefined ? { upstreamUrl: options.upstreamUrl } : {}),
     ...(options.allowUnauthenticatedHttp !== undefined
       ? { allowUnauthenticatedHttp: options.allowUnauthenticatedHttp }
       : {}),

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -660,6 +660,11 @@ function mergeServeOptions(
       : existing?.serve.remoteCredentialStateDir
         ? { remoteStatePath: existing.serve.remoteCredentialStateDir }
         : {}),
+    ...(install.upstreamUrl !== undefined
+      ? { upstreamUrl: install.upstreamUrl }
+      : existing?.serve.upstreamUrl
+        ? { upstreamUrl: existing.serve.upstreamUrl }
+        : {}),
     ...(install.allowUnauthenticatedHttp !== undefined
       ? { allowUnauthenticatedHttp: install.allowUnauthenticatedHttp }
       : existing

--- a/packages/core/src/daemon/process.ts
+++ b/packages/core/src/daemon/process.ts
@@ -42,6 +42,7 @@ export function daemonServeArgs(options: HttpServeOptions): string[] {
   if (options.auth.type === "remote_credentials" && options.remoteCredentialStateDir) {
     args.push("--remote-state-path", options.remoteCredentialStateDir);
   }
+  if (options.upstreamUrl) args.push("--upstream-url", options.upstreamUrl);
   if (options.allowUnauthenticatedHttp) args.push("--allow-unauthenticated-http");
   if (options.trustProxy) args.push("--trust-proxy");
   return args;

--- a/packages/core/test/serve-daemon.test.ts
+++ b/packages/core/test/serve-daemon.test.ts
@@ -86,6 +86,38 @@ describe("caplets daemon CLI", () => {
     }
   });
 
+  it("passes upstream URL through daemon install", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-cli-upstream-"));
+    try {
+      const out: string[] = [];
+      await runCli(
+        [
+          "daemon",
+          "install",
+          "--dry-run",
+          "--json",
+          "--upstream-url",
+          "https://upstream.caplets.example.com/caplets",
+        ],
+        {
+          env: testEnv(dir),
+          writeOut: (value) => out.push(value),
+          daemon: { platform: "linux", commandRunner: fakeRunner() },
+        },
+      );
+
+      const result = JSON.parse(out.join("")) as {
+        config: { serve: { upstreamUrl: string }; command: { args: string[] } };
+      };
+      expect(result.config.serve.upstreamUrl).toBe("https://upstream.caplets.example.com/caplets");
+      expect(result.config.command.args).toEqual(
+        expect.arrayContaining(["--upstream-url", "https://upstream.caplets.example.com/caplets"]),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("moves removed serve daemon subcommands to daemon guidance", async () => {
     await expect(runCli(["serve", "start"], { writeErr: () => {} })).rejects.toThrow(
       /Use caplets daemon start/u,

--- a/packages/core/test/serve-daemon.test.ts
+++ b/packages/core/test/serve-daemon.test.ts
@@ -88,17 +88,11 @@ describe("caplets daemon CLI", () => {
 
   it("passes upstream URL through daemon install", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-cli-upstream-"));
+    const upstreamUrl = "https://upstream.caplets.example.com/caplets";
     try {
       const out: string[] = [];
       await runCli(
-        [
-          "daemon",
-          "install",
-          "--dry-run",
-          "--json",
-          "--upstream-url",
-          "https://upstream.caplets.example.com/caplets",
-        ],
+        ["daemon", "install", "--json", "--no-validate", "--upstream-url", upstreamUrl],
         {
           env: testEnv(dir),
           writeOut: (value) => out.push(value),
@@ -109,10 +103,25 @@ describe("caplets daemon CLI", () => {
       const result = JSON.parse(out.join("")) as {
         config: { serve: { upstreamUrl: string }; command: { args: string[] } };
       };
-      expect(result.config.serve.upstreamUrl).toBe("https://upstream.caplets.example.com/caplets");
-      expect(result.config.command.args).toEqual(
-        expect.arrayContaining(["--upstream-url", "https://upstream.caplets.example.com/caplets"]),
-      );
+      const upstreamArgIndex = result.config.command.args.indexOf("--upstream-url");
+      expect(result.config.serve.upstreamUrl).toBe(upstreamUrl);
+      expect(upstreamArgIndex).toBeGreaterThanOrEqual(0);
+      expect(result.config.command.args[upstreamArgIndex + 1]).toBe(upstreamUrl);
+
+      const updateOut: string[] = [];
+      await runCli(["daemon", "install", "--dry-run", "--json"], {
+        env: testEnv(dir),
+        writeOut: (value) => updateOut.push(value),
+        daemon: { platform: "linux", commandRunner: fakeRunner() },
+      });
+
+      const updateResult = JSON.parse(updateOut.join("")) as {
+        config: { serve: { upstreamUrl: string }; command: { args: string[] } };
+      };
+      const updateUpstreamArgIndex = updateResult.config.command.args.indexOf("--upstream-url");
+      expect(updateResult.config.serve.upstreamUrl).toBe(upstreamUrl);
+      expect(updateUpstreamArgIndex).toBeGreaterThanOrEqual(0);
+      expect(updateResult.config.command.args[updateUpstreamArgIndex + 1]).toBe(upstreamUrl);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

`caplets daemon install` can now persist the same `--upstream-url` stacking configuration supported by foreground HTTP serve. Before this change, daemon users could run stacked HTTP services only in the foreground path; the daemon install command rejected the option and could not write a managed stacked service. The daemon installer now accepts the option, preserves it across config updates, and serializes it into the managed `caplets serve` command.

## Validation

- `pnpm verify` via the pre-push hook
- `pnpm changeset status --since=origin/main`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `--upstream-url` option to daemon installation, allowing managed HTTP daemons to use a specified upstream endpoint.
  * The upstream URL is now carried through during setup and included when the daemon starts.

* **Tests**
  * Added coverage to verify the upstream URL is preserved and passed along correctly during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->