### PR TITLE
fix(core): stabilize stacked remote attach

### DIFF
--- a/.changeset/fix-stacked-remote-attach.md
+++ b/.changeset/fix-stacked-remote-attach.md
@@ -1,0 +1,6 @@
+---
+"@caplets/core": patch
+"caplets": patch
+---
+
+Avoid wedging stacked remote execution when attach-session creation stalls, keep fresh self-hosted profiles from blocking behind refresh locks, report unsupported self-hosted Project Binding sessions clearly in doctor, and suppress unsupported Project Binding session warnings during self-hosted attach negotiation.

--- a/.changeset/fix-stacked-remote-attach.md
+++ b/.changeset/fix-stacked-remote-attach.md
@@ -3,4 +3,4 @@
 "caplets": patch
 ---
 
-Avoid wedging stacked remote execution when attach-session creation stalls, keep fresh self-hosted profiles from blocking behind refresh locks, report unsupported self-hosted Project Binding sessions clearly in doctor, and suppress unsupported Project Binding session warnings during self-hosted attach negotiation.
+Avoid wedging stacked remote execution when attach-session creation stalls, close late attach sessions after a timeout fallback, keep fresh self-hosted profiles from blocking behind refresh locks, report unsupported self-hosted Project Binding sessions clearly in doctor, and suppress unsupported Project Binding session warnings during self-hosted attach negotiation.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -2555,17 +2555,16 @@ export function createProgram(io: CliIO = {}): Command {
     .description("Diagnose Caplets local, remote, and project-sync configuration.")
     .option("--json", "print JSON output")
     .action(async (options: { json?: boolean }) => {
+      const doctorOptions = {
+        env,
+        ...(io.authDir ? { authDir: io.authDir } : {}),
+        ...(io.daemon ? { daemon: io.daemon } : {}),
+      };
       if (options.json) {
-        writeOut(
-          `${JSON.stringify(
-            await doctorJsonReport({ env, ...(io.daemon ? { daemon: io.daemon } : {}) }),
-            null,
-            2,
-          )}\n`,
-        );
+        writeOut(`${JSON.stringify(await doctorJsonReport(doctorOptions), null, 2)}\n`);
         return;
       }
-      writeOut(await formatDoctorReport({ env, ...(io.daemon ? { daemon: io.daemon } : {}) }));
+      writeOut(await formatDoctorReport(doctorOptions));
     });
 
   const vault = program.command(cliCommands.vault).description("Manage Caplets Vault values.");

--- a/packages/core/src/cli/doctor.ts
+++ b/packages/core/src/cli/doctor.ts
@@ -80,13 +80,11 @@ export async function doctorJsonReport(options: DoctorOptions = {}): Promise<Doc
           : "unconfigured",
       selectedWorkspace: remoteLogin.selectedWorkspace ?? remote.workspace ?? null,
       webSocketUrl: remote.webSocketUrl,
+      sessionSupport:
+        remoteLogin.authenticated && remoteLogin.kind === "self-hosted" ? "unsupported" : "unknown",
       lease: null,
       lastUpgradeError: null,
-      recoveryCommand: remoteLogin.authenticated
-        ? "caplets attach --once"
-        : remote.configured || remoteLogin.configured
-          ? `caplets remote login ${remoteLogin.hostUrl ?? "<url>"}`
-          : "caplets remote login <url>",
+      recoveryCommand: projectBindingRecovery(remoteLogin, remote),
     },
     sync: {
       state: options.syncStatus?.state ?? "idle",
@@ -130,6 +128,9 @@ export async function formatDoctorReport(options: DoctorOptions = {}): Promise<s
     `  Auth mode: ${report.projectBinding.authMode}`,
     `  Selected Workspace: ${report.projectBinding.selectedWorkspace ?? "none"}`,
     `  Binding Session: ${report.projectBinding.state}`,
+    ...(report.projectBinding.sessionSupport !== "unknown"
+      ? [`  Session support: ${report.projectBinding.sessionSupport}`]
+      : []),
     `  Recovery: ${report.projectBinding.recoveryCommand}`,
     "",
     "Project sync",
@@ -233,6 +234,21 @@ function vaultIssueFromWarning(message: string, path: string) {
     target: recoveryCommand.includes("--remote") ? "remote" : "global",
     recoveryCommand,
   };
+}
+
+function projectBindingRecovery(
+  remoteLogin: DoctorRemoteLoginSection,
+  remote: Record<string, unknown>,
+): string {
+  if (remoteLogin.authenticated) {
+    return remoteLogin.kind === "self-hosted"
+      ? "Self-hosted Project Binding sessions are not implemented by this runtime."
+      : "caplets attach --once";
+  }
+  if (remote.configured || remoteLogin.configured) {
+    return `caplets remote login ${remoteLogin.hostUrl ?? "<url>"}`;
+  }
+  return "caplets remote login <url>";
 }
 
 async function resolveDaemonSection(

--- a/packages/core/src/cli/doctor.ts
+++ b/packages/core/src/cli/doctor.ts
@@ -80,8 +80,7 @@ export async function doctorJsonReport(options: DoctorOptions = {}): Promise<Doc
           : "unconfigured",
       selectedWorkspace: remoteLogin.selectedWorkspace ?? remote.workspace ?? null,
       webSocketUrl: remote.webSocketUrl,
-      sessionSupport:
-        remoteLogin.authenticated && remoteLogin.kind === "self-hosted" ? "unsupported" : "unknown",
+      sessionSupport: remoteLogin.kind === "self-hosted" ? "unsupported" : "unknown",
       lease: null,
       lastUpgradeError: null,
       recoveryCommand: projectBindingRecovery(remoteLogin, remote),

--- a/packages/core/src/native/remote.ts
+++ b/packages/core/src/native/remote.ts
@@ -610,25 +610,35 @@ async function createAttachSession(
 ): Promise<string | undefined> {
   const headers = new Headers(requestInit?.headers);
   headers.set("content-type", "application/json");
-  const abortController = new AbortController();
   let timeout: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  const sessionUrl = new URL("sessions", slashUrl(attachUrl));
   const timeoutReached = new Promise<undefined>((resolve) => {
     timeout = setTimeout(() => {
-      abortController.abort();
+      timedOut = true;
       resolve(undefined);
     }, ATTACH_SESSION_CREATE_TIMEOUT_MS);
     timeout.unref?.();
   });
-  const fetchSession = fetchImpl(new URL("sessions", slashUrl(attachUrl)), {
+  const fetchSession = fetchImpl(sessionUrl, {
     ...requestInit,
     method: "POST",
     headers,
     body: JSON.stringify(metadata),
-    signal: abortController.signal,
   }).catch((error: unknown) => {
-    if (abortController.signal.aborted) return undefined;
+    if (timedOut) return undefined;
     throw error;
   });
+  void fetchSession
+    .then(async (response) => {
+      if (!timedOut || !response?.ok) return;
+      const lateSessionId = await attachSessionIdFromResponse(response).catch(() => undefined);
+      if (!lateSessionId) return;
+      await closeAttachSession(attachUrl, requestInit, fetchImpl, lateSessionId).catch(
+        () => undefined,
+      );
+    })
+    .catch(() => undefined);
   let response: Response | undefined;
   try {
     response = await Promise.race([fetchSession, timeoutReached]);
@@ -652,11 +662,22 @@ async function createAttachSession(
       `Caplets attach session returned HTTP ${response.status}.`,
     );
   }
-  const payload = (await response.json()) as unknown;
-  if (!isPlainObject(payload) || typeof payload.sessionId !== "string") {
+  return await parseAttachSessionIdResponse(response);
+}
+
+async function parseAttachSessionIdResponse(response: Response): Promise<string> {
+  const sessionId = await attachSessionIdFromResponse(response);
+  if (!sessionId) {
     throw new CapletsError("SERVER_UNAVAILABLE", "Caplets attach session response was invalid.");
   }
-  return payload.sessionId;
+  return sessionId;
+}
+
+async function attachSessionIdFromResponse(response: Response): Promise<string | undefined> {
+  const payload = (await response.json()) as unknown;
+  return isPlainObject(payload) && typeof payload.sessionId === "string"
+    ? payload.sessionId
+    : undefined;
 }
 
 async function closeAttachSession(

--- a/packages/core/src/native/remote.ts
+++ b/packages/core/src/native/remote.ts
@@ -71,6 +71,9 @@ export type SdkRemoteCapletsClientOptions = RemoteCapletsClientOptions["remote"]
 
 const ATTACH_SESSION_UNSUPPORTED_RETRY_MS = 60_000;
 const ATTACH_SESSION_CREATE_TIMEOUT_MS = 5_000;
+const ATTACH_SESSION_CREATE_TIMED_OUT = Symbol("attach session create timed out");
+
+type AttachSessionCreateResult = string | undefined | typeof ATTACH_SESSION_CREATE_TIMED_OUT;
 
 export type RemoteNativeCapletsServiceOptions = {
   client: RemoteCapletsClient;
@@ -90,7 +93,7 @@ export function createSdkRemoteCapletsClient(
   let eventsStartInFlight: Promise<void> | undefined;
   let eventsReconnectTimer: ReturnType<typeof setTimeout> | undefined;
   let attachSessionId: string | undefined;
-  let attachSessionInFlight: Promise<string | undefined> | undefined;
+  let attachSessionInFlight: Promise<AttachSessionCreateResult> | undefined;
   let attachSessionsUnsupportedUntil = 0;
   let closed = false;
 
@@ -136,7 +139,10 @@ export function createSdkRemoteCapletsClient(
     if (attachSessionsUnsupportedUntil > Date.now()) return undefined;
     attachSessionsUnsupportedUntil = 0;
     if (attachSessionId) return attachSessionId;
-    if (attachSessionInFlight) return await attachSessionInFlight;
+    if (attachSessionInFlight) {
+      const inFlightSessionId = await attachSessionInFlight;
+      return inFlightSessionId === ATTACH_SESSION_CREATE_TIMED_OUT ? undefined : inFlightSessionId;
+    }
     attachSessionInFlight = createAttachSession(
       runtimeOptions.url,
       runtimeOptions.requestInit,
@@ -144,7 +150,11 @@ export function createSdkRemoteCapletsClient(
       options.attachSessionMetadata,
     );
     try {
-      attachSessionId = await attachSessionInFlight;
+      const createdSessionId = await attachSessionInFlight;
+      if (createdSessionId === ATTACH_SESSION_CREATE_TIMED_OUT) {
+        return undefined;
+      }
+      attachSessionId = createdSessionId;
       if (!attachSessionId) {
         attachSessionsUnsupportedUntil = Date.now() + ATTACH_SESSION_UNSUPPORTED_RETRY_MS;
       }
@@ -309,7 +319,9 @@ export function createSdkRemoteCapletsClient(
       eventsAbort?.abort();
       eventsAbort = undefined;
       listeners.clear();
-      const pendingSessionId = await attachSessionInFlight?.catch(() => undefined);
+      const pendingSessionResult = await attachSessionInFlight?.catch(() => undefined);
+      const pendingSessionId =
+        typeof pendingSessionResult === "string" ? pendingSessionResult : undefined;
       const sessionId = attachSessionId ?? pendingSessionId;
       attachSessionId = undefined;
       if (sessionId) {
@@ -607,16 +619,16 @@ async function createAttachSession(
   requestInit: RequestInit | undefined,
   fetchImpl: typeof fetch,
   metadata: AttachSessionMetadata,
-): Promise<string | undefined> {
+): Promise<AttachSessionCreateResult> {
   const headers = new Headers(requestInit?.headers);
   headers.set("content-type", "application/json");
   let timeout: ReturnType<typeof setTimeout> | undefined;
   let timedOut = false;
   const sessionUrl = new URL("sessions", slashUrl(attachUrl));
-  const timeoutReached = new Promise<undefined>((resolve) => {
+  const timeoutReached = new Promise<typeof ATTACH_SESSION_CREATE_TIMED_OUT>((resolve) => {
     timeout = setTimeout(() => {
       timedOut = true;
-      resolve(undefined);
+      resolve(ATTACH_SESSION_CREATE_TIMED_OUT);
     }, ATTACH_SESSION_CREATE_TIMEOUT_MS);
     timeout.unref?.();
   });
@@ -639,12 +651,13 @@ async function createAttachSession(
       );
     })
     .catch(() => undefined);
-  let response: Response | undefined;
+  let response: Response | typeof ATTACH_SESSION_CREATE_TIMED_OUT | undefined;
   try {
     response = await Promise.race([fetchSession, timeoutReached]);
   } finally {
     if (timeout) clearTimeout(timeout);
   }
+  if (response === ATTACH_SESSION_CREATE_TIMED_OUT) return ATTACH_SESSION_CREATE_TIMED_OUT;
   if (!response) return undefined;
   if (!response.ok) {
     if (response.status === 404) return undefined;

--- a/packages/core/src/native/remote.ts
+++ b/packages/core/src/native/remote.ts
@@ -70,6 +70,7 @@ export type SdkRemoteCapletsClientOptions = RemoteCapletsClientOptions["remote"]
 };
 
 const ATTACH_SESSION_UNSUPPORTED_RETRY_MS = 60_000;
+const ATTACH_SESSION_CREATE_TIMEOUT_MS = 5_000;
 
 export type RemoteNativeCapletsServiceOptions = {
   client: RemoteCapletsClient;
@@ -609,12 +610,32 @@ async function createAttachSession(
 ): Promise<string | undefined> {
   const headers = new Headers(requestInit?.headers);
   headers.set("content-type", "application/json");
-  const response = await fetchImpl(new URL("sessions", slashUrl(attachUrl)), {
+  const abortController = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutReached = new Promise<undefined>((resolve) => {
+    timeout = setTimeout(() => {
+      abortController.abort();
+      resolve(undefined);
+    }, ATTACH_SESSION_CREATE_TIMEOUT_MS);
+    timeout.unref?.();
+  });
+  const fetchSession = fetchImpl(new URL("sessions", slashUrl(attachUrl)), {
     ...requestInit,
     method: "POST",
     headers,
     body: JSON.stringify(metadata),
+    signal: abortController.signal,
+  }).catch((error: unknown) => {
+    if (abortController.signal.aborted) return undefined;
+    throw error;
   });
+  let response: Response | undefined;
+  try {
+    response = await Promise.race([fetchSession, timeoutReached]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+  if (!response) return undefined;
   if (!response.ok) {
     if (response.status === 404) return undefined;
     let payload: unknown;

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -79,6 +79,8 @@ import { resolveRemoteSelection, type ResolvedRemoteSelection } from "../remote/
 
 const REMOTE_PROJECT_BINDING_FALLBACK_WARNING =
   "Remote project binding unavailable; using local Caplets only. Run caplets doctor for details.\n";
+const SELF_HOSTED_PROJECT_BINDING_UNSUPPORTED_MESSAGE =
+  "Self-hosted Project Binding sessions are not implemented by this runtime.";
 let hasWarnedRemoteProjectBindingFallback = false;
 
 export type NativeCapletsServiceOptions = NativeCapletsServiceResolutionInput & {
@@ -1764,7 +1766,11 @@ class RemoteProjectBindingSessionManager implements NativeProjectBindingManager 
 }
 
 function isUnsupportedProjectBinding(error: unknown): boolean {
-  return isRecord(error) && error.code === "UNSUPPORTED_CAPABILITY";
+  return (
+    isRecord(error) &&
+    error.code === "UNSUPPORTED_CAPABILITY" &&
+    error.message === SELF_HOSTED_PROJECT_BINDING_UNSUPPORTED_MESSAGE
+  );
 }
 
 function projectBindingUrl(attachUrl: URL, ...segments: string[]): URL {

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -1425,6 +1425,7 @@ class CompositeNativeCapletsService implements NativeCapletsService {
 
   private startPresence(): void {
     void this.presence?.start().catch((error) => {
+      if (isUnsupportedProjectBinding(error)) return;
       writeErr(this.options, `Could not start upstream Project Binding: ${errorMessage(error)}\n`);
     });
   }

--- a/packages/core/src/remote/profile-store.ts
+++ b/packages/core/src/remote/profile-store.ts
@@ -193,13 +193,21 @@ export class FileRemoteProfileStore {
       kind: "self-hosted",
       hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
     });
+    const snapshot = await this.withMutationLock(async () =>
+      this.selfHostedRefreshSnapshot(key, input),
+    );
+    if (!snapshot || !snapshot.needsRefresh) return snapshot?.result;
+
     return await this.withRefreshLock(key, async () => {
-      const snapshot = await this.withMutationLock(async () =>
+      const lockedSnapshot = await this.withMutationLock(async () =>
         this.selfHostedRefreshSnapshot(key, input),
       );
-      if (!snapshot || !snapshot.needsRefresh) return snapshot?.result;
+      if (!lockedSnapshot || !lockedSnapshot.needsRefresh) return lockedSnapshot?.result;
 
-      const refreshed = await input.refresh(snapshot.result.status, snapshot.result.credential);
+      const refreshed = await input.refresh(
+        lockedSnapshot.result.status,
+        lockedSnapshot.result.credential,
+      );
       return await this.withMutationLock(async () => {
         const current = await this.selfHostedRefreshSnapshot(key, input);
         if (!current || !current.needsRefresh) return current?.result;

--- a/packages/core/test/doctor-cli.test.ts
+++ b/packages/core/test/doctor-cli.test.ts
@@ -190,6 +190,39 @@ describe("caplets doctor", () => {
     }
   });
 
+  it("reports unsupported Project Binding sessions for unauthenticated self-hosted remotes", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-doctor-self-hosted-"));
+    const configPath = join(dir, "config.json");
+    const out: string[] = [];
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(configPath, "{}");
+
+      await runCli(["doctor", "--json"], {
+        authDir: join(dir, "auth"),
+        env: {
+          CAPLETS_MODE: "remote",
+          CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
+          CAPLETS_CONFIG: configPath,
+          XDG_STATE_HOME: join(dir, "state"),
+        },
+        writeOut: (value) => out.push(value),
+      });
+
+      const report = JSON.parse(out.join(""));
+      expect(report.remoteLogin).toMatchObject({
+        kind: "self-hosted",
+        authenticated: false,
+      });
+      expect(report.projectBinding).toMatchObject({
+        authMode: "remote_login_required",
+        sessionSupport: "unsupported",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("reports unresolved local Vault references with repair commands", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-doctor-vault-"));
     const configPath = join(dir, "config.json");

--- a/packages/core/test/doctor-cli.test.ts
+++ b/packages/core/test/doctor-cli.test.ts
@@ -151,6 +151,45 @@ describe("caplets doctor", () => {
     });
   });
 
+  it("does not recommend Project Binding recovery for authenticated self-hosted remotes", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-doctor-self-hosted-"));
+    const authDir = join(dir, "auth");
+    const out: string[] = [];
+    try {
+      await new FileRemoteProfileStore({
+        root: join(authDir, "remote-profiles"),
+      }).saveSelfHostedProfile({
+        hostUrl: "http://127.0.0.1:5387",
+        clientId: "rcli_test",
+        credentials: {
+          accessToken: "remote-access",
+          refreshToken: "remote-refresh",
+          expiresAt: "2999-01-01T00:00:00.000Z",
+        },
+      });
+
+      await runCli(["doctor"], {
+        authDir,
+        env: {
+          CAPLETS_MODE: "remote",
+          CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
+          XDG_STATE_HOME: join(dir, "state"),
+        },
+        writeOut: (value) => out.push(value),
+      });
+
+      const report = out.join("");
+      expect(report).toContain("Auth mode: self_hosted_remote");
+      expect(report).toContain("Session support: unsupported");
+      expect(report).toContain(
+        "Recovery: Self-hosted Project Binding sessions are not implemented by this runtime.",
+      );
+      expect(report).not.toContain("Recovery: caplets attach --once");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("reports unresolved local Vault references with repair commands", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-doctor-vault-"));
     const configPath = join(dir, "config.json");

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -382,6 +382,59 @@ describe("RemoteNativeCapletsService", () => {
     }
   });
 
+  it("closes attach sessions that finish creating after the session creation timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const sessionsStarted = deferred<Response>();
+      const requests: Array<{ url: string; method: string; headers: Headers }> = [];
+      const fetchStub: typeof fetch = vi.fn(async (input, init) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        const headers = new Headers(init?.headers);
+        requests.push({ url, method, headers });
+        if (url.endsWith("/sessions") && method === "POST") {
+          return await sessionsStarted.promise;
+        }
+        if (url.endsWith("/manifest")) {
+          return Response.json(attachManifest("rev-1", "export-1"));
+        }
+        return Response.json({ ok: true });
+      });
+      const client = createSdkRemoteCapletsClient({
+        url: new URL("https://caplets.example.com/v1/attach"),
+        requestInit: {},
+        fetch: fetchStub,
+        auth: { enabled: false, user: "caplets" },
+        pollIntervalMs: 60_000,
+        attachSessionMetadata: { projectRoot: "/repo" },
+      });
+
+      const listed = client.listTools();
+      await vi.waitFor(() =>
+        expect(requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+          "POST https://caplets.example.com/v1/attach/sessions",
+        ]),
+      );
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(listed).resolves.toEqual([
+        expect.objectContaining({ name: "remote", capletId: "remote" }),
+      ]);
+      sessionsStarted.resolve(Response.json({ sessionId: "attach_session_late" }, { status: 201 }));
+      await vi.waitFor(() =>
+        expect(requests.map((request) => `${request.method} ${request.url}`)).toContain(
+          "DELETE https://caplets.example.com/v1/attach/sessions/attach_session_late",
+        ),
+      );
+      await client.close();
+
+      const manifestRequest = requests.find((request) => request.url.endsWith("/manifest"));
+      expect(manifestRequest?.headers.get(CAPLETS_ATTACH_SESSION_HEADER)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("recreates attach sessions when the remote forgets the previous session", async () => {
     const requests: Array<{ url: string; method: string; headers: Headers }> = [];
     const fetchStub: typeof fetch = vi.fn(async (input, init) => {

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -333,6 +333,55 @@ describe("RemoteNativeCapletsService", () => {
     expect(requests[1]?.headers.get(CAPLETS_ATTACH_SESSION_HEADER)).toBeNull();
   });
 
+  it("falls back to a plain attach manifest when session creation stalls", async () => {
+    vi.useFakeTimers();
+    try {
+      const requests: Array<{ url: string; method: string; headers: Headers }> = [];
+      const fetchStub: typeof fetch = vi.fn(async (input, init) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        const headers = new Headers(init?.headers);
+        requests.push({ url, method, headers });
+        if (url.endsWith("/sessions")) {
+          return await new Promise<Response>(() => undefined);
+        }
+        if (url.endsWith("/manifest")) {
+          return Response.json(attachManifest("rev-1", "export-1"));
+        }
+        return Response.json({ ok: true });
+      });
+      const client = createSdkRemoteCapletsClient({
+        url: new URL("https://caplets.example.com/v1/attach"),
+        requestInit: {},
+        fetch: fetchStub,
+        auth: { enabled: false, user: "caplets" },
+        pollIntervalMs: 60_000,
+        attachSessionMetadata: { projectRoot: "/repo" },
+      });
+
+      const listed = client.listTools();
+      await vi.waitFor(() =>
+        expect(requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+          "POST https://caplets.example.com/v1/attach/sessions",
+        ]),
+      );
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(listed).resolves.toEqual([
+        expect.objectContaining({ name: "remote", capletId: "remote" }),
+      ]);
+      await client.close();
+
+      expect(requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+        "POST https://caplets.example.com/v1/attach/sessions",
+        "GET https://caplets.example.com/v1/attach/manifest",
+      ]);
+      expect(requests[1]?.headers.get(CAPLETS_ATTACH_SESSION_HEADER)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("recreates attach sessions when the remote forgets the previous session", async () => {
     const requests: Array<{ url: string; method: string; headers: Headers }> = [];
     const fetchStub: typeof fetch = vi.fn(async (input, init) => {
@@ -3910,9 +3959,13 @@ describe("createNativeCapletsService remote mode", () => {
     });
 
     await vi.waitFor(() =>
-      expect(writeErr).toHaveBeenCalledWith(
-        "Could not start upstream Project Binding: Self-hosted Project Binding sessions are not implemented by this runtime.\n",
-      ),
+      expect(
+        fetch.mock.calls.filter(
+          ([input, init]) =>
+            new URL(input.toString()).pathname.endsWith("/v1/attach/project-bindings/sessions") &&
+            init?.method === "POST",
+        ),
+      ).toHaveLength(1),
     );
     await service.reload();
     await service.reload();
@@ -3924,6 +3977,7 @@ describe("createNativeCapletsService remote mode", () => {
           init?.method === "POST",
       ),
     ).toHaveLength(1);
+    expect(writeErr).not.toHaveBeenCalled();
     await service.close();
   });
 

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -337,12 +337,20 @@ describe("RemoteNativeCapletsService", () => {
     vi.useFakeTimers();
     try {
       const requests: Array<{ url: string; method: string; headers: Headers }> = [];
+      let sessionAttempts = 0;
       const fetchStub: typeof fetch = vi.fn(async (input, init) => {
         const url = String(input);
         const method = init?.method ?? "GET";
         const headers = new Headers(init?.headers);
         requests.push({ url, method, headers });
         if (url.endsWith("/sessions")) {
+          sessionAttempts += 1;
+          if (sessionAttempts > 1) {
+            return Response.json(
+              { sessionId: `attach_session_${sessionAttempts}` },
+              { status: 201 },
+            );
+          }
           return await new Promise<Response>(() => undefined);
         }
         if (url.endsWith("/manifest")) {
@@ -370,13 +378,20 @@ describe("RemoteNativeCapletsService", () => {
       await expect(listed).resolves.toEqual([
         expect.objectContaining({ name: "remote", capletId: "remote" }),
       ]);
+      await expect(client.listTools()).resolves.toEqual([
+        expect.objectContaining({ name: "remote", capletId: "remote" }),
+      ]);
       await client.close();
 
       expect(requests.map((request) => `${request.method} ${request.url}`)).toEqual([
         "POST https://caplets.example.com/v1/attach/sessions",
         "GET https://caplets.example.com/v1/attach/manifest",
+        "POST https://caplets.example.com/v1/attach/sessions",
+        "GET https://caplets.example.com/v1/attach/manifest",
+        "DELETE https://caplets.example.com/v1/attach/sessions/attach_session_2",
       ]);
       expect(requests[1]?.headers.get(CAPLETS_ATTACH_SESSION_HEADER)).toBeNull();
+      expect(requests[3]?.headers.get(CAPLETS_ATTACH_SESSION_HEADER)).toBe("attach_session_2");
     } finally {
       vi.useRealTimers();
     }
@@ -4031,6 +4046,63 @@ describe("createNativeCapletsService remote mode", () => {
       ),
     ).toHaveLength(1);
     expect(writeErr).not.toHaveBeenCalled();
+    await service.close();
+  });
+
+  it("reports unsupported capability errors that do not match self-hosted Project Binding support", async () => {
+    const fixture = client([{ name: "remote", title: "Remote", description: "Remote Caplet." }]);
+    const fetch = vi.fn(
+      async (input: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
+        const url = new URL(input.toString());
+        if (
+          url.pathname.endsWith("/v1/attach/project-bindings/sessions") &&
+          init?.method === "POST"
+        ) {
+          return Response.json(
+            {
+              ok: false,
+              error: {
+                code: "UNSUPPORTED_CAPABILITY",
+                message: "Another unsupported capability.",
+              },
+            },
+            { status: 501 },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      },
+    );
+    const { dir, configPath, projectConfigPath } = tempConfig({});
+    dirs.push(dir);
+    const writeErr = vi.fn();
+    const service = createNativeCapletsService({
+      mode: "remote",
+      remote: {
+        url: "http://127.0.0.1:5387",
+        fetch,
+      },
+      remoteClientFactory: vi.fn(() => fixture.api),
+      configPath,
+      projectConfigPath,
+      projectRoot: dirname(dirname(projectConfigPath)),
+      writeErr,
+    });
+
+    await vi.waitFor(() =>
+      expect(writeErr).toHaveBeenCalledWith(
+        "Could not start upstream Project Binding: Another unsupported capability.\n",
+      ),
+    );
+    await service.reload();
+    await vi.waitFor(() =>
+      expect(
+        fetch.mock.calls.filter(
+          ([input, init]) =>
+            new URL(input.toString()).pathname.endsWith("/v1/attach/project-bindings/sessions") &&
+            init?.method === "POST",
+        ),
+      ).toHaveLength(2),
+    );
     await service.close();
   });
 

--- a/packages/core/test/remote-profiles.test.ts
+++ b/packages/core/test/remote-profiles.test.ts
@@ -332,6 +332,45 @@ describe("Remote Profile storage", () => {
     expect(existsSync(lockPath)).toBe(false);
   });
 
+  it("does not wait for a refresh lock when self-hosted credentials are still fresh", async () => {
+    const root = tempDir("caplets-remote-profiles-");
+    const store = new FileRemoteProfileStore({ root });
+    const hostUrl = "https://caplets.example.com";
+    await store.saveSelfHostedProfile({
+      hostUrl,
+      clientId: "rcli_123",
+      credentials: {
+        accessToken: "fresh_access",
+        refreshToken: "fresh_refresh",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+      },
+    });
+    const key = remoteProfileKey({ kind: "self-hosted", hostUrl });
+    const refreshLockPath = join(
+      root,
+      "remote-profile-refresh-locks",
+      `${encodeURIComponent(key)}.lock`,
+    );
+    mkdirSync(refreshLockPath, { recursive: true });
+    let refreshCalls = 0;
+
+    await expect(
+      store.refreshSelfHostedProfileIfNeeded({
+        hostUrl,
+        needsRefresh: (credential) => Date.parse(credential.expiresAt ?? "") <= Date.now() + 60_000,
+        refresh: async () => {
+          refreshCalls += 1;
+          throw new Error("unexpected refresh");
+        },
+      }),
+    ).resolves.toMatchObject({
+      credential: { accessToken: "fresh_access" },
+      status: { authenticated: true },
+    });
+    expect(refreshCalls).toBe(0);
+    expect(existsSync(refreshLockPath)).toBe(true);
+  });
+
   it("rejects credential-bearing remote URLs before persisting profile data", async () => {
     const root = tempDir("caplets-remote-profiles-");
     const store = new FileRemoteProfileStore({ root });


### PR DESCRIPTION
## Summary

Stacked self-hosted attach clients now recover instead of hanging when attach-session creation stalls, and `doctor` no longer points users at `caplets attach --once` for self-hosted Project Binding sessions that this runtime does not implement.

Self-hosted Remote Login refreshes now check the stored credential before taking the refresh lock, so fresh credentials can continue serving attach discovery while another process is refreshing the same host. Unsupported Project Binding session negotiation is treated as capability negotiation instead of noisy runtime failure.

## Validation

- `pnpm --filter @caplets/core test -- test/native-remote.test.ts test/doctor-cli.test.ts test/remote-profiles.test.ts`
- `pnpm --filter @caplets/core typecheck`
- `pnpm format:check`
- `pnpm --filter @caplets/core build`
- Pre-push gate passed: format, lint, generated API/schema/docs checks, typecheck, full test suite, benchmark check, and build.
- Isolated source-built smoke: `attach --once` against `https://caplets.tail7ff085.ts.net` refreshed an expired copied profile and returned `ok: true`.

## Notes

The live local daemon still needs a fresh approved Remote Login to the VPS before the real Sentry path can be exercised end-to-end; the current local tailnet credential is rejected by the VPS as revoked.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved remote attach reliability by preventing stalls and falling back more gracefully when session setup is slow.
  - Refined self-hosted profile refresh behavior so valid credentials are reused more consistently.
  - Reduced noisy warnings and errors for unsupported self-hosted Project Binding sessions.
  - Updated doctor output to give clearer recovery guidance for self-hosted remotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->