### PR TITLE
chore: version packages

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # caplets
 
+## 0.25.5
+
+### Patch Changes
+
+- Support `caplets doctor --format json`, `--format md`, and `--format plain`.
+- Updated dependencies
+  - @caplets/core@0.32.3
+
 ## 0.25.4
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caplets",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "description": "Progressive disclosure gateway CLI for MCP servers and native Caplets adapters.",
   "keywords": [
     "caplets",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @caplets/core
 
+## 0.32.3
+
+### Patch Changes
+
+- Support `caplets doctor --format json`, `--format md`, and `--format plain`.
+
 ## 0.32.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caplets/core",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "description": "Core runtime library for Caplets Code Mode and progressive disclosure gateways.",
   "keywords": [
     "caplets",

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @caplets/opencode
 
+## 0.8.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @caplets/core@0.32.3
+
 ## 0.8.12
 
 ### Patch Changes

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caplets/opencode",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "Native OpenCode plugin for Caplets.",
   "homepage": "https://github.com/spiritledsoftware/caplets#readme",
   "bugs": {

--- a/packages/pi/CHANGELOG.md
+++ b/packages/pi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @caplets/pi
 
+## 0.9.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @caplets/core@0.32.3
+
 ## 0.9.11
 
 ### Patch Changes

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caplets/pi",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "Native Pi extension for Caplets.",
   "homepage": "https://github.com/spiritledsoftware/caplets#readme",
   "bugs": {


### PR DESCRIPTION
## Summary
- publish the missing release for PR #188
- bump caplets to 0.25.5 and @caplets/core to 0.32.3
- bump native integration packages for the updated core dependency

## Verification
- pnpm format:check
- pnpm lint
- full pre-push pnpm verify passed locally before branch push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `caplets doctor` now supports multiple output formats: JSON, Markdown, and plain text.

* **Chores**
  * Updated release versions across related packages.
  * Reflected the latest dependency update in changelogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->