### PR TITLE
fix: OpenCode array item schemas

### DIFF
--- a/.changeset/sharp-array-schemas.md
+++ b/.changeset/sharp-array-schemas.md
@@ -1,0 +1,5 @@
+---
+"@caplets/opencode": patch
+---
+
+Preserve JSON Schema array item types when registering direct native tools with OpenCode.

--- a/packages/opencode/src/schema.ts
+++ b/packages/opencode/src/schema.ts
@@ -79,7 +79,12 @@ function jsonSchemaPropertyToOpenCode(
     return options.optional ? numberSchema.optional() : numberSchema;
   }
   if (schema.type === "boolean" && "boolean" in tool.schema) {
-    return (tool.schema as typeof tool.schema & { boolean: () => OpenCodeSchema }).boolean();
+    const booleanSchema = (
+      tool.schema as typeof tool.schema & {
+        boolean: () => OpenCodeSchema & { optional: () => OpenCodeSchema };
+      }
+    ).boolean();
+    return options.optional ? booleanSchema.optional() : booleanSchema;
   }
   if (schema.type === "object") {
     const objectSchema = tool.schema.record(tool.schema.string(), tool.schema.unknown());

--- a/packages/opencode/src/schema.ts
+++ b/packages/opencode/src/schema.ts
@@ -1,6 +1,8 @@
 import { tool } from "@opencode-ai/plugin";
 import { operations } from "@caplets/core/generated-tool-input-schema";
 
+type OpenCodeSchema = Parameters<typeof tool>[0]["args"][string];
+
 export function capletsOpenCodeArgs(operationNames: string[] = [...operations]) {
   const enumValues = operationNames.length > 0 ? operationNames : [...operations];
   return {
@@ -52,28 +54,47 @@ export function capletsOpenCodeJsonSchemaArgs(schema: Record<string, unknown> | 
     return {};
   }
   return Object.fromEntries(
-    Object.entries(properties).map(([key, value]) => [key, jsonSchemaPropertyToOpenCode(value)]),
+    Object.entries(properties).map(([key, value]) => [
+      key,
+      jsonSchemaPropertyToOpenCode(value, { optional: true }),
+    ]),
   );
 }
 
-function jsonSchemaPropertyToOpenCode(value: unknown) {
+function jsonSchemaPropertyToOpenCode(
+  value: unknown,
+  options: { optional: boolean },
+): OpenCodeSchema {
   if (!value || typeof value !== "object" || Array.isArray(value)) return tool.schema.unknown();
   const schema = value as Record<string, unknown>;
   if (Array.isArray(schema.enum) && schema.enum.every((item) => typeof item === "string")) {
     return tool.schema.enum(schema.enum as [string, ...string[]]);
   }
-  if (schema.type === "string") return tool.schema.string().optional();
+  if (schema.type === "string") {
+    const stringSchema = tool.schema.string();
+    return options.optional ? stringSchema.optional() : stringSchema;
+  }
   if (schema.type === "number" || schema.type === "integer") {
-    return tool.schema.number().int().positive().optional();
+    const numberSchema = tool.schema.number().int().positive();
+    return options.optional ? numberSchema.optional() : numberSchema;
   }
   if (schema.type === "boolean" && "boolean" in tool.schema) {
-    return (tool.schema as typeof tool.schema & { boolean: () => unknown }).boolean();
+    return (tool.schema as typeof tool.schema & { boolean: () => OpenCodeSchema }).boolean();
   }
   if (schema.type === "object") {
-    return tool.schema.record(tool.schema.string(), tool.schema.unknown()).optional();
+    const objectSchema = tool.schema.record(tool.schema.string(), tool.schema.unknown());
+    return options.optional ? objectSchema.optional() : objectSchema;
   }
   if (schema.type === "array") {
-    return tool.schema.array(tool.schema.unknown()).min(1).optional();
+    const itemSchema =
+      schema.items &&
+      typeof schema.items === "object" &&
+      !Array.isArray(schema.items) &&
+      Object.keys(schema.items).length > 0
+        ? jsonSchemaPropertyToOpenCode(schema.items, { optional: false })
+        : tool.schema.string();
+    const arraySchema = tool.schema.array(itemSchema).min(1);
+    return options.optional ? arraySchema.optional() : arraySchema;
   }
   return tool.schema.unknown();
 }

--- a/packages/opencode/src/schema.ts
+++ b/packages/opencode/src/schema.ts
@@ -68,7 +68,8 @@ function jsonSchemaPropertyToOpenCode(
   if (!value || typeof value !== "object" || Array.isArray(value)) return tool.schema.unknown();
   const schema = value as Record<string, unknown>;
   if (Array.isArray(schema.enum) && schema.enum.every((item) => typeof item === "string")) {
-    return tool.schema.enum(schema.enum as [string, ...string[]]);
+    const enumSchema = tool.schema.enum(schema.enum as [string, ...string[]]);
+    return options.optional ? enumSchema.optional() : enumSchema;
   }
   if (schema.type === "string") {
     const stringSchema = tool.schema.string();
@@ -91,15 +92,27 @@ function jsonSchemaPropertyToOpenCode(
     return options.optional ? objectSchema.optional() : objectSchema;
   }
   if (schema.type === "array") {
-    const itemSchema =
-      schema.items &&
-      typeof schema.items === "object" &&
-      !Array.isArray(schema.items) &&
-      Object.keys(schema.items).length > 0
-        ? jsonSchemaPropertyToOpenCode(schema.items, { optional: false })
-        : tool.schema.string();
+    const itemSchema = isSupportedOpenCodeJsonSchema(schema.items)
+      ? jsonSchemaPropertyToOpenCode(schema.items, { optional: false })
+      : tool.schema.string();
     const arraySchema = tool.schema.array(itemSchema).min(1);
     return options.optional ? arraySchema.optional() : arraySchema;
   }
   return tool.schema.unknown();
+}
+
+function isSupportedOpenCodeJsonSchema(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const schema = value as Record<string, unknown>;
+  if (Array.isArray(schema.enum) && schema.enum.every((item) => typeof item === "string")) {
+    return schema.enum.length > 0;
+  }
+  return (
+    schema.type === "string" ||
+    schema.type === "number" ||
+    schema.type === "integer" ||
+    schema.type === "boolean" ||
+    schema.type === "object" ||
+    schema.type === "array"
+  );
 }

--- a/packages/opencode/test/opencode.test.ts
+++ b/packages/opencode/test/opencode.test.ts
@@ -9,7 +9,10 @@ vi.mock("@opencode-ai/plugin", () => ({
         optional: () => ({ type: "string", optional: true }),
         min: () => ({ type: "string" }),
       }),
-      boolean: () => ({ type: "boolean" }),
+      boolean: () => ({
+        type: "boolean",
+        optional: () => ({ type: "boolean", optional: true }),
+      }),
       number: () => ({
         int: () => ({ positive: () => ({ optional: () => ({ type: "number", optional: true }) }) }),
       }),
@@ -206,7 +209,7 @@ describe("@caplets/opencode", () => {
     };
 
     expect(directTool.args).toMatchObject({
-      verbose: { type: "boolean" },
+      verbose: { type: "boolean", optional: true },
       tags: { type: "array", item: { type: "string" }, optional: true },
     });
     await directTool.execute({ verbose: true }, {} as never);

--- a/packages/opencode/test/opencode.test.ts
+++ b/packages/opencode/test/opencode.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@opencode-ai/plugin", () => ({
   tool: Object.assign((definition: unknown) => definition, {
     schema: {
-      enum: () => ({ type: "enum" }),
+      enum: (values: string[]) => ({
+        type: "enum",
+        values,
+        optional: () => ({ type: "enum", values, optional: true }),
+      }),
       string: () => ({
         type: "string",
         optional: () => ({ type: "string", optional: true }),
@@ -190,8 +194,11 @@ describe("@caplets/opencode", () => {
           inputSchema: {
             type: "object",
             properties: {
+              mode: { enum: ["fast", "safe"] },
               verbose: { type: "boolean" },
               tags: { type: "array", items: { type: "string" } },
+              priorityTags: { type: "array", items: { enum: ["high", "low"] } },
+              looseTags: { type: "array", items: { anyOf: [{ type: "string" }] } },
             },
           },
         },
@@ -209,8 +216,15 @@ describe("@caplets/opencode", () => {
     };
 
     expect(directTool.args).toMatchObject({
+      mode: { type: "enum", values: ["fast", "safe"], optional: true },
       verbose: { type: "boolean", optional: true },
       tags: { type: "array", item: { type: "string" }, optional: true },
+      priorityTags: {
+        type: "array",
+        item: { type: "enum", values: ["high", "low"] },
+        optional: true,
+      },
+      looseTags: { type: "array", item: { type: "string" }, optional: true },
     });
     await directTool.execute({ verbose: true }, {} as never);
     expect(service.execute).toHaveBeenCalledWith("status__ping", { verbose: true });

--- a/packages/opencode/test/opencode.test.ts
+++ b/packages/opencode/test/opencode.test.ts
@@ -31,7 +31,9 @@ vi.mock("@opencode-ai/plugin", () => ({
         options,
         optional: () => ({ type: "union", options, optional: true }),
       }),
-      array: () => ({ min: () => ({ optional: () => ({ type: "array", optional: true }) }) }),
+      array: (item: unknown) => ({
+        min: () => ({ optional: () => ({ type: "array", item, optional: true }) }),
+      }),
     },
   }),
 }));
@@ -184,7 +186,10 @@ describe("@caplets/opencode", () => {
           promptGuidance: ["Use caplets__status__ping."],
           inputSchema: {
             type: "object",
-            properties: { verbose: { type: "boolean" } },
+            properties: {
+              verbose: { type: "boolean" },
+              tags: { type: "array", items: { type: "string" } },
+            },
           },
         },
       ],
@@ -200,7 +205,10 @@ describe("@caplets/opencode", () => {
       execute(args: unknown, context: unknown): Promise<string>;
     };
 
-    expect(directTool.args).toEqual({ verbose: { type: "boolean" } });
+    expect(directTool.args).toMatchObject({
+      verbose: { type: "boolean" },
+      tags: { type: "array", item: { type: "string" }, optional: true },
+    });
     await directTool.execute({ verbose: true }, {} as never);
     expect(service.execute).toHaveBeenCalledWith("status__ping", { verbose: true });
   });


### PR DESCRIPTION
## Summary

- Fixes #178 by preserving JSON Schema `items` definitions when `@caplets/opencode` registers direct native tool schemas.
- Falls back to string array items when a downstream array schema has no usable `items` object, avoiding empty Gemini array item declarations.
- Adds a regression assertion for `array<string>` direct native input schemas and a patch changeset for `@caplets/opencode`.

## Validation

- `pnpm --filter @caplets/opencode test -- test/opencode.test.ts`
- `pnpm --filter @caplets/opencode typecheck`
- `pnpm --filter @caplets/opencode build`
- `pnpm format:check`
- `pnpm changeset status --since=origin/main`
- `pnpm verify`
- pre-push `pnpm verify`

Fixes #178


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved array item types when generating argument schemas from native tools.
  * Improved schema handling so boolean and array arguments keep the correct required/optional behavior.
  * Better support for arrays with nested item definitions in generated tool inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->