### PR TITLE
fix(core): keep MCP health checks available

### DIFF
--- a/.changeset/posthog-healthcheck.md
+++ b/.changeset/posthog-healthcheck.md
@@ -1,0 +1,6 @@
+---
+"@caplets/core": patch
+"caplets": patch
+---
+
+Keep MCP backend health checks available when a server supports resources but not resource templates.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -42,6 +42,16 @@ Vault Access Grants are identified by Caplet ID, reference name, and config orig
 
 The persisted daemon agreement that defines what command runs, which environment model applies, which native service identity owns it, and how updates become active.
 
+### MCP Resource
+
+A concrete read-only content item exposed by an MCP backend, identified by a URI and optionally accompanied by metadata such as a name or media type.
+
+### MCP Resource Template
+
+A templated MCP resource URI that describes a family of readable resources rather than one concrete item.
+
+MCP Resource Templates are distinct from MCP Resources: a backend can support concrete resources without supporting templates, so runtime health and discovery should treat template listing as optional.
+
 ### Native Service Manager
 
 The operating system facility that owns per-user service registration and lifecycle for the Caplets Daemon.

--- a/docs/solutions/integration-issues/mcp-resource-templates-healthcheck.md
+++ b/docs/solutions/integration-issues/mcp-resource-templates-healthcheck.md
@@ -44,6 +44,8 @@ try {
 }
 ```
 
+When normalizing the method-not-found response, replace the cached template list with an empty array and refresh its timestamp before throwing `UNSUPPORTED_CAPABILITY`. That clears any stale templates from earlier successful probes and avoids repeated live calls to a known-unsupported method during the cache TTL.
+
 Add a regression test with an HTTP MCP fixture that advertises resources, implements `tools/list` and `resources/list`, but returns JSON-RPC `-32601` for `resources/templates/list`. The health check should return `status: "available"`, `resourceTemplateCount: 0`, and leave the registry status available.
 
 ## Why This Works

--- a/docs/solutions/integration-issues/mcp-resource-templates-healthcheck.md
+++ b/docs/solutions/integration-issues/mcp-resource-templates-healthcheck.md
@@ -1,0 +1,61 @@
+---
+title: MCP resource templates should be optional in health checks
+date: 2026-06-24
+category: docs/solutions/integration-issues
+module: MCP backend health checks
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - PostHog check-backend reported unavailable with MCP error -32601 Method not found
+  - Tools and resources still listed successfully for the same backend
+root_cause: wrong_api
+resolution_type: code_fix
+severity: medium
+tags: [mcp, healthcheck, resource-templates, posthog]
+---
+
+# MCP resource templates should be optional in health checks
+
+## Problem
+
+A backend health check can falsely report an MCP server as unavailable when the server supports concrete resources but does not implement resource templates. The visible failure is confusing because core operations such as tool listing and resource listing may still work.
+
+## Symptoms
+
+- `caplets check-backend posthog --format json` returned `status: "unavailable"` with `MCP error -32601: Method not found`.
+- `caplets list-tools posthog` and `caplets list-resources posthog` succeeded.
+- `caplets list-resource-templates posthog` returned the same method-not-found error.
+
+## What Didn't Work
+
+- Treating the healthcheck failure as an auth or connectivity problem did not match the evidence: authenticated tool calls and resource listing were already succeeding.
+- Checking only `tools/list` did not explain why `check-backend` failed, because the health check also probes optional MCP surfaces.
+
+## Solution
+
+Treat resource-template listing as optional when a server reports resources support. If `resources/templates/list` returns method-not-found, normalize that response to `UNSUPPORTED_CAPABILITY`, set the health payload's `resourceTemplates` capability to `false`, and keep the backend available.
+
+```ts
+try {
+  resourceTemplateCount = (await this.listResourceTemplates(server, true)).length;
+} catch (error) {
+  if (!isUnsupportedCapability(error)) throw error;
+  capabilitySummary.resourceTemplates = false;
+}
+```
+
+Add a regression test with an HTTP MCP fixture that advertises resources, implements `tools/list` and `resources/list`, but returns JSON-RPC `-32601` for `resources/templates/list`. The health check should return `status: "available"`, `resourceTemplateCount: 0`, and leave the registry status available.
+
+## Why This Works
+
+In MCP, concrete resources and resource templates are related but not equivalent capabilities. A server can be a healthy resources-capable backend without supporting templated resource URIs. The health check should therefore separate required backend availability from optional surface probing.
+
+## Prevention
+
+- When adding MCP capability probes, distinguish advertised core capabilities from optional methods that may still be absent.
+- Regression tests should cover partially implemented MCP surfaces, not only servers that advertise tools.
+- For health checks, optional surface failures should degrade the reported capability summary instead of changing the whole backend status.
+
+## Related Issues
+
+- Captured from PR #157 investigation.

--- a/packages/core/src/downstream.ts
+++ b/packages/core/src/downstream.ts
@@ -280,6 +280,8 @@ export class DownstreamManager {
       } while (cursor);
     } catch (error) {
       if (isMcpMethodNotFoundError(error)) {
+        connection.resourceTemplates = [];
+        connection.resourceTemplatesFetchedAt = Date.now();
         throw new CapletsError(
           "UNSUPPORTED_CAPABILITY",
           `${server.server} does not implement MCP resource templates`,
@@ -946,7 +948,7 @@ function isUnsupportedCapability(error: unknown): boolean {
 }
 
 function isMcpMethodNotFoundError(error: unknown): boolean {
-  return error instanceof Error && /MCP error -32601|Method not found/i.test(error.message);
+  return error instanceof Error && /MCP error -32601/i.test(error.message);
 }
 
 function stringifyPromptArgs(args: Record<string, unknown>): Record<string, string> {

--- a/packages/core/src/downstream.ts
+++ b/packages/core/src/downstream.ts
@@ -138,23 +138,31 @@ export class DownstreamManager {
       const capabilities = connection.client.getServerCapabilities() ?? {};
       const tools = await this.refreshTools(server, true);
       this.registry.setStatus(server.server, "available");
+      const capabilitySummary = {
+        tools: Boolean(capabilities.tools),
+        resources: Boolean(capabilities.resources),
+        resourceTemplates: Boolean(capabilities.resources),
+        prompts: Boolean(capabilities.prompts),
+        completions: Boolean(capabilities.completions),
+      };
       const result = {
         id: server.server,
         status: "available",
-        capabilities: {
-          tools: Boolean(capabilities.tools),
-          resources: Boolean(capabilities.resources),
-          resourceTemplates: Boolean(capabilities.resources),
-          prompts: Boolean(capabilities.prompts),
-          completions: Boolean(capabilities.completions),
-        },
+        capabilities: capabilitySummary,
         toolCount: tools.length,
         elapsedMs: Date.now() - startedAt,
       };
       if (capabilities.resources) {
+        let resourceTemplateCount = 0;
+        try {
+          resourceTemplateCount = (await this.listResourceTemplates(server, true)).length;
+        } catch (error) {
+          if (!isUnsupportedCapability(error)) throw error;
+          capabilitySummary.resourceTemplates = false;
+        }
         Object.assign(result, {
           resourceCount: (await this.listResources(server, true)).length,
-          resourceTemplateCount: (await this.listResourceTemplates(server, true)).length,
+          resourceTemplateCount,
         });
       }
       if (capabilities.prompts) {
@@ -261,14 +269,25 @@ export class DownstreamManager {
       return connection.resourceTemplates;
     const resourceTemplates: McpResourceTemplate[] = [];
     let cursor: string | undefined;
-    do {
-      const result = await connection.client.listResourceTemplates(
-        cursor ? { cursor } : undefined,
-        { timeout: server.startupTimeoutMs },
-      );
-      resourceTemplates.push(...(result.resourceTemplates ?? []));
-      cursor = result.nextCursor;
-    } while (cursor);
+    try {
+      do {
+        const result = await connection.client.listResourceTemplates(
+          cursor ? { cursor } : undefined,
+          { timeout: server.startupTimeoutMs },
+        );
+        resourceTemplates.push(...(result.resourceTemplates ?? []));
+        cursor = result.nextCursor;
+      } while (cursor);
+    } catch (error) {
+      if (isMcpMethodNotFoundError(error)) {
+        throw new CapletsError(
+          "UNSUPPORTED_CAPABILITY",
+          `${server.server} does not implement MCP resource templates`,
+          { server: server.server, capability: "resourceTemplates" },
+        );
+      }
+      throw error;
+    }
     connection.resourceTemplates = resourceTemplates;
     connection.resourceTemplatesFetchedAt = Date.now();
     return resourceTemplates;
@@ -920,6 +939,14 @@ function nearbyToolNames(tools: Tool[], needle: string): string[] {
 
 function isTimeoutLike(error: unknown): boolean {
   return error instanceof Error && /timeout|timed out|aborted/i.test(error.message);
+}
+
+function isUnsupportedCapability(error: unknown): boolean {
+  return error instanceof CapletsError && error.code === "UNSUPPORTED_CAPABILITY";
+}
+
+function isMcpMethodNotFoundError(error: unknown): boolean {
+  return error instanceof Error && /MCP error -32601|Method not found/i.test(error.message);
 }
 
 function stringifyPromptArgs(args: Record<string, unknown>): Record<string, string> {

--- a/packages/core/test/downstream.test.ts
+++ b/packages/core/test/downstream.test.ts
@@ -465,6 +465,114 @@ describe("downstream stdio lifecycle", () => {
     }
   });
 
+  it("keeps health checks available when resource templates are not implemented", async () => {
+    let resourceTemplatesListCount = 0;
+    const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        void (async () => {
+          if (!body) {
+            response.statusCode = 202;
+            response.end();
+            return;
+          }
+          const message = JSON.parse(body) as { id?: number; method?: string };
+          response.setHeader("content-type", "application/json");
+          if (message.method === "initialize") {
+            response.end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                result: {
+                  protocolVersion: "2025-06-18",
+                  capabilities: { tools: {}, resources: {} },
+                  serverInfo: { name: "fixture-remote", version: "1.0.0" },
+                },
+              }),
+            );
+            return;
+          }
+          if (message.method === "tools/list") {
+            response.end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                result: { tools: [{ name: "remote_echo", inputSchema: { type: "object" } }] },
+              }),
+            );
+            return;
+          }
+          if (message.method === "resources/list") {
+            response.end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                result: { resources: [] },
+              }),
+            );
+            return;
+          }
+          if (message.method === "resources/templates/list") {
+            resourceTemplatesListCount += 1;
+            response.end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: message.id,
+                error: { code: -32601, message: "Method not found" },
+              }),
+            );
+            return;
+          }
+          response.statusCode = 202;
+          response.end();
+        })().catch((error) => {
+          response.statusCode = 500;
+          response.end(String(error));
+        });
+      });
+    });
+
+    try {
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Could not bind fixture server");
+      }
+      const config = parseConfig({
+        mcpServers: {
+          remote: {
+            name: "Remote",
+            description: "A useful remote server.",
+            transport: "http",
+            url: `http://127.0.0.1:${address.port}/mcp`,
+          },
+        },
+      });
+      const registry = new ServerRegistry(config);
+      const manager = new DownstreamManager(registry);
+
+      const checkResult = await manager.checkServer(config.mcpServers.remote!);
+
+      expect(checkResult).toMatchObject({
+        id: "remote",
+        status: "available",
+        toolCount: 1,
+        resourceCount: 0,
+        resourceTemplateCount: 0,
+      });
+      expect(resourceTemplatesListCount).toBe(1);
+      expect(registry.getStatus("remote")).toBe("available");
+
+      await manager.close();
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("wraps shared pending connection failures for concurrent callers", async () => {
     const releaseInitialize = deferred<void>();
     let initializeCount = 0;

--- a/packages/core/test/downstream.test.ts
+++ b/packages/core/test/downstream.test.ts
@@ -467,6 +467,7 @@ describe("downstream stdio lifecycle", () => {
 
   it("keeps health checks available when resource templates are not implemented", async () => {
     let resourceTemplatesListCount = 0;
+    let resourceTemplatesSupported = true;
     const server = createServer((request: IncomingMessage, response: ServerResponse) => {
       let body = "";
       request.setEncoding("utf8");
@@ -518,6 +519,20 @@ describe("downstream stdio lifecycle", () => {
           }
           if (message.method === "resources/templates/list") {
             resourceTemplatesListCount += 1;
+            if (resourceTemplatesSupported) {
+              response.end(
+                JSON.stringify({
+                  jsonrpc: "2.0",
+                  id: message.id,
+                  result: {
+                    resourceTemplates: [
+                      { name: "Repository file", uriTemplate: "file:///repo/{path}" },
+                    ],
+                  },
+                }),
+              );
+              return;
+            }
             response.end(
               JSON.stringify({
                 jsonrpc: "2.0",
@@ -554,18 +569,29 @@ describe("downstream stdio lifecycle", () => {
       });
       const registry = new ServerRegistry(config);
       const manager = new DownstreamManager(registry);
+      const serverConfig = config.mcpServers.remote!;
 
-      const checkResult = await manager.checkServer(config.mcpServers.remote!);
+      await expect(manager.listResourceTemplates(serverConfig)).resolves.toEqual([
+        expect.objectContaining({ uriTemplate: "file:///repo/{path}" }),
+      ]);
+      expect(resourceTemplatesListCount).toBe(1);
+
+      resourceTemplatesSupported = false;
+
+      const checkResult = await manager.checkServer(serverConfig);
 
       expect(checkResult).toMatchObject({
         id: "remote",
         status: "available",
+        capabilities: expect.objectContaining({ resourceTemplates: false }),
         toolCount: 1,
         resourceCount: 0,
         resourceTemplateCount: 0,
       });
-      expect(resourceTemplatesListCount).toBe(1);
+      expect(resourceTemplatesListCount).toBe(2);
       expect(registry.getStatus("remote")).toBe("available");
+      await expect(manager.listResourceTemplates(serverConfig)).resolves.toEqual([]);
+      expect(resourceTemplatesListCount).toBe(2);
 
       await manager.close();
     } finally {


### PR DESCRIPTION
## Summary

MCP backends that support resources but not resource templates now remain healthy instead of being marked unavailable. This fixes the PostHog healthcheck case: tools and resources continue to work, while `resourceTemplates` is reported as unsupported with a zero template count. Unsupported `resources/templates/list` responses are normalized to an unsupported-capability path so discovery can treat that method as optional instead of a backend failure.

## Validation

- `pnpm verify` via the pre-push hook
- `node packages/cli/dist/index.js check-backend posthog --format json` returned `status: "available"` with `resourceTemplates: false`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![gpt-5.5_%28high%29](https://img.shields.io/badge/gpt--5.5_%28high%29-000000)
