### PR TITLE
fix: keep daemon service on stable caplets command

### DIFF
--- a/.changeset/stable-daemon-command.md
+++ b/.changeset/stable-daemon-command.md
@@ -1,0 +1,6 @@
+---
+"@caplets/core": patch
+"caplets": patch
+---
+
+Keep daemon service descriptors pointed at the stable `caplets` command instead of pnpm's versioned package target so pnpm updates do not strand installed daemons on removed package paths.

--- a/packages/core/src/daemon/process.ts
+++ b/packages/core/src/daemon/process.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync } from "node:fs";
+import { accessSync, constants, existsSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, resolve } from "node:path";
 import { defaultConfigPath } from "../config/paths";
@@ -55,8 +55,12 @@ export function buildDaemonCommandPlan(options: {
   inheritEnv?: boolean;
 }): DaemonCommandPlan {
   const platform = options.operation.platform ?? process.platform;
-  const executable = resolveDaemonExecutable(process.argv[1]);
-  const args = daemonServeArgs(options.serve);
+  const command = resolveDaemonCommand({
+    env: options.operation.env ?? process.env,
+    platform,
+    scriptPath: process.argv[1],
+    serveArgs: daemonServeArgs(options.serve),
+  });
   const workingDirectory = options.operation.home ?? homedir();
   const explicitEnv = options.explicitEnv ?? {};
   const serviceEnv = daemonServiceEnv({
@@ -67,8 +71,8 @@ export function buildDaemonCommandPlan(options: {
     workingDirectory,
   });
   const base = {
-    executable,
-    args,
+    executable: command.executable,
+    args: command.args,
     workingDirectory,
     env: serviceEnv,
     inheritEnv: options.inheritEnv ?? false,
@@ -129,7 +133,21 @@ function configSelectionEnvKeys(platform: NodeJS.Platform): string[] {
     : ["XDG_CONFIG_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME"];
 }
 
-function resolveDaemonExecutable(scriptPath: string | undefined): string {
+function resolveDaemonCommand(options: {
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  platform: NodeJS.Platform;
+  scriptPath: string | undefined;
+  serveArgs: string[];
+}): { executable: string; args: string[] } {
+  const script = resolveDaemonCliScript(options.scriptPath);
+  const stableCommand = resolvePathCommand("caplets", options.env, options.platform);
+  if (stableCommand) {
+    return { executable: stableCommand, args: options.serveArgs };
+  }
+  return { executable: process.execPath, args: [script, ...options.serveArgs] };
+}
+
+function resolveDaemonCliScript(scriptPath: string | undefined): string {
   if (!scriptPath) {
     throw new CapletsError(
       "REQUEST_INVALID",
@@ -151,6 +169,71 @@ function resolveDaemonExecutable(scriptPath: string | undefined): string {
     );
   }
   return executable;
+}
+
+function resolvePathCommand(
+  command: string,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+  platform: NodeJS.Platform,
+): string | undefined {
+  const path = env.PATH ?? env.Path ?? env.path;
+  if (!path) return undefined;
+  const delimiter = platform === "win32" ? ";" : ":";
+  for (const entry of path.split(delimiter)) {
+    const directory = entry.trim();
+    if (!directory) continue;
+    for (const candidate of pathCommandCandidates(directory, command, env, platform)) {
+      if (!isRunnableCommand(candidate, platform)) continue;
+      const realCandidate = safeRealpath(candidate);
+      if (isTransientRunnerPath(candidate) || isTransientRunnerPath(realCandidate)) {
+        throw new CapletsError(
+          "REQUEST_INVALID",
+          "Cannot install the daemon from a temporary runner such as npx or pnpm dlx. Install caplets first, then rerun caplets daemon install.",
+        );
+      }
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function pathCommandCandidates(
+  directory: string,
+  command: string,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+  platform: NodeJS.Platform,
+): string[] {
+  const resolved = isAbsolute(directory) ? directory : resolve(directory);
+  if (platform !== "win32") return [resolve(resolved, command)];
+  const lower = command.toLocaleLowerCase();
+  if (/\.[^.\\/]+$/u.test(lower)) return [resolve(resolved, command)];
+  const extensions = (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return [command, ...extensions.map((extension) => `${command}${extension}`)].map((value) =>
+    resolve(resolved, value),
+  );
+}
+
+function isRunnableCommand(path: string, platform: NodeJS.Platform): boolean {
+  try {
+    const stat = statSync(path);
+    if (!stat.isFile()) return false;
+    if (platform === "win32") return true;
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function safeRealpath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
 }
 
 function isTransientRunnerPath(path: string): boolean {

--- a/packages/core/src/daemon/process.ts
+++ b/packages/core/src/daemon/process.ts
@@ -70,6 +70,14 @@ export function buildDaemonCommandPlan(options: {
     serve: options.serve,
     workingDirectory,
   });
+  if (
+    command.pathEnv &&
+    serviceEnv.PATH === undefined &&
+    serviceEnv.Path === undefined &&
+    serviceEnv.path === undefined
+  ) {
+    serviceEnv.PATH = command.pathEnv;
+  }
   const base = {
     executable: command.executable,
     args: command.args,
@@ -138,12 +146,16 @@ function resolveDaemonCommand(options: {
   platform: NodeJS.Platform;
   scriptPath: string | undefined;
   serveArgs: string[];
-}): { executable: string; args: string[] } {
-  const script = resolveDaemonCliScript(options.scriptPath);
+}): { executable: string; args: string[]; pathEnv?: string | undefined } {
   const stableCommand = resolvePathCommand("caplets", options.env, options.platform);
   if (stableCommand) {
-    return { executable: stableCommand, args: options.serveArgs };
+    return {
+      executable: stableCommand,
+      args: options.serveArgs,
+      pathEnv: pathEnvValue(options.env),
+    };
   }
+  const script = resolveDaemonCliScript(options.scriptPath);
   return { executable: process.execPath, args: [script, ...options.serveArgs] };
 }
 
@@ -176,7 +188,7 @@ function resolvePathCommand(
   env: NodeJS.ProcessEnv | Record<string, string | undefined>,
   platform: NodeJS.Platform,
 ): string | undefined {
-  const path = env.PATH ?? env.Path ?? env.path;
+  const path = pathEnvValue(env);
   if (!path) return undefined;
   const delimiter = platform === "win32" ? ";" : ":";
   for (const entry of path.split(delimiter)) {
@@ -211,9 +223,13 @@ function pathCommandCandidates(
     .split(";")
     .map((value) => value.trim())
     .filter(Boolean);
-  return [command, ...extensions.map((extension) => `${command}${extension}`)].map((value) =>
-    resolve(resolved, value),
-  );
+  return extensions.map((extension) => resolve(resolved, `${command}${extension}`));
+}
+
+function pathEnvValue(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): string | undefined {
+  return env.PATH ?? env.Path ?? env.path;
 }
 
 function isRunnableCommand(path: string, platform: NodeJS.Platform): boolean {

--- a/packages/core/src/daemon/shell.ts
+++ b/packages/core/src/daemon/shell.ts
@@ -13,7 +13,7 @@ export function serviceCommand(config: {
     shell?: { executable: string; args: string[] };
   };
 }): { executable: string; args: string[]; display: string } {
-  const direct = [process.execPath, config.command.executable, ...config.command.args];
+  const direct = [config.command.executable, ...config.command.args];
   if (!config.command.shell) {
     return {
       executable: direct[0]!,

--- a/packages/core/src/daemon/validation.ts
+++ b/packages/core/src/daemon/validation.ts
@@ -1,7 +1,7 @@
 import { CapletsError } from "../errors";
 import { servicePaths } from "../serve/http";
 import type { DaemonConfig, DaemonHealthResult } from "./types";
-import { serviceCommand } from "./shell";
+import { serviceCommand, shellCommandLine } from "./shell";
 
 export async function validateDaemonCommand(
   config: DaemonConfig,
@@ -161,9 +161,20 @@ function healthUrl(config: DaemonConfig, port = config.serve.port): string {
   return `http://${formatHost(config.serve.host)}:${port}${servicePaths(config.serve.path).health}`;
 }
 
-function validationSpawnCommand(config: DaemonConfig): { command: string; args: string[] } {
+export function validationSpawnCommand(config: DaemonConfig): { command: string; args: string[] } {
   const planned = serviceCommand(config);
+  if (isWindowsCommandShim(planned.executable)) {
+    const shell = { executable: "cmd.exe", args: ["/d", "/s", "/c"] };
+    return {
+      command: shell.executable,
+      args: [...shell.args, shellCommandLine(shell, [planned.executable, ...planned.args])],
+    };
+  }
   return { command: planned.executable, args: planned.args };
+}
+
+function isWindowsCommandShim(path: string): boolean {
+  return /\.(?:bat|cmd)$/iu.test(path);
 }
 
 async function sleep(ms: number): Promise<void> {

--- a/packages/core/test/serve-daemon.test.ts
+++ b/packages/core/test/serve-daemon.test.ts
@@ -1127,6 +1127,54 @@ describe("daemon paths and config", () => {
     }
   });
 
+  it("uses the stable caplets command instead of pnpm's versioned package target", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-pnpm-stable-bin-"));
+    const originalArgv = process.argv[1];
+    try {
+      const binDir = join(dir, "pnpm", "bin");
+      const packageTarget = join(
+        dir,
+        "pnpm",
+        "global",
+        "v11",
+        "233dbf-19efa214857",
+        "node_modules",
+        "caplets",
+        "dist",
+        "index.js",
+      );
+      const stableBin = join(binDir, "caplets");
+      mkdirSync(dirname(packageTarget), { recursive: true });
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(packageTarget, "#!/usr/bin/env node\n");
+      chmodSync(packageTarget, 0o755);
+      writeFileSync(stableBin, '#!/bin/sh\nexec node /changed-by-pnpm/global/path "$@"\n');
+      chmodSync(stableBin, 0o755);
+      process.argv[1] = packageTarget;
+
+      const result = await installDaemon(
+        { validate: false, dryRun: true },
+        {
+          env: { ...testEnv(dir), PATH: binDir },
+          home: "/home/alice",
+          platform: "linux",
+          commandRunner: fakeRunner(),
+        },
+      );
+
+      expect(result.config.command.executable).toBe(stableBin);
+      expect(result.config.command.args[0]).toBe("serve");
+      expect(result.descriptor.kind).toBe("systemd-user");
+      if (result.descriptor.kind !== "systemd-user") throw new Error("expected systemd");
+      expect(result.descriptor.contents).toContain(`ExecStart="${stableBin}" "serve"`);
+      expect(result.descriptor.contents).not.toContain(packageTarget);
+    } finally {
+      if (originalArgv === undefined) process.argv.splice(1, 1);
+      else process.argv[1] = originalArgv;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("rolls back descriptor files when native registration fails", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-rollback-"));
     try {
@@ -2431,8 +2479,8 @@ describe("daemon validation", () => {
         ...result.config,
         command: {
           ...result.config.command,
-          executable: candidate,
-          args: [],
+          executable: process.execPath,
+          args: [candidate],
         },
       };
 
@@ -2518,8 +2566,8 @@ createServer((_request, response) => response.end("ok")).listen(${port}, "127.0.
         ...result.config,
         command: {
           ...result.config.command,
-          executable: serverFile,
-          args: [],
+          executable: process.execPath,
+          args: [serverFile],
         },
       };
 

--- a/packages/core/test/serve-daemon.test.ts
+++ b/packages/core/test/serve-daemon.test.ts
@@ -31,7 +31,11 @@ import {
 } from "../src/daemon";
 import { daemonHostPath } from "../src/daemon/host-path";
 import { serviceCommand } from "../src/daemon/shell";
-import { allocateLoopbackPort, validateDaemonCommand } from "../src/daemon/validation";
+import {
+  allocateLoopbackPort,
+  validateDaemonCommand,
+  validationSpawnCommand,
+} from "../src/daemon/validation";
 
 function cwdBackslashEntriesContaining(marker: string): string[] {
   return readdirSync(process.cwd()).filter(
@@ -1171,6 +1175,101 @@ describe("daemon paths and config", () => {
     } finally {
       if (originalArgv === undefined) process.argv.splice(1, 1);
       else process.argv[1] = originalArgv;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("checks PATH before rejecting a transient runner fallback", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-path-before-runner-"));
+    const originalArgv = process.argv[1];
+    try {
+      const binDir = join(dir, "bin");
+      const stableBin = join(binDir, "caplets");
+      const transientCli = join(dir, "dlx-12345", "node_modules", ".bin", "caplets");
+      mkdirSync(binDir, { recursive: true });
+      mkdirSync(dirname(transientCli), { recursive: true });
+      writeFileSync(stableBin, "#!/bin/sh\n");
+      writeFileSync(transientCli, "#!/usr/bin/env node\n");
+      chmodSync(stableBin, 0o755);
+      chmodSync(transientCli, 0o755);
+      process.argv[1] = transientCli;
+
+      const result = await installDaemon(
+        { validate: false, dryRun: true },
+        {
+          env: { ...testEnv(dir), PATH: binDir },
+          home: "/home/alice",
+          platform: "linux",
+          commandRunner: fakeRunner(),
+        },
+      );
+
+      expect(result.config.command.executable).toBe(stableBin);
+    } finally {
+      if (originalArgv === undefined) process.argv.splice(1, 1);
+      else process.argv[1] = originalArgv;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves PATH when the daemon command uses an installed shim", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-shim-path-"));
+    try {
+      const binDir = join(dir, "bin");
+      const nodeDir = join(dir, "node");
+      const stableBin = join(binDir, "caplets");
+      const path = `${binDir}:${nodeDir}`;
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(stableBin, '#!/bin/sh\nexec node "$@"\n');
+      chmodSync(stableBin, 0o755);
+
+      const result = await installDaemon(
+        { validate: false, dryRun: true },
+        {
+          env: { ...testEnv(dir), PATH: path },
+          home: "/home/alice",
+          platform: "linux",
+          commandRunner: fakeRunner(),
+        },
+      );
+
+      expect(result.config.command.executable).toBe(stableBin);
+      expect(result.config.command.env.PATH).toBe(path);
+      expect(result.descriptor.kind).toBe("systemd-user");
+      if (result.descriptor.kind !== "systemd-user") throw new Error("expected systemd");
+      expect(result.descriptor.contents).toContain(`Environment="PATH=${path}"`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses PATHEXT candidates without extensionless commands on Windows", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-windows-pathext-"));
+    try {
+      const binDir = join(dir, "bin");
+      const extensionless = join(binDir, "caplets");
+      const cmdShim = join(binDir, "caplets.CMD");
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(extensionless, "not executable by Windows PATH lookup\n");
+      writeFileSync(cmdShim, "@echo off\r\n");
+
+      const result = await installDaemon(
+        { validate: false, dryRun: true },
+        {
+          env: {
+            APPDATA: win32.join(dir, "AppData", "Roaming"),
+            LOCALAPPDATA: win32.join(dir, "AppData", "Local"),
+            PATH: binDir,
+            PATHEXT: ".CMD",
+          },
+          home: "C:\\Users\\Alice",
+          platform: "win32",
+          commandRunner: fakeRunner(),
+        },
+      );
+
+      expect(result.config.command.executable).toBe(cmdShim);
+    } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -2578,6 +2677,44 @@ createServer((_request, response) => response.end("ok")).listen(${port}, "127.0.
 
       expect(childEnv.SERVICE_ONLY).toBe("1");
       expect(childEnv.INSTALLER_ONLY).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("wraps Windows cmd shims for validation", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-daemon-validation-cmd-"));
+    try {
+      const result = await installDaemon(
+        { validate: false, dryRun: true },
+        {
+          env: {
+            APPDATA: win32.join(dir, "AppData", "Roaming"),
+            LOCALAPPDATA: win32.join(dir, "AppData", "Local"),
+          },
+          home: "C:\\Users\\Alice",
+          platform: "win32",
+          commandRunner: fakeRunner(),
+        },
+      );
+      const config = {
+        ...result.config,
+        command: {
+          ...result.config.command,
+          executable: "C:\\Users\\Alice\\AppData\\Roaming\\pnpm\\caplets.cmd",
+          args: ["serve", "--path", "pa th"],
+        },
+      };
+
+      expect(validationSpawnCommand(config)).toEqual({
+        command: "cmd.exe",
+        args: [
+          "/d",
+          "/s",
+          "/c",
+          '"C:\\Users\\Alice\\AppData\\Roaming\\pnpm\\caplets.cmd" serve --path "pa th"',
+        ],
+      });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- resolve daemon installs to the stable `caplets` command on `PATH` before falling back to the current CLI script
- execute stored daemon command plans directly across native service descriptors and validation
- add a pnpm-style regression test and patch changeset for `@caplets/core` and `caplets`

## Root Cause

`caplets daemon install` persisted the current Node script path from `process.argv[1]`. With pnpm global installs, that path can point inside pnpm's versioned global package store. Updating Caplets rewrites the stable shim but can remove or replace the old package target, leaving the installed daemon pointed at a stale path.

## Validation

- `pnpm --filter @caplets/core test -- test/serve-daemon.test.ts`
- `pnpm --filter @caplets/core typecheck`
- `pnpm format:check`
- `pnpm lint`
- pre-push `pnpm verify` passed on retry, including full tests, benchmark check, and build

## Notes

Existing daemons already pointing at removed pnpm package targets still need one reinstall/restart after upgrading, for example `caplets daemon install --restart`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Daemon services now keep using the stable `caplets` command, preventing installs from breaking when package paths change.
  * Command execution for daemons no longer includes an extra runtime wrapper in the reported or executed command, improving consistency.
* **Tests**
  * Added and updated test coverage for daemon installation and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->