### PR TITLE
fix(catalog): preserve virtual result rows

### DIFF
--- a/apps/catalog/src/scripts/virtual-results.ts
+++ b/apps/catalog/src/scripts/virtual-results.ts
@@ -56,6 +56,7 @@ export function initVirtualCatalogSearch(
   const rows = parseRows(index.textContent ?? "[]");
   let visibleRows = [...rows];
   let lastFocusedControl: HTMLElement | null = null;
+  const renderedRows = new Map<string, HTMLElement>();
   const virtualizer = new Virtualizer<Window, HTMLElement>({
     count: visibleRows.length,
     getScrollElement: () => window,
@@ -128,7 +129,36 @@ export function initVirtualCatalogSearch(
   function renderVirtualRows(): void {
     const items = virtualizer.getVirtualItems();
     resultSpacerEl.style.height = `${Math.max(virtualizer.getTotalSize(), visibleRows.length ? estimateRowHeight() : 1)}px`;
-    resultListEl.replaceChildren(...items.map((item) => renderRow(item, visibleRows[item.index])));
+    const nextKeys = new Set<string>();
+    let cursor: ChildNode | null = resultListEl.firstChild;
+
+    for (const item of items) {
+      const row = visibleRows[item.index];
+      const key = virtualRowKey(item, row);
+      nextKeys.add(key);
+
+      let element = renderedRows.get(key);
+      if (!element) {
+        element = renderRow(item, row);
+        renderedRows.set(key, element);
+      } else {
+        updateRowPosition(element, item, row);
+      }
+
+      if (element !== cursor) {
+        resultListEl.insertBefore(element, cursor);
+      }
+      cursor = element.nextSibling;
+    }
+
+    for (const element of Array.from(
+      resultListEl.querySelectorAll<HTMLElement>("[data-result-row]"),
+    )) {
+      const key = element.dataset.virtualKey;
+      if (key && nextKeys.has(key)) continue;
+      element.remove();
+      if (key) renderedRows.delete(key);
+    }
   }
 
   function navigateFromRowClick(event: MouseEvent): void {
@@ -249,10 +279,7 @@ function renderRow(item: VirtualItem, row: CatalogSearchRow | undefined): HTMLEl
   element.className = "catalog-result-row";
   element.role = "row";
   element.dataset.resultRow = "";
-  element.dataset.detailHref = row?.detailHref ?? "";
-  element.dataset.index = String(item.index);
-  element.setAttribute("aria-rowindex", String(item.index + 2));
-  element.style.transform = `translateY(${item.start}px)`;
+  updateRowPosition(element, item, row);
   if (!row) return element;
   element.innerHTML = `
     <div class="catalog-result-row__name" role="cell">
@@ -276,6 +303,22 @@ function renderRow(item: VirtualItem, row: CatalogSearchRow | undefined): HTMLEl
     </div>
   `;
   return element;
+}
+
+function updateRowPosition(
+  element: HTMLElement,
+  item: VirtualItem,
+  row: CatalogSearchRow | undefined,
+): void {
+  element.dataset.virtualKey = virtualRowKey(item, row);
+  element.dataset.detailHref = row?.detailHref ?? "";
+  element.dataset.index = String(item.index);
+  element.setAttribute("aria-rowindex", String(item.index + 2));
+  element.style.transform = `translateY(${item.start}px)`;
+}
+
+function virtualRowKey(item: VirtualItem, row: CatalogSearchRow | undefined): string {
+  return row?.id ?? String(item.key);
 }
 
 function renderCapletIcon(row: CatalogSearchRow): string {

--- a/apps/catalog/test/virtual-results.test.ts
+++ b/apps/catalog/test/virtual-results.test.ts
@@ -84,6 +84,18 @@ describe("virtual catalog results", () => {
     expect(icon.getAttribute("loading")).toBe("lazy");
   });
 
+  it("reuses row nodes that remain visible while scrolling", async () => {
+    mountSearchShell(manyCatalogSearchRows(200));
+
+    const { initVirtualCatalogSearch } = await import("../src/scripts/virtual-results");
+    initVirtualCatalogSearch();
+    const firstRow = resultRows()[0];
+
+    window.scrollTo({ top: 72 });
+
+    expect(resultRows()).toContain(firstRow);
+  });
+
   it("hydrates filters from the url and resets to the first row", async () => {
     mountSearchShell(manyCatalogSearchRows(80), "http://localhost:3000/?q=caplet-70");
 


### PR DESCRIPTION
## Summary

Catalog icons should no longer flicker while scrolling the production search results. The virtual list now keeps row DOM nodes alive when they remain in the visible window instead of replacing the entire row group on every scroll update.

## Validation

- `pnpm --filter @caplets/catalog test -- test/virtual-results.test.ts test/search-row.test.ts`
- `pnpm --filter @caplets/catalog typecheck`
- `pnpm --filter @caplets/catalog build`
- `pnpm format:check`
- pre-push `pnpm verify`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Virtual catalog search now reuses existing result rows while scrolling, reducing unnecessary re-renders and keeping the visible list more stable.
  * Row position and accessibility attributes are updated correctly as items move within the virtual window.
* **Tests**
  * Added coverage to confirm a rendered row element is preserved during scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->