### PR TITLE
fix(core): report self-hosted project binding support

### DIFF
--- a/.changeset/gentle-rivers-check.md
+++ b/.changeset/gentle-rivers-check.md
@@ -1,0 +1,6 @@
+---
+"@caplets/core": patch
+"caplets": patch
+---
+
+Fix `caplets doctor` Project Binding diagnostics for authenticated self-hosted remotes so supported session routes are reported as supported instead of always unsupported.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -2557,6 +2557,7 @@ export function createProgram(io: CliIO = {}): Command {
     .action(async (options: { json?: boolean }) => {
       const doctorOptions = {
         env,
+        ...(io.fetch ? { fetch: io.fetch } : {}),
         ...(io.authDir ? { authDir: io.authDir } : {}),
         ...(io.daemon ? { daemon: io.daemon } : {}),
       };

--- a/packages/core/src/cli/doctor.ts
+++ b/packages/core/src/cli/doctor.ts
@@ -12,6 +12,7 @@ import {
   resolveCapletsRemote,
   resolveHostedCloudRemote,
   resolveRemoteMode,
+  type ResolvedCapletsRemote,
 } from "../remote/options";
 import { createRemoteProfileStore } from "../remote/profile-store";
 import type { RemoteProfileCredential, RemoteProfileStatus } from "../remote/profiles";
@@ -40,6 +41,7 @@ export type DoctorOptions = {
   authDir?: string;
   observedOutputShapeCacheDir?: string;
   daemon?: DaemonOperationOptions;
+  fetch?: typeof fetch;
 };
 
 export type DoctorJsonReport = {
@@ -62,6 +64,7 @@ export async function doctorJsonReport(options: DoctorOptions = {}): Promise<Doc
   const remoteLogin = await resolveRemoteLoginSection(options, env);
   const server = resolveServerSection(env);
   const remote = resolveRemoteSection(env, remoteLogin);
+  const sessionSupport = await resolveProjectBindingSessionSupport(options, env, remoteLogin);
 
   return {
     server,
@@ -80,10 +83,10 @@ export async function doctorJsonReport(options: DoctorOptions = {}): Promise<Doc
           : "unconfigured",
       selectedWorkspace: remoteLogin.selectedWorkspace ?? remote.workspace ?? null,
       webSocketUrl: remote.webSocketUrl,
-      sessionSupport: remoteLogin.kind === "self-hosted" ? "unsupported" : "unknown",
+      sessionSupport: sessionSupport.value,
       lease: null,
-      lastUpgradeError: null,
-      recoveryCommand: projectBindingRecovery(remoteLogin, remote),
+      lastUpgradeError: sessionSupport.lastError,
+      recoveryCommand: projectBindingRecovery(remoteLogin, remote, sessionSupport.value),
     },
     sync: {
       state: options.syncStatus?.state ?? "idle",
@@ -238,16 +241,119 @@ function vaultIssueFromWarning(message: string, path: string) {
 function projectBindingRecovery(
   remoteLogin: DoctorRemoteLoginSection,
   remote: Record<string, unknown>,
+  sessionSupport: ProjectBindingSessionSupport,
 ): string {
   if (remoteLogin.authenticated) {
-    return remoteLogin.kind === "self-hosted"
-      ? "Self-hosted Project Binding sessions are not implemented by this runtime."
-      : "caplets attach --once";
+    if (sessionSupport === "supported") return "caplets attach --once";
+    if (sessionSupport === "unsupported") {
+      return "Upgrade the remote Caplets service and rerun caplets doctor.";
+    }
+    return "caplets doctor";
   }
   if (remote.configured || remoteLogin.configured) {
     return `caplets remote login ${remoteLogin.hostUrl ?? "<url>"}`;
   }
   return "caplets remote login <url>";
+}
+
+type ProjectBindingSessionSupport = "supported" | "unsupported" | "unknown";
+
+async function resolveProjectBindingSessionSupport(
+  options: DoctorOptions,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+  remoteLogin: DoctorRemoteLoginSection,
+): Promise<{ value: ProjectBindingSessionSupport; lastError: string | null }> {
+  if (remoteLogin.kind !== "self-hosted") return { value: "unknown", lastError: null };
+  if (!remoteLogin.authenticated || !remoteLogin.credential?.accessToken) {
+    return { value: "unknown", lastError: null };
+  }
+
+  let remote: ResolvedCapletsRemote;
+  try {
+    remote = resolveCapletsRemote(selfHostedDoctorInput(remoteLogin), env);
+  } catch (error) {
+    return { value: "unknown", lastError: errorMessage(error) };
+  }
+
+  const fetchImpl = options.fetch ?? remote.fetch ?? fetch;
+  const headers = new Headers(remote.requestInit.headers);
+  headers.set("content-type", "application/json");
+  try {
+    const response = await fetchImpl(projectBindingSessionsUrl(remote), {
+      ...remote.requestInit,
+      method: "POST",
+      headers,
+      body: JSON.stringify({ diagnosticProbe: true }),
+    });
+    if (response.status === 201) {
+      const created = (await response.json().catch(() => ({}))) as {
+        binding?: { bindingId?: unknown };
+        sessionId?: unknown;
+      };
+      const bindingId =
+        typeof created.binding?.bindingId === "string" ? created.binding.bindingId : undefined;
+      const sessionId = typeof created.sessionId === "string" ? created.sessionId : undefined;
+      if (bindingId && sessionId) {
+        await endProjectBindingDiagnosticSession(fetchImpl, remote, bindingId, sessionId);
+      }
+      return { value: "supported", lastError: null };
+    }
+    if (response.status === 400) return { value: "supported", lastError: null };
+    if (response.status === 404 || response.status === 405 || response.status === 501) {
+      return {
+        value: "unsupported",
+        lastError: `Project Binding session endpoint returned ${response.status}.`,
+      };
+    }
+    if (response.status === 401 || response.status === 403) {
+      return {
+        value: "unknown",
+        lastError: `Project Binding session probe was not authorized (${response.status}).`,
+      };
+    }
+    return {
+      value: "unknown",
+      lastError: `Project Binding session probe returned ${response.status}.`,
+    };
+  } catch (error) {
+    return { value: "unknown", lastError: errorMessage(error) };
+  }
+}
+
+function projectBindingSessionsUrl(remote: ResolvedCapletsRemote): URL {
+  return controlProjectBindingUrl(remote, "sessions");
+}
+
+async function endProjectBindingDiagnosticSession(
+  fetchImpl: typeof fetch,
+  remote: ResolvedCapletsRemote,
+  bindingId: string,
+  sessionId: string,
+): Promise<void> {
+  const headers = new Headers(remote.requestInit.headers);
+  headers.set("content-type", "application/json");
+  await fetchImpl(controlProjectBindingUrl(remote, `${encodeURIComponent(bindingId)}/session`), {
+    ...remote.requestInit,
+    method: "DELETE",
+    headers,
+    body: JSON.stringify({
+      sessionId,
+      terminalReason: {
+        code: "completed",
+        message: "Project Binding diagnostic probe completed.",
+      },
+    }),
+  }).catch(() => undefined);
+}
+
+function controlProjectBindingUrl(remote: ResolvedCapletsRemote, suffix: string): URL {
+  const url = new URL(remote.projectBindingWebSocketUrl);
+  if (url.protocol === "wss:") url.protocol = "https:";
+  if (url.protocol === "ws:") url.protocol = "http:";
+  url.pathname = url.pathname.replace(/\/connect$/u, `/${suffix}`);
+  url.search = "";
+  url.hash = "";
+  return url;
 }
 
 async function resolveDaemonSection(
@@ -570,6 +676,10 @@ function observedOutputShapePath(value: unknown): string | undefined {
     typeof (value as { path?: unknown }).path === "string"
     ? (value as { path: string }).path
     : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function allCaplets(config: { [key: string]: unknown }): CapletConfig[] {

--- a/packages/core/src/cli/doctor.ts
+++ b/packages/core/src/cli/doctor.ts
@@ -33,6 +33,8 @@ import { loadConfig, loadLocalOverlayConfigWithSources, type CapletConfig } from
 import { resolveExposure } from "../exposure/policy";
 import { daemonStatus, type DaemonOperationOptions } from "../daemon";
 
+const PROJECT_BINDING_DOCTOR_PROBE_TIMEOUT_MS = 5_000;
+
 export type DoctorOptions = {
   env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
   cwd?: string;
@@ -42,6 +44,7 @@ export type DoctorOptions = {
   observedOutputShapeCacheDir?: string;
   daemon?: DaemonOperationOptions;
   fetch?: typeof fetch;
+  projectBindingProbeTimeoutMs?: number;
 };
 
 export type DoctorJsonReport = {
@@ -244,6 +247,7 @@ function projectBindingRecovery(
   sessionSupport: ProjectBindingSessionSupport,
 ): string {
   if (remoteLogin.authenticated) {
+    if (remoteLogin.kind === "cloud") return "caplets attach --once";
     if (sessionSupport === "supported") return "caplets attach --once";
     if (sessionSupport === "unsupported") {
       return "Upgrade the remote Caplets service and rerun caplets doctor.";
@@ -276,29 +280,53 @@ async function resolveProjectBindingSessionSupport(
   }
 
   const fetchImpl = options.fetch ?? remote.fetch ?? fetch;
+  const timeoutMs = options.projectBindingProbeTimeoutMs ?? PROJECT_BINDING_DOCTOR_PROBE_TIMEOUT_MS;
   const headers = new Headers(remote.requestInit.headers);
   headers.set("content-type", "application/json");
   try {
-    const response = await fetchImpl(projectBindingSessionsUrl(remote), {
-      ...remote.requestInit,
-      method: "POST",
-      headers,
-      body: JSON.stringify({ diagnosticProbe: true }),
-    });
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      projectBindingSessionsUrl(remote),
+      timeoutMs,
+      {
+        ...remote.requestInit,
+        method: "POST",
+        headers,
+        body: JSON.stringify({ diagnosticProbe: true }),
+      },
+    );
     if (response.status === 201) {
-      const created = (await response.json().catch(() => ({}))) as {
-        binding?: { bindingId?: unknown };
-        sessionId?: unknown;
-      };
+      const created = await readDiagnosticSessionResponse(response);
+      if (!created.ok) return { value: "unknown", lastError: created.error };
       const bindingId =
-        typeof created.binding?.bindingId === "string" ? created.binding.bindingId : undefined;
-      const sessionId = typeof created.sessionId === "string" ? created.sessionId : undefined;
-      if (bindingId && sessionId) {
-        await endProjectBindingDiagnosticSession(fetchImpl, remote, bindingId, sessionId);
+        typeof created.value.binding?.bindingId === "string"
+          ? created.value.binding.bindingId
+          : undefined;
+      const sessionId =
+        typeof created.value.sessionId === "string" ? created.value.sessionId : undefined;
+      if (!bindingId || !sessionId) {
+        return {
+          value: "unknown",
+          lastError:
+            "Project Binding diagnostic session response was missing bindingId or sessionId; cleanup was not attempted.",
+        };
+      }
+      const cleanupError = await endProjectBindingDiagnosticSession(
+        fetchImpl,
+        remote,
+        bindingId,
+        sessionId,
+        timeoutMs,
+      );
+      if (cleanupError) {
+        return { value: "unknown", lastError: cleanupError };
       }
       return { value: "supported", lastError: null };
     }
     if (response.status === 400) return { value: "supported", lastError: null };
+    if (response.status >= 200 && response.status < 300) {
+      return { value: "supported", lastError: null };
+    }
     if (response.status === 404 || response.status === 405 || response.status === 501) {
       return {
         value: "unsupported",
@@ -324,26 +352,85 @@ function projectBindingSessionsUrl(remote: ResolvedCapletsRemote): URL {
   return controlProjectBindingUrl(remote, "sessions");
 }
 
+async function readDiagnosticSessionResponse(response: Response): Promise<
+  | {
+      ok: true;
+      value: {
+        binding?: { bindingId?: unknown };
+        sessionId?: unknown;
+      };
+    }
+  | { ok: false; error: string }
+> {
+  try {
+    return {
+      ok: true,
+      value: (await response.json()) as {
+        binding?: { bindingId?: unknown };
+        sessionId?: unknown;
+      },
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Project Binding diagnostic session response could not be parsed; cleanup was not attempted: ${errorMessage(error)}`,
+    };
+  }
+}
+
 async function endProjectBindingDiagnosticSession(
   fetchImpl: typeof fetch,
   remote: ResolvedCapletsRemote,
   bindingId: string,
   sessionId: string,
-): Promise<void> {
+  timeoutMs: number,
+): Promise<string | null> {
   const headers = new Headers(remote.requestInit.headers);
   headers.set("content-type", "application/json");
-  await fetchImpl(controlProjectBindingUrl(remote, `${encodeURIComponent(bindingId)}/session`), {
-    ...remote.requestInit,
-    method: "DELETE",
-    headers,
-    body: JSON.stringify({
-      sessionId,
-      terminalReason: {
-        code: "completed",
-        message: "Project Binding diagnostic probe completed.",
+  try {
+    const response = await fetchWithTimeout(
+      fetchImpl,
+      controlProjectBindingUrl(remote, `${encodeURIComponent(bindingId)}/session`),
+      timeoutMs,
+      {
+        ...remote.requestInit,
+        method: "DELETE",
+        headers,
+        body: JSON.stringify({
+          sessionId,
+          terminalReason: {
+            code: "completed",
+            message: "Project Binding diagnostic probe completed.",
+          },
+        }),
       },
-    }),
-  }).catch(() => undefined);
+    );
+    return response.ok ? null : `Project Binding diagnostic cleanup returned ${response.status}.`;
+  } catch (error) {
+    return `Project Binding diagnostic cleanup failed: ${errorMessage(error)}`;
+  }
+}
+
+async function fetchWithTimeout(
+  fetchImpl: typeof fetch,
+  url: URL,
+  timeoutMs: number,
+  init: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () =>
+      controller.abort(new Error(`Project Binding session probe timed out after ${timeoutMs}ms.`)),
+    timeoutMs,
+  );
+  try {
+    return await fetchImpl(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 function controlProjectBindingUrl(remote: ResolvedCapletsRemote, suffix: string): URL {

--- a/packages/core/test/doctor-cli.test.ts
+++ b/packages/core/test/doctor-cli.test.ts
@@ -151,10 +151,11 @@ describe("caplets doctor", () => {
     });
   });
 
-  it("does not recommend Project Binding recovery for authenticated self-hosted remotes", async () => {
+  it("reports supported Project Binding sessions for authenticated self-hosted remotes", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-doctor-self-hosted-"));
     const authDir = join(dir, "auth");
     const out: string[] = [];
+    const requests: Array<{ method: string; path: string }> = [];
     try {
       await new FileRemoteProfileStore({
         root: join(authDir, "remote-profiles"),
@@ -175,22 +176,34 @@ describe("caplets doctor", () => {
           CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
           XDG_STATE_HOME: join(dir, "state"),
         },
+        fetch: async (url, init) => {
+          requests.push({
+            method: init?.method ?? "GET",
+            path: new URL(String(url)).pathname,
+          });
+          if (String(url).endsWith("/v1/attach/project-bindings/sessions")) {
+            return Response.json(
+              { ok: false, error: { code: "REQUEST_INVALID" } },
+              { status: 400 },
+            );
+          }
+          return Response.json({ ok: true });
+        },
         writeOut: (value) => out.push(value),
       });
 
       const report = out.join("");
       expect(report).toContain("Auth mode: self_hosted_remote");
-      expect(report).toContain("Session support: unsupported");
-      expect(report).toContain(
-        "Recovery: Self-hosted Project Binding sessions are not implemented by this runtime.",
-      );
-      expect(report).not.toContain("Recovery: caplets attach --once");
+      expect(report).toContain("Session support: supported");
+      expect(report).toContain("Recovery: caplets attach --once");
+      expect(report).not.toContain("Self-hosted Project Binding sessions are not implemented");
+      expect(requests).toEqual([{ method: "POST", path: "/v1/attach/project-bindings/sessions" }]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it("reports unsupported Project Binding sessions for unauthenticated self-hosted remotes", async () => {
+  it("requires Remote Login before probing self-hosted Project Binding sessions", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-doctor-self-hosted-"));
     const configPath = join(dir, "config.json");
     const out: string[] = [];
@@ -216,7 +229,49 @@ describe("caplets doctor", () => {
       });
       expect(report.projectBinding).toMatchObject({
         authMode: "remote_login_required",
-        sessionSupport: "unsupported",
+        sessionSupport: "unknown",
+        recoveryCommand: "caplets remote login http://127.0.0.1:5387/",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports unsupported Project Binding sessions when an authenticated self-hosted remote lacks the route", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-doctor-self-hosted-"));
+    const authDir = join(dir, "auth");
+    const out: string[] = [];
+    try {
+      await new FileRemoteProfileStore({
+        root: join(authDir, "remote-profiles"),
+      }).saveSelfHostedProfile({
+        hostUrl: "http://127.0.0.1:5387",
+        clientId: "rcli_test",
+        credentials: {
+          accessToken: "remote-access",
+          refreshToken: "remote-refresh",
+          expiresAt: "2999-01-01T00:00:00.000Z",
+        },
+      });
+
+      await runCli(["doctor", "--json"], {
+        authDir,
+        env: {
+          CAPLETS_MODE: "remote",
+          CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
+          XDG_STATE_HOME: join(dir, "state"),
+        },
+        fetch: async () => Response.json({ ok: false }, { status: 404 }),
+        writeOut: (value) => out.push(value),
+      });
+
+      expect(JSON.parse(out.join(""))).toMatchObject({
+        projectBinding: {
+          authMode: "self_hosted_remote",
+          sessionSupport: "unsupported",
+          lastUpgradeError: "Project Binding session endpoint returned 404.",
+          recoveryCommand: "Upgrade the remote Caplets service and rerun caplets doctor.",
+        },
       });
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/packages/core/test/doctor-cli.test.ts
+++ b/packages/core/test/doctor-cli.test.ts
@@ -87,6 +87,11 @@ describe("caplets doctor", () => {
         hostUrl: "https://cloud.caplets.dev/",
         workspaceSlug: "personal-c9b49d",
       },
+      projectBinding: {
+        authMode: "hosted_cloud",
+        sessionSupport: "unknown",
+        recoveryCommand: "caplets attach --once",
+      },
     });
   });
 
@@ -198,6 +203,140 @@ describe("caplets doctor", () => {
       expect(report).toContain("Recovery: caplets attach --once");
       expect(report).not.toContain("Self-hosted Project Binding sessions are not implemented");
       expect(requests).toEqual([{ method: "POST", path: "/v1/attach/project-bindings/sessions" }]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("treats non-201 2xx self-hosted Project Binding probe responses as supported", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-doctor-self-hosted-"));
+    const authDir = join(dir, "auth");
+    const out: string[] = [];
+    try {
+      await saveSelfHostedProfile(authDir);
+
+      await runCli(["doctor", "--json"], {
+        authDir,
+        env: {
+          CAPLETS_MODE: "remote",
+          CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
+          XDG_STATE_HOME: join(dir, "state"),
+        },
+        fetch: async () => new Response(null, { status: 204 }),
+        writeOut: (value) => out.push(value),
+      });
+
+      expect(JSON.parse(out.join(""))).toMatchObject({
+        projectBinding: {
+          authMode: "self_hosted_remote",
+          sessionSupport: "supported",
+          lastUpgradeError: null,
+          recoveryCommand: "caplets attach --once",
+        },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces malformed Project Binding diagnostic session responses", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-doctor-self-hosted-"));
+    const authDir = join(dir, "auth");
+    const out: string[] = [];
+    try {
+      await saveSelfHostedProfile(authDir);
+
+      await runCli(["doctor", "--json"], {
+        authDir,
+        env: {
+          CAPLETS_MODE: "remote",
+          CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
+          XDG_STATE_HOME: join(dir, "state"),
+        },
+        fetch: async () => Response.json({ binding: { bindingId: "binding_1" } }, { status: 201 }),
+        writeOut: (value) => out.push(value),
+      });
+
+      expect(JSON.parse(out.join(""))).toMatchObject({
+        projectBinding: {
+          authMode: "self_hosted_remote",
+          sessionSupport: "unknown",
+          lastUpgradeError:
+            "Project Binding diagnostic session response was missing bindingId or sessionId; cleanup was not attempted.",
+          recoveryCommand: "caplets doctor",
+        },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces Project Binding diagnostic session cleanup failures", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-doctor-self-hosted-"));
+    const authDir = join(dir, "auth");
+    const out: string[] = [];
+    try {
+      await saveSelfHostedProfile(authDir);
+
+      await runCli(["doctor", "--json"], {
+        authDir,
+        env: {
+          CAPLETS_MODE: "remote",
+          CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
+          XDG_STATE_HOME: join(dir, "state"),
+        },
+        fetch: async (url, init) => {
+          if (init?.method === "DELETE") return Response.json({ ok: false }, { status: 503 });
+          if (String(url).endsWith("/v1/attach/project-bindings/sessions")) {
+            return Response.json(
+              { binding: { bindingId: "binding_1" }, sessionId: "session_1" },
+              { status: 201 },
+            );
+          }
+          return Response.json({ ok: true });
+        },
+        writeOut: (value) => out.push(value),
+      });
+
+      expect(JSON.parse(out.join(""))).toMatchObject({
+        projectBinding: {
+          authMode: "self_hosted_remote",
+          sessionSupport: "unknown",
+          lastUpgradeError: "Project Binding diagnostic cleanup returned 503.",
+          recoveryCommand: "caplets doctor",
+        },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("bounds self-hosted Project Binding doctor probes", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "caplets-doctor-self-hosted-"));
+    const authDir = join(dir, "auth");
+    try {
+      await saveSelfHostedProfile(authDir);
+
+      const report = await doctorJsonReport({
+        authDir,
+        env: {
+          CAPLETS_MODE: "remote",
+          CAPLETS_REMOTE_URL: "http://127.0.0.1:5387",
+          XDG_STATE_HOME: join(dir, "state"),
+        },
+        projectBindingProbeTimeoutMs: 1,
+        fetch: async (_url, init) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+          }),
+      });
+
+      expect(report.projectBinding).toMatchObject({
+        authMode: "self_hosted_remote",
+        sessionSupport: "unknown",
+        lastUpgradeError: "Project Binding session probe timed out after 1ms.",
+        recoveryCommand: "caplets doctor",
+      });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -463,3 +602,17 @@ describe("caplets doctor", () => {
     });
   });
 });
+
+async function saveSelfHostedProfile(authDir: string): Promise<void> {
+  await new FileRemoteProfileStore({
+    root: join(authDir, "remote-profiles"),
+  }).saveSelfHostedProfile({
+    hostUrl: "http://127.0.0.1:5387",
+    clientId: "rcli_test",
+    credentials: {
+      accessToken: "remote-access",
+      refreshToken: "remote-refresh",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+    },
+  });
+}


### PR DESCRIPTION
## Summary

`caplets doctor` now reports authenticated self-hosted Project Binding support from the actual session route instead of assuming every self-hosted remote is unsupported. Supported remotes now show `sessionSupport: "supported"` and recover with `caplets attach --once`; older remotes without the route still report `unsupported` with an upgrade-oriented diagnostic.

The probe authenticates against the Project Binding session endpoint with a non-creating diagnostic request, so current servers prove support without leaving a binding lease behind. A patch changeset is included for the published CLI/runtime packages.

## Validation

- `pnpm changeset status --since=origin/main`
- `pnpm verify`
- `node packages/cli/dist/index.js doctor --json` against the live self-hosted daemon reported `sessionSupport: "supported"`, `lastUpgradeError: null`, and `recoveryCommand: "caplets attach --once"`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `caplets doctor` Project Binding session diagnostics for authenticated self-hosted remotes.
  * Session route support is now detected more reliably, with updated `recoveryCommand` guidance when support is unavailable, missing, or errors occur (including probe timeouts).
  * Enhanced error reporting for failed diagnostic checks and cleanup attempts.

* **Tests**
  * Expanded `caplets doctor` test coverage for session probing outcomes, request handling, recovery messaging, and timeout/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->