### PR TITLE
fix(core): preserve namespace shadowing across stacked attach

### DIFF
--- a/.changeset/fix-stacked-namespace-code-mode.md
+++ b/.changeset/fix-stacked-namespace-code-mode.md
@@ -1,0 +1,6 @@
+---
+"@caplets/core": patch
+"caplets": patch
+---
+
+Preserve namespace shadowing across stacked attach manifests so re-attached Code Mode handles do not expose duplicate bare Caplet IDs.

--- a/packages/core/src/attach/api.ts
+++ b/packages/core/src/attach/api.ts
@@ -62,6 +62,7 @@ export type AttachManifestExport = {
   annotations?: unknown;
   schemaHash: string | null;
   capletId: string;
+  sourceCapletId?: string | undefined;
   shadowing: CapletShadowingPolicy;
 };
 
@@ -222,6 +223,7 @@ function nativeProgressiveCaplets(
       annotations: tool.annotations,
       schemaHash: schemaHash(tool.inputSchema ?? null),
       capletId: tool.caplet,
+      ...(tool.sourceCaplet ? { sourceCapletId: tool.sourceCaplet } : {}),
       shadowing: tool.shadowing ?? "forbid",
     }));
 }
@@ -272,6 +274,7 @@ function nativeCodeModeCaplets(
       description: caplet.description,
       schemaHash: null,
       capletId: caplet.id,
+      ...(caplet.sourceCapletId ? { sourceCapletId: caplet.sourceCapletId } : {}),
       shadowing: caplet.shadowing ?? "forbid",
     })),
   );

--- a/packages/core/src/code-mode/types.ts
+++ b/packages/core/src/code-mode/types.ts
@@ -3,6 +3,7 @@ export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue
 
 export type CodeModeCallableCaplet = {
   id: string;
+  sourceCapletId?: string | undefined;
   name: string;
   description: string;
   shadowing?: "forbid" | "allow" | "namespace";

--- a/packages/core/src/native/remote.ts
+++ b/packages/core/src/native/remote.ts
@@ -538,6 +538,7 @@ function remoteToolToNativeTool(tool: RemoteCapletsTool): NativeCapletTool {
       ? {
           codeModeCaplets: tool.codeModeCaplets.map((caplet) => ({
             id: caplet.capletId,
+            ...(caplet.sourceCapletId ? { sourceCapletId: caplet.sourceCapletId } : {}),
             name: caplet.name,
             description: caplet.description ?? "",
             shadowing: caplet.shadowing,
@@ -575,6 +576,9 @@ function remoteCodeModeCallableNativeTools(tools: NativeCapletTool[]): NativeCap
     const tool = byId.get(caplet.id);
     return {
       caplet: caplet.id,
+      ...(caplet.sourceCapletId && caplet.sourceCapletId !== caplet.id
+        ? { sourceCaplet: caplet.sourceCapletId }
+        : {}),
       toolName: tool?.toolName ?? nativeCapletToolName(caplet.id),
       title: caplet.name,
       description: caplet.description,
@@ -894,6 +898,7 @@ function toolsFromManifest(manifest: AttachManifest): RemoteCapletsTool[] {
     ...manifest.caplets.map((entry) => ({
       name: entry.capletId,
       capletId: entry.capletId,
+      sourceCapletId: entry.sourceCapletId,
       title: entry.title ?? entry.name,
       description: entry.description,
       inputSchema: entry.inputSchema,

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -659,6 +659,9 @@ function codeModeCallableNativeTools(
     const tool = byId.get(caplet.id);
     return {
       caplet: caplet.id,
+      ...(caplet.sourceCapletId && caplet.sourceCapletId !== caplet.id
+        ? { sourceCaplet: caplet.sourceCapletId }
+        : {}),
       toolName: tool?.toolName ?? nativeCapletToolName(caplet.id),
       title: caplet.name,
       description: caplet.description,

--- a/packages/core/src/native/service.ts
+++ b/packages/core/src/native/service.ts
@@ -617,6 +617,7 @@ function readTelemetryOnlyConfig(path: string): boolean | undefined {
 function codeModeRunNativeTool(capletTools: NativeCapletTool[]): NativeCapletTool {
   const codeModeCaplets = capletTools.map((tool) => ({
     id: tool.caplet,
+    ...(tool.sourceCaplet ? { sourceCapletId: tool.sourceCaplet } : {}),
     name: tool.title,
     description: tool.description,
     ...(tool.shadowing ? { shadowing: tool.shadowing } : {}),
@@ -1526,21 +1527,18 @@ function sourceBaseId(tool: NativeCapletTool): string {
 
 function renameNativeTool(tool: NativeCapletTool, visibleBaseId: string): NativeCapletTool {
   const baseId = sourceBaseId(tool);
-  const visibleCapletId =
-    tool.sourceCaplet && tool.caplet.startsWith(`${baseId}__`)
-      ? `${visibleBaseId}${tool.caplet.slice(baseId.length)}`
-      : visibleBaseId;
-  const operationName =
-    tool.sourceCaplet && tool.caplet.startsWith(`${baseId}__`)
-      ? tool.caplet.slice(baseId.length + 2)
-      : undefined;
+  const directTool = Boolean(tool.sourceCaplet && tool.caplet.startsWith(`${baseId}__`));
+  const visibleCapletId = directTool
+    ? `${visibleBaseId}${tool.caplet.slice(baseId.length)}`
+    : visibleBaseId;
+  const operationName = directTool ? tool.caplet.slice(baseId.length + 2) : undefined;
   const toolName = operationName
     ? nativeDirectToolName(visibleBaseId, operationName)
     : nativeCapletToolName(visibleCapletId);
   return {
     ...tool,
     caplet: visibleCapletId,
-    ...(tool.sourceCaplet ? { sourceCaplet: visibleBaseId } : {}),
+    sourceCaplet: directTool ? visibleBaseId : baseId,
     toolName,
   };
 }

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ProjectBindingSessionManager } from "../src/cloud/presence";
 import { CAPLETS_ATTACH_SESSION_HEADER } from "../src/attach/api";
+import { listCodeModeCallableCaplets } from "../src/code-mode/api";
+import { buildNativeAttachProjection } from "../src/attach/api";
 import type { CapletsError } from "../src/errors";
 import { CloudAuthStore } from "../src/cloud-auth/store";
 import { CapletsEngine } from "../src/engine";
@@ -2612,6 +2614,98 @@ describe("createNativeCapletsService remote mode", () => {
       "Local Caplet 'shared' is suppressed because the remote attach manifest forbids shadowing that Caplet ID.\n",
     );
     await service.close();
+  });
+
+  it("omits bare Code Mode handles when namespace shadowing qualifies remote and local overlays", async () => {
+    const fixture = client([{ name: "shared", title: "Remote Shared", shadowing: "namespace" }]);
+    const { dir, configPath, projectConfigPath } = tempConfig({
+      mcpServers: {
+        shared: {
+          name: "Local Shared",
+          description: "Local shared Caplet.",
+          command: process.execPath,
+          shadowing: "namespace",
+        },
+      },
+    });
+    dirs.push(dir);
+    const service = createNativeCapletsService({
+      mode: "remote",
+      remote: { url: "http://127.0.0.1:5387" },
+      remoteClientFactory: vi.fn(() => fixture.api),
+      configPath,
+      projectConfigPath,
+    });
+
+    await service.reload();
+
+    const callableIds = listCodeModeCallableCaplets(service).map((caplet) => caplet.id);
+    expect(callableIds).not.toContain("shared");
+    expect(callableIds).toEqual([
+      expect.stringMatching(/^local-[a-f0-9]{4}__shared$/u),
+      expect.stringMatching(/^remote-[a-f0-9]{4}__shared$/u),
+    ]);
+    await service.close();
+  });
+
+  it("preserves namespace collisions across stacked attach manifests", async () => {
+    const innerRemote = client([
+      { name: "computer-use", title: "VPS Computer Use", shadowing: "namespace" },
+    ]);
+    const { dir, configPath, projectConfigPath } = tempConfig({
+      mcpServers: {
+        "computer-use": {
+          name: "MacBook Computer Use",
+          description: "MacBook computer use.",
+          command: process.execPath,
+          shadowing: "namespace",
+        },
+      },
+    });
+    dirs.push(dir);
+    const innerService = createNativeCapletsService({
+      mode: "remote",
+      remote: { url: "http://127.0.0.1:5387" },
+      remoteClientFactory: vi.fn(() => innerRemote.api),
+      configPath,
+      projectConfigPath,
+    });
+    await innerService.reload();
+    const innerProjection = await buildNativeAttachProjection(innerService);
+
+    const outerFetch: typeof fetch = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/manifest")) return Response.json(innerProjection.manifest);
+      if (url.endsWith("/invoke") && init?.method === "POST") {
+        return Response.json({ ok: true, data: { remote: true } });
+      }
+      return Response.json({ ok: true });
+    });
+    const outerRemoteClient = createSdkRemoteCapletsClient({
+      url: new URL("http://127.0.0.1:5387/v1/attach"),
+      requestInit: {},
+      fetch: outerFetch,
+      auth: { enabled: false, user: "caplets" },
+      pollIntervalMs: 60_000,
+    });
+    const outerService = createNativeCapletsService({
+      mode: "remote",
+      remote: { url: "http://127.0.0.1:5387" },
+      remoteClientFactory: vi.fn(() => outerRemoteClient),
+      configPath,
+      projectConfigPath,
+    });
+
+    await outerService.reload();
+
+    const callableIds = listCodeModeCallableCaplets(outerService).map((caplet) => caplet.id);
+    expect(callableIds).not.toContain("computer-use");
+    expect(callableIds).toEqual([
+      expect.stringMatching(/^local-[a-f0-9]{4}__computer-use$/u),
+      expect.stringMatching(/^remote-[a-f0-9]{4}__computer-use$/u),
+    ]);
+    await outerService.close();
+    await innerService.close();
   });
 
   it("uses configured namespace aliases for native remote and local overlays", async () => {

--- a/packages/core/test/native-remote.test.ts
+++ b/packages/core/test/native-remote.test.ts
@@ -4,9 +4,8 @@ import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ProjectBindingSessionManager } from "../src/cloud/presence";
-import { CAPLETS_ATTACH_SESSION_HEADER } from "../src/attach/api";
+import { CAPLETS_ATTACH_SESSION_HEADER, buildNativeAttachProjection } from "../src/attach/api";
 import { listCodeModeCallableCaplets } from "../src/code-mode/api";
-import { buildNativeAttachProjection } from "../src/attach/api";
 import type { CapletsError } from "../src/errors";
 import { CloudAuthStore } from "../src/cloud-auth/store";
 import { CapletsEngine } from "../src/engine";
@@ -18,6 +17,7 @@ import {
 } from "../src/native/remote";
 import {
   createNativeCapletsService,
+  type NativeCapletTool,
   type NativeCapletsService,
   resetNativeProjectBindingFallbackWarningForTests,
 } from "../src/native/service";
@@ -2703,6 +2703,100 @@ describe("createNativeCapletsService remote mode", () => {
     expect(callableIds).toEqual([
       expect.stringMatching(/^local-[a-f0-9]{4}__computer-use$/u),
       expect.stringMatching(/^remote-[a-f0-9]{4}__computer-use$/u),
+    ]);
+    await outerService.close();
+    await innerService.close();
+  });
+
+  it("preserves Code Mode-only namespace collisions across stacked attach manifests", async () => {
+    const localCodeModeTool = (): NativeCapletTool => ({
+      caplet: "code_mode",
+      toolName: "caplets__code_mode",
+      title: "Code Mode",
+      description: "Local Code Mode.",
+      codeModeRun: true,
+      codeModeCaplets: [
+        {
+          id: "shared",
+          name: "MacBook Shared",
+          description: "MacBook shared handle.",
+          shadowing: "namespace",
+        },
+      ],
+      promptGuidance: [],
+    });
+    const innerRemote = client([
+      {
+        name: "code_mode",
+        title: "Code Mode",
+        description: "Remote Code Mode.",
+        codeModeRun: true,
+        codeModeCaplets: [
+          {
+            stableId: "code_mode:shared",
+            exportId: "remote-shared",
+            kind: "caplet",
+            name: "VPS Shared",
+            description: "VPS shared handle.",
+            schemaHash: null,
+            capletId: "shared",
+            shadowing: "namespace",
+          },
+        ],
+      },
+    ]);
+    const innerLocalService = {
+      listTools: vi.fn(() => [localCodeModeTool()]),
+      execute: vi.fn(async () => ({ local: true })),
+      reload: vi.fn(async () => true),
+      onToolsChanged: vi.fn(() => () => undefined),
+      close: vi.fn(async () => undefined),
+    } satisfies NativeCapletsService;
+    const innerService = createNativeCapletsService({
+      mode: "remote",
+      remote: { url: "http://127.0.0.1:5387" },
+      remoteClientFactory: vi.fn(() => innerRemote.api),
+      localServiceFactory: vi.fn(() => innerLocalService),
+    });
+    await innerService.reload();
+    const innerProjection = await buildNativeAttachProjection(innerService);
+
+    const outerFetch: typeof fetch = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/manifest")) return Response.json(innerProjection.manifest);
+      if (url.endsWith("/invoke") && init?.method === "POST") {
+        return Response.json({ ok: true, data: { remote: true } });
+      }
+      return Response.json({ ok: true });
+    });
+    const outerRemoteClient = createSdkRemoteCapletsClient({
+      url: new URL("http://127.0.0.1:5387/v1/attach"),
+      requestInit: {},
+      fetch: outerFetch,
+      auth: { enabled: false, user: "caplets" },
+      pollIntervalMs: 60_000,
+    });
+    const outerLocalService = {
+      listTools: vi.fn(() => [localCodeModeTool()]),
+      execute: vi.fn(async () => ({ local: true })),
+      reload: vi.fn(async () => true),
+      onToolsChanged: vi.fn(() => () => undefined),
+      close: vi.fn(async () => undefined),
+    } satisfies NativeCapletsService;
+    const outerService = createNativeCapletsService({
+      mode: "remote",
+      remote: { url: "http://127.0.0.1:5387" },
+      remoteClientFactory: vi.fn(() => outerRemoteClient),
+      localServiceFactory: vi.fn(() => outerLocalService),
+    });
+
+    await outerService.reload();
+
+    const callableIds = listCodeModeCallableCaplets(outerService).map((caplet) => caplet.id);
+    expect(callableIds).not.toContain("shared");
+    expect(callableIds).toEqual([
+      expect.stringMatching(/^local-[a-f0-9]{4}__shared$/u),
+      expect.stringMatching(/^remote-[a-f0-9]{4}__shared$/u),
     ]);
     await outerService.close();
     await innerService.close();


### PR DESCRIPTION
## Summary
- preserve original source Caplet IDs through native attach manifests
- keep namespace shadowing intact when a local attach client re-attaches to a daemon that is already attached upstream
- add regressions covering Code Mode namespace collisions and stacked attach manifests

## Testing
- pnpm --filter @caplets/core test -- test/native-remote.test.ts --runInBand
- pnpm --filter @caplets/core typecheck
- pnpm format:check
- git diff --check
- pnpm verify
- pre-push pnpm verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Code Mode session behavior for namespace shadowing when attachment manifests are stacked, avoiding duplicate bare caplet IDs on re-attach.
  * Ensured the associated source-caplet identifier metadata is preserved and propagated consistently across attach-to-native and remote Code Mode conversions.
* **Tests**
  * Added coverage for namespace shadowing edge cases in remote and stacked attach scenarios, including Code Mode-only collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->