### PR TITLE
feat: add SQL authoritative host storage

### DIFF
--- a/.changeset/sql-host-storage.md
+++ b/.changeset/sql-host-storage.md
@@ -1,0 +1,6 @@
+---
+"@caplets/core": minor
+"caplets": minor
+---
+
+Add authoritative SQLite and PostgreSQL host storage, relational Caplet Records with Markdown import/export, and SQL-backed host administration across CLI, HTTP, and remote-control surfaces.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,17 @@
 
 ## Agent skills
 
-- Issues and PRDs live in GitHub Issues for `spiritledsoftware/caplets`; use `gh` with `--repo spiritledsoftware/caplets`. Details: `docs/agents/issue-tracker.md`.
-- Triage labels are documented in `docs/agents/triage-labels.md`; current live labels include `question` for `needs-info` and `wontfix` for `wontfix`.
-- This is a single-context repo. Start with `CONTEXT.md`, relevant ADRs in `docs/adr/`, and `docs/agents/domain.md`; use `STRATEGY.md`, `CONCEPTS.md`, and `docs/solutions/` when the task touches product direction, vocabulary, or documented patterns.
+### Issue tracker
+
+Issues and PRDs live in GitHub Issues for `spiritledsoftware/caplets`; use `gh` with `--repo spiritledsoftware/caplets`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the five canonical triage labels without overrides. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a single-context repo: start with root `CONTEXT.md` and relevant ADRs in `docs/adr/`. See `docs/agents/domain.md`.
 
 ## Test Quality Bar
 

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -60,9 +60,9 @@ In v1, Catalog Presentation Metadata is limited to `catalog.icon`, which may ide
 
 ### Caplets Lockfile
 
-A `caplets.lock.json` file that records installed catalog Caplets, their source repository, source path, destination, tracked source channel, resolved revision when available, content hash, and portability status.
+A project-local `.caplets.lock.json` file that records installed project Caplets, their source repository, source path, destination, tracked source channel, resolved revision when available, content hash, and portability status.
 
-Caplets Lockfiles let `caplets install`, no-argument install restore, and `caplets update` manage installed Caplets from recorded provenance rather than from copied files alone. Project installs use `./.caplets.lock.json`; global installs use the target machine's Caplets state directory.
+Caplets Lockfiles let project `caplets install`, no-argument restore, and `caplets update` manage filesystem Caplets from recorded provenance rather than from copied files alone. Global and remote SQL-backed Caplets use Caplet Installations instead.
 
 Caplets Lockfiles are share-safe and integrity-aware. They strip credential-bearing source URLs, prefer project-relative paths where possible, verify recorded content before restore, and fail closed when local-source entries are unavailable or marked non-portable.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,38 @@ _Avoid_: Caplets utility namespace, custom helper surface
 The first compatibility-global set for Code Mode: URL and query handling, text encoding, base64 and Buffer-compatible byte handling, web binary payload objects, safe crypto primitives, timing, scheduling, and structured cloning.
 _Avoid_: Minimal encoding helpers, full Node compatibility
 
+**Caplet Record**:
+The canonical structured form of a Caplet persisted in runtime-owned storage. A Caplet File is its portable Markdown import/export projection, not the stored record itself.
+_Avoid_: SQL Caplet File, stored Caplet File
+
+**Caplet Revision**:
+An immutable saved version of a Caplet Record's structured content and Caplet Bundle Snapshot; the record's current Caplet ID is stable metadata outside content history. A record selects one current revision; removing it promotes the newest remaining revision, while removing the sole revision removes the record.
+_Avoid_: Mutable draft, audit-log entry
+
+**Caplet Installation**:
+A provenance-bearing lifecycle that connects a Caplet Record to an external source and update channel. Detaching ends update tracking without erasing that lifecycle; replacing a detached install starts a new Caplet Installation.
+_Avoid_: Global lockfile entry, permanent source ownership
+
+**Caplet Bundle Snapshot**:
+A portable normalized snapshot of every regular auxiliary file in a Caplet bundle, including its relative path, content identity, and executable intent; `CAPLET.md` is represented by the Caplet Record instead. Safe in-bundle symlinks become regular files; escaping or broken links and special files are invalid.
+_Avoid_: Bundle archive blob, mounted bundle path
+
+**Caplet File Layer**:
+A live filesystem-backed source whose Caplet Files can shadow lower-precedence Caplets without modifying them. Project Caplet Files outrank global Caplet Files, which outrank SQL-backed Caplet Records.
+_Avoid_: One-time bootstrap import, filesystem synchronization
+
+**Effective Caplet**:
+The Caplet selected for an ID after all configured Caplet sources are resolved. Ordinary runtime and dashboard views show only the Effective Caplet; explicit storage operations may still address a shadowed Caplet Record.
+_Avoid_: Active record, merged Caplet
+
+**Authoritative Host State**:
+The correctness-bearing state owned by a Caplets host that must present one coherent view across all of that host's server nodes. It excludes node-local caches and artifacts, client-owned credentials, and native service files.
+_Avoid_: All runtime files, shared cache
+
+**Host Node**:
+A running server instance participating in one logical Caplets host. Host Nodes share Authoritative Host State but own their live Code Mode heap, bound workspace copy, and any node-local artifacts.
+_Avoid_: Independent host, tenant
+
 **Caplets exposure projection**:
 A shared adapter-neutral runtime view of which local and remote Caplets are exposed as Code Mode handles, progressive tools, direct downstream operations, or direct MCP surfaces, including non-callable diagnostic breadcrumbs for hidden Caplets. MCP, native, and attach host adapters render it differently; they do not own exposure policy or execution behavior.
 _Avoid_: Tool registration list, exposure wrapper map, transport-specific surface

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Long-lived docs:
 - [Benchmark methodology](https://github.com/spiritledsoftware/caplets/blob/main/docs/benchmarks/coding-agent.md)
 - [Native integrations](https://github.com/spiritledsoftware/caplets/blob/main/docs/native-integrations.md)
 - [Project Binding](https://github.com/spiritledsoftware/caplets/blob/main/docs/project-binding.md)
+- [SQL Authoritative Host State operations](https://github.com/spiritledsoftware/caplets/blob/main/docs/operations/sql-authoritative-host-state.md)
 
 ## License
 

--- a/apps/dashboard/src/components/DashboardApp.test.tsx
+++ b/apps/dashboard/src/components/DashboardApp.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@/lib/api", () => ({
 vi.mock("@/components/ui/sonner", () => ({ Toaster: () => null }));
 vi.mock("sonner", () => ({ toast }));
 
-import { DashboardApp, catalogMutationLabel } from "./DashboardApp";
+import { DashboardApp, catalogMutationLabel, routeFromPath } from "./DashboardApp";
 
 type Deferred<T> = {
   promise: Promise<T>;
@@ -173,6 +173,12 @@ describe("catalog update presentation", () => {
     );
     expect(catalogMutationLabel({ installed: [{ status: "updated" }] })).toBe("Updated");
     expect(catalogMutationLabel({ installed: [{ status: "noop" }] })).toBe("Already current");
+  });
+});
+
+describe("dashboard routing", () => {
+  it("recognizes the Stored Caplets route", () => {
+    expect(routeFromPath("/dashboard/stored-caplets")).toBe("stored-caplets");
   });
 });
 

--- a/apps/dashboard/src/components/DashboardApp.tsx
+++ b/apps/dashboard/src/components/DashboardApp.tsx
@@ -95,6 +95,7 @@ import { EPHEMERAL_REVEAL_TTL_MS, createEphemeralRevealExpiry } from "@/lib/ephe
 import { dashboardBasePath, dashboardPath } from "@/lib/paths";
 
 import { CatalogPage } from "@/components/catalog/CatalogPage";
+import { StoredCapletsPage } from "@/components/StoredCapletsPage";
 const REVEAL_DURATION_SECONDS = EPHEMERAL_REVEAL_TTL_MS / 1_000;
 const ACTION_DISCARDED = Symbol("dashboard-action-discarded");
 
@@ -131,6 +132,7 @@ type RouteKey =
   | "overview"
   | "access"
   | "caplets"
+  | "stored-caplets"
   | "catalog"
   | "vault"
   | "runtime"
@@ -191,6 +193,12 @@ const routes: Array<{
   { key: "overview", label: "Overview", href: dashboardPath(), icon: HomeIcon },
   { key: "access", label: "Access", href: dashboardPath("access"), icon: ShieldCheckIcon },
   { key: "caplets", label: "Caplets", href: dashboardPath("caplets"), icon: BoxesIcon },
+  {
+    key: "stored-caplets",
+    label: "Stored Caplets",
+    href: dashboardPath("stored-caplets"),
+    icon: DatabaseIcon,
+  },
   { key: "catalog", label: "Catalog", href: dashboardPath("catalog"), icon: BoxIcon },
   { key: "vault", label: "Vault", href: dashboardPath("vault"), icon: KeyRoundIcon },
   { key: "runtime", label: "Runtime", href: dashboardPath("runtime"), icon: TerminalIcon },
@@ -255,6 +263,15 @@ function useActionConfirm() {
   return {
     confirmAction: async (title: string, description: string) =>
       Boolean(await confirm({ title, description, confirmLabel: "Continue" })),
+    confirmDestructive: async (title: string, description: string, confirmLabel = "Delete") =>
+      Boolean(
+        await confirm({
+          title,
+          description,
+          confirmLabel,
+          destructive: true,
+        }),
+      ),
     confirmTyped: async (title: string, description: string, expectedPhrase: string) =>
       Boolean(
         await confirm({
@@ -783,9 +800,18 @@ function Page({
   session: DashboardSession;
   action: DashboardAction;
 }) {
-  const { confirmTyped } = useActionConfirm();
+  const { confirmAction, confirmDestructive, confirmTyped } = useActionConfirm();
   if (route === "access") return <AccessPage data={data} loading={loading} action={action} />;
   if (route === "caplets") return <CapletsPage data={data} loading={loading} action={action} />;
+  if (route === "stored-caplets")
+    return (
+      <StoredCapletsPage
+        action={action}
+        confirmAction={confirmAction}
+        confirmDestructive={confirmDestructive}
+        confirmTyped={confirmTyped}
+      />
+    );
   if (route === "catalog")
     return <CatalogPage data={data} action={action} confirmTyped={confirmTyped} />;
   if (route === "vault") return <VaultPage data={data} loading={loading} action={action} />;

--- a/apps/dashboard/src/components/StoredCapletsPage.test.tsx
+++ b/apps/dashboard/src/components/StoredCapletsPage.test.tsx
@@ -1,0 +1,401 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dashboardApi, toast } = vi.hoisted(() => ({
+  dashboardApi: vi.fn(),
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", () => ({ dashboardApi }));
+vi.mock("sonner", () => ({ toast }));
+
+import {
+  StoredCapletsPage,
+  type StoredCapletRecord,
+  type StoredCapletsPageProps,
+} from "./StoredCapletsPage";
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+let records: StoredCapletRecord[];
+let documentBody: string;
+let revisions: Array<{ revisionKey: string; sequence: number; name: string }>;
+let confirmAction: StoredCapletsPageProps["confirmAction"];
+let confirmDestructive: StoredCapletsPageProps["confirmDestructive"];
+let confirmTyped: StoredCapletsPageProps["confirmTyped"];
+let action: StoredCapletsPageProps["action"];
+
+function storedRecord(overrides: Partial<StoredCapletRecord> = {}): StoredCapletRecord {
+  return {
+    id: "alpha",
+    recordKey: "record-alpha",
+    headGeneration: 2,
+    historyLimit: 5,
+    updatedAt: "2026-07-18T12:00:00.000Z",
+    currentRevision: {
+      revisionKey: "revision-2",
+      sequence: 2,
+      name: "Alpha tools",
+      description: "Current SQL record",
+      contentHash: "sha256:current",
+    },
+    ...overrides,
+  };
+}
+
+function generation(record: StoredCapletRecord): number {
+  return record.generation ?? record.headGeneration ?? 0;
+}
+
+function currentRecord(): StoredCapletRecord {
+  const record = records[0];
+  if (!record) throw new Error("Expected a stored Caplet fixture.");
+  return record;
+}
+
+function replaceCurrent(record: StoredCapletRecord) {
+  records = [record];
+}
+
+function responseFor(path: string, options?: RequestInit) {
+  const method = options?.method ?? "GET";
+  if (path === "stored-caplets" && method === "GET") return { records };
+  if (path === "stored-caplets" && method === "POST") {
+    const body = JSON.parse(String(options?.body)) as {
+      id: string;
+      document: string;
+      historyLimit?: number;
+    };
+    documentBody = body.document;
+    revisions = [{ revisionKey: "revision-1", sequence: 1, name: "Imported Caplet" }];
+    const record = storedRecord({
+      id: body.id,
+      recordKey: `record-${body.id}`,
+      headGeneration: 1,
+      historyLimit: body.historyLimit,
+      currentRevision: {
+        revisionKey: "revision-1",
+        sequence: 1,
+        name: "Imported Caplet",
+      },
+    });
+    replaceCurrent(record);
+    return { record };
+  }
+
+  if (path.endsWith("/revisions") && method === "GET") return { revisions };
+  if (path.endsWith("/restore") && method === "POST") {
+    const previous = currentRecord();
+    const restored = storedRecord({
+      ...previous,
+      headGeneration: generation(previous) + 1,
+      currentRevision: {
+        revisionKey: "revision-restored",
+        sequence: 3,
+        name: "Alpha tools restored",
+      },
+    });
+    documentBody = "# Alpha restored\n";
+    revisions = [
+      { revisionKey: "revision-restored", sequence: 3, name: "Alpha tools restored" },
+      ...revisions,
+    ];
+    replaceCurrent(restored);
+    return { record: restored };
+  }
+
+  if (path.includes("/revisions/") && method === "DELETE") {
+    const revisionKey = decodeURIComponent(path.split("/revisions/")[1] ?? "");
+    revisions = revisions.filter((revision) => revision.revisionKey !== revisionKey);
+    const previous = currentRecord();
+    const record = storedRecord({ ...previous, headGeneration: generation(previous) + 1 });
+    replaceCurrent(record);
+    return { record };
+  }
+
+  if (path === "stored-caplets/alpha" && method === "PUT") {
+    const body = JSON.parse(String(options?.body)) as {
+      document: string;
+      expectedGeneration: number;
+    };
+    documentBody = body.document;
+    const previous = currentRecord();
+    const record = storedRecord({
+      ...previous,
+      headGeneration: body.expectedGeneration + 1,
+      currentRevision: {
+        revisionKey: "revision-3",
+        sequence: 3,
+        name: "Alpha tools",
+      },
+    });
+    revisions = [{ revisionKey: "revision-3", sequence: 3, name: "Alpha tools" }, ...revisions];
+    replaceCurrent(record);
+    return { record };
+  }
+
+  if (path === "stored-caplets/alpha" && method === "DELETE") {
+    records = [];
+    revisions = [];
+    return { deleted: true, id: "alpha" };
+  }
+
+  if (path.startsWith("stored-caplets/") && method === "GET") {
+    return { record: currentRecord(), document: documentBody };
+  }
+  throw new Error(`Unexpected dashboard request: ${method} ${path}`);
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function waitFor<T>(read: () => T | undefined): Promise<T> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const value = read();
+    if (value !== undefined) return value;
+    await flush();
+  }
+  throw new Error("Timed out waiting for Stored Caplets state.");
+}
+
+function button(label: string): HTMLButtonElement {
+  const result = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+    (candidate) =>
+      candidate.getAttribute("aria-label") === label || candidate.textContent?.trim() === label,
+  );
+  if (!result) throw new Error(`Could not find button: ${label}`);
+  return result;
+}
+
+async function click(label: string) {
+  await act(async () => {
+    button(label).click();
+  });
+  await flush();
+}
+
+async function setValue(control: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const prototype =
+    control instanceof HTMLTextAreaElement
+      ? HTMLTextAreaElement.prototype
+      : HTMLInputElement.prototype;
+  const valueSetter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+  await act(async () => {
+    valueSetter?.call(control, value);
+    control.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function mount() {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      <StoredCapletsPage
+        action={action}
+        confirmAction={confirmAction}
+        confirmDestructive={confirmDestructive}
+        confirmTyped={confirmTyped}
+      />,
+    );
+  });
+  await waitFor(() =>
+    document.body.textContent?.includes("SQL record inventory") ? true : undefined,
+  );
+  await flush();
+}
+
+async function inspectAlpha() {
+  await waitFor(() =>
+    document.body.textContent?.includes("Alpha tools") ? button("Inspect") : undefined,
+  );
+  await click("Inspect");
+  await waitFor(() =>
+    document.body.textContent?.includes("Current CAPLET.md") ? true : undefined,
+  );
+}
+
+beforeEach(() => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  records = [storedRecord()];
+  documentBody = "# Alpha tools\n\nCurrent document.\n";
+  revisions = [
+    { revisionKey: "revision-2", sequence: 2, name: "Alpha tools" },
+    { revisionKey: "revision-1", sequence: 1, name: "Alpha tools old" },
+  ];
+  dashboardApi.mockImplementation((path: string, options?: RequestInit) =>
+    Promise.resolve(responseFor(path, options)),
+  );
+  dashboardApi.mockClear();
+  toast.error.mockClear();
+  toast.success.mockClear();
+  action = vi.fn(async (_label, callback) => {
+    await callback();
+  });
+  confirmAction = vi.fn(async () => true);
+  confirmDestructive = vi.fn(async () => true);
+  confirmTyped = vi.fn(async () => true);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = undefined;
+  container = undefined;
+  vi.restoreAllMocks();
+});
+
+describe("Stored Caplets administration", () => {
+  it("lists SQL records with provenance, generation, and retention", async () => {
+    await mount();
+
+    await waitFor(() => (document.body.textContent?.includes("Alpha tools") ? true : undefined));
+    expect(document.body.textContent).toContain("SQL record");
+    expect(document.body.textContent).toContain("Generation");
+    expect(document.body.textContent).toContain("5 revisions");
+    expect(dashboardApi).toHaveBeenCalledWith("stored-caplets");
+  });
+
+  it("imports CAPLET.md with an optional history limit", async () => {
+    records = [];
+    await mount();
+    await click("Import CAPLET.md");
+
+    const id = document.querySelector<HTMLInputElement>("#stored-caplet-id");
+    const historyLimit = document.querySelector<HTMLInputElement>("#stored-caplet-history-limit");
+    const markdown = document.querySelector<HTMLTextAreaElement>("#stored-caplet-document");
+    if (!id || !historyLimit || !markdown) throw new Error("Import fields were not rendered.");
+    await setValue(id, "imported-caplet");
+    await setValue(historyLimit, "7");
+    await setValue(markdown, "# Imported Caplet\n");
+    await click("Import record");
+
+    await waitFor(() =>
+      dashboardApi.mock.calls.some(
+        ([path, options]) => path === "stored-caplets" && options?.method === "POST",
+      )
+        ? true
+        : undefined,
+    );
+    expect(dashboardApi).toHaveBeenCalledWith("stored-caplets", {
+      method: "POST",
+      body: JSON.stringify({
+        id: "imported-caplet",
+        document: "# Imported Caplet\n",
+        historyLimit: 7,
+      }),
+    });
+    expect(action).toHaveBeenCalledWith("Imported imported-caplet", expect.any(Function));
+  });
+
+  it("edits the current Markdown with its observed CAS generation", async () => {
+    await mount();
+    await inspectAlpha();
+    await click("Edit Markdown");
+
+    const editor = document.querySelector<HTMLTextAreaElement>("#stored-caplet-editor");
+    if (!editor) throw new Error("Stored Caplet editor was not rendered.");
+    await setValue(editor, "# Alpha tools\n\nUpdated document.\n");
+    await click("Save new revision");
+
+    await waitFor(() =>
+      dashboardApi.mock.calls.some(
+        ([path, options]) => path === "stored-caplets/alpha" && options?.method === "PUT",
+      )
+        ? true
+        : undefined,
+    );
+    expect(dashboardApi).toHaveBeenCalledWith("stored-caplets/alpha", {
+      method: "PUT",
+      body: JSON.stringify({
+        document: "# Alpha tools\n\nUpdated document.\n",
+        expectedGeneration: 2,
+      }),
+    });
+  });
+
+  it("restores a prior revision after confirmation", async () => {
+    await mount();
+    await inspectAlpha();
+    await click("Restore revision 1");
+
+    await waitFor(() =>
+      dashboardApi.mock.calls.some(
+        ([path]) => path === "stored-caplets/alpha/revisions/revision-1/restore",
+      )
+        ? true
+        : undefined,
+    );
+    expect(confirmAction).toHaveBeenCalledWith(
+      "Restore revision 1?",
+      expect.stringContaining("creates a new current revision"),
+    );
+    expect(dashboardApi).toHaveBeenCalledWith("stored-caplets/alpha/revisions/revision-1/restore", {
+      method: "POST",
+      body: JSON.stringify({ expectedGeneration: 2 }),
+    });
+  });
+
+  it("deletes a revision only after destructive confirmation", async () => {
+    await mount();
+    await inspectAlpha();
+    await click("Delete revision 1");
+
+    await waitFor(() =>
+      dashboardApi.mock.calls.some(
+        ([path, options]) =>
+          path === "stored-caplets/alpha/revisions/revision-1" && options?.method === "DELETE",
+      )
+        ? true
+        : undefined,
+    );
+    expect(confirmDestructive).toHaveBeenCalledWith(
+      "Delete revision 1?",
+      expect.stringContaining("permanently removes"),
+      "Delete revision",
+    );
+    expect(dashboardApi).toHaveBeenCalledWith("stored-caplets/alpha/revisions/revision-1", {
+      method: "DELETE",
+      body: JSON.stringify({ expectedGeneration: 2 }),
+    });
+  });
+
+  it("hard-deletes a record only after typed id confirmation", async () => {
+    await mount();
+    await inspectAlpha();
+    await click("Hard-delete record");
+
+    await waitFor(() =>
+      dashboardApi.mock.calls.some(
+        ([path, options]) => path === "stored-caplets/alpha" && options?.method === "DELETE",
+      )
+        ? true
+        : undefined,
+    );
+    expect(confirmTyped).toHaveBeenCalledWith(
+      "Hard-delete Alpha tools?",
+      expect.stringContaining("permanently deletes the SQL record"),
+      "delete alpha",
+    );
+    expect(dashboardApi).toHaveBeenCalledWith("stored-caplets/alpha", {
+      method: "DELETE",
+      body: JSON.stringify({ expectedGeneration: 2 }),
+    });
+    await waitFor(() =>
+      document.body.textContent?.includes("No SQL Caplet Records yet") ? true : undefined,
+    );
+  });
+});

--- a/apps/dashboard/src/components/StoredCapletsPage.tsx
+++ b/apps/dashboard/src/components/StoredCapletsPage.tsx
@@ -1,0 +1,1125 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from "react";
+import {
+  AlertTriangleIcon,
+  ArrowLeftIcon,
+  ClipboardIcon,
+  DatabaseIcon,
+  DownloadIcon,
+  FilePenLineIcon,
+  HistoryIcon,
+  RefreshCwIcon,
+  SaveIcon,
+  Trash2Icon,
+  UploadIcon,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { dashboardApi } from "@/lib/api";
+
+type StoredCapletRevision = {
+  revisionKey: string;
+  sequence?: number;
+  name?: string;
+  description?: string;
+  contentHash?: string;
+  sourceRevision?: string | null;
+  createdAt?: string;
+};
+
+export type StoredCapletRecord = {
+  id: string;
+  name?: string;
+  description?: string;
+  generation?: number;
+  headGeneration?: number;
+  recordKey?: string;
+  historyLimit?: number | null;
+  createdAt?: string;
+  updatedAt?: string;
+  storageKind?: string;
+  currentRevision?: StoredCapletRevision | string;
+};
+
+type StoredCapletDetail = {
+  record: StoredCapletRecord;
+  document: string;
+  revisions: StoredCapletRevision[];
+};
+
+type StoredCapletsAction = (
+  label: string | ((result: unknown) => string),
+  callback: () => Promise<unknown>,
+) => Promise<void>;
+
+export type StoredCapletsPageProps = {
+  action: StoredCapletsAction;
+  confirmAction: (title: string, description: string) => Promise<boolean>;
+  confirmDestructive: (
+    title: string,
+    description: string,
+    confirmLabel?: string,
+  ) => Promise<boolean>;
+  confirmTyped: (title: string, description: string, expectedPhrase: string) => Promise<boolean>;
+};
+
+function generationOf(record: StoredCapletRecord): number {
+  return record.generation ?? record.headGeneration ?? 0;
+}
+
+function currentRevisionKey(record: StoredCapletRecord): string | undefined {
+  if (typeof record.currentRevision === "string") return record.currentRevision;
+  return record.currentRevision?.revisionKey;
+}
+
+function recordName(record: StoredCapletRecord): string {
+  if (record.name) return record.name;
+  if (typeof record.currentRevision === "object" && record.currentRevision?.name) {
+    return record.currentRevision.name;
+  }
+  return record.id;
+}
+
+function recordDescription(record: StoredCapletRecord): string | undefined {
+  if (record.description) return record.description;
+  if (typeof record.currentRevision === "object") return record.currentRevision?.description;
+  return undefined;
+}
+
+function retentionLabel(limit: number | null | undefined): string {
+  if (limit === null) return "Host default";
+  if (limit === undefined) return "Not reported";
+  return `${limit} revision${limit === 1 ? "" : "s"}`;
+}
+
+function timestampLabel(value: string | undefined): string {
+  if (!value) return "Not reported";
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) return value;
+  return timestamp.toLocaleString();
+}
+
+async function fetchStoredCaplets(): Promise<StoredCapletRecord[]> {
+  const response = await dashboardApi<{ records?: StoredCapletRecord[] }>("stored-caplets");
+  return response.records ?? [];
+}
+
+async function fetchStoredCapletDetail(id: string): Promise<StoredCapletDetail> {
+  const encodedId = encodeURIComponent(id);
+  const [current, history] = await Promise.all([
+    dashboardApi<{ record: StoredCapletRecord; document: string }>(`stored-caplets/${encodedId}`),
+    dashboardApi<{ revisions?: StoredCapletRevision[] }>(`stored-caplets/${encodedId}/revisions`),
+  ]);
+  return { record: current.record, document: current.document, revisions: history.revisions ?? [] };
+}
+
+export function StoredCapletsPage({
+  action,
+  confirmAction,
+  confirmDestructive,
+  confirmTyped,
+}: StoredCapletsPageProps) {
+  const [records, setRecords] = useState<StoredCapletRecord[]>([]);
+  const [listLoading, setListLoading] = useState(true);
+  const [listError, setListError] = useState<string>();
+  const [importOpen, setImportOpen] = useState(false);
+  const [importId, setImportId] = useState("");
+  const [importHistoryLimit, setImportHistoryLimit] = useState("");
+  const [importDocument, setImportDocument] = useState("");
+  const [importFileName, setImportFileName] = useState<string>();
+  const [importError, setImportError] = useState<string>();
+  const [selectedId, setSelectedId] = useState<string>();
+  const [detail, setDetail] = useState<StoredCapletDetail>();
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string>();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [busyAction, setBusyAction] = useState<string>();
+  const [mutationError, setMutationError] = useState<string>();
+  const detailRequest = useRef(0);
+
+  const loadRecords = useCallback(async () => {
+    setListLoading(true);
+    setListError(undefined);
+    try {
+      setRecords(await fetchStoredCaplets());
+    } catch (error) {
+      setListError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setListLoading(false);
+    }
+  }, []);
+
+  const loadDetail = useCallback(async (id: string) => {
+    const request = ++detailRequest.current;
+    setDetailLoading(true);
+    setDetailError(undefined);
+    try {
+      const loaded = await fetchStoredCapletDetail(id);
+      if (request !== detailRequest.current) return;
+      setDetail(loaded);
+      setDraft(loaded.document);
+      setEditing(false);
+      setMutationError(undefined);
+    } catch (error) {
+      if (request === detailRequest.current) {
+        setDetail(undefined);
+        setDetailError(error instanceof Error ? error.message : String(error));
+      }
+    } finally {
+      if (request === detailRequest.current) setDetailLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadRecords();
+  }, [loadRecords]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      ++detailRequest.current;
+      setDetail(undefined);
+      setDetailError(undefined);
+      setEditing(false);
+      setMutationError(undefined);
+      return;
+    }
+    void loadDetail(selectedId);
+  }, [loadDetail, selectedId]);
+
+  const sortedRecords = useMemo(
+    () => [...records].sort((left, right) => left.id.localeCompare(right.id)),
+    [records],
+  );
+  const dirty = Boolean(detail && editing && draft !== detail.document);
+
+  async function refreshAfterMutation(id: string) {
+    const [nextDetail, nextRecords] = await Promise.all([
+      fetchStoredCapletDetail(id),
+      fetchStoredCaplets(),
+    ]);
+    setDetail(nextDetail);
+    setDraft(nextDetail.document);
+    setRecords(nextRecords);
+    setEditing(false);
+    setMutationError(undefined);
+  }
+
+  function mutationFailure(error: unknown): never {
+    const message = error instanceof Error ? error.message : String(error);
+    setMutationError(message);
+    throw error;
+  }
+
+  function resetImport() {
+    setImportId("");
+    setImportHistoryLimit("");
+    setImportDocument("");
+    setImportFileName(undefined);
+    setImportError(undefined);
+  }
+
+  async function submitImport(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const id = importId.trim();
+    const historyLimitText = importHistoryLimit.trim();
+    const historyLimit = historyLimitText === "" ? undefined : Number(historyLimitText);
+    if (!id) {
+      setImportError("Enter the stored Caplet id.");
+      return;
+    }
+    if (!importDocument.trim()) {
+      setImportError("Add a CAPLET.md document or choose a Markdown file.");
+      return;
+    }
+    if (historyLimit !== undefined && (!Number.isSafeInteger(historyLimit) || historyLimit < 0)) {
+      setImportError("History limit must be a non-negative whole number.");
+      return;
+    }
+
+    setImportError(undefined);
+    setBusyAction("import");
+    try {
+      await action(`Imported ${id}`, async () => {
+        try {
+          const response = await dashboardApi<{ record: StoredCapletRecord }>("stored-caplets", {
+            method: "POST",
+            body: JSON.stringify({
+              id,
+              document: importDocument,
+              ...(historyLimit === undefined ? {} : { historyLimit }),
+            }),
+          });
+          const nextRecords = await fetchStoredCaplets();
+          setRecords(nextRecords);
+          resetImport();
+          setImportOpen(false);
+          setSelectedId(response.record.id);
+          return response;
+        } catch (error) {
+          setImportError(error instanceof Error ? error.message : String(error));
+          throw error;
+        }
+      });
+    } finally {
+      setBusyAction(undefined);
+    }
+  }
+
+  async function chooseMarkdown(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      setImportDocument(await file.text());
+      setImportFileName(file.name);
+      setImportError(undefined);
+    } catch (error) {
+      setImportError(error instanceof Error ? error.message : "Could not read the Markdown file.");
+    }
+  }
+
+  async function saveDocument() {
+    if (!detail || !draft.trim() || busyAction) return;
+    const id = detail.record.id;
+    setBusyAction("save");
+    setMutationError(undefined);
+    try {
+      await action(`Saved ${id}`, async () => {
+        try {
+          const result = await dashboardApi(`stored-caplets/${encodeURIComponent(id)}`, {
+            method: "PUT",
+            body: JSON.stringify({
+              document: draft,
+              expectedGeneration: generationOf(detail.record),
+            }),
+          });
+          await refreshAfterMutation(id);
+          return result;
+        } catch (error) {
+          return mutationFailure(error);
+        }
+      });
+    } finally {
+      setBusyAction(undefined);
+    }
+  }
+
+  async function restoreRevision(revision: StoredCapletRevision) {
+    if (!detail || busyAction) return;
+    const id = detail.record.id;
+    const confirmed = await confirmAction(
+      `Restore revision ${revision.sequence ?? revision.revisionKey}?`,
+      "Restoring creates a new current revision from this stored snapshot. The present document remains in SQL history.",
+    );
+    if (!confirmed) return;
+
+    setBusyAction(`restore:${revision.revisionKey}`);
+    setMutationError(undefined);
+    try {
+      await action(`Restored revision ${revision.sequence ?? revision.revisionKey}`, async () => {
+        try {
+          const result = await dashboardApi(
+            `stored-caplets/${encodeURIComponent(id)}/revisions/${encodeURIComponent(revision.revisionKey)}/restore`,
+            {
+              method: "POST",
+              body: JSON.stringify({ expectedGeneration: generationOf(detail.record) }),
+            },
+          );
+          await refreshAfterMutation(id);
+          return result;
+        } catch (error) {
+          return mutationFailure(error);
+        }
+      });
+    } finally {
+      setBusyAction(undefined);
+    }
+  }
+
+  async function deleteRevision(revision: StoredCapletRevision) {
+    if (!detail || busyAction) return;
+    const id = detail.record.id;
+    const confirmed = await confirmDestructive(
+      `Delete revision ${revision.sequence ?? revision.revisionKey}?`,
+      "This permanently removes the selected SQL revision. It does not delete file overlays or Vault values.",
+      "Delete revision",
+    );
+    if (!confirmed) return;
+
+    setBusyAction(`delete-revision:${revision.revisionKey}`);
+    setMutationError(undefined);
+    try {
+      await action(`Deleted revision ${revision.sequence ?? revision.revisionKey}`, async () => {
+        try {
+          const result = await dashboardApi<{ record: StoredCapletRecord | null }>(
+            `stored-caplets/${encodeURIComponent(id)}/revisions/${encodeURIComponent(revision.revisionKey)}`,
+            {
+              method: "DELETE",
+              body: JSON.stringify({ expectedGeneration: generationOf(detail.record) }),
+            },
+          );
+          const nextRecords = await fetchStoredCaplets();
+          setRecords(nextRecords);
+          if (result.record) {
+            const nextDetail = await fetchStoredCapletDetail(id);
+            setDetail(nextDetail);
+            setDraft(nextDetail.document);
+            setEditing(false);
+          } else {
+            setSelectedId(undefined);
+          }
+          return result;
+        } catch (error) {
+          return mutationFailure(error);
+        }
+      });
+    } finally {
+      setBusyAction(undefined);
+    }
+  }
+
+  async function deleteRecord() {
+    if (!detail || busyAction) return;
+    const id = detail.record.id;
+    const phrase = `delete ${id}`;
+    const confirmed = await confirmTyped(
+      `Hard-delete ${recordName(detail.record)}?`,
+      "This permanently deletes the SQL record and its revision history. Effective Caplets supplied by files or overlays are not removed.",
+      phrase,
+    );
+    if (!confirmed) return;
+
+    setBusyAction("delete-record");
+    setMutationError(undefined);
+    try {
+      await action(`Deleted stored Caplet ${id}`, async () => {
+        try {
+          const result = await dashboardApi(`stored-caplets/${encodeURIComponent(id)}`, {
+            method: "DELETE",
+            body: JSON.stringify({ expectedGeneration: generationOf(detail.record) }),
+          });
+          setRecords(await fetchStoredCaplets());
+          setSelectedId(undefined);
+          return result;
+        } catch (error) {
+          return mutationFailure(error);
+        }
+      });
+    } finally {
+      setBusyAction(undefined);
+    }
+  }
+
+  async function returnToList() {
+    if (dirty) {
+      const confirmed = await confirmAction(
+        "Discard unsaved Markdown?",
+        "Your edits have not been saved to the SQL record.",
+      );
+      if (!confirmed) return;
+    }
+    setSelectedId(undefined);
+  }
+
+  async function copyDocument() {
+    if (!detail) return;
+    try {
+      await navigator.clipboard.writeText(detail.document);
+      toast.success("CAPLET.md copied");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not copy CAPLET.md");
+    }
+  }
+
+  function downloadDocument() {
+    if (!detail) return;
+    const blob = new Blob([detail.document], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${detail.record.id}-CAPLET.md`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+    toast.success("CAPLET.md downloaded");
+  }
+
+  if (selectedId) {
+    return (
+      <StoredCapletDetailView
+        id={selectedId}
+        detail={detail}
+        loading={detailLoading}
+        error={detailError}
+        editing={editing}
+        draft={draft}
+        dirty={dirty}
+        busyAction={busyAction}
+        mutationError={mutationError}
+        onBack={() => void returnToList()}
+        onRetry={() => void loadDetail(selectedId)}
+        onEdit={() => setEditing(true)}
+        onCancelEdit={() => {
+          setDraft(detail?.document ?? "");
+          setEditing(false);
+          setMutationError(undefined);
+        }}
+        onDraftChange={setDraft}
+        onSave={() => void saveDocument()}
+        onCopy={() => void copyDocument()}
+        onDownload={downloadDocument}
+        onRestore={(revision) => void restoreRevision(revision)}
+        onDeleteRevision={(revision) => void deleteRevision(revision)}
+        onDeleteRecord={() => void deleteRecord()}
+      />
+    );
+  }
+
+  return (
+    <main className="flex flex-col gap-4" aria-labelledby="stored-caplets-title">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 id="stored-caplets-title" className="text-2xl font-semibold">
+            Stored Caplets
+          </h1>
+          <p className="max-w-[70ch] text-muted-foreground">
+            Import and maintain versioned Caplet Records in the Current Host SQL store.
+          </p>
+        </div>
+        <Button
+          type="button"
+          onClick={() => {
+            setImportOpen((open) => !open);
+            setImportError(undefined);
+          }}
+          aria-expanded={importOpen}
+          aria-controls="stored-caplet-import"
+        >
+          <UploadIcon data-icon="inline-start" />
+          Import CAPLET.md
+        </Button>
+      </header>
+
+      <Alert>
+        <DatabaseIcon />
+        <AlertTitle>SQL records are a separate source</AlertTitle>
+        <AlertDescription>
+          This inventory shows stored SQL records and their revisions. The effective Caplets view
+          can also include filesystem or overlay sources. Vault values and stored asset contents are
+          never shown here.
+        </AlertDescription>
+      </Alert>
+
+      {importOpen ? (
+        <Card id="stored-caplet-import">
+          <CardHeader>
+            <CardTitle>Import a stored Caplet</CardTitle>
+            <CardDescription>
+              Supply the record id and exact CAPLET.md document. History retention is optional and
+              can only be set during import through the available dashboard API.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="flex flex-col gap-4" onSubmit={(event) => void submitImport(event)}>
+              <FieldGroup>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <Field data-invalid={Boolean(importError && !importId.trim())}>
+                    <FieldLabel htmlFor="stored-caplet-id">Record id</FieldLabel>
+                    <Input
+                      id="stored-caplet-id"
+                      value={importId}
+                      onChange={(event) => setImportId(event.target.value)}
+                      placeholder="team-caplet"
+                      autoComplete="off"
+                      aria-invalid={Boolean(importError && !importId.trim())}
+                      disabled={busyAction === "import"}
+                    />
+                    <FieldDescription>The stable SQL Caplet Record id.</FieldDescription>
+                  </Field>
+                  <Field>
+                    <FieldLabel htmlFor="stored-caplet-history-limit">
+                      History limit (optional)
+                    </FieldLabel>
+                    <Input
+                      id="stored-caplet-history-limit"
+                      type="number"
+                      min={0}
+                      step={1}
+                      inputMode="numeric"
+                      value={importHistoryLimit}
+                      onChange={(event) => setImportHistoryLimit(event.target.value)}
+                      placeholder="Host default"
+                      disabled={busyAction === "import"}
+                    />
+                    <FieldDescription>Leave empty to inherit the host default.</FieldDescription>
+                  </Field>
+                </div>
+                <Field>
+                  <FieldLabel htmlFor="stored-caplet-file">Markdown file (optional)</FieldLabel>
+                  <Input
+                    id="stored-caplet-file"
+                    type="file"
+                    accept=".md,text/markdown,text/plain"
+                    onChange={(event) => void chooseMarkdown(event)}
+                    disabled={busyAction === "import"}
+                  />
+                  <FieldDescription>
+                    {importFileName
+                      ? `${importFileName} loaded into the editor below.`
+                      : "Choose CAPLET.md or paste its contents below."}
+                  </FieldDescription>
+                </Field>
+                <Field data-invalid={Boolean(importError && !importDocument.trim())}>
+                  <FieldLabel htmlFor="stored-caplet-document">CAPLET.md</FieldLabel>
+                  <Textarea
+                    id="stored-caplet-document"
+                    className="min-h-64 font-mono leading-relaxed"
+                    value={importDocument}
+                    onChange={(event) => setImportDocument(event.target.value)}
+                    placeholder="# Caplet name"
+                    spellCheck={false}
+                    aria-invalid={Boolean(importError && !importDocument.trim())}
+                    disabled={busyAction === "import"}
+                  />
+                  <FieldDescription>
+                    Only the Markdown document is imported; this form does not upload asset
+                    contents.
+                  </FieldDescription>
+                  {importError ? <FieldError>{importError}</FieldError> : null}
+                </Field>
+              </FieldGroup>
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={busyAction === "import"}
+                  onClick={() => {
+                    resetImport();
+                    setImportOpen(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={busyAction === "import"}
+                  aria-busy={busyAction === "import"}
+                >
+                  {busyAction === "import" ? (
+                    <RefreshCwIcon data-icon="inline-start" className="animate-spin" />
+                  ) : (
+                    <UploadIcon data-icon="inline-start" />
+                  )}
+                  Import record
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>SQL record inventory</CardTitle>
+          <CardDescription>
+            {listLoading
+              ? "Loading stored records…"
+              : `${records.length} stored record${records.length === 1 ? "" : "s"}`}
+          </CardDescription>
+          <CardAction>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={listLoading}
+              aria-label="Refresh stored Caplets"
+              onClick={() => void loadRecords()}
+            >
+              <RefreshCwIcon
+                data-icon="inline-start"
+                className={listLoading ? "animate-spin" : undefined}
+              />
+              Refresh
+            </Button>
+          </CardAction>
+        </CardHeader>
+        <CardContent className="p-0">
+          {listLoading ? (
+            <div
+              className="flex flex-col gap-3 px-4 py-5"
+              role="status"
+              aria-label="Loading stored Caplets"
+            >
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : listError ? (
+            <Alert variant="destructive" className="m-4">
+              <AlertTriangleIcon />
+              <AlertTitle>Stored Caplets unavailable</AlertTitle>
+              <AlertDescription>{listError}</AlertDescription>
+              <Button type="button" variant="outline" onClick={() => void loadRecords()}>
+                <RefreshCwIcon data-icon="inline-start" />
+                Retry
+              </Button>
+            </Alert>
+          ) : sortedRecords.length === 0 ? (
+            <Empty className="border">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <DatabaseIcon />
+                </EmptyMedia>
+                <EmptyTitle>No SQL Caplet Records yet</EmptyTitle>
+                <EmptyDescription>
+                  Import a CAPLET.md to create a versioned record. File and overlay Caplets remain
+                  in the separate effective view.
+                </EmptyDescription>
+              </EmptyHeader>
+              <EmptyContent>
+                <Button type="button" onClick={() => setImportOpen(true)}>
+                  <UploadIcon data-icon="inline-start" />
+                  Import the first record
+                </Button>
+              </EmptyContent>
+            </Empty>
+          ) : (
+            <Table>
+              <TableCaption className="sr-only">
+                SQL-backed Caplet Records with generation and retention metadata
+              </TableCaption>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Caplet Record</TableHead>
+                  <TableHead>Storage</TableHead>
+                  <TableHead>Generation</TableHead>
+                  <TableHead>Retention</TableHead>
+                  <TableHead className="text-right">Action</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sortedRecords.map((record) => (
+                  <TableRow key={record.id}>
+                    <TableCell className="max-w-80 whitespace-normal">
+                      <div className="font-medium">{recordName(record)}</div>
+                      <div className="font-mono text-xs text-muted-foreground">{record.id}</div>
+                      {recordDescription(record) ? (
+                        <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                          {recordDescription(record)}
+                        </div>
+                      ) : null}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline">
+                        <DatabaseIcon data-icon="inline-start" />
+                        {record.storageKind ?? "SQL record"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="font-mono">{generationOf(record)}</TableCell>
+                    <TableCell>{retentionLabel(record.historyLimit)}</TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setSelectedId(record.id)}
+                      >
+                        Inspect
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}
+
+type StoredCapletDetailViewProps = {
+  id: string;
+  detail?: StoredCapletDetail;
+  loading: boolean;
+  error?: string;
+  editing: boolean;
+  draft: string;
+  dirty: boolean;
+  busyAction?: string;
+  mutationError?: string;
+  onBack: () => void;
+  onRetry: () => void;
+  onEdit: () => void;
+  onCancelEdit: () => void;
+  onDraftChange: (document: string) => void;
+  onSave: () => void;
+  onCopy: () => void;
+  onDownload: () => void;
+  onRestore: (revision: StoredCapletRevision) => void;
+  onDeleteRevision: (revision: StoredCapletRevision) => void;
+  onDeleteRecord: () => void;
+};
+
+function StoredCapletDetailView({
+  id,
+  detail,
+  loading,
+  error,
+  editing,
+  draft,
+  dirty,
+  busyAction,
+  mutationError,
+  onBack,
+  onRetry,
+  onEdit,
+  onCancelEdit,
+  onDraftChange,
+  onSave,
+  onCopy,
+  onDownload,
+  onRestore,
+  onDeleteRevision,
+  onDeleteRecord,
+}: StoredCapletDetailViewProps) {
+  if (loading) {
+    return (
+      <main className="flex flex-col gap-4" aria-label={`Loading stored Caplet ${id}`}>
+        <Skeleton className="h-9 w-44" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-96 w-full" />
+      </main>
+    );
+  }
+
+  if (error || !detail) {
+    return (
+      <main className="flex flex-col gap-4" aria-labelledby="stored-caplet-error-title">
+        <Button type="button" variant="ghost" className="w-fit" onClick={onBack}>
+          <ArrowLeftIcon data-icon="inline-start" />
+          Stored Caplets
+        </Button>
+        <Alert variant="destructive">
+          <AlertTriangleIcon />
+          <AlertTitle id="stored-caplet-error-title">Stored Caplet unavailable</AlertTitle>
+          <AlertDescription>{error ?? `Could not load ${id}.`}</AlertDescription>
+          <Button type="button" variant="outline" onClick={onRetry}>
+            <RefreshCwIcon data-icon="inline-start" />
+            Retry
+          </Button>
+        </Alert>
+      </main>
+    );
+  }
+
+  const { record, revisions } = detail;
+  const currentKey = currentRevisionKey(record);
+  const current = typeof record.currentRevision === "object" ? record.currentRevision : undefined;
+
+  return (
+    <main className="flex flex-col gap-4" aria-labelledby="stored-caplet-detail-title">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex flex-col gap-2">
+          <Button type="button" variant="ghost" className="w-fit" onClick={onBack}>
+            <ArrowLeftIcon data-icon="inline-start" />
+            Stored Caplets
+          </Button>
+          <div>
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              <Badge variant="outline">
+                <DatabaseIcon data-icon="inline-start" />
+                SQL record
+              </Badge>
+              <Badge variant="secondary">Generation {generationOf(record)}</Badge>
+              {dirty ? <Badge variant="secondary">Unsaved changes</Badge> : null}
+            </div>
+            <h1 id="stored-caplet-detail-title" className="text-2xl font-semibold">
+              {recordName(record)}
+            </h1>
+            <p className="font-mono text-sm text-muted-foreground">{record.id}</p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="destructive"
+          disabled={Boolean(busyAction)}
+          aria-busy={busyAction === "delete-record"}
+          onClick={onDeleteRecord}
+        >
+          <Trash2Icon data-icon="inline-start" />
+          Hard-delete record
+        </Button>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Storage provenance</CardTitle>
+          <CardDescription>
+            Authoritative SQL metadata for this record. This does not describe effective file or
+            overlay precedence.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <MetadataTerm label="Storage" value={record.storageKind ?? "SQL-backed record"} />
+            <MetadataTerm label="Generation" value={String(generationOf(record))} mono />
+            <MetadataTerm label="Current revision" value={currentKey ?? "Not reported"} mono />
+            <MetadataTerm label="History retention" value={retentionLabel(record.historyLimit)} />
+            {record.recordKey ? (
+              <MetadataTerm label="Record key" value={record.recordKey} mono />
+            ) : null}
+            <MetadataTerm label="Updated" value={timestampLabel(record.updatedAt)} />
+            {current?.sourceRevision ? (
+              <MetadataTerm label="Source revision" value={current.sourceRevision} mono />
+            ) : null}
+            {current?.contentHash ? (
+              <MetadataTerm label="Content hash" value={current.contentHash} mono />
+            ) : null}
+          </dl>
+        </CardContent>
+      </Card>
+
+      {mutationError ? (
+        <Alert variant="destructive" role="alert">
+          <AlertTriangleIcon />
+          <AlertTitle>Stored record changed</AlertTitle>
+          <AlertDescription>
+            {mutationError} Reload the record before retrying if its generation is stale.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="col-span-2 sm:col-span-1">Current CAPLET.md</CardTitle>
+          <CardDescription className="col-span-2 sm:col-span-1">
+            Saves use compare-and-swap generation {generationOf(record)}. Asset and Vault contents
+            are not loaded into this editor.
+          </CardDescription>
+          <CardAction className="col-span-2 col-start-1 row-start-3 mt-2 flex flex-wrap justify-start gap-2 sm:col-span-1 sm:col-start-2 sm:row-span-2 sm:row-start-1 sm:mt-0 sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onCopy}
+              disabled={Boolean(busyAction)}
+            >
+              <ClipboardIcon data-icon="inline-start" />
+              Copy
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onDownload}
+              disabled={Boolean(busyAction)}
+            >
+              <DownloadIcon data-icon="inline-start" />
+              Download
+            </Button>
+            {!editing ? (
+              <Button type="button" size="sm" onClick={onEdit} disabled={Boolean(busyAction)}>
+                <FilePenLineIcon data-icon="inline-start" />
+                Edit Markdown
+              </Button>
+            ) : null}
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <Field data-invalid={editing && !draft.trim()}>
+            <FieldLabel htmlFor="stored-caplet-editor" className="sr-only">
+              Current CAPLET.md document
+            </FieldLabel>
+            <Textarea
+              id="stored-caplet-editor"
+              className="min-h-96 font-mono leading-relaxed"
+              value={draft}
+              onChange={(event) => onDraftChange(event.target.value)}
+              readOnly={!editing}
+              aria-readonly={!editing}
+              aria-invalid={editing && !draft.trim()}
+              spellCheck={false}
+            />
+            {editing && !draft.trim() ? <FieldError>CAPLET.md cannot be empty.</FieldError> : null}
+          </Field>
+        </CardContent>
+        {editing ? (
+          <CardFooter className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={busyAction === "save"}
+              onClick={onCancelEdit}
+            >
+              Cancel edits
+            </Button>
+            <Button
+              type="button"
+              disabled={!dirty || !draft.trim() || busyAction === "save"}
+              aria-busy={busyAction === "save"}
+              onClick={onSave}
+            >
+              {busyAction === "save" ? (
+                <RefreshCwIcon data-icon="inline-start" className="animate-spin" />
+              ) : (
+                <SaveIcon data-icon="inline-start" />
+              )}
+              Save new revision
+            </Button>
+          </CardFooter>
+        ) : null}
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Revision history</CardTitle>
+          <CardDescription>
+            Restore a prior snapshot or permanently remove one SQL revision. Retention is reported
+            here but no separate retention mutation is exposed by this dashboard API.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          {revisions.length === 0 ? (
+            <Empty>
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <HistoryIcon />
+                </EmptyMedia>
+                <EmptyTitle>No revisions reported</EmptyTitle>
+                <EmptyDescription>
+                  Save a document change to create history for this SQL record.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          ) : (
+            <Table>
+              <TableCaption className="sr-only">Revision history for {record.id}</TableCaption>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Revision</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Key</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {revisions.map((revision) => {
+                  const currentRevision = revision.revisionKey === currentKey;
+                  const restoring = busyAction === `restore:${revision.revisionKey}`;
+                  const deleting = busyAction === `delete-revision:${revision.revisionKey}`;
+                  return (
+                    <TableRow key={revision.revisionKey}>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono">{revision.sequence ?? "—"}</span>
+                          {currentRevision ? <Badge variant="secondary">Current</Badge> : null}
+                        </div>
+                      </TableCell>
+                      <TableCell>{revision.name ?? recordName(record)}</TableCell>
+                      <TableCell
+                        className="max-w-64 truncate font-mono text-xs"
+                        title={revision.revisionKey}
+                      >
+                        {revision.revisionKey}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            disabled={Boolean(busyAction) || currentRevision}
+                            aria-busy={restoring}
+                            aria-label={`Restore revision ${revision.sequence ?? revision.revisionKey}`}
+                            onClick={() => onRestore(revision)}
+                          >
+                            {restoring ? (
+                              <RefreshCwIcon className="animate-spin" />
+                            ) : (
+                              <HistoryIcon />
+                            )}
+                            Restore
+                          </Button>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="destructive"
+                            disabled={Boolean(busyAction)}
+                            aria-busy={deleting}
+                            aria-label={`Delete revision ${revision.sequence ?? revision.revisionKey}`}
+                            onClick={() => onDeleteRevision(revision)}
+                          >
+                            {deleting ? <RefreshCwIcon className="animate-spin" /> : <Trash2Icon />}
+                            Delete
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}
+
+function MetadataTerm({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+      <dd className={mono ? "truncate font-mono text-sm" : "text-sm"} title={value}>
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/ui/empty.tsx
+++ b/apps/dashboard/src/components/ui/empty.tsx
@@ -1,0 +1,94 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex w-full min-w-0 flex-1 flex-col items-center justify-center gap-4 rounded-xl border-dashed p-6 text-center text-balance",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn("flex max-w-sm flex-col items-center gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-4",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  );
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("font-heading text-sm font-medium tracking-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-2.5 text-sm text-balance",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Empty, EmptyHeader, EmptyTitle, EmptyDescription, EmptyContent, EmptyMedia };

--- a/apps/dashboard/src/components/ui/field.tsx
+++ b/apps/dashboard/src/components/ui/field.tsx
@@ -1,0 +1,222 @@
+import { useMemo } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-4 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-1.5 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-5 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const fieldVariants = cva("group/field flex w-full gap-2 data-[invalid=true]:text-destructive", {
+  variants: {
+    orientation: {
+      vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
+      horizontal:
+        "flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+      responsive:
+        "flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+    },
+  },
+  defaultVariants: {
+    orientation: "vertical",
+  },
+});
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  );
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn("group/field-content flex flex-1 flex-col gap-0.5 leading-snug", className)}
+      {...props}
+    />
+  );
+}
+
+function FieldLabel({ className, ...props }: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-2.5 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "text-left text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+        "last:mt-0 nth-last-2:-mt-1",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode;
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className,
+      )}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>;
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children;
+    }
+
+    if (!errors?.length) {
+      return null;
+    }
+
+    const uniqueErrors = [...new Map(errors.map((error) => [error?.message, error])).values()];
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message;
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map((error, index) => error?.message && <li key={index}>{error.message}</li>)}
+      </ul>
+    );
+  }, [children, errors]);
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  );
+}
+
+export {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle,
+};

--- a/apps/dashboard/src/components/ui/label.tsx
+++ b/apps/dashboard/src/components/ui/label.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/apps/dashboard/src/components/ui/textarea.tsx
+++ b/apps/dashboard/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/apps/dashboard/src/pages/dashboard/stored-caplets.astro
+++ b/apps/dashboard/src/pages/dashboard/stored-caplets.astro
@@ -1,0 +1,12 @@
+---
+import { DashboardApp } from "@/components/DashboardApp";
+import DashboardHead from "@/components/DashboardHead.astro";
+import "@/styles/globals.css";
+---
+
+<html lang="en">
+  <DashboardHead title="Stored Caplets" />
+  <body>
+    <DashboardApp client:load initialRoute="stored-caplets" />
+  </body>
+</html>

--- a/apps/docs/src/content/docs/reference/config.mdx
+++ b/apps/docs/src/content/docs/reference/config.mdx
@@ -83,6 +83,7 @@ Public OpenAPI endpoint:
 | `defaultSearchLimit`  | Optional | integer | Default maximum number of same-server search results.                     |
 | `maxSearchLimit`      | Optional | integer | Maximum accepted search_tools limit.                                      |
 | `telemetry`           | Optional | boolean | Set false to disable anonymous Caplets telemetry for this user config.    |
+| `storage`             | Optional | object  | Authoritative Host State backend. SQLite is used when omitted.            |
 | `serve`               | Optional | object  | User-owned HTTP serve defaults. Ignored from project config for security. |
 | `completion`          | Optional | object  | Shell completion discovery timeout and cache settings.                    |
 | `options`             | Optional | object  | Global Caplets runtime options.                                           |

--- a/apps/landing/public/config.schema.json
+++ b/apps/landing/public/config.schema.json
@@ -33,6 +33,194 @@
       "description": "Set false to disable anonymous Caplets telemetry for this user config.",
       "type": "boolean"
     },
+    "storage": {
+      "default": {
+        "type": "sqlite"
+      },
+      "description": "Authoritative Host State backend. SQLite is used when omitted.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "sqlite"
+            },
+            "path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "assets": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "sql"
+                    }
+                  },
+                  "required": ["type"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "s3"
+                    },
+                    "endpoint": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "region": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "bucket": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "prefix": {
+                      "type": "string"
+                    },
+                    "forcePathStyle": {
+                      "type": "boolean"
+                    },
+                    "accessKeyId": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "secretAccessKey": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": ["type", "region", "bucket"],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "bundleLimits": {
+              "type": "object",
+              "properties": {
+                "maxFiles": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 100000
+                },
+                "maxFileBytes": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "maxTotalBytes": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["type"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "postgres"
+            },
+            "connectionString": {
+              "type": "string",
+              "minLength": 1
+            },
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z_][a-z0-9_]{0,62}$"
+            },
+            "assets": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "sql"
+                    }
+                  },
+                  "required": ["type"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "s3"
+                    },
+                    "endpoint": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "region": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "bucket": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "prefix": {
+                      "type": "string"
+                    },
+                    "forcePathStyle": {
+                      "type": "boolean"
+                    },
+                    "accessKeyId": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "secretAccessKey": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": ["type", "region", "bucket"],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "bundleLimits": {
+              "type": "object",
+              "properties": {
+                "maxFiles": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 100000
+                },
+                "maxFileBytes": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "maxTotalBytes": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["type", "connectionString"],
+          "additionalProperties": false
+        }
+      ]
+    },
     "serve": {
       "description": "User-owned HTTP serve defaults. Ignored from project config for security.",
       "type": "object",

--- a/deploy/postgres/finalize-runtime-grants.mjs
+++ b/deploy/postgres/finalize-runtime-grants.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire("/app/dist/index.js");
+const { Pool } = require("pg");
+const configPath = process.env.CAPLETS_CONFIG || "/tmp/caplets-migrator-config.json";
+const storage = JSON.parse(readFileSync(configPath, "utf8")).storage;
+if (storage?.type !== "postgres" || typeof storage.connectionString !== "string") {
+  throw new Error("rendered PostgreSQL migrator config is required");
+}
+const schema = storage.schema || "caplets";
+if (!/^[a-z_][a-z0-9_]{0,62}$/u.test(schema)) {
+  throw new Error("invalid PostgreSQL schema");
+}
+const quotedSchema = `"${schema}"`;
+const runtimeRole = "caplets_runtime";
+const pool = new Pool({ connectionString: storage.connectionString });
+
+try {
+  await pool.query(`GRANT USAGE ON SCHEMA ${quotedSchema} TO ${runtimeRole}`);
+  await pool.query(
+    `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${quotedSchema} TO ${runtimeRole}`,
+  );
+  await pool.query(
+    `REVOKE ALL ON TABLE ${quotedSchema}."caplets_migrations", ${quotedSchema}."caplets_schema" FROM ${runtimeRole}`,
+  );
+  await pool.query(`GRANT SELECT ON TABLE ${quotedSchema}."caplets_schema" TO ${runtimeRole}`);
+
+  const sequences = await pool.query(
+    `SELECT sequence.relname AS sequence_name, owner_table.relname AS owner_table
+       FROM pg_class sequence
+       JOIN pg_namespace namespace ON namespace.oid = sequence.relnamespace
+       LEFT JOIN pg_depend dependency
+         ON dependency.objid = sequence.oid AND dependency.deptype IN ('a', 'i')
+       LEFT JOIN pg_class owner_table ON owner_table.oid = dependency.refobjid
+      WHERE sequence.relkind = 'S' AND namespace.nspname = $1`,
+    [schema],
+  );
+  for (const row of sequences.rows) {
+    const sequence = `"${String(row.sequence_name).replaceAll('"', '""')}"`;
+    if (row.owner_table === "caplets_migrations" || row.owner_table === "caplets_schema") {
+      await pool.query(`REVOKE ALL ON SEQUENCE ${quotedSchema}.${sequence} FROM ${runtimeRole}`);
+    } else {
+      await pool.query(
+        `GRANT USAGE, SELECT ON SEQUENCE ${quotedSchema}.${sequence} TO ${runtimeRole}`,
+      );
+    }
+  }
+} finally {
+  await pool.end();
+}

--- a/deploy/postgres/init-caplets-roles.sh
+++ b/deploy/postgres/init-caplets-roles.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+: "${POSTGRES_DB:?POSTGRES_DB is required}"
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${CAPLETS_POSTGRES_MIGRATOR_PASSWORD:?CAPLETS_POSTGRES_MIGRATOR_PASSWORD is required}"
+: "${CAPLETS_POSTGRES_RUNTIME_PASSWORD:?CAPLETS_POSTGRES_RUNTIME_PASSWORD is required}"
+
+schema=${CAPLETS_POSTGRES_SCHEMA:-caplets}
+case "$schema" in
+  [a-z_]* ) ;;
+  * ) echo "CAPLETS_POSTGRES_SCHEMA must start with a lowercase letter or underscore" >&2; exit 1 ;;
+esac
+case "$schema" in
+  *[!a-z0-9_]* ) echo "CAPLETS_POSTGRES_SCHEMA contains an invalid character" >&2; exit 1 ;;
+esac
+if [ "${#schema}" -gt 63 ]; then
+  echo "CAPLETS_POSTGRES_SCHEMA must not exceed 63 characters" >&2
+  exit 1
+fi
+
+psql --set=ON_ERROR_STOP=1 \
+  --username "$POSTGRES_USER" \
+  --dbname "$POSTGRES_DB" \
+  --set=database="$POSTGRES_DB" \
+  --set=schema="$schema" \
+  --set=migrator_password="$CAPLETS_POSTGRES_MIGRATOR_PASSWORD" \
+  --set=runtime_password="$CAPLETS_POSTGRES_RUNTIME_PASSWORD" <<'SQL'
+REVOKE ALL ON DATABASE :"database" FROM PUBLIC;
+
+CREATE ROLE caplets_migrator LOGIN NOINHERIT PASSWORD :'migrator_password';
+CREATE ROLE caplets_runtime LOGIN NOINHERIT PASSWORD :'runtime_password';
+
+GRANT CONNECT, CREATE ON DATABASE :"database" TO caplets_migrator;
+GRANT CONNECT ON DATABASE :"database" TO caplets_runtime;
+
+CREATE SCHEMA :"schema" AUTHORIZATION caplets_migrator;
+REVOKE ALL ON SCHEMA :"schema" FROM PUBLIC;
+GRANT USAGE ON SCHEMA :"schema" TO caplets_runtime;
+
+ALTER ROLE caplets_migrator IN DATABASE :"database" SET search_path TO :"schema";
+ALTER ROLE caplets_runtime IN DATABASE :"database" SET search_path TO :"schema";
+
+ALTER DEFAULT PRIVILEGES FOR ROLE caplets_migrator IN SCHEMA :"schema"
+  REVOKE ALL ON TABLES FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES FOR ROLE caplets_migrator IN SCHEMA :"schema"
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO caplets_runtime;
+ALTER DEFAULT PRIVILEGES FOR ROLE caplets_migrator IN SCHEMA :"schema"
+  REVOKE ALL ON SEQUENCES FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES FOR ROLE caplets_migrator IN SCHEMA :"schema"
+  GRANT USAGE, SELECT ON SEQUENCES TO caplets_runtime;
+SQL

--- a/deploy/postgres/render-config.mjs
+++ b/deploy/postgres/render-config.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+const mode = process.argv[2];
+if (mode !== "migrator" && mode !== "runtime") {
+  throw new Error("usage: render-config.mjs <migrator|runtime>");
+}
+
+const required = (name) => {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+};
+
+const schema = process.env.CAPLETS_POSTGRES_SCHEMA || "caplets";
+if (!/^[a-z_][a-z0-9_]{0,62}$/u.test(schema)) {
+  throw new Error("CAPLETS_POSTGRES_SCHEMA must match ^[a-z_][a-z0-9_]{0,62}$");
+}
+
+const role = mode === "migrator" ? "caplets_migrator" : "caplets_runtime";
+const password = required(
+  mode === "migrator" ? "CAPLETS_POSTGRES_MIGRATOR_PASSWORD" : "CAPLETS_POSTGRES_RUNTIME_PASSWORD",
+);
+const host = process.env.CAPLETS_POSTGRES_HOST || "caplets-postgres";
+const port = process.env.CAPLETS_POSTGRES_PORT || "5432";
+const database = process.env.CAPLETS_POSTGRES_DATABASE || "caplets";
+const target = process.env.CAPLETS_CONFIG || "/tmp/caplets-config.json";
+const basePath = process.env.CAPLETS_BASE_CONFIG;
+const config =
+  basePath && existsSync(basePath) ? JSON.parse(readFileSync(basePath, "utf8")) : { version: 1 };
+const previousStorage = config.storage && typeof config.storage === "object" ? config.storage : {};
+const connection = new URL("postgresql://localhost");
+connection.username = role;
+connection.password = password;
+connection.hostname = host;
+connection.port = port;
+connection.pathname = `/${database}`;
+
+config.storage = {
+  type: "postgres",
+  connectionString: connection.toString(),
+  schema,
+  ...(previousStorage.assets ? { assets: previousStorage.assets } : {}),
+  ...(previousStorage.bundleLimits ? { bundleLimits: previousStorage.bundleLimits } : {}),
+};
+
+writeFileSync(target, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,77 @@
+services:
+  caplets-postgres:
+    image: postgres:17.6-bookworm
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${CAPLETS_POSTGRES_DATABASE:-caplets}
+      POSTGRES_USER: caplets_admin
+      POSTGRES_PASSWORD: ${CAPLETS_POSTGRES_ADMIN_PASSWORD:?set CAPLETS_POSTGRES_ADMIN_PASSWORD}
+      CAPLETS_POSTGRES_SCHEMA: ${CAPLETS_POSTGRES_SCHEMA:-caplets}
+      CAPLETS_POSTGRES_MIGRATOR_PASSWORD: ${CAPLETS_POSTGRES_MIGRATOR_PASSWORD:?set CAPLETS_POSTGRES_MIGRATOR_PASSWORD}
+      CAPLETS_POSTGRES_RUNTIME_PASSWORD: ${CAPLETS_POSTGRES_RUNTIME_PASSWORD:?set CAPLETS_POSTGRES_RUNTIME_PASSWORD}
+    volumes:
+      - caplets-postgres-data:/var/lib/postgresql/data
+      - ./deploy/postgres/init-caplets-roles.sh:/docker-entrypoint-initdb.d/10-caplets-roles.sh:ro
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready --username caplets_admin --dbname "$${POSTGRES_DB}"
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+
+  caplets-postgres-migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: caplets:local
+    restart: "no"
+    depends_on:
+      caplets-postgres:
+        condition: service_healthy
+    environment:
+      CAPLETS_CONFIG: /tmp/caplets-migrator-config.json
+      CAPLETS_POSTGRES_HOST: caplets-postgres
+      CAPLETS_POSTGRES_PORT: "5432"
+      CAPLETS_POSTGRES_DATABASE: ${CAPLETS_POSTGRES_DATABASE:-caplets}
+      CAPLETS_POSTGRES_SCHEMA: ${CAPLETS_POSTGRES_SCHEMA:-caplets}
+      CAPLETS_POSTGRES_MIGRATOR_PASSWORD: ${CAPLETS_POSTGRES_MIGRATOR_PASSWORD:?set CAPLETS_POSTGRES_MIGRATOR_PASSWORD}
+    volumes:
+      - ./deploy/postgres/render-config.mjs:/usr/local/bin/render-caplets-postgres-config.mjs:ro
+      - ./deploy/postgres/finalize-runtime-grants.mjs:/usr/local/bin/finalize-caplets-postgres-grants.mjs:ro
+    entrypoint:
+      - /bin/sh
+      - -ec
+    command:
+      - |
+        node /usr/local/bin/render-caplets-postgres-config.mjs migrator
+        node dist/index.js storage schema-migrate
+        node /usr/local/bin/finalize-caplets-postgres-grants.mjs
+
+  caplets:
+    depends_on:
+      caplets-postgres:
+        condition: service_healthy
+      caplets-postgres-migrate:
+        condition: service_completed_successfully
+    environment:
+      CAPLETS_CONFIG: /tmp/caplets-runtime-config.json
+      CAPLETS_BASE_CONFIG: /data/config/caplets/config.json
+      CAPLETS_POSTGRES_HOST: caplets-postgres
+      CAPLETS_POSTGRES_PORT: "5432"
+      CAPLETS_POSTGRES_DATABASE: ${CAPLETS_POSTGRES_DATABASE:-caplets}
+      CAPLETS_POSTGRES_SCHEMA: ${CAPLETS_POSTGRES_SCHEMA:-caplets}
+      CAPLETS_POSTGRES_RUNTIME_PASSWORD: ${CAPLETS_POSTGRES_RUNTIME_PASSWORD:?set CAPLETS_POSTGRES_RUNTIME_PASSWORD}
+    volumes:
+      - ./deploy/postgres/render-config.mjs:/usr/local/bin/render-caplets-postgres-config.mjs:ro
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        test -f "$${CAPLETS_BASE_CONFIG}" || env CAPLETS_CONFIG="$${CAPLETS_BASE_CONFIG}" CAPLETS_MODE=local node dist/index.js init --global
+        node /usr/local/bin/render-caplets-postgres-config.mjs runtime
+        exec env CAPLETS_MODE=local node dist/index.js serve --transport http --host 0.0.0.0
+
+volumes:
+  caplets-postgres-data:

--- a/docs/adr/0004-sql-authoritative-host-state.md
+++ b/docs/adr/0004-sql-authoritative-host-state.md
@@ -1,0 +1,7 @@
+# Store Authoritative Host State In One SQL Backend
+
+Caplets will replace correctness-bearing host filesystem stores with one authoritative SQL backend per logical host. New single-node hosts use SQLite by default; multi-node hosts use PostgreSQL, with all Host Nodes for one logical host sharing one database schema. A host never dual-writes, mirrors, or falls back between SQLite, PostgreSQL, and legacy files because doing so would create split-brain state.
+
+Authoritative Host State includes Caplet Records and installation provenance, backend auth state, encrypted Vault values and grants, remote-client and pending-login state, dashboard sessions, setup approvals and attempts, Project Binding coordination metadata, and the Operator Activity Log. Client-owned Remote Profiles, reconstructible caches and telemetry, native service files, live Code Mode heap state, synchronized workspace contents, and node-local artifacts remain outside this boundary.
+
+PostgreSQL clusters use transactional reads for security and coordination state and revisioned in-memory snapshots for Caplet configuration. Caplet snapshots converge across healthy nodes within a bounded interval, while loss of the authoritative database fails closed. SQLite schema upgrades run automatically under an exclusive migration transaction; PostgreSQL schema changes run in a successful pre-start migration job using a separate migrator role.

--- a/docs/adr/0005-caplet-file-layers-over-sql-records.md
+++ b/docs/adr/0005-caplet-file-layers-over-sql-records.md
@@ -1,0 +1,7 @@
+# Keep Caplet File Layers Above SQL Records
+
+Caplet Files remain live authoritative overlays rather than becoming one-time SQL import inputs. Effective Caplet precedence is project Caplet Files, then global Caplet Files, then SQL-backed Caplet Records, with existing JSON config below those Caplet sources. This preserves project-local capability overrides and lets an image or read-only mount bootstrap a host without making the filesystem a second mutable SQL replica.
+
+A filesystem Caplet shadows but never mutates the lower SQL record; deleting the file reveals that record again. Ordinary runtime and dashboard views show only the Effective Caplet, and filesystem Caplets are read-only in the dashboard. Operator-only storage views may explicitly address hidden SQL records.
+
+Because global files can change host behavior, PostgreSQL Host Nodes must register identical global-file manifests and keyed fingerprints of resolved runtime-affecting configuration. A mismatched node fails readiness instead of serving a different Effective Caplet view.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -13,6 +13,10 @@ Issues and PRDs for this repo live as GitHub issues in `spiritledsoftware/caplet
 
 `gh` can infer the repo from the current clone, but commands in skills should include `--repo spiritledsoftware/caplets` when practical so worktree location does not change the target repository.
 
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo later treats external PRs as feature requests.)_
+
 ## When a skill says "publish to the issue tracker"
 
 Create a GitHub issue in `spiritledsoftware/caplets`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -2,16 +2,14 @@
 
 The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used for this repo's GitHub issue tracker.
 
-Current GitHub labels were checked for `spiritledsoftware/caplets` on 2026-06-18. `question` and `wontfix` already exist. The other mapped labels are the desired canonical labels for triage roles and may need to be created before first use if they are still absent.
-
 | Label in mattpocock/skills | Label in our tracker | Meaning                                  |
 | -------------------------- | -------------------- | ---------------------------------------- |
 | `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `question`           | Waiting on reporter for more information |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
 | `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
 | `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
 | `wontfix`                  | `wontfix`            | Will not be actioned                     |
 
 When a skill mentions a role, use the corresponding label string from this table.
 
-If the repo later adopts different GitHub label names, edit the right-hand column to match the live labels rather than creating duplicates.
+Edit the right-hand column if the repo later adopts different GitHub label names.

--- a/docs/operations/sql-authoritative-host-state.md
+++ b/docs/operations/sql-authoritative-host-state.md
@@ -1,0 +1,498 @@
+# SQL Authoritative Host State Operations
+
+Caplets stores host-owned records in exactly one SQL backend. SQLite is the default for a single
+Host Node. PostgreSQL supports several Host Nodes for one logical host. There is no PostgreSQL to
+SQLite fallback, SQLite write buffer, dual write, or built-in backend copier.
+
+Run storage administration as a server-local operator and keep every Host Node stopped whenever a
+procedure below says the operation is offline.
+
+## SQLite
+
+### Location and configuration
+
+With no `storage` field, Caplets uses SQLite at:
+
+| Environment                       | Default database                                           |
+| --------------------------------- | ---------------------------------------------------------- |
+| Linux/macOS                       | `${XDG_STATE_HOME:-$HOME/.local/state}/caplets.sqlite3`    |
+| Windows                           | `%LOCALAPPDATA%\caplets.sqlite3`                           |
+| Docker Compose in this repository | `/data/state/caplets.sqlite3` in the `caplets-data` volume |
+
+An explicit global config path overrides the database location:
+
+```json
+{
+  "version": 1,
+  "storage": {
+    "type": "sqlite",
+    "path": "/srv/caplets/state/host.sqlite3"
+  }
+}
+```
+
+The global config owns this setting; project config cannot override it. On startup, SQLite enables
+foreign keys, WAL journaling, full synchronous writes, and a busy timeout. Ordered migrations run
+before SQLite serves. A failed migration rolls back and prevents startup; a binary that sees a newer
+unknown schema also fails closed.
+
+Check the configured backend, released schema version, Caplet Record count, and asset health:
+
+```sh
+caplets storage status --json
+```
+
+### Backup
+
+Stop the daemon and every foreground Host Node first. `sqlite3 .backup` produces one consistent
+file even if WAL sidecars remain from the last run:
+
+```sh
+set -eu
+DB=${XDG_STATE_HOME:-"$HOME/.local/state"}/caplets.sqlite3
+BACKUP="/srv/backups/caplets-$(date -u +%Y%m%dT%H%M%SZ).sqlite3"
+umask 077
+sqlite3 "$DB" ".backup '$BACKUP'"
+sqlite3 "$BACKUP" 'PRAGMA integrity_check; PRAGMA foreign_key_check;'
+```
+
+The first result must be `ok`; `foreign_key_check` must print no rows. Store the backup on different
+durable media and record the Caplets release and `schemaVersion` beside it. If `storage.assets.type`
+is `s3`, also take a versioned snapshot of the configured bucket/prefix at the same offline point.
+SQL-backed asset payloads are already inside the SQLite backup. Back up node-local media artifacts
+separately if they matter; SQL does not make their bytes durable.
+
+### Restore
+
+1. Stop every Host Node.
+2. Preserve the failed/current database and any `-wal`/`-shm` sidecars for diagnosis.
+3. Restore the database to the exact configured path with owner-only permissions. Restore the
+   matching object-store snapshot when S3 assets were in use.
+4. Remove stale SQLite `-wal` and `-shm` files only after preserving them and only while no process
+   has the database open.
+5. Start one node and require both `caplets storage status --json` and `/v1/healthz` to report ready
+   before returning traffic.
+
+```sh
+set -eu
+DB=${XDG_STATE_HOME:-"$HOME/.local/state"}/caplets.sqlite3
+install -m 600 /srv/backups/caplets-YYYYMMDDTHHMMSSZ.sqlite3 "$DB"
+sqlite3 "$DB" 'PRAGMA integrity_check; PRAGMA foreign_key_check;'
+caplets storage status --json
+```
+
+Do not restore a database whose schema is newer than the running Caplets release.
+
+## PostgreSQL
+
+### One schema is one logical host
+
+One PostgreSQL schema represents one logical Caplets host and one stable host identity. Multiple
+logical hosts may share a database only when each has a separate schema and separate credentials.
+Do not put a tenant/host discriminator into Caplets tables and do not point two logical hosts at the
+same schema.
+
+All nodes for one host need the same global storage configuration:
+
+```json
+{
+  "version": 1,
+  "storage": {
+    "type": "postgres",
+    "connectionString": "postgresql://caplets_runtime:<injected-password>@db.example:5432/caplets",
+    "schema": "caplets_prod"
+  }
+}
+```
+
+The database URL is a bootstrap secret: the database must open before Caplets Vault can be read.
+Render the global config from a deployment secret, mount a secret-generated file, or use an
+orchestrator secret mechanism. Do not commit the rendered URL, log it, or place it in a Caplets Vault
+reference. The config file itself does not define `CAPLETS_STORAGE_*` environment mappings.
+
+The schema name defaults to `caplets` and must match `^[a-z_][a-z0-9_]{0,62}$`. Every connection
+sets that schema as its PostgreSQL `search_path`.
+
+### Separate migration and runtime roles
+
+PostgreSQL runtime startup never applies DDL. An explicit, one-shot job must run:
+
+```sh
+caplets storage schema-migrate
+```
+
+Use a DDL-capable migrator URL for that job. Runtime nodes use a different DML-only URL and start
+only after the job exits successfully. The following is the concrete privilege boundary used by
+`deploy/postgres/init-caplets-roles.sh`; substitute identifiers through your provisioning tool
+rather than interpolating untrusted strings into SQL:
+
+```sql
+REVOKE ALL ON DATABASE caplets FROM PUBLIC;
+
+CREATE ROLE caplets_migrator LOGIN NOINHERIT PASSWORD '<deployment-secret>';
+CREATE ROLE caplets_runtime LOGIN NOINHERIT PASSWORD '<different-deployment-secret>';
+
+GRANT CONNECT, CREATE ON DATABASE caplets TO caplets_migrator;
+GRANT CONNECT ON DATABASE caplets TO caplets_runtime;
+
+CREATE SCHEMA caplets_prod AUTHORIZATION caplets_migrator;
+REVOKE ALL ON SCHEMA caplets_prod FROM PUBLIC;
+GRANT USAGE ON SCHEMA caplets_prod TO caplets_runtime;
+
+ALTER ROLE caplets_migrator IN DATABASE caplets SET search_path TO caplets_prod;
+ALTER ROLE caplets_runtime IN DATABASE caplets SET search_path TO caplets_prod;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE caplets_migrator IN SCHEMA caplets_prod
+  REVOKE ALL ON TABLES FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES FOR ROLE caplets_migrator IN SCHEMA caplets_prod
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO caplets_runtime;
+ALTER DEFAULT PRIVILEGES FOR ROLE caplets_migrator IN SCHEMA caplets_prod
+  REVOKE ALL ON SEQUENCES FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES FOR ROLE caplets_migrator IN SCHEMA caplets_prod
+  GRANT USAGE, SELECT ON SEQUENCES TO caplets_runtime;
+```
+
+After every migration, revoke runtime writes to the migration control tables while preserving the
+schema marker read required by health checks:
+
+```sql
+REVOKE ALL ON TABLE
+  caplets_prod.caplets_migrations,
+  caplets_prod.caplets_schema
+FROM caplets_runtime;
+GRANT SELECT ON TABLE caplets_prod.caplets_schema TO caplets_runtime;
+```
+
+Default privileges apply again when future migration objects are created, so this is part of the
+one-shot migration job, not a one-time bootstrap. The Compose overlay runs
+`deploy/postgres/finalize-runtime-grants.mjs` after `schema-migrate`.
+
+`LISTEN`/`NOTIFY` and advisory-lock functions do not require table ownership. Do not grant the
+runtime role `CREATE`, `TRUNCATE`, schema ownership, role administration, or migration credentials.
+Default privileges are attached to objects subsequently created by `caplets_migrator`; if an
+administrator or another owner creates an object, explicitly repair its ownership/grants before
+runtime starts. Rotate migrator and runtime credentials independently.
+
+The PostgreSQL documentation defines the relevant
+[`GRANT`](https://www.postgresql.org/docs/17/sql-grant.html),
+[`ALTER DEFAULT PRIVILEGES`](https://www.postgresql.org/docs/17/sql-alterdefaultprivileges.html),
+and [schema/search-path](https://www.postgresql.org/docs/17/ddl-schemas.html) behavior.
+
+### Docker Compose overlay
+
+`docker-compose.yml` remains the default SQLite, single-node deployment. The additive
+`docker-compose.postgres.yml` provides:
+
+- a PostgreSQL 17.6 service with `pg_isready` health;
+- initialization of separate administrator, migrator, and runtime roles;
+- a one-shot `caplets-postgres-migrate` service;
+- `service_completed_successfully` gating before the runtime service starts; and
+- ephemeral, mode-`0600` config rendering so URLs are not committed.
+
+Put three distinct, randomly generated passwords in an owner-only `.env` file:
+
+```dotenv
+CAPLETS_POSTGRES_ADMIN_PASSWORD=<deployment-secret>
+CAPLETS_POSTGRES_MIGRATOR_PASSWORD=<different-deployment-secret>
+CAPLETS_POSTGRES_RUNTIME_PASSWORD=<different-deployment-secret>
+CAPLETS_POSTGRES_SCHEMA=caplets
+```
+
+Then validate and start the merged deployment:
+
+```sh
+chmod 600 .env
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml config --quiet
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml up --build -d
+```
+
+The role initializer runs only when the PostgreSQL data volume is first created. Editing `.env` does
+not rotate roles in an existing database. Use `ALTER ROLE ... PASSWORD` through a protected
+administrator session, update the deployment secret, and restart the affected job/nodes.
+
+The overlay mounts the same `caplets-data` volume into runtime replicas, so its global Caplet File
+manifest is shared on one Docker host. Do not treat a local Docker volume as cross-host storage.
+
+### Readiness and fail-closed behavior
+
+`GET /v1/healthz` is the readiness probe and returns HTTP 503 when the host is not ready. PostgreSQL
+readiness requires:
+
+- authoritative database connectivity and the exact released schema version;
+- successful host/node identity registration;
+- no global Caplet File manifest conflict;
+- no keyed runtime-affecting configuration fingerprint conflict;
+- a valid current SQL snapshot; and
+- object-store connectivity when current Caplet bundle assets require it.
+
+An absent/outdated PostgreSQL schema is not auto-migrated. A newer unknown schema also fails closed.
+If PostgreSQL becomes unavailable, SQL-dependent requests return retryable unavailable errors; nodes
+do not keep serving stale SQL Caplets or stale security state. A committed mutation invalidates other
+nodes through PostgreSQL notification, with host-generation polling as fallback; the default
+cross-node convergence bound is five seconds.
+
+Liveness must be a separate process/container check if an orchestrator needs to distinguish “process
+running” from “safe to receive traffic.” Do not replace readiness with a TCP-only database check.
+
+## Cluster runtime parity and node-local state
+
+### Global Caplet Files
+
+Global Caplet Files remain authoritative overlays and therefore must have the same manifest on every
+node in one PostgreSQL host. Mount the same immutable release/config volume or deploy byte-identical
+files to every node. Resolved runtime-affecting global configuration must also be identical, including
+resolved environment values. Caplets compares a keyed fingerprint without storing or logging those
+values. Listen addresses, logs, and process-local options are excluded; project files are
+session/project-scoped and excluded.
+
+A manifest or fingerprint mismatch fails readiness. Do not drain that protection by routing traffic
+to a disagreeing node anyway.
+
+### Code Mode affinity
+
+Live Code Mode Sessions and heap objects are node-local. Use connection/session affinity for a live
+session. Losing its owning node loses closures, objects, timers, and handles; SQL does not reconstruct
+them. Follow the existing Code Mode recovery guidance and replay only operations the operator/agent
+has determined are safe. New work may start a fresh session on a healthy node.
+
+### Project Binding loss and rebind
+
+Workspace bytes remain on the owning node. PostgreSQL durably coordinates binding leases,
+manifests/revisions, and readiness metadata, not workspace content. When an owning node is lost,
+affected Caplets are quarantined rather than silently routed to another node. The client must rebind
+to a healthy node and fully resynchronize before those Caplets become ready. Do not clear quarantine
+or mark a binding ready without the resync.
+
+Node-local media artifacts likewise require owner routing/affinity and are lost with local storage.
+Use S3-compatible artifact storage when artifacts must survive node loss or be read from any node.
+
+## Caplet asset object storage
+
+The default bundle asset payload store is content-addressed SQL storage. To move bundle assets to an
+S3-compatible backend, configure the common `storage.assets` field:
+
+```json
+{
+  "version": 1,
+  "storage": {
+    "type": "postgres",
+    "connectionString": "postgresql://caplets_runtime:<injected-password>@db.example:5432/caplets",
+    "schema": "caplets_prod",
+    "assets": {
+      "type": "s3",
+      "endpoint": "https://objects.example.com",
+      "region": "us-east-1",
+      "bucket": "caplets-production",
+      "prefix": "host-a",
+      "forcePathStyle": false
+    }
+  }
+}
+```
+
+`endpoint`, `prefix`, and `forcePathStyle` are optional. `region` and `bucket` are required. Prefer
+workload identity/the AWS SDK credential chain; otherwise render both `accessKeyId` and
+`secretAccessKey` from deployment secrets. These are database-bootstrap peers and cannot come from
+Caplets Vault.
+
+Uploads are staged and read-back hash-verified before SQL references them. SQL reference deletion
+precedes retryable object deletion; leased garbage collection removes unreferenced objects only
+after its safety grace period. Give every node the same bucket/prefix and credentials. Back up and
+restore SQL plus the matching object version set as one recovery point.
+
+Object-store failure makes storage unhealthy when a current Caplet bundle needs an object. The
+Caplet is quarantined; missing bytes are never replaced with empty content. Optional media-artifact
+storage can be degraded independently only when a configured local fallback is valid.
+
+## Offline legacy filesystem migration
+
+This migration moves tracked global Caplets and the old global lockfile into the selected SQL
+backend. Untracked global Caplet Files remain in place as authoritative overlays. There is no dual
+write and no destructive migration at first startup.
+
+1. Stop every Host Node (or enter exclusive maintenance).
+2. Back up the global Caplets root, old lockfile, selected SQL database, and object prefix.
+3. Verify with a dry run using explicit paths:
+
+   ```sh
+   caplets storage migrate-legacy \
+     --caplets-root /srv/caplets/global \
+     --lockfile /srv/caplets/caplets.lock.json \
+     --dry-run
+   ```
+
+4. Resolve every missing artifact, hash/provenance mismatch, ID collision, or validation failure.
+5. Run the same command without `--dry-run`:
+
+   ```sh
+   caplets storage migrate-legacy \
+     --caplets-root /srv/caplets/global \
+     --lockfile /srv/caplets/caplets.lock.json
+   ```
+
+The command takes an exclusive migration lock, imports transactionally, compares counts/content
+hashes, and only after commit moves migrated files and the old lockfile into a timestamped backup.
+Record the printed backup path. Restart only after `caplets storage status --json` is ready. After
+cutover the legacy stores are not a fallback.
+
+## Offline SQLite-to-PostgreSQL transfer
+
+Caplets intentionally has no built-in backend copier. The following external recipe pins the
+official pgloader image by immutable manifest digest:
+
+```text
+ghcr.io/dimitri/pgloader@sha256:f4d2e2d7229980516da69b1eb73d9e11f97fb567fce7421f5a0bc70cbe6c76bf
+```
+
+That artifact reports `pgloader 3.6.10~devel` and identifies official source revision
+[`1c8e2e6d7b2f474191c0c63214f75bfcc329e604`](https://github.com/dimitri/pgloader/tree/1c8e2e6d7b2f474191c0c63214f75bfcc329e604).
+The digest, rather than mutable `latest`, is the executable version pin. Rehearse the exact Caplets
+release, data volume, architecture, network path, and object store against a disposable target
+first.
+
+The exact options below are source-verified against the pinned revision's official
+[SQLite loader reference](https://github.com/dimitri/pgloader/blob/1c8e2e6d7b2f474191c0c63214f75bfcc329e604/docs/ref/sqlite.rst):
+
+- `data only`, `include no drop`, `no truncate`, and `reset no sequences` constrain the run to row
+  copy without target drop/truncate/sequence changes;
+- `create no tables` is deliberately **not** used: the official reference says that option removes
+  and reinstalls target constraints/indexes, which is not a DML-only transfer;
+- `no foreign keys` prevents pgloader from dropping/recreating the already migrated foreign keys;
+- `INCLUDING ONLY TABLE NAMES LIKE` selects one table per command so the verifier can execute tables
+  in the SQLite foreign-key graph's topological order while target constraints stay enabled;
+- `ALTER SCHEMA 'public' RENAME TO ...` maps SQLite's source catalog to the pre-migrated host schema;
+  the pinned
+  [SQLite command grammar](https://github.com/dimitri/pgloader/blob/1c8e2e6d7b2f474191c0c63214f75bfcc329e604/src/parsers/command-sqlite.lisp)
+  accepts the foreign-key, filter, and common schema clauses; and
+- `EXCLUDING TABLE NAMES LIKE` omits backend-specific migration metadata already created by the
+  PostgreSQL migration job.
+
+The image metadata and digest come from pgloader's official
+[container publishing workflow](https://github.com/dimitri/pgloader/blob/1c8e2e6d7b2f474191c0c63214f75bfcc329e604/.github/workflows/docker-publish.yml).
+
+### 1. Freeze and back up
+
+- Run the same released Caplets version on source and target tooling.
+- Stop **all** source Host Nodes and keep writers stopped through verification/cutover.
+- Create and integrity-check a SQLite `.backup` as described above.
+- Snapshot the S3 bucket/prefix and node-local artifacts when used.
+- Preserve the original global config unchanged for rollback.
+
+### 2. Prepare a fresh target
+
+Create a new, otherwise unused PostgreSQL schema. Run `caplets storage schema-migrate` with its
+migrator URL. Never point the runtime at it yet. Use the DML-only runtime role for the transfer; its
+`current_schema()` must be the target schema.
+
+Require equal released schema markers:
+
+```sh
+sqlite3 "$SQLITE_BACKUP" \
+  'SELECT version FROM caplets_schema WHERE singleton = 1;'
+psql "$CAPLETS_POSTGRES_RUNTIME_URL" -X -qAt -v ON_ERROR_STOP=1 \
+  -c 'SELECT current_schema(), version FROM caplets_schema WHERE singleton = 1;'
+```
+
+Abort unless versions are present and equal, `current_schema()` is the intended one, source/target
+application table sets match, and every target application table is empty. `caplets_schema` and
+`caplets_migrations` are target migration metadata, not copied application data.
+
+### 3. Transfer data only
+
+Create the load file in a mode-`0700` temporary directory, with a mode-`0600` file, and delete it on
+exit because it contains the target URL. Use one command of this form per application table, ordered
+by the source SQLite foreign-key graph. `scripts/verify-sqlite-postgres-transfer.sh` derives that
+order from `pragma_foreign_key_list` and generates the complete file:
+
+```lisp
+LOAD DATABASE
+     FROM sqlite:///work/source.sqlite3
+     INTO postgresql://caplets_runtime:PERCENT_ENCODED_PASSWORD@127.0.0.1:5432/caplets
+
+ WITH data only,
+      include no drop,
+      no truncate,
+      reset no sequences,
+      no foreign keys,
+      downcase identifiers
+
+ INCLUDING ONLY TABLE NAMES LIKE 'ONE_TABLE_FROM_FK_ORDER'
+ ALTER SCHEMA 'public' RENAME TO 'caplets_prod'
+ EXCLUDING TABLE NAMES LIKE 'caplets_migrations', 'caplets_schema';
+```
+
+Copy the offline backup into `$TRANSFER_WORK`; pgloader's SQLite client needs that disposable copy's
+directory writable for SQLite sidecars. The original backup remains untouched and the mode-`0700`
+work directory is deleted after the run:
+
+```sh
+docker run --rm --network host \
+  --mount type=bind,src="$TRANSFER_WORK",dst=/work \
+  ghcr.io/dimitri/pgloader@sha256:f4d2e2d7229980516da69b1eb73d9e11f97fb567fce7421f5a0bc70cbe6c76bf \
+  pgloader /work/sqlite-data-only.load
+```
+
+Do not combine all tables into one parallel COPY and do not add `disable triggers`: child tables may
+race their parents, while disabled triggers can leave invalid data. The verifier instead preserves
+and exercises target foreign keys throughout the dependency-ordered COPY. Do not retry into a
+partially loaded schema; if pgloader fails, drop/recreate the disposable target schema, rerun the
+Caplets migration job, and start again.
+
+### 4. Verify while still offline
+
+`scripts/verify-sqlite-postgres-transfer.sh` performs the guarded empty-target check, pinned transfer,
+per-table row counts, SQLite integrity/foreign-key checks, PostgreSQL constraint checks, and durable
+content-hash projections for revisions, asset bytes/keys, bundle entries, and installation
+observations. It requires `sqlite3`, Docker (also used for a pinned `psql` client when no local
+client is installed), a stopped source, and a newly migrated disposable target:
+
+```sh
+CAPLETS_SQL_TRANSFER_CONFIRM=offline-empty-target \
+CAPLETS_SQLITE_SNAPSHOT=/srv/backups/caplets.sqlite3 \
+CAPLETS_TEST_POSTGRES_URL="$CAPLETS_POSTGRES_RUNTIME_URL" \
+CAPLETS_POSTGRES_SCHEMA=caplets_prod \
+./scripts/verify-sqlite-postgres-transfer.sh
+```
+
+The current released schema owns no PostgreSQL sequences. The verifier asserts that. If a future
+released schema introduces an identity/sequence, stop and use that release's documented reset
+procedure with the migrator role, then prove the next generated value is above the imported maximum.
+Do not guess or rely on pgloader's generic reset against a pre-migrated schema.
+
+Finally run Caplets' own health check with the target runtime configuration, including real object
+store credentials:
+
+```sh
+caplets storage status --json
+```
+
+For the Compose overlay before runtime cutover:
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml run --rm --no-deps caplets \
+  /bin/sh -ec 'node /usr/local/bin/render-caplets-postgres-config.mjs runtime && node dist/index.js storage status --json'
+```
+
+Require ready database/schema health, expected Caplet Record and asset counts, object-store
+connectivity, no missing current bundle object, and successful read/export smoke checks for critical
+Caplets.
+
+### 5. Cut over atomically
+
+1. Keep source nodes stopped.
+2. Render a new owner-only global config selecting the verified PostgreSQL schema/runtime URL.
+3. Atomically rename it over the global config on the same filesystem, or atomically promote the
+   orchestrator release/secret version.
+4. Start one node; require storage status and `/v1/healthz` readiness. Confirm global-file manifest
+   parity and critical read-only Caplet operations.
+5. Start remaining nodes and only then move traffic.
+6. Retain the untouched SQLite backup/config and object snapshot for the rollback window.
+
+### Rollback
+
+Stop every PostgreSQL-backed node before rollback. Atomically restore the saved SQLite global config
+and database file plus its matching object snapshot, then start one SQLite node and verify storage
+status/readiness before restoring traffic. Do not merge writes made after PostgreSQL cutover back into
+SQLite. If PostgreSQL accepted writes, rollback loses them; either accept that recovery point or
+repair PostgreSQL and roll forward. Keep the failed target schema isolated for diagnosis rather than
+reusing it for another transfer.

--- a/docs/specs/2026-07-18-sql-authoritative-host-state.md
+++ b/docs/specs/2026-07-18-sql-authoritative-host-state.md
@@ -1,0 +1,397 @@
+# SQL Authoritative Host State And Caplet Records
+
+## Summary
+
+Replace Caplets' correctness-bearing host filesystem stores with one SQL storage backend. SQLite is the default for standard single-node installations. PostgreSQL supports multiple Host Nodes that together represent one logical Caplets host.
+
+Caplet Files remain first-class filesystem sources. SQL adds a structured Caplet Record model rather than storing Markdown as a document blob. Project and global Caplet File layers may shadow SQL records without modifying them, and Caplets can import and export canonical Markdown bundles across project, global, and remote targets.
+
+## Goals
+
+- Make Authoritative Host State coherent across multiple server nodes.
+- Use SQLite without external services for the standard local installation.
+- Support PostgreSQL clusters with explicit consistency, migration, readiness, and failure contracts.
+- Store Caplet identity, human metadata, body, tags, backend children, history, and installation provenance as structured data.
+- Preserve complete Caplet bundles, including scripts and auxiliary files, across SQL import and export.
+- Preserve project and global Caplet Files as authoritative live layers.
+- Replace the global Caplets Lockfile with relational Caplet Installation provenance.
+- Keep project installs filesystem-backed and keep the project Caplets Lockfile.
+- Provide safe, atomic, Operator-only import, export, history, restore, detach, and deletion operations.
+
+## Non-Goals
+
+- Do not retain the filesystem as an alternative authoritative host-state backend.
+- Do not dual-write or automatically fail over between SQLite and PostgreSQL.
+- Do not make live Code Mode heap state durable or portable between Host Nodes.
+- Do not put synchronized project workspace contents, caches, telemetry, daemon files, or ordinary node-local artifacts in SQL.
+- Do not provide multi-tenant host tables in one PostgreSQL schema.
+- Do not ship a built-in SQLite-to-PostgreSQL data copier.
+- Do not preserve original YAML comments, formatting, key order, or symlink identity during round-trip export.
+- Do not add a persisted collaborative Caplet draft workflow.
+- Do not reject or encrypt literal secrets found in otherwise valid Caplet frontmatter. Public guidance continues to prefer environment and Vault references.
+
+## Domain Model
+
+### Authoritative Host State
+
+Authoritative Host State is correctness-bearing state that every Host Node must observe coherently:
+
+- Caplet Records, Caplet Revisions, Caplet Installations, and current-head metadata
+- content-addressed Caplet bundle metadata and payload references
+- backend OAuth/OIDC token state and other server-owned backend auth state
+- encrypted Vault values and Vault Access Grants
+- remote-client, token-family, Pairing Code, and Pending Remote Login state
+- dashboard sessions
+- Caplet setup approvals, attempts, retention, and retry state
+- Project Binding leases, revisions, readiness, and coordination metadata
+- Operator Activity Log entries
+- host identity, schema version, node registrations, configuration generations, leases, and maintenance cursors
+
+The following remain outside Authoritative Host State:
+
+- client-owned Remote Profiles and client credential stores
+- anonymous telemetry state, update checks, completion caches, and observed-output-shape caches
+- native service descriptors, daemon logs, and native service-manager state
+- live Code Mode Sessions and heap objects
+- Code Mode logs and Recovery Journals unless a later decision promotes them into host-owned shared state
+- synchronized Project Binding workspace files
+- media artifact bytes when local or object artifact storage is configured
+- Vault key material and storage/object-store bootstrap credentials
+
+### Caplet Record
+
+A Caplet Record is the SQL-resident parent entity for one Caplet authoring/install unit. It has:
+
+- an immutable internal record key
+- a unique, editable Caplet ID used for runtime identity and export directory naming
+- a monotonically changing head generation for optimistic concurrency
+- one selected current Caplet Revision
+- host-default or per-record revision-retention policy
+- created, updated, and actor metadata
+
+The Caplet ID is stable record metadata outside revision content. Renaming it does not rewrite historical revisions, change the immutable record key, or transfer Vault authority to another record. Exporting or restoring any revision uses the record's current Caplet ID.
+
+A Multi-Backend Caplet File remains one Caplet Record. Its backend children are separate ordered rows with child IDs unique inside the parent. The runtime continues to derive expanded runtime Caplets through the existing Caplet parser and configuration model.
+
+### Caplet Revision
+
+A Caplet Revision is an immutable, complete, validated version of a record's structured Caplet content and Caplet Bundle Snapshot. Partial field writes never become current.
+
+Every successful content change creates a revision and selects it as current. A source update whose resolved source revision changed but whose bundle content did not may create a provenance-distinct non-current revision only when revision history is enabled.
+
+History is off by default. Global host configuration may enable a retained revision count, and an individual Caplet Record may override it. The count includes every retained revision, including the current revision and non-current provenance-only revisions. The current revision is never pruned; a limit of one means current only.
+
+Users may:
+
+- delete a historical revision
+- delete the current revision, which promotes the newest remaining revision
+- delete the sole revision, which removes the Caplet Record
+- restore an older revision by creating a new current revision
+- hard-delete a Caplet Record, all revisions, all installation lifecycles, and all now-unreferenced bundle entries
+
+The Operator Activity Log survives a hard-delete but contains only sanitized mutation metadata, not removed Caplet content.
+
+### Caplet Installation
+
+A Caplet Installation is a provenance-bearing lifecycle connecting a Caplet Record to an external repository/path and update channel. It records source identity, tracked channel, resolved source observations, status, detach metadata, and operator metadata. Each installed Caplet Revision records the resolved source revision, content hash, and risk snapshot that produced it.
+
+Only one Caplet Installation lifecycle may be active for a record. Detaching ends update tracking but retains the lifecycle. Explicitly replacing a detached install creates a new active lifecycle while retaining the old detached lifecycle and Caplet history.
+
+A manual import over an actively installed record fails unless the operator explicitly detaches the source. If an upstream Caplet disappears, update retains the current record, reports the source as unavailable, and offers an explicit detach path; it never deletes or silently detaches the Caplet.
+
+### Effective Caplet
+
+Caplet resolution uses this precedence, highest first:
+
+1. project Caplet File layer
+2. global Caplet File layer
+3. SQL Caplet Record layer
+4. existing global JSON executable-backend config
+
+Project JSON config retains its current restrictions and cannot introduce executable backend maps.
+
+A higher layer shadows a lower layer without writing to it. Deleting a shadowing file reveals the lower SQL record. Ordinary runtime, CLI list/inspect, and dashboard views show only the Effective Caplet. A filesystem Effective Caplet appears read-only in the dashboard, with editing controls disabled. The dashboard does not show the hidden SQL record.
+
+Operator-only commands and APIs may request the stored SQL view explicitly. CLI surfaces use `--stored` and must report whether the record is currently shadowed.
+
+## Logical SQL Model
+
+SQLite and PostgreSQL implement one logical schema. PostgreSQL may use native `jsonb` and `bytea`; SQLite may use canonical JSON text and BLOB storage. Application validation remains authoritative for typed JSON in both backends.
+
+The logical Caplet model requires at least:
+
+- `caplet_records`: immutable key, current Caplet ID, current revision, head generation, retention override, lifecycle metadata
+- `caplet_revisions`: immutable revision key/sequence, record key, name, description, Markdown body, schema/export metadata, validated top-level typed subsections, content hash, source provenance, actor, timestamps
+- `caplet_tags`: revision-to-tag rows
+- `caplet_backends`: revision-to-backend-child rows, backend family, optional child ID, ordering, and validated backend-specific typed JSON
+- `caplet_bundle_entries`: revision, normalized relative path, content hash, media type, size, and executable bit
+- `caplet_asset_blobs`: content hash, size, and SQL payload or object-storage key/status
+- `caplet_installations`: source identity, tracked channel, active/detached status, timestamps, and operator metadata
+- `caplet_installation_observations`: resolved source revision, content hash, risk snapshot, check status, and timestamps
+
+Other Authoritative Host State uses domain-specific tables rather than one generic key/value or JSON-document table. Security and coordination transitions must retain their existing invariants, including compare-and-swap token rotation, stale-token detection, session expiry, setup retry limits, Vault encryption, and Project Binding lease ownership.
+
+Rows may contain validated typed JSON where a nested backend-specific shape is expected to evolve. Whole Caplet Markdown documents, whole lockfile entries, and whole host-state files are not stored as opaque JSON/blob records.
+
+## Caplet Bundle Snapshot
+
+`CAPLET.md` is parsed into structured Caplet Record fields and exact Markdown body text; its original raw YAML document is not retained. Every auxiliary regular file in the directory bundle is retained, whether or not frontmatter currently references it.
+
+Import normalizes and validates every bundle entry:
+
+- relative paths only
+- no traversal or platform-absolute paths
+- regular files only in the persisted snapshot
+- safe in-bundle symlinks are materialized as regular-file content
+- escaping, broken, cyclic, or unsupported links fail the import
+- device, socket, FIFO, and other special files fail the import
+- executable intent is retained as a portable executable bit
+
+Default limits are:
+
+- 2,048 auxiliary files per bundle
+- 64 MiB per auxiliary file
+- 256 MiB total auxiliary bytes per bundle
+- the existing Caplet Markdown size/body limits remain unchanged
+
+All limits are host-configurable. Import streams and validates data before commit and identifies the path that exceeded a limit.
+
+### Asset Payloads
+
+The default asset payload store is content-addressed SQL storage. Bundle-entry rows reference a shared payload by cryptographic content hash, so identical assets and retained revisions do not duplicate bytes.
+
+Operators may configure an S3-compatible asset backend with endpoint, region, bucket, prefix, path-style behavior, and bootstrap credentials. Object upload is staged and hash-verified before a SQL revision may reference it. A failed SQL commit may leave an unreferenced object, which leased garbage collection removes only after a safety grace period. Deleting a record or revision removes references first; object deletion remains retryable and idempotent.
+
+Media artifacts use a separate object namespace and retention policy. Object storage is recommended for cluster-safe media artifacts. Node-local artifacts remain allowed with affinity/owner routing and are lost when their node or local storage is lost.
+
+## Storage Configuration
+
+Global Caplets config selects the storage backend and nonsecret options. Project config cannot select or override host storage.
+
+SQLite is the default when no backend is configured. Its database lives under the Caplets-owned state directory unless an explicit path is configured. SQLite startup enables the durability, foreign-key, busy-timeout, and concurrency settings required by the implementation.
+
+PostgreSQL configuration selects one schema for one logical Caplets host. Several hosts may share a database only by using separate schemas and credentials. Multi-host/tenant keys inside application tables are out of scope.
+
+Database and S3 credentials are bootstrap inputs. They come from environment or deployment secret-file references, not Caplets Vault references, because the database must open before the Vault can be read. Plain literal values remain valid user input when the existing global-config policy permits them, but documentation recommends deployment secret injection.
+
+A host selects exactly one backend. It never:
+
+- falls back from PostgreSQL to SQLite
+- uses SQLite as a PostgreSQL write buffer
+- dual-writes legacy files and SQL
+- splits domain stores across independently selected backends
+
+All config-loading APIs become asynchronous. Pure parsing and validation may remain internally synchronous, but every public config/runtime assembly caller awaits the selected backend and the resolved source layers. Engines receive complete immutable snapshots; requests do not perform blocking network I/O.
+
+## Mutations And Concurrency
+
+All complete Caplet candidates validate before becoming durable. Frontmatter, body, backend children, bundle paths, asset hashes, source provenance, and retention effects commit atomically.
+
+Every mutable SQL record exposes a head generation. Update, rename, delete, revision delete, restore, detach, and replace operations require the generation observed by the caller. A stale generation returns a conflict and never overwrites another operator's change.
+
+Batch import is all-or-nothing. A validation error, existing-ID collision, stale generation, object-staging failure, or authorization failure leaves every target record unchanged.
+
+Operator mutations that also require an Operator Activity Log entry append that sanitized entry in the same SQL transaction whenever both records use SQL. External object writes use staged-before-commit semantics instead of pretending SQL and object storage share a distributed transaction.
+
+## Import And Export
+
+Import and export follow the existing target model:
+
+- project target: filesystem Caplet bundles and project Caplets Lockfile
+- global target: the configured local host SQL backend
+- remote target: the selected remote host SQL backend through its authenticated admin API
+
+The default mutation target remains project. Global and remote add/install/import/update/delete operations mutate Caplet Records. Explicit print/output generation remains a filesystem operation.
+
+### Import
+
+- A missing Caplet ID creates a record.
+- An existing ID fails by default.
+- Explicit update requires the observed head generation and creates a new revision.
+- Updating an actively source-tracked install with local Markdown additionally requires explicit source detachment.
+- A directory containing several Caplets commits as one transaction or not at all.
+- Literal secret-bearing fields accepted by the current Caplet schema are preserved as authored.
+
+### Export
+
+Export produces a deterministic semantic projection, not a byte-perfect source restoration:
+
+- always writes `<id>/CAPLET.md`
+- writes canonical YAML frontmatter from validated structured data
+- preserves exact stored Markdown body text
+- writes normalized auxiliary regular files and executable intent
+- does not recreate YAML comments, formatting, key order, or symlinks
+- exports current revision by default and accepts an explicit retained revision
+- fails if the destination directory exists unless replace is explicit
+- explicit replace stages a sibling directory and atomically swaps it, so stale files cannot survive
+
+Export and history operations are Operator-only because valid frontmatter may contain literal credentials.
+
+## Install And Update Lifecycle
+
+Project catalog installs keep their filesystem destination and project `.caplets.lock.json` behavior.
+
+Global and remote catalog installs create or update Caplet Records and relational Caplet Installations. The global filesystem lockfile is retired after verified migration. Restore and update read SQL provenance rather than serializing lockfile entries into JSON columns.
+
+A content-changing update creates and selects a new current revision. If the resolved source revision changes while Caplet content does not:
+
+- with history enabled, create a provenance-distinct non-current revision that counts toward retention
+- with history disabled, update installation observation metadata without retaining a Caplet Revision
+
+If the source no longer contains the Caplet, retain the current record, report `source unavailable`, and offer an explicit detach operation/flag.
+
+Replacing a detached Caplet is explicit. It preserves the record identity and retained revisions, creates a new current revision, retains the old detached Installation lifecycle, and creates one new active lifecycle.
+
+## Authorization And Audit
+
+Only a server-local operator or Operator Client may:
+
+- inspect stored or shadowed SQL records
+- import or export records/bundles
+- list or delete revisions
+- restore revisions
+- change retention
+- rename, detach, replace, delete, or hard-delete records/installations
+
+Access Clients continue to see only agent-safe Effective Caplet capability surfaces. They cannot read raw structured config, history, bundle assets, literal secrets, or inactive fallback records.
+
+Storage-scoped reads that can reveal raw config and every mutation append sanitized Operator Activity Log entries. Raw Caplet content, body, asset bytes, database URLs, object-store credentials, Vault values, tokens, and filesystem paths never enter activity metadata.
+
+SQL Vault Access Grants bind to the immutable Caplet Record key and reference name. Renaming the Caplet ID preserves grants; deleting and recreating the same ID does not inherit grants from the deleted record. File-layer grants retain their existing origin-path identity.
+
+## Distributed Consistency
+
+PostgreSQL mode uses risk-tiered consistency.
+
+Security and coordination operations read and mutate PostgreSQL transactionally, including:
+
+- remote credential validation, refresh rotation, revocation, and pending login
+- dashboard session validation
+- Vault value/grant reads and mutations
+- setup approval and retry state
+- Project Binding lease/revision transitions
+- record mutation generations and installation ownership
+
+Caplet/config reads use immutable per-node snapshots. A committed SQL Caplet mutation is visible immediately to the writing node. Other healthy nodes invalidate through database notification and poll a host generation as a fallback. The documented default cross-node convergence bound is five seconds. Requests already in flight retain the snapshot with which they started.
+
+A dropped notification cannot cause indefinite staleness. If the database is unavailable, Host Nodes fail readiness and SQL-dependent host/capability requests return a retryable unavailable error. They do not continue serving stale SQL Caplets or security state.
+
+## Cluster Contract
+
+One PostgreSQL schema represents one logical Caplets host with one stable host identity. Every Host Node registers an ephemeral node identity and heartbeat.
+
+### Runtime Parity
+
+Global Caplet Files remain authoritative, so every node must expose an identical global Caplet File manifest. Nodes also compute a deterministic keyed fingerprint of resolved runtime-affecting global configuration, including resolved environment values without storing or logging those values. Node-local listen, log, and process options are excluded.
+
+Manifest or runtime-fingerprint disagreement fails readiness. Project Caplet Files are session/project-scoped and are not part of the global cluster fingerprint.
+
+### Node-Local Runtime State
+
+Live Code Mode Sessions remain node-local and require connection/session affinity. Losing the owning node loses live heap state and follows existing recovery behavior; SQL does not claim to restore closures, objects, timers, or handles.
+
+Project Binding workspace content remains node-local. PostgreSQL stores binding leases, manifests/revisions, and readiness metadata. Losing the owning node quarantines affected Caplets until the client rebinds and resynchronizes on another node.
+
+Node-local media artifacts require affinity/owner routing. S3-compatible artifact storage is recommended when artifacts must survive node loss or be readable from any node.
+
+### Maintenance
+
+Revision pruning, expired-state cleanup, installation checks, activity retention, object garbage collection, and other recurring maintenance use short database-backed leases/advisory locks and idempotent bounded batches. Any healthy Host Node may acquire a job; another may continue after lease expiry. Lease time uses database time where possible.
+
+## Schema And Data Migration
+
+### New And Upgraded SQLite Hosts
+
+New installations create SQLite automatically. Ordered SQLite schema migrations run under an exclusive migration transaction before the host serves. A migration failure rolls back and prevents startup. A binary encountering a newer unknown schema fails closed.
+
+Existing filesystem-backed hosts do not migrate destructively on first startup. An explicit offline migration command must:
+
+1. require the daemon/host to be stopped or in exclusive maintenance mode
+2. support a dry run
+3. acquire an exclusive migration lock
+4. validate legacy Authoritative Host State
+5. verify every global-lockfile artifact and its recorded hash/provenance
+6. import all SQL state transactionally
+7. compare migrated counts and content hashes
+8. move only migrated state files, tracked global artifacts, and the old global lockfile to a timestamped backup after commit
+9. leave untracked global Caplet Files in place as authoritative overlays
+10. print the backup location and restart/cutover instructions
+
+There is no dual-write transition. After cutover, migrated legacy stores are not read as fallback state.
+
+### PostgreSQL Deployments
+
+PostgreSQL schema migration is an explicit deployment job that must succeed before any Host Node starts. Kubernetes, Docker Compose, and other deployment examples must model this dependency.
+
+The migration job uses a DDL-capable migrator role. Runtime nodes use a separate least-privilege role limited to the configured schema's required DML, sequences, notifications, and advisory locks. Runtime startup refuses an absent or outdated schema and fails closed against a newer unknown schema.
+
+### SQLite To PostgreSQL
+
+Caplets does not ship a built-in backend copier. Operator documentation must provide a version-pinned, tested offline recipe using an external migration tool, including:
+
+- stopping the host
+- backing up SQLite and any object storage
+- applying the target PostgreSQL schema with the migration job
+- copying every authoritative table and payload
+- resetting sequences/identities where required
+- comparing row counts and content hashes
+- running integrity/foreign-key checks
+- switching global storage config only after verification
+- rollback instructions that restore the untouched SQLite configuration and backup
+
+Illustrative, unverified dump/load snippets do not satisfy this requirement.
+
+## Health And Readiness
+
+Liveness reports whether the process is running. Readiness additionally requires:
+
+- authoritative database connectivity
+- exact supported schema version
+- successful host identity registration
+- no global-file manifest conflict
+- no keyed runtime-fingerprint conflict
+- object-store connectivity when configured for required Caplet assets
+- a valid current SQL snapshot
+
+A missing optional media-artifact object store may degrade artifact health without making unrelated capabilities ready if local artifact fallback is configured. A missing object containing a current Caplet bundle asset quarantines the affected Caplet and makes storage health unhealthy; it never substitutes empty content.
+
+## Required User Surfaces
+
+The completed feature must expose:
+
+- storage status and health for SQLite/PostgreSQL/object storage
+- PostgreSQL schema migration command suitable for deployment jobs
+- explicit offline legacy-filesystem migration with dry run
+- project/global/remote targets for add, install, import, update, export, and delete
+- `--stored` operator views for hidden SQL records
+- revision list, export, restore, delete, retention, and hard-delete operations
+- installation status, detach, source-unavailable handling, and detached replacement
+- deterministic plain and JSON conflict/error outputs with record generation and shadow source
+- dashboard read-only filesystem Caplets and editable effective SQL Caplets
+
+## Acceptance Criteria
+
+1. A new unconfigured single-node host creates and uses SQLite for all Authoritative Host State.
+2. A host cannot start with two authoritative backends, an unsupported schema, or an unavailable configured database.
+3. PostgreSQL nodes sharing one schema observe transactional security state and converge Caplet snapshots within the documented healthy bound.
+4. Database loss fails readiness and does not serve stale SQL Caplets or revoked security state.
+5. Project files shadow global files, global files shadow SQL records, and deleting a file reveals the lower record without mutating it.
+6. Cluster nodes with different global file manifests or resolved runtime fingerprints fail readiness.
+7. Dashboard and normal list views show only the Effective Caplet; filesystem Caplets are read-only; Operator-only `--stored` views can address hidden SQL records.
+8. Caplet Markdown is decomposed into structured relational data and exact body text; whole Markdown documents and lockfile entries are not stored as opaque records.
+9. Multi-Backend Caplet Files retain one parent identity and round-trip as one bundle.
+10. Entire bounded auxiliary bundles round-trip semantically, including executable intent; unsafe links and special files fail before commit.
+11. SQL and S3 asset stores verify content hashes, deduplicate payloads, and never expose a revision before all required content is durable.
+12. Concurrent stale mutations fail without lost updates.
+13. Batch import either commits every Caplet or none.
+14. Export is deterministic, always produces directory bundles, and never leaves stale destination files after explicit replacement.
+15. Revision retention, current promotion, sole-revision deletion, restore, specific deletion, and hard-delete follow the defined lifecycle.
+16. Global and remote install/update use relational Caplet Installations; project install/update keep the project lockfile.
+17. Manual overwrite of a tracked install requires explicit detach; detached replacement creates a new Installation lifecycle.
+18. Operator-only raw record/history/export operations are activity-logged and never available to Access Clients.
+19. Vault grants survive record rename through immutable record identity and never transfer through Caplet ID reuse.
+20. Existing filesystem state migrates only through the explicit verified offline path and remains recoverable from its timestamped backup.
+21. SQLite schema migration is transactional; PostgreSQL deployment examples require the migration job and separate database roles.
+22. The documented external SQLite-to-PostgreSQL recipe is executed and verified against the released schema before publication.
+23. Live Code Mode and Project Binding behavior under node affinity, node loss, and rebind is documented and observable.
+24. Leased maintenance is idempotent across concurrent Host Nodes and safe for external object deletion.

--- a/package.json
+++ b/package.json
@@ -35,13 +35,14 @@
     "release:publish": "pnpm telemetry:prepare-release-env && pnpm release",
     "schema:check": "tsx ./scripts/generate-config-schema.ts --check",
     "schema:generate": "tsx ./scripts/generate-config-schema.ts",
+    "storage:check": "pnpm --filter @caplets/core storage:check",
     "test": "vitest run",
     "telemetry:check-release-env": "tsx ./scripts/check-telemetry-release-env.ts",
     "telemetry:check-source-maps": "tsx ./scripts/check-sentry-source-maps.ts",
     "telemetry:check-web-env": "tsx ./scripts/check-web-observability-env.ts",
     "telemetry:prepare-release-env": "tsx ./scripts/check-telemetry-release-env.ts --write-bundled-intake",
     "typecheck": "tsgo --noEmit && turbo typecheck",
-    "verify": "pnpm format:check && pnpm lint && pnpm code-mode:check-api && pnpm schema:check && pnpm docs:check && pnpm typecheck && pnpm test && pnpm benchmark:check && pnpm build",
+    "verify": "pnpm format:check && pnpm lint && pnpm code-mode:check-api && pnpm schema:check && pnpm storage:check && pnpm docs:check && pnpm typecheck && pnpm test && pnpm benchmark:check && pnpm build",
     "version-packages": "changeset version && oxlint --fix --quiet && oxfmt --write ."
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,8 @@
   },
   "dependencies": {
     "@caplets/core": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "pg": "^8.22.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/packages/core/drizzle.postgres.config.ts
+++ b/packages/core/drizzle.postgres.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./src/storage/schema/postgres.ts",
+  out: "./src/storage/drizzle/postgres",
+});

--- a/packages/core/drizzle.sqlite.config.ts
+++ b/packages/core/drizzle.sqlite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "sqlite",
+  schema: "./src/storage/schema/sqlite.ts",
+  out: "./src/storage/drizzle/sqlite",
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -89,14 +89,17 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "node ./scripts/build-dashboard-for-core.mjs && pnpm run clean && rolldown -c && tsc -p tsconfig.build.json && node ./scripts/copy-dashboard-dist.mjs",
+    "build": "node ./scripts/build-dashboard-for-core.mjs && pnpm run clean && rolldown -c && tsc -p tsconfig.build.json && node ./scripts/copy-dashboard-dist.mjs && node ./scripts/copy-storage-migrations.mjs",
     "build:watch": "pnpm run clean && rolldown -c --watch",
     "prepack": "pnpm build",
     "typecheck": "tsgo --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "storage:check": "drizzle-kit check --config=drizzle.sqlite.config.ts && drizzle-kit check --config=drizzle.postgres.config.ts",
+    "storage:generate": "drizzle-kit generate --config=drizzle.sqlite.config.ts && drizzle-kit generate --config=drizzle.postgres.config.ts && node ./scripts/normalize-storage-migrations.mjs"
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",
+    "@aws-sdk/client-s3": "^3.1089.0",
     "@babel/parser": "^8.0.0",
     "@exodus/bytes": "^1.15.1",
     "@hono/mcp": "^0.3.0",
@@ -106,12 +109,15 @@
     "@ungap/structured-clone": "^1.3.2",
     "add-mcp": "1.13.0",
     "ajv": "^8.20.0",
+    "better-sqlite3": "^12.11.1",
     "commander": "^15.0.0",
+    "drizzle-orm": "^0.45.2",
     "formdata-node": "^6.0.3",
     "graphql": "^17.0.1",
     "headers-polyfill": "^5.0.1",
     "hono": "^4.12.27",
     "jsonc-parser": "^3.3.1",
+    "pg": "^8.22.0",
     "posthog-node": "^5.38.6",
     "quickjs-emscripten": "^0.32.0",
     "semver": "^7.8.5",
@@ -125,10 +131,13 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.18.0",
+    "@types/pg": "^8.20.0",
     "@types/semver": "^7.7.1",
     "@types/ws": "^8.18.1",
     "@typescript/native-preview": "7.0.0-dev.20260628.1",
+    "drizzle-kit": "^0.31.10",
     "rolldown": "^1.1.3",
     "vitest": "^4.1.9"
   },

--- a/packages/core/rolldown.config.ts
+++ b/packages/core/rolldown.config.ts
@@ -17,7 +17,7 @@ export default defineConfig([
       sourcemap: sentryConfigured(),
     },
     plugins: runtimeSentryPlugins("core"),
-    external: ["jsonc-parser", "quickjs-emscripten", "typescript"],
+    external: ["better-sqlite3", "jsonc-parser", "quickjs-emscripten", "typescript"],
     platform: "node",
   },
   {

--- a/packages/core/scripts/copy-storage-migrations.mjs
+++ b/packages/core/scripts/copy-storage-migrations.mjs
@@ -1,0 +1,12 @@
+import { cpSync, mkdirSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = dirname(here);
+const sourceDir = join(packageRoot, "src/storage/drizzle");
+const targetDir = join(packageRoot, "dist/drizzle");
+
+rmSync(targetDir, { recursive: true, force: true });
+mkdirSync(dirname(targetDir), { recursive: true });
+cpSync(sourceDir, targetDir, { recursive: true });

--- a/packages/core/scripts/normalize-storage-migrations.mjs
+++ b/packages/core/scripts/normalize-storage-migrations.mjs
@@ -1,0 +1,14 @@
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(dirname(here), "src/storage/drizzle/postgres");
+
+for (const name of readdirSync(migrationsDir)) {
+  if (!name.endsWith(".sql")) continue;
+  const path = join(migrationsDir, name);
+  const sql = readFileSync(path, "utf8");
+  const normalized = sql.replaceAll('REFERENCES "public".', "REFERENCES ");
+  if (normalized !== sql) writeFileSync(path, normalized);
+}

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -13,10 +13,10 @@ import type {
 } from "@modelcontextprotocol/sdk/shared/auth";
 import {
   isTokenBundleExpired,
-  readTokenBundle,
-  writeTokenBundle,
   type StoredOAuthTokenBundle,
+  type StoredOAuthTokenBundleView,
 } from "./auth/store";
+import type { BackendAuthStateStore } from "./storage/backend-auth";
 import type { CapletServerConfig } from "./config";
 import { CapletsError, redactSecrets } from "./errors";
 
@@ -55,6 +55,7 @@ export type GenericAuthTarget = {
   auth?: OAuthLikeAuthConfig | { type: string } | undefined;
   requestTimeoutMs?: number | undefined;
 };
+type BackendAuthStoreInput = BackendAuthStateStore | string | undefined;
 
 export function staticRemoteHeaders(server: CapletServerConfig): Record<string, string> {
   if (server.auth?.type === "bearer") {
@@ -68,19 +69,21 @@ export function staticRemoteHeaders(server: CapletServerConfig): Record<string, 
 
 export async function oauthHeaders(
   server: CapletServerConfig,
-  authDir?: string,
+  authStoreInput: BackendAuthStoreInput,
 ): Promise<Record<string, string>> {
   if (server.auth?.type !== "oauth2" && server.auth?.type !== "oidc") {
     return {};
   }
-  let bundle = readTokenBundle(server.server, authDir);
-  if (!bundle?.accessToken && !bundle?.refreshToken) {
+  const authStore = requireBackendAuthStore(authStoreInput);
+  const state = await authStore.readTokenBundle(server.server);
+  if (!state || (!state.bundle.accessToken && !state.bundle.refreshToken)) {
     throw new CapletsError("AUTH_REQUIRED", `OAuth credentials required for ${server.server}`, {
       server: server.server,
       authType: server.auth.type,
       nextAction: "run_caplets_auth_login",
     });
   }
+  let bundle = state.bundle;
   if (!bundle.accessToken || isTokenBundleExpired(bundle)) {
     if (!server.url) {
       throw new CapletsError("CONFIG_INVALID", `${server.server} is missing url`);
@@ -102,7 +105,8 @@ export async function oauthHeaders(
         protectedResourceOrigin:
           bundle.protectedResourceOrigin ?? (server.url ? new URL(server.url).origin : undefined),
       },
-      authDir,
+      authStore,
+      state.generation,
     );
   }
   if (!bundle.accessToken || isTokenBundleExpired(bundle)) {
@@ -117,14 +121,15 @@ export async function oauthHeaders(
 
 export async function genericOAuthHeaders(
   target: GenericAuthTarget,
-  authDir?: string,
+  authStoreInput?: BackendAuthStateStore | string,
 ): Promise<Record<string, string>> {
   if (target.auth?.type !== "oauth2" && target.auth?.type !== "oidc") {
     return {};
   }
+  const authStore = requireBackendAuthStore(authStoreInput);
   const authConfig = target.auth as OAuthLikeAuthConfig;
-  let bundle = readTokenBundle(target.server, authDir);
-  if (!bundle?.accessToken && !bundle?.refreshToken) {
+  const state = await authStore.readTokenBundle(target.server);
+  if (!state || (!state.bundle.accessToken && !state.bundle.refreshToken)) {
     throw new CapletsError("AUTH_REQUIRED", `OAuth credentials required for ${target.server}`, {
       server: target.server,
       backend: target.backend,
@@ -132,9 +137,16 @@ export async function genericOAuthHeaders(
       nextAction: "run_caplets_auth_login",
     });
   }
+  let bundle = state.bundle;
   assertTokenBundleMatchesTarget(bundle, target, authConfig);
   if (!bundle.accessToken || isTokenBundleExpired(bundle)) {
-    bundle = await refreshGenericOAuthBundle(target, authConfig, bundle, authDir);
+    bundle = await refreshGenericOAuthBundle(
+      target,
+      authConfig,
+      bundle,
+      authStore,
+      state.generation,
+    );
   }
   if (!bundle.accessToken || isTokenBundleExpired(bundle)) {
     throw new CapletsError("AUTH_REFRESH_FAILED", `OAuth token for ${target.server} is expired`, {
@@ -149,17 +161,18 @@ export async function genericOAuthHeaders(
 
 export async function refreshOAuthTokenBundle(
   target: CapletServerConfig | GenericAuthTarget,
-  authDir?: string,
+  authStoreInput: BackendAuthStoreInput,
 ): Promise<StoredOAuthTokenBundle> {
   if (target.auth?.type !== "oauth2" && target.auth?.type !== "oidc") {
     throw new CapletsError("AUTH_REFRESH_FAILED", `${target.server} is not configured for OAuth`, {
       server: target.server,
     });
   }
+  const authStore = requireBackendAuthStore(authStoreInput);
   const genericTarget = authRefreshTarget(target);
   const authConfig = target.auth as OAuthLikeAuthConfig;
-  const bundle = readTokenBundle(target.server, authDir);
-  if (!bundle?.refreshToken) {
+  const state = await authStore.readTokenBundle(target.server);
+  if (!state?.bundle.refreshToken) {
     throw new CapletsError(
       "AUTH_REFRESH_FAILED",
       `OAuth refresh token required for ${target.server}`,
@@ -171,6 +184,7 @@ export async function refreshOAuthTokenBundle(
       },
     );
   }
+  const bundle = state.bundle;
   const normalized = stripUndefined({
     ...bundle,
     server: target.server,
@@ -181,7 +195,13 @@ export async function refreshOAuthTokenBundle(
       bundle.protectedResourceOrigin ?? protectedResourceOrigin(genericTarget, authConfig),
   }) as StoredOAuthTokenBundle;
   assertTokenBundleMatchesTarget(normalized, genericTarget, authConfig);
-  return refreshGenericOAuthBundle(genericTarget, authConfig, normalized, authDir);
+  return refreshGenericOAuthBundle(
+    genericTarget,
+    authConfig,
+    normalized,
+    authStore,
+    state.generation,
+  );
 }
 
 function authRefreshTarget(target: CapletServerConfig | GenericAuthTarget): GenericAuthTarget {
@@ -200,6 +220,8 @@ function authRefreshTarget(target: CapletServerConfig | GenericAuthTarget): Gene
 export class FileOAuthProvider implements OAuthClientProvider {
   private verifier = base64url(randomBytes(32));
   private readonly stateValue = base64url(randomBytes(24));
+  private bundle: StoredOAuthTokenBundle | undefined;
+  private generation: number | undefined;
   private clientInfo?: OAuthClientInformationMixed;
   readonly clientMetadataUrl?: string;
 
@@ -207,9 +229,15 @@ export class FileOAuthProvider implements OAuthClientProvider {
     readonly server: CapletServerConfig,
     readonly redirectUrl: string,
     private readonly onRedirect: (url: URL) => void,
-    private readonly authDir?: string,
-    private readonly options: { ignoreLegacyDynamicTokens?: boolean } = {},
+    private readonly authStore?: BackendAuthStateStore | string,
+    initialState?: StoredOAuthTokenBundleView,
+    private readonly options: {
+      ignoreLegacyDynamicTokens?: boolean;
+      operatorClientId?: string;
+    } = {},
   ) {
+    this.bundle = initialState?.bundle;
+    this.generation = initialState?.generation;
     if (
       (this.server.auth?.type === "oauth2" || this.server.auth?.type === "oidc") &&
       this.server.auth.clientMetadataUrl
@@ -254,12 +282,11 @@ export class FileOAuthProvider implements OAuthClientProvider {
         ...(this.server.auth.clientSecret ? { client_secret: this.server.auth.clientSecret } : {}),
       };
     }
-    const bundle = readTokenBundle(this.server.server, this.authDir);
-    if (bundle?.clientId) {
+    if (this.bundle?.clientId) {
       return {
         ...this.clientMetadata,
-        client_id: bundle.clientId,
-        ...(bundle.clientSecret ? { client_secret: bundle.clientSecret } : {}),
+        client_id: this.bundle.clientId,
+        ...(this.bundle.clientSecret ? { client_secret: this.bundle.clientSecret } : {}),
       };
     }
     return undefined;
@@ -270,7 +297,7 @@ export class FileOAuthProvider implements OAuthClientProvider {
   }
 
   tokens(): OAuthTokens | undefined {
-    const bundle = readTokenBundle(this.server.server, this.authDir);
+    const bundle = this.bundle;
     if (!bundle) {
       return undefined;
     }
@@ -298,23 +325,27 @@ export class FileOAuthProvider implements OAuthClientProvider {
     );
   }
 
-  saveTokens(tokens: OAuthTokens): void {
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
     const clientInformation = this.clientInformation();
-    writeTokenBundle(
-      stripUndefined({
-        server: this.server.server,
-        accessToken: tokens.access_token,
-        refreshToken: tokens.refresh_token,
-        tokenType: tokens.token_type,
-        expiresAt: tokens.expires_in
-          ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
-          : undefined,
-        scope: tokens.scope,
-        clientId: clientInformation?.client_id,
-        clientSecret: clientInformation?.client_secret,
-      }),
-      this.authDir,
-    );
+    const bundle = stripUndefined({
+      server: this.server.server,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      tokenType: tokens.token_type,
+      expiresAt: tokens.expires_in
+        ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+        : undefined,
+      scope: tokens.scope,
+      clientId: clientInformation?.client_id,
+      clientSecret: clientInformation?.client_secret,
+    });
+    const authStore = requireBackendAuthStore(this.authStore);
+    const persisted = await authStore.writeTokenBundle(bundle, {
+      expectedGeneration: this.generation,
+      ...(this.options.operatorClientId ? { operatorClientId: this.options.operatorClientId } : {}),
+    });
+    this.bundle = persisted.bundle;
+    this.generation = persisted.generation;
   }
 
   redirectToAuthorization(authorizationUrl: URL): void {
@@ -353,7 +384,13 @@ export type StartedOAuthFlow = {
 
 export async function startOAuthFlow(
   server: CapletServerConfig,
-  options: { redirectUri: string; authDir?: string; print?: (line: string) => void },
+  options: {
+    redirectUri: string;
+    authStore?: BackendAuthStateStore;
+    authDir?: string;
+    operatorClientId?: string;
+    print?: (line: string) => void;
+  },
 ): Promise<StartedOAuthFlow> {
   if (
     server.transport === "stdio" ||
@@ -366,6 +403,8 @@ export async function startOAuthFlow(
     );
   }
 
+  const authStore = requireBackendAuthStore(options.authStore);
+  const initialState = await authStore.readTokenBundle(server.server);
   let redirectUrl: URL | undefined;
   const provider = new FileOAuthProvider(
     server,
@@ -374,8 +413,12 @@ export async function startOAuthFlow(
       redirectUrl = url;
       options.print?.(`Open this URL to authorize ${server.server}:\n${url.toString()}`);
     },
-    options.authDir,
-    { ignoreLegacyDynamicTokens: true },
+    authStore,
+    initialState,
+    {
+      ignoreLegacyDynamicTokens: true,
+      ...(options.operatorClientId ? { operatorClientId: options.operatorClientId } : {}),
+    },
   );
   const scope = scopesFor(server.auth);
   try {
@@ -417,13 +460,16 @@ export async function runOAuthFlow(
   server: CapletServerConfig,
   options: {
     noOpen?: boolean;
+    authStore?: BackendAuthStateStore;
     authDir?: string;
+    operatorClientId?: string;
     manualInput?: string;
     readManualInput?: () => Promise<string | undefined>;
     open?: (url: string) => Promise<void>;
     print?: (line: string) => void;
-  } = {},
+  },
 ): Promise<AuthResult> {
+  const authStore = requireBackendAuthStore(options.authStore);
   let callbackCode: string | undefined;
   let callbackState: string | undefined;
   const callback = await createLoopbackCallback((url) => {
@@ -441,7 +487,8 @@ export async function runOAuthFlow(
   try {
     const started = await startOAuthFlow(server, {
       redirectUri: callback.redirectUri,
-      ...(options.authDir ? { authDir: options.authDir } : {}),
+      authStore,
+      ...(options.operatorClientId ? { operatorClientId: options.operatorClientId } : {}),
       ...(options.print ? { print: options.print } : {}),
     });
     if (!started.authorizationUrl) {
@@ -531,12 +578,20 @@ type AuthorizationServerMetadata = {
 
 export async function startGenericOAuthFlow(
   target: GenericAuthTarget,
-  options: { redirectUri: string; authDir?: string; print?: (line: string) => void },
+  options: {
+    redirectUri: string;
+    authStore?: BackendAuthStateStore;
+    authDir?: string;
+    operatorClientId?: string;
+    print?: (line: string) => void;
+  },
 ): Promise<StartedOAuthFlow> {
   if (target.auth?.type !== "oauth2" && target.auth?.type !== "oidc") {
     throw new CapletsError("REQUEST_INVALID", `${target.server} is not configured for OAuth`);
   }
+  const authStore = requireBackendAuthStore(options.authStore);
   const authConfig = target.auth as OAuthLikeAuthConfig;
+  const initialState = await authStore.readTokenBundle(target.server);
   const redirectUri = authConfig.redirectUri ?? options.redirectUri;
   const verifier = base64url(randomBytes(32));
   const state = base64url(randomBytes(24));
@@ -601,7 +656,7 @@ export async function startGenericOAuthFlow(
       const idToken = asString(tokenResponse.id_token);
       const idClaims = parseJwtPayload(idToken);
       validateOidcToken(authConfig, metadata, idToken, idClaims, client.clientId);
-      writeTokenBundle(
+      await authStore.writeTokenBundle(
         stripUndefined({
           server: target.server,
           authType: authConfig.type,
@@ -626,7 +681,10 @@ export async function startGenericOAuthFlow(
             dynamicClient: client.dynamic ? { client_id: client.clientId } : undefined,
           }) as Record<string, unknown>,
         }),
-        options.authDir,
+        {
+          expectedGeneration: initialState?.generation,
+          ...(options.operatorClientId ? { operatorClientId: options.operatorClientId } : {}),
+        },
       );
     },
   };
@@ -636,17 +694,21 @@ export async function runGenericOAuthFlow(
   target: GenericAuthTarget,
   options: {
     noOpen?: boolean;
+    authStore?: BackendAuthStateStore;
     authDir?: string;
+    operatorClientId?: string;
     manualInput?: string;
     readManualInput?: () => Promise<string | undefined>;
     open?: (url: string) => Promise<void>;
     print?: (line: string) => void;
-  } = {},
+  },
 ): Promise<StoredOAuthTokenBundle> {
   if (target.auth?.type !== "oauth2" && target.auth?.type !== "oidc") {
     throw new CapletsError("REQUEST_INVALID", `${target.server} is not configured for OAuth`);
   }
+  const authStore = requireBackendAuthStore(options.authStore);
   const authConfig = target.auth as OAuthLikeAuthConfig;
+  const initialState = await authStore.readTokenBundle(target.server);
   let callbackCode: string | undefined;
   let callbackState: string | undefined;
   const callback = await createLoopbackCallback((url) => {
@@ -761,7 +823,10 @@ export async function runGenericOAuthFlow(
         dynamicClient: client.dynamic ? { client_id: client.clientId } : undefined,
       }) as Record<string, unknown>,
     });
-    writeTokenBundle(bundle, options.authDir);
+    await authStore.writeTokenBundle(bundle, {
+      expectedGeneration: initialState?.generation,
+      ...(options.operatorClientId ? { operatorClientId: options.operatorClientId } : {}),
+    });
     return bundle;
   } finally {
     await callback.close();
@@ -1009,11 +1074,20 @@ async function resolveGenericClient(
   };
 }
 
+function requireBackendAuthStore(input: BackendAuthStoreInput): BackendAuthStateStore {
+  if (input && typeof input !== "string") return input;
+  throw new CapletsError(
+    "REQUEST_INVALID",
+    "Backend OAuth state requires Authoritative Host State storage.",
+  );
+}
+
 async function refreshGenericOAuthBundle(
   target: GenericAuthTarget,
   authConfig: OAuthLikeAuthConfig,
   bundle: StoredOAuthTokenBundle,
-  authDir?: string,
+  authStore: BackendAuthStateStore,
+  expectedGeneration: number,
 ): Promise<StoredOAuthTokenBundle> {
   if (!bundle.refreshToken) {
     throw new CapletsError("AUTH_REFRESH_FAILED", `OAuth token for ${target.server} is expired`, {
@@ -1110,7 +1184,7 @@ async function refreshGenericOAuthBundle(
     clientSecret,
     protectedResourceOrigin: protectedResourceOrigin(target, authConfig),
   });
-  writeTokenBundle(refreshed, authDir);
+  await authStore.writeTokenBundle(refreshed, { expectedGeneration });
   return refreshed;
 }
 

--- a/packages/core/src/auth/store.ts
+++ b/packages/core/src/auth/store.ts
@@ -29,6 +29,41 @@ export type StoredOAuthTokenBundle = {
   metadata?: Record<string, unknown>;
 };
 
+export type StoredOAuthTokenBundleView = {
+  bundle: StoredOAuthTokenBundle;
+  generation: number;
+};
+
+export function isStoredOAuthTokenBundle(value: unknown): value is StoredOAuthTokenBundle {
+  if (!isRecord(value)) return false;
+  if (typeof value.server !== "string" || !value.server) return false;
+  if (typeof value.accessToken !== "string") return false;
+  if (value.authType !== undefined && value.authType !== "oauth2" && value.authType !== "oidc") {
+    return false;
+  }
+  for (const field of optionalTokenBundleStringFields) {
+    if (value[field] !== undefined && typeof value[field] !== "string") return false;
+  }
+  return value.metadata === undefined || isRecord(value.metadata);
+}
+
+const optionalTokenBundleStringFields = [
+  "refreshToken",
+  "tokenType",
+  "expiresAt",
+  "scope",
+  "idToken",
+  "issuer",
+  "subject",
+  "clientId",
+  "clientSecret",
+  "protectedResourceOrigin",
+] as const satisfies ReadonlyArray<keyof StoredOAuthTokenBundle>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function authStorePath(server: string, authDir = DEFAULT_AUTH_DIR): string {
   if (!server || server.includes("/") || server.includes("\\") || server.includes("..")) {
     throw new CapletsError("REQUEST_INVALID", `Invalid auth store server name ${server}`);
@@ -67,6 +102,44 @@ export function listTokenBundles(authDir?: string): StoredOAuthTokenBundle[] {
     .map((entry) => readTokenBundle(entry.name.slice(0, -".json".length), dir))
     .filter((bundle): bundle is StoredOAuthTokenBundle => Boolean(bundle))
     .sort((left, right) => left.server.localeCompare(right.server));
+}
+
+export type LegacyOAuthTokenBundleSnapshot = {
+  bundles: StoredOAuthTokenBundle[];
+  sourcePaths: string[];
+};
+
+/**
+ * Strict migration reader. Unlike the runtime compatibility reader, this fails
+ * the whole snapshot when any legacy token file is malformed.
+ */
+export function readLegacyOAuthTokenBundleSnapshot(
+  authDir: string,
+): LegacyOAuthTokenBundleSnapshot {
+  if (!existsSync(authDir)) return { bundles: [], sourcePaths: [] };
+  const bundles: StoredOAuthTokenBundle[] = [];
+  const sourcePaths: string[] = [];
+  for (const entry of readdirSync(authDir, { withFileTypes: true })
+    .filter((candidate) => candidate.name.endsWith(".json"))
+    .sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isFile()) {
+      throw new CapletsError("CONFIG_INVALID", "A legacy OAuth token artifact is not a file.");
+    }
+    const server = entry.name.slice(0, -".json".length);
+    const path = authStorePath(server, authDir);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    } catch {
+      throw new CapletsError("CONFIG_INVALID", `Legacy OAuth token bundle ${server} is invalid.`);
+    }
+    if (!isStoredOAuthTokenBundle(parsed) || parsed.server !== server) {
+      throw new CapletsError("CONFIG_INVALID", `Legacy OAuth token bundle ${server} is invalid.`);
+    }
+    bundles.push(parsed);
+    sourcePaths.push(path);
+  }
+  return { bundles, sourcePaths };
 }
 
 export function deleteTokenBundle(server: string, authDir?: string): boolean {

--- a/packages/core/src/caplet-files-bundle.ts
+++ b/packages/core/src/caplet-files-bundle.ts
@@ -925,7 +925,7 @@ export const capletFileSchema = z
     }
   });
 
-type CapletFileFrontmatter = z.infer<typeof capletFileSchema>;
+export type CapletFileFrontmatter = z.infer<typeof capletFileSchema>;
 
 function pluralBackendChildIds(
   frontmatter: CapletFileFrontmatter,
@@ -1230,12 +1230,12 @@ function discoverCapletFileMapCandidates(paths: string[]): Array<{ id: string; p
   });
 }
 
-export function readCapletFileContent(
-  path: string,
-  text: string,
-  baseDir: string,
-  normalizePath: (value: string | undefined, baseDir: string) => string | undefined,
-): unknown {
+export type ParsedCapletFileDocument = {
+  frontmatter: CapletFileFrontmatter;
+  body: string;
+};
+
+export function parseCapletFileDocument(path: string, text: string): ParsedCapletFileDocument {
   if (byteLength(text) > MAX_CAPLET_FILE_BYTES) {
     throw new CapletsError(
       "CONFIG_INVALID",
@@ -1257,8 +1257,18 @@ export function readCapletFileContent(
       parsed.error.issues,
     );
   }
+  return { frontmatter: parsed.data, body };
+}
 
-  return capletToServerConfig(parsed.data, baseDir, normalizePath);
+export function readCapletFileContent(
+  path: string,
+  text: string,
+  baseDir: string,
+  normalizePath: (value: string | undefined, baseDir: string) => string | undefined,
+): unknown {
+  const { frontmatter } = parseCapletFileDocument(path, text);
+
+  return capletToServerConfig(frontmatter, baseDir, normalizePath);
 }
 
 function capletToServerConfig(

--- a/packages/core/src/caplet-files.ts
+++ b/packages/core/src/caplet-files.ts
@@ -1,13 +1,20 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, dirname, extname, isAbsolute, join } from "node:path";
 import { CapletsError } from "./errors";
-export { capletFileSchema, capletJsonSchema, loadCapletFilesFromMap } from "./caplet-files-bundle";
+export {
+  capletFileSchema,
+  capletJsonSchema,
+  loadCapletFilesFromMap,
+  parseCapletFileDocument,
+} from "./caplet-files-bundle";
 export type {
   BestEffortCapletFileLoadResult,
   CapletFileConfig,
   CapletFileLoadResult,
   CapletFileMapInput,
   CapletFileWarning,
+  CapletFileFrontmatter,
+  ParsedCapletFileDocument,
 } from "./caplet-files-bundle";
 import {
   buildCapletFileLoadResultFromEntries,

--- a/packages/core/src/caplet-sets.ts
+++ b/packages/core/src/caplet-sets.ts
@@ -27,6 +27,7 @@ import { OpenApiManager } from "./openapi";
 import { capabilityDescription, ServerRegistry } from "./registry";
 import { generatedToolInputJsonSchema } from "./generated-tool-input-schema";
 import { searchToolList } from "./tool-search";
+import type { BackendAuthStateStore } from "./storage/backend-auth";
 import { handleServerTool } from "./tools";
 
 type ChildRuntime = {
@@ -47,6 +48,7 @@ export class CapletSetManager {
     private registry: ServerRegistry,
     private readonly options: {
       authDir?: string;
+      backendAuth?: BackendAuthStateStore;
       artifactDir?: string;
       exposeLocalArtifactPaths?: boolean;
       mediaInlineThresholdBytes?: number;
@@ -219,6 +221,7 @@ export class CapletSetManager {
       const registry = new ServerRegistry(childConfig);
       const sharedOptions = {
         ...(this.options.authDir ? { authDir: this.options.authDir } : {}),
+        ...(this.options.backendAuth ? { backendAuth: this.options.backendAuth } : {}),
         ...(this.options.artifactDir ? { artifactDir: this.options.artifactDir } : {}),
         ...(this.options.exposeLocalArtifactPaths === false
           ? { exposeLocalArtifactPaths: false }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -2,7 +2,7 @@ import { Command, CommanderError, Option } from "commander";
 import { Buffer } from "node:buffer";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { arch, platform } from "node:os";
-import { dirname, isAbsolute, join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { Writable } from "node:stream";
 import { version as packageJsonVersion } from "../package.json";
@@ -59,9 +59,9 @@ import {
   indexInstalledCapletsFromLockfile,
   restoreCapletsFromLockfile,
   updateCapletsFromLockfile,
-} from "./cli/install";
+} from "./install";
 import type { CatalogIndexingResult } from "./catalog-indexing/payload";
-import { readCapletsLockfile } from "./cli/lockfile";
+import { readCapletsLockfile } from "./lockfile";
 import {
   formatSetupMenu,
   runInteractiveSetup,
@@ -79,11 +79,12 @@ import {
   type LocalOverlayConfigWithSources,
   defaultUpdateCheckCacheDir,
   defaultUpdateCheckStateDir,
-  defaultCapletsLockfilePath,
   formatVaultRecoveryCommand,
   loadGlobalServeDefaults,
   loadConfigWithSources,
+  loadConfigWithHostStorage,
   loadLocalOverlayConfigWithSources,
+  loadHostStorageConfig,
   resolveCapletsRoot,
   resolveConfigPath,
   resolveProjectCapletsRoot,
@@ -99,13 +100,12 @@ import { attachProjectOnce } from "./project-binding/attach";
 import { ProjectBindingError } from "./project-binding/errors";
 import type { ProjectBindingWebSocketFactory } from "./project-binding/transport";
 import { RemoteControlClient } from "./remote-control/client";
-import type { RemoteCliCommand } from "./remote-control/types";
+import type { RemoteCapletBundleFile, RemoteCliCommand } from "./remote-control/types";
 import {
   cloudCredentialsFromRemoteProfile,
   createRemoteProfileStore,
   type FileRemoteProfileStore,
 } from "./remote/profile-store";
-import { RemoteServerCredentialStore } from "./remote/server-credential-store";
 import type { RemoteClientRole } from "./remote/server-credentials";
 import { resolveRemoteSelection } from "./remote/selection";
 import {
@@ -131,7 +131,7 @@ import {
   type DaemonOperationOptions,
 } from "./daemon";
 import { resolveServeOptions, serveResolvedCaplets, type ServeOptions } from "./serve";
-import { DEFAULT_AUTH_DIR, defaultTelemetryStateDir } from "./config/paths";
+import { defaultTelemetryStateDir } from "./config/paths";
 import { appendBasePath } from "./server/options";
 import {
   acknowledgeTelemetryAttributionClaim,
@@ -157,11 +157,35 @@ import {
   writeTelemetryAttribution,
 } from "./telemetry";
 import { maybePrintUpdateNotice } from "./update-check";
-import { FileVaultStore, VAULT_MAX_VALUE_BYTES, validateVaultKeyName } from "./vault";
-import type { VaultAccessGrantFilter } from "./vault";
+import {
+  VAULT_MAX_VALUE_BYTES,
+  validateVaultKeyName,
+  type VaultDeleteStatus,
+  type VaultValueStatus,
+} from "./vault";
+import {
+  createHostStorage,
+  createHostStorageVaultResolver,
+  migrateHostStorage,
+  migrateLegacyHostState,
+  type BackendAuthStateStore,
+  type HostStorage,
+  type RemoteSecurityStore,
+  type StoredVaultGrant,
+} from "./storage";
+import {
+  materializeCapletBundleFiles,
+  type CapletBundleInputFile,
+  type CapletRecordView,
+} from "./storage/caplet-records";
+import {
+  installSqlCatalogCaplets,
+  readCapletBundleFiles,
+  updateSqlCatalogCaplets,
+} from "./storage/catalog-lifecycle";
 
 export { initConfig, starterConfig } from "./cli/init";
-export { installCaplets, normalizeGitRepo } from "./cli/install";
+export { installCaplets, normalizeGitRepo } from "./install";
 export {
   addCliCaplet,
   addGoogleDiscoveryCaplet,
@@ -750,14 +774,45 @@ function hiddenOption(flags: string, description: string): Option {
   return new Option(flags, description).hideHelp();
 }
 
-function remoteServerCredentialStore(
+async function useRemoteSecurityStore<T>(
   statePath: string | undefined,
-  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
-): RemoteServerCredentialStore {
-  return new RemoteServerCredentialStore({
-    dir:
-      statePath ?? env.CAPLETS_REMOTE_SERVER_STATE_DIR ?? join(DEFAULT_AUTH_DIR, "remote-server"),
-  });
+  configPath: string | undefined,
+  run: (store: RemoteSecurityStore) => Promise<T>,
+): Promise<T> {
+  if (statePath !== undefined) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "--state-path no longer selects server credential state; configure Authoritative Host State storage instead.",
+    );
+  }
+  const storage = await createHostStorage(loadHostStorageConfig(configPath));
+  try {
+    return await run(storage.remoteSecurity);
+  } finally {
+    await storage.close();
+  }
+}
+async function useBackendAuthStore<T>(
+  configPath: string | undefined,
+  run: (store: BackendAuthStateStore) => Promise<T>,
+): Promise<T> {
+  const storage = await createHostStorage(loadHostStorageConfig(configPath));
+  try {
+    return await run(storage.backendAuth);
+  } finally {
+    await storage.close();
+  }
+}
+async function useConfiguredHostStorage<T>(
+  configPath: string | undefined,
+  run: (storage: HostStorage) => Promise<T>,
+): Promise<T> {
+  const storage = await createHostStorage(loadHostStorageConfig(configPath));
+  try {
+    return await run(storage);
+  } finally {
+    await storage.close();
+  }
 }
 
 function compactCloudCaplet(value: unknown): Record<string, unknown> {
@@ -2245,10 +2300,14 @@ export function createProgram(io: CliIO = {}): Command {
   remoteHost
     .command("clients")
     .description("List paired self-hosted remote clients from server state.")
-    .option("--state-path <path>", "server-owned remote credential state directory")
+    .option("--state-path <path>", "deprecated; Authoritative Host State uses SQL storage")
     .option("--json", "print JSON output")
-    .action((options: { statePath?: string; json?: boolean }) => {
-      const clients = remoteServerCredentialStore(options.statePath, env).listClients();
+    .action(async (options: { statePath?: string; json?: boolean }) => {
+      const clients = await useRemoteSecurityStore(
+        options.statePath,
+        currentConfigPath(),
+        async (store) => await store.listClients(),
+      );
       if (options.json) {
         writeOut(`${JSON.stringify({ clients }, null, 2)}\n`);
         return;
@@ -2266,10 +2325,14 @@ export function createProgram(io: CliIO = {}): Command {
   remoteHost
     .command("logins")
     .description("List pending self-hosted Remote Login approvals from server state.")
-    .option("--state-path <path>", "server-owned remote credential state directory")
+    .option("--state-path <path>", "deprecated; Authoritative Host State uses SQL storage")
     .option("--json", "print JSON output")
-    .action((options: { statePath?: string; json?: boolean }) => {
-      const pendingLogins = remoteServerCredentialStore(options.statePath, env).listPendingLogins();
+    .action(async (options: { statePath?: string; json?: boolean }) => {
+      const pendingLogins = await useRemoteSecurityStore(
+        options.statePath,
+        currentConfigPath(),
+        async (store) => await store.listPendingLogins(),
+      );
       if (options.json) {
         writeOut(`${JSON.stringify({ pendingLogins }, null, 2)}\n`);
         return;
@@ -2288,22 +2351,28 @@ export function createProgram(io: CliIO = {}): Command {
     .command("approve")
     .description("Approve one pending self-hosted Remote Login code from server state.")
     .argument("<code>", "operator-visible Remote Login code")
-    .option("--state-path <path>", "server-owned remote credential state directory")
+    .option("--state-path <path>", "deprecated; Authoritative Host State uses SQL storage")
     .option("--role <role>", "grant role override: access or operator", parseRemoteClientRole)
     .option("--yes", "approve without an interactive confirmation prompt")
     .option("--json", "print JSON output")
     .action(
-      (
+      async (
         code: string,
         options: { statePath?: string; role?: RemoteClientRole; yes?: boolean; json?: boolean },
       ) => {
         if (!options.yes && !options.json) {
           throw new CapletsError("REQUEST_INVALID", "Use --yes to approve this pending login.");
         }
-        const approved = remoteServerCredentialStore(options.statePath, env).approvePendingLogin({
-          operatorCode: code,
-          ...(options.role ? { grantedRole: options.role } : {}),
-        });
+        const approved = await useRemoteSecurityStore(
+          options.statePath,
+          currentConfigPath(),
+          async (store) =>
+            await store.approvePendingLogin({
+              operatorClientId: "local_cli",
+              operatorCode: code,
+              ...(options.role ? { grantedRole: options.role } : {}),
+            }),
+        );
         if (options.json) {
           writeOut(`${JSON.stringify(approved, null, 2)}\n`);
           return;
@@ -2315,12 +2384,18 @@ export function createProgram(io: CliIO = {}): Command {
     .command("deny")
     .description("Deny one pending self-hosted Remote Login code from server state.")
     .argument("<code>", "operator-visible Remote Login code")
-    .option("--state-path <path>", "server-owned remote credential state directory")
+    .option("--state-path <path>", "deprecated; Authoritative Host State uses SQL storage")
     .option("--json", "print JSON output")
-    .action((code: string, options: { statePath?: string; json?: boolean }) => {
-      const denied = remoteServerCredentialStore(options.statePath, env).denyPendingLogin({
-        operatorCode: code,
-      });
+    .action(async (code: string, options: { statePath?: string; json?: boolean }) => {
+      const denied = await useRemoteSecurityStore(
+        options.statePath,
+        currentConfigPath(),
+        async (store) =>
+          await store.denyPendingLogin({
+            operatorClientId: "local_cli",
+            operatorCode: code,
+          }),
+      );
       if (options.json) {
         writeOut(`${JSON.stringify(denied, null, 2)}\n`);
         return;
@@ -2331,10 +2406,14 @@ export function createProgram(io: CliIO = {}): Command {
     .command("revoke")
     .description("Revoke one paired self-hosted remote client from server state.")
     .argument("<client-id>", "remote client ID")
-    .option("--state-path <path>", "server-owned remote credential state directory")
+    .option("--state-path <path>", "deprecated; Authoritative Host State uses SQL storage")
     .option("--json", "print JSON output")
-    .action((clientId: string, options: { statePath?: string; json?: boolean }) => {
-      const revoked = remoteServerCredentialStore(options.statePath, env).revokeClient(clientId);
+    .action(async (clientId: string, options: { statePath?: string; json?: boolean }) => {
+      const revoked = await useRemoteSecurityStore(
+        options.statePath,
+        currentConfigPath(),
+        async (store) => await store.revokeClient({ operatorClientId: "local_cli", clientId }),
+      );
       if (options.json) {
         writeOut(`${JSON.stringify({ revoked, clientId }, null, 2)}\n`);
         return;
@@ -2716,38 +2795,47 @@ export function createProgram(io: CliIO = {}): Command {
           return;
         }
         const value = await readVaultValue(io);
-        const store = new FileVaultStore({ env });
-        const existed = store.getStatus(name).present;
-        const previousValue = existed && options.grant ? store.resolveValue(name) : undefined;
-        const status = store.set(name, value, { force: Boolean(options.force) });
-        try {
+        await useConfiguredHostStorage(currentConfigPath(), async (storage) => {
+          const existed = (await storage.vaultValues.getStatus(name)).present;
+          const previousValue =
+            existed && options.grant ? await storage.vaultValues.resolveValue(name) : undefined;
+          const status = await storage.vaultValues.set(name, value, {
+            force: Boolean(options.force),
+            operatorClientId: "local_cli",
+          });
+          try {
+            if (options.grant) {
+              await storage.vaultGrants.grant({
+                capletId: options.grant,
+                vaultKey: name,
+                referenceName: options.as ?? name,
+                originKind: "stored-record",
+                operator: { role: "operator", clientId: "local_cli" },
+              });
+            }
+          } catch (error) {
+            if (existed && previousValue !== undefined) {
+              await storage.vaultValues.set(name, previousValue, {
+                force: true,
+                operatorClientId: "local_cli",
+              });
+            } else {
+              await storage.vaultValues.delete(name, { operatorClientId: "local_cli" });
+            }
+            throw error;
+          }
+          await storage.invalidateConfig("local_cli");
+          if (options.json) {
+            writeOut(`${JSON.stringify(status, null, 2)}\n`);
+            return;
+          }
+          writeOut(`Set Vault key ${validateVaultKeyName(name)}.\n`);
           if (options.grant) {
-            const origin = resolveVaultAccessOrigin(options.grant, io);
-            store.grantAccess({
-              storedKey: name,
-              referenceName: options.as ?? name,
-              capletId: options.grant,
-              origin,
-            });
+            writeOut(
+              `Granted Vault key ${validateVaultKeyName(name)} to ${options.grant} as ${validateVaultKeyName(options.as ?? name)}.\n`,
+            );
           }
-        } catch (error) {
-          if (existed && previousValue !== undefined) {
-            store.set(name, previousValue, { force: true });
-          } else {
-            store.delete(name);
-          }
-          throw error;
-        }
-        if (options.json) {
-          writeOut(`${JSON.stringify(status, null, 2)}\n`);
-          return;
-        }
-        writeOut(`Set Vault key ${validateVaultKeyName(name)}.\n`);
-        if (options.grant) {
-          writeOut(
-            `Granted Vault key ${validateVaultKeyName(name)} to ${options.grant} as ${validateVaultKeyName(options.as ?? name)}.\n`,
-          );
-        }
+        });
       },
     );
 
@@ -2772,23 +2860,24 @@ export function createProgram(io: CliIO = {}): Command {
             writeOut(options.json ? `${JSON.stringify(result, null, 2)}\n` : `${value}\n`);
             return;
           }
+          writeOut(formatVaultValueStatus(result as VaultValueStatus, Boolean(options.json)));
+          return;
+        }
+        await useConfiguredHostStorage(currentConfigPath(), async (storage) => {
+          if (options.show) {
+            const value = await storage.vaultValues.resolveValue(name);
+            writeOut(
+              options.json ? `${JSON.stringify({ key: name, value }, null, 2)}\n` : `${value}\n`,
+            );
+            return;
+          }
           writeOut(
             formatVaultValueStatus(
-              result as ReturnType<FileVaultStore["getStatus"]>,
+              await storage.vaultValues.getStatus(name),
               Boolean(options.json),
             ),
           );
-          return;
-        }
-        const store = new FileVaultStore({ env });
-        if (options.show) {
-          const value = store.resolveValue(name);
-          writeOut(
-            options.json ? `${JSON.stringify({ key: name, value }, null, 2)}\n` : `${value}\n`,
-          );
-          return;
-        }
-        writeOut(formatVaultValueStatus(store.getStatus(name), Boolean(options.json)));
+        });
       },
     );
 
@@ -2802,17 +2891,14 @@ export function createProgram(io: CliIO = {}): Command {
       const target = parseVaultTarget(options);
       if (target === "remote") {
         const result = await remoteVaultList(io);
-        writeOut(
-          formatVaultValueList(
-            result as ReturnType<FileVaultStore["listValues"]>,
-            Boolean(options.json),
-          ),
-        );
+        writeOut(formatVaultValueList(result as VaultValueStatus[], Boolean(options.json)));
         return;
       }
-      writeOut(
-        formatVaultValueList(new FileVaultStore({ env }).listValues(), Boolean(options.json)),
-      );
+      await useConfiguredHostStorage(currentConfigPath(), async (storage) => {
+        writeOut(
+          formatVaultValueList(await storage.vaultValues.listValues(), Boolean(options.json)),
+        );
+      });
     });
 
   vault
@@ -2826,17 +2912,24 @@ export function createProgram(io: CliIO = {}): Command {
       const target = parseVaultTarget(options);
       if (target === "remote") {
         const result = await remoteVaultDelete(io, name);
+        writeOut(formatVaultDeleteStatus(result as VaultDeleteStatus, Boolean(options.json)));
+        return;
+      }
+      await useConfiguredHostStorage(currentConfigPath(), async (storage) => {
+        const grantsRetained = (await storage.vaultGrants.list()).filter(
+          (grant) => grant.vaultKey === validateVaultKeyName(name),
+        ).length;
+        const result = await storage.vaultValues.delete(name, {
+          operatorClientId: "local_cli",
+        });
+        if (result.deleted) await storage.invalidateConfig("local_cli");
         writeOut(
           formatVaultDeleteStatus(
-            result as ReturnType<FileVaultStore["delete"]>,
+            { key: result.key, deleted: result.deleted, grantsRetained },
             Boolean(options.json),
           ),
         );
-        return;
-      }
-      writeOut(
-        formatVaultDeleteStatus(new FileVaultStore({ env }).delete(name), Boolean(options.json)),
-      );
+      });
     });
 
   const vaultAccess = vault.command("access").description("Manage Vault access grants.");
@@ -2865,20 +2958,34 @@ export function createProgram(io: CliIO = {}): Command {
           });
           writeOut(
             formatVaultAccessGrant(
-              grant as ReturnType<FileVaultStore["grantAccess"]>,
+              grant as Parameters<typeof formatVaultAccessGrant>[0],
               Boolean(options.json),
             ),
           );
           return;
         }
-        const origin = resolveVaultAccessOrigin(capletId, io);
-        const grant = new FileVaultStore({ env }).grantAccess({
-          storedKey: name,
-          referenceName: options.as ?? name,
-          capletId,
-          origin,
+        await useConfiguredHostStorage(currentConfigPath(), async (storage) => {
+          await storage.vaultGrants.grant({
+            capletId,
+            vaultKey: name,
+            referenceName: options.as ?? name,
+            originKind: "stored-record",
+            operator: { role: "operator", clientId: "local_cli" },
+          });
+          const grant = (await storage.vaultGrants.list(capletId)).find(
+            (candidate) =>
+              candidate.vaultKey === validateVaultKeyName(name) &&
+              candidate.referenceName === validateVaultKeyName(options.as ?? name),
+          );
+          if (!grant) {
+            throw new CapletsError(
+              "INTERNAL_ERROR",
+              "Stored Vault access grant could not be reloaded.",
+            );
+          }
+          await storage.invalidateConfig("local_cli");
+          writeOut(formatVaultAccessGrant(storedVaultGrantForCli(grant), Boolean(options.json)));
         });
-        writeOut(formatVaultAccessGrant(grant, Boolean(options.json)));
       },
     );
 
@@ -2912,18 +3019,20 @@ export function createProgram(io: CliIO = {}): Command {
           });
           writeOut(
             formatVaultAccessList(
-              grants as ReturnType<FileVaultStore["listAccess"]>,
+              grants as Parameters<typeof formatVaultAccessList>[0],
               Boolean(options.json),
             ),
           );
           return;
         }
-        writeOut(
-          formatVaultAccessList(
-            new FileVaultStore({ env }).listAccess(vaultAccessFilter(name, capletFilter)),
-            Boolean(options.json),
-          ),
-        );
+        await useConfiguredHostStorage(currentConfigPath(), async (storage) => {
+          const grants = (await storage.vaultGrants.list(capletFilter)).filter(
+            (grant) => name === undefined || grant.vaultKey === validateVaultKeyName(name),
+          );
+          writeOut(
+            formatVaultAccessList(grants.map(storedVaultGrantForCli), Boolean(options.json)),
+          );
+        });
       },
     );
 
@@ -2957,9 +3066,28 @@ export function createProgram(io: CliIO = {}): Command {
           );
           return;
         }
-        const filter = vaultAccessFilter(name, capletId, options.as);
-        const revoked = new FileVaultStore({ env }).revokeAccess(filter);
-        writeOut(formatVaultAccessRevoke(revoked.length, Boolean(options.json)));
+        await useConfiguredHostStorage(currentConfigPath(), async (storage) => {
+          const candidates = (await storage.vaultGrants.list(capletId)).filter(
+            (grant) =>
+              grant.vaultKey === validateVaultKeyName(name) &&
+              (options.as === undefined || grant.referenceName === options.as),
+          );
+          let revoked = 0;
+          for (const grant of candidates) {
+            if (
+              await storage.vaultGrants.revoke({
+                capletId,
+                vaultKey: grant.vaultKey,
+                referenceName: grant.referenceName,
+                operator: { role: "operator", clientId: "local_cli" },
+              })
+            ) {
+              revoked += 1;
+            }
+          }
+          if (revoked > 0) await storage.invalidateConfig("local_cli");
+          writeOut(formatVaultAccessRevoke(revoked, Boolean(options.json)));
+        });
       },
     );
 
@@ -2969,33 +3097,83 @@ export function createProgram(io: CliIO = {}): Command {
     .option("--all", "include disabled Caplets")
     .option("--json", "print JSON output")
     .option("--format <format>", "output format: plain, markdown, md, or json", parseOutputFormat)
-    .action(async (options: { all?: boolean; json?: boolean; format?: CliOutputFormat }) => {
-      const includeDisabled = Boolean(options.all);
-      const remote = remoteClientForCli(io);
-      if (remote) {
-        const remoteRows = (await remote.request("list", { includeDisabled })) as CapletListRow[];
-        const localOverlay = tryLoadLocalOverlayForCli(io, writeErr);
-        const rows = mergeRemoteAndLocalRows(remoteRows, localOverlay, {
-          includeDisabled,
-          writeErr,
-        });
-        if (options.json || options.format === "json") {
-          writeOut(`${JSON.stringify(rows, null, 2)}\n`);
+    .option("--stored", "show the Operator-only stored SQL view, including hidden records")
+    .action(
+      async (options: {
+        all?: boolean;
+        json?: boolean;
+        format?: CliOutputFormat;
+        stored?: boolean;
+      }) => {
+        const includeDisabled = Boolean(options.all);
+        const remote = remoteClientForCli(io);
+        if (options.stored) {
+          if (remote) {
+            throw new CapletsError(
+              "REQUEST_INVALID",
+              "Remote stored-record inspection is available through the remote Operator dashboard.",
+            );
+          }
+          const rows = await useConfiguredHostStorage(currentConfigPath(), async (storage) => {
+            const loaded = await loadConfigWithHostStorage(
+              storage,
+              currentConfigPath(),
+              envProjectConfigPath(env),
+              { vaultResolver: await createHostStorageVaultResolver(storage) },
+            );
+            return (
+              await storage.caplets.listStored({
+                role: "operator",
+                clientId: "local_cli",
+              })
+            ).map((record) => {
+              const source = loaded.sources[record.id];
+              return {
+                ...record,
+                shadowed: source !== undefined && source.kind !== "stored-record",
+                ...(source === undefined || source.kind === "stored-record"
+                  ? {}
+                  : { shadowSource: source }),
+              };
+            });
+          });
+          if (options.json || options.format === "json") {
+            writeOut(`${JSON.stringify(rows, null, 2)}\n`);
+            return;
+          }
+          writeOut(formatStoredCapletRows(rows, options.format ?? "plain"));
           return;
         }
-        writeOut(formatCapletList(rows, options.format ?? "plain"));
-        return;
-      }
-      const config = loadConfigWithSources(currentConfigPath(), envProjectConfigPath(env), {
-        vaultResolver: vaultBootstrapResolver,
-      });
-      const rows = listCaplets(config, { includeDisabled });
-      if (options.json || options.format === "json") {
-        writeOut(`${JSON.stringify(rows, null, 2)}\n`);
-        return;
-      }
-      writeOut(formatCapletList(rows, options.format ?? "plain"));
-    });
+        if (remote) {
+          const remoteRows = (await remote.request("list", { includeDisabled })) as CapletListRow[];
+          const localOverlay = tryLoadLocalOverlayForCli(io, writeErr);
+          const rows = mergeRemoteAndLocalRows(remoteRows, localOverlay, {
+            includeDisabled,
+            writeErr,
+          });
+          if (options.json || options.format === "json") {
+            writeOut(`${JSON.stringify(rows, null, 2)}\n`);
+            return;
+          }
+          writeOut(formatCapletList(rows, options.format ?? "plain"));
+          return;
+        }
+        await useConfiguredHostStorage(currentConfigPath(), async (storage) => {
+          const loaded = await loadConfigWithHostStorage(
+            storage,
+            currentConfigPath(),
+            envProjectConfigPath(env),
+            { vaultResolver: await createHostStorageVaultResolver(storage) },
+          );
+          const rows = listCaplets(loaded, { includeDisabled });
+          if (options.json || options.format === "json") {
+            writeOut(`${JSON.stringify(rows, null, 2)}\n`);
+            return;
+          }
+          writeOut(formatCapletList(rows, options.format ?? "plain"));
+        });
+      },
+    );
 
   program
     .command(cliCommands.install)
@@ -3016,11 +3194,7 @@ export function createProgram(io: CliIO = {}): Command {
         printTelemetryNotice("cli");
         const target = parseCatalogLifecycleTarget(options);
         const localLockfilePath =
-          target === "remote"
-            ? undefined
-            : target === "global"
-              ? defaultCapletsLockfilePath(env)
-              : resolveProjectLockfilePath(process.cwd());
+          target === "project" ? resolveProjectLockfilePath(process.cwd()) : undefined;
         const installSource =
           repo &&
           isInstallSourceArgument(repo, {
@@ -3062,10 +3236,38 @@ export function createProgram(io: CliIO = {}): Command {
           }
           return;
         }
-        const destinationRoot =
-          target === "global"
-            ? resolveCapletsRoot(resolveConfigPath(currentConfigPath()))
-            : envProjectCapletsRoot(env);
+        if (target === "global") {
+          if (!installSource) {
+            throw new CapletsError(
+              "REQUEST_INVALID",
+              "Global SQL catalog install requires a repository source.",
+            );
+          }
+          const result = await useConfiguredHostStorage(currentConfigPath(), async (storage) =>
+            installSqlCatalogCaplets({
+              storage,
+              operator: { clientId: "local_cli", role: "operator" },
+              source: installSource,
+              capletIds: selectedCapletIds,
+              force: Boolean(options.force),
+              disableCatalogIndexing: catalogIndexingDisabled(env),
+            }),
+          );
+          attachVaultSetupResults(result.installed, io);
+          if (options.json) {
+            writeOut(`${JSON.stringify(installJsonResult(result.installed), null, 2)}\n`);
+            return;
+          }
+          for (const caplet of result.installed) {
+            writeOut(
+              `${installStatusLabel(caplet.status, "Installed")} ${caplet.id} to ${caplet.destination}\n`,
+            );
+            writeCatalogIndexingNotice(caplet.catalogIndexing, writeOut);
+            writeVaultSetupNotice(caplet.vaultSetup, writeOut);
+          }
+          return;
+        }
+        const destinationRoot = envProjectCapletsRoot(env);
         const lockfilePath = localLockfilePath ?? resolveProjectLockfilePath(process.cwd());
         if (!installSource) {
           const result = restoreCapletsFromLockfile({
@@ -3154,14 +3356,31 @@ export function createProgram(io: CliIO = {}): Command {
           }
           return;
         }
-        const destinationRoot =
-          target === "global"
-            ? resolveCapletsRoot(resolveConfigPath(currentConfigPath()))
-            : envProjectCapletsRoot(env);
-        const lockfilePath =
-          target === "global"
-            ? defaultCapletsLockfilePath(env)
-            : resolveProjectLockfilePath(process.cwd());
+        if (target === "global") {
+          const result = await useConfiguredHostStorage(currentConfigPath(), async (storage) =>
+            updateSqlCatalogCaplets({
+              storage,
+              operator: { clientId: "local_cli", role: "operator" },
+              capletIds,
+              force: Boolean(options.force),
+              allowRiskIncrease: Boolean(options.force),
+              disableCatalogIndexing: catalogIndexingDisabled(env),
+            }),
+          );
+          attachVaultSetupResults(result.installed, io);
+          if (options.json) {
+            writeOut(`${JSON.stringify(installJsonResult(result.installed), null, 2)}\n`);
+            return;
+          }
+          for (const caplet of result.installed) {
+            writeOut(`${updateStatusLabel(caplet.status)} ${caplet.id} at ${caplet.destination}\n`);
+            writeCatalogIndexingNotice(caplet.catalogIndexing, writeOut);
+            writeVaultSetupNotice(caplet.vaultSetup, writeOut);
+          }
+          return;
+        }
+        const destinationRoot = envProjectCapletsRoot(env);
+        const lockfilePath = resolveProjectLockfilePath(process.cwd());
         const result = updateCapletsFromLockfile({
           capletIds,
           force: Boolean(options.force),
@@ -3756,20 +3975,23 @@ export function createProgram(io: CliIO = {}): Command {
       }
       const configPath = currentConfigPath();
       const projectConfigPath = envProjectConfigPath(env);
-      await loginAuth(serverId, {
-        noOpen: options.open === false,
-        writeOut,
-        writeErr,
+      const config = localAuthConfigForTarget({
+        serverId,
+        ...(io.authDir ? { authDir: io.authDir } : {}),
         ...(configPath ? { configPath } : {}),
         ...(projectConfigPath ? { projectConfigPath } : {}),
-        config: localAuthConfigForTarget({
-          serverId,
-          ...(io.authDir ? { authDir: io.authDir } : {}),
+        source: target,
+      });
+      await useBackendAuthStore(configPath, async (authStore) => {
+        await loginAuth(serverId, {
+          authStore,
+          noOpen: options.open === false,
+          writeOut,
+          writeErr,
           ...(configPath ? { configPath } : {}),
-          ...(projectConfigPath ? { projectConfigPath } : {}),
-          source: target,
-        }),
-        ...(io.authDir ? { authDir: io.authDir } : {}),
+          config,
+          ...(io.authDir ? { authDir: io.authDir } : {}),
+        });
       });
     });
 
@@ -3796,17 +4018,21 @@ export function createProgram(io: CliIO = {}): Command {
       }
       const configPath = currentConfigPath();
       const projectConfigPath = envProjectConfigPath(env);
-      logoutAuth(serverId, {
-        writeOut,
-        ...(configPath ? { configPath } : {}),
-        config: localAuthConfigForTarget({
-          serverId,
-          ...(io.authDir ? { authDir: io.authDir } : {}),
-          ...(configPath ? { configPath } : {}),
-          ...(projectConfigPath ? { projectConfigPath } : {}),
-          source: target,
-        }),
+      const config = localAuthConfigForTarget({
+        serverId,
         ...(io.authDir ? { authDir: io.authDir } : {}),
+        ...(configPath ? { configPath } : {}),
+        ...(projectConfigPath ? { projectConfigPath } : {}),
+        source: target,
+      });
+      await useBackendAuthStore(configPath, async (authStore) => {
+        await logoutAuth(serverId, {
+          authStore,
+          writeOut,
+          ...(configPath ? { configPath } : {}),
+          config,
+          ...(io.authDir ? { authDir: io.authDir } : {}),
+        });
       });
     });
 
@@ -3827,17 +4053,21 @@ export function createProgram(io: CliIO = {}): Command {
       }
       const configPath = currentConfigPath();
       const projectConfigPath = envProjectConfigPath(env);
-      await refreshAuth(serverId, {
-        writeOut,
-        ...(configPath ? { configPath } : {}),
-        config: localAuthConfigForTarget({
-          serverId,
-          ...(io.authDir ? { authDir: io.authDir } : {}),
-          ...(configPath ? { configPath } : {}),
-          ...(projectConfigPath ? { projectConfigPath } : {}),
-          source: target,
-        }),
+      const config = localAuthConfigForTarget({
+        serverId,
         ...(io.authDir ? { authDir: io.authDir } : {}),
+        ...(configPath ? { configPath } : {}),
+        ...(projectConfigPath ? { projectConfigPath } : {}),
+        source: target,
+      });
+      await useBackendAuthStore(configPath, async (authStore) => {
+        await refreshAuth(serverId, {
+          authStore,
+          writeOut,
+          ...(configPath ? { configPath } : {}),
+          config,
+          ...(io.authDir ? { authDir: io.authDir } : {}),
+        });
       });
     });
 
@@ -3863,7 +4093,676 @@ export function createProgram(io: CliIO = {}): Command {
       writeOut(formatAuthRows(rows, format));
     });
 
+  configureStorageCommands(program, {
+    configPath: () => resolveConfigPath(currentConfigPath()),
+    env,
+    writeOut,
+    io,
+  });
+
   return program;
+}
+function configureStorageCommands(
+  program: Command,
+  context: {
+    configPath: () => string;
+    env: NodeJS.ProcessEnv | Record<string, string | undefined>;
+    writeOut: (value: string) => void;
+    io: CliIO;
+  },
+): void {
+  const operator = { role: "operator" as const, clientId: "local_cli" };
+  const storage = program.command("storage").description("Administer Authoritative Host State.");
+
+  storage
+    .command("status")
+    .description("Inspect Authoritative Host State health and record counts.")
+    .option("--json", "print JSON output")
+    .action(async (options: { json?: boolean }) => {
+      const status = await useConfiguredHostStorage(context.configPath(), async (hostStorage) => ({
+        ...(await hostStorage.health()),
+        records: (await hostStorage.caplets.list()).length,
+        assetRows: await hostStorage.caplets.assetStats(),
+      }));
+      context.writeOut(
+        options.json
+          ? `${JSON.stringify(status, null, 2)}\n`
+          : `Authoritative Host State: ${status.ready ? "ready" : "unavailable"} (${status.backend}, schema ${status.schemaVersion ?? "unknown"}, ${status.records} records).\n`,
+      );
+    });
+
+  storage
+    .command("schema-migrate")
+    .description("Apply configured SQLite or PostgreSQL Authoritative Host State DDL.")
+    .action(async () => {
+      const config = loadHostStorageConfig(context.configPath());
+      await migrateHostStorage(config);
+      context.writeOut(`${JSON.stringify({ migrated: true, backend: config.type }, null, 2)}\n`);
+    });
+
+  storage
+    .command("migrate-legacy")
+    .description("Migrate verified legacy Host state into SQL storage.")
+    .requiredOption("--caplets-root <path>", "tracked global Caplet installation root")
+    .requiredOption("--lockfile <path>", "tracked global Caplet lockfile")
+    .option("--dry-run", "verify migration inputs without writing or moving files")
+    .option("--backup-root <path>", "timestamped backup destination")
+    .option(
+      "--operator-client <id>",
+      "Operator Client identity for the migration audit",
+      "cli-migration",
+    )
+    .action(
+      async (options: {
+        capletsRoot: string;
+        lockfile: string;
+        dryRun?: boolean;
+        backupRoot?: string;
+        operatorClient: string;
+      }) => {
+        const configPath = context.configPath();
+        const report = await migrateLegacyHostState({
+          storage: loadHostStorageConfig(configPath),
+          capletsRoot: resolve(options.capletsRoot),
+          lockfilePath: resolve(options.lockfile),
+          operatorClientId: options.operatorClient,
+          ...(options.backupRoot ? { backupRoot: options.backupRoot } : {}),
+          dryRun: options.dryRun ?? false,
+        });
+        context.writeOut(`${JSON.stringify(report, null, 2)}\n`);
+      },
+    );
+
+  const records = storage.command("records").description("Administer stored SQL Caplet Records.");
+
+  records
+    .command("list")
+    .description("List stored SQL Caplet Records.")
+    .requiredOption("--stored", "select the stored SQL view")
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(async (options: StorageRemoteOptions) => {
+      const remote = remoteClientForStorageOptions(context.io, options);
+      const result = remote
+        ? await remote.request("storage_records_list", {})
+        : await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+            hostStorage.caplets.listStored(operator),
+          );
+      context.writeOut(`${JSON.stringify(result, null, 2)}\n`);
+    });
+
+  records
+    .command("get")
+    .description("Read one stored SQL Caplet Record.")
+    .argument("<id>", "Caplet Record ID")
+    .requiredOption("--stored", "select the stored SQL view")
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(async (id: string, options: StorageRemoteOptions) => {
+      const remote = remoteClientForStorageOptions(context.io, options);
+      const record = remote
+        ? parseRemoteCapletBundleResult(await remote.request("storage_records_get", { id })).record
+        : await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+            hostStorage.caplets.getStored(id, operator),
+          );
+      if (!record) throw new CapletsError("CONFIG_NOT_FOUND", `Caplet Record ${id} was not found.`);
+      context.writeOut(`${JSON.stringify(record, null, 2)}\n`);
+    });
+
+  records
+    .command("import")
+    .description("Import a filesystem Caplet bundle as a new SQL record.")
+    .argument("<bundle-path>", "directory bundle or CAPLET.md path")
+    .option("--id <id>", "Caplet Record ID override")
+    .option("--history-limit <n>", "retained revision count", parseStorageNonNegativeInteger)
+    .option("--source-kind <kind>", "installation source kind")
+    .option("--source-identity <identity>", "installation source identity")
+    .option("--channel <channel>", "installation source channel")
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(
+      async (
+        bundlePath: string,
+        options: StorageRemoteOptions & {
+          id?: string;
+          historyLimit?: number;
+          sourceKind?: string;
+          sourceIdentity?: string;
+          channel?: string;
+        },
+      ) => {
+        const bundle = readCapletBundleFiles(bundlePath);
+        const installation = installationSourceOptions(options);
+        const remote = remoteClientForStorageOptions(context.io, options);
+        const record = remote
+          ? await remote.request("storage_records_import", {
+              id: options.id ?? bundle.id,
+              files: encodeRemoteCapletBundleFiles(bundle.files),
+              ...(options.historyLimit === undefined ? {} : { historyLimit: options.historyLimit }),
+              ...installation,
+            })
+          : await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+              hostStorage.caplets.importBundle({
+                id: options.id ?? bundle.id,
+                files: bundle.files,
+                operator,
+                ...(options.historyLimit === undefined
+                  ? {}
+                  : { historyLimit: options.historyLimit }),
+                ...(installation ? { installation } : {}),
+              }),
+            );
+        context.writeOut(`${JSON.stringify(record, null, 2)}\n`);
+      },
+    );
+
+  records
+    .command("update")
+    .description("Replace a SQL Caplet Record with a complete filesystem bundle.")
+    .argument("<id>", "Caplet Record ID")
+    .argument("<bundle-path>", "directory bundle or CAPLET.md path")
+    .requiredOption("--generation <n>", "observed record generation", parsePositiveInteger)
+    .option("--detach-installation", "detach an active tracked installation before updating")
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(
+      async (
+        id: string,
+        bundlePath: string,
+        options: StorageRemoteOptions & { generation: number; detachInstallation?: boolean },
+      ) => {
+        const bundle = readCapletBundleFiles(bundlePath);
+        const remote = remoteClientForStorageOptions(context.io, options);
+        const record = remote
+          ? await remote.request("storage_records_update", {
+              id,
+              files: encodeRemoteCapletBundleFiles(bundle.files),
+              expectedGeneration: options.generation,
+              ...(options.detachInstallation ? { detachInstallation: true } : {}),
+            })
+          : await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+              hostStorage.caplets.updateBundle({
+                id,
+                files: bundle.files,
+                operator,
+                expectedGeneration: options.generation,
+                ...(options.detachInstallation ? { detachInstallation: true } : {}),
+              }),
+            );
+        context.writeOut(`${JSON.stringify(record, null, 2)}\n`);
+      },
+    );
+
+  records
+    .command("export")
+    .description("Export a stored Caplet bundle to the filesystem.")
+    .argument("<id>", "Caplet Record ID")
+    .argument("<destination>", "export destination directory")
+    .option("--revision <key>", "specific revision key")
+    .option("--replace", "replace an existing destination")
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(
+      async (
+        id: string,
+        destination: string,
+        options: StorageRemoteOptions & { revision?: string; replace?: boolean },
+      ) => {
+        const remote = remoteClientForStorageOptions(context.io, options);
+        if (remote) {
+          const result = parseRemoteCapletBundleResult(
+            await remote.request("storage_records_export", {
+              id,
+              ...(options.revision ? { revisionKey: options.revision } : {}),
+            }),
+          );
+          materializeCapletBundleFiles(result.files, destination, options);
+        } else {
+          await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+            hostStorage.caplets.exportBundle(id, destination, {
+              operator,
+              ...(options.revision ? { revisionKey: options.revision } : {}),
+              ...(options.replace ? { replace: true } : {}),
+            }),
+          );
+        }
+        context.writeOut(
+          `${JSON.stringify({ exported: true, id, destination: resolve(destination) }, null, 2)}\n`,
+        );
+      },
+    );
+
+  records
+    .command("revisions")
+    .description("List retained revisions for a Caplet Record.")
+    .argument("<id>", "Caplet Record ID")
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(async (id: string, options: StorageRemoteOptions) => {
+      const remote = remoteClientForStorageOptions(context.io, options);
+      const revisions = remote
+        ? await remote.request("storage_records_revisions", { id })
+        : await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+            hostStorage.caplets.listRevisions(id, operator),
+          );
+      context.writeOut(`${JSON.stringify(revisions, null, 2)}\n`);
+    });
+
+  records
+    .command("restore")
+    .description("Restore a retained revision as a new current revision.")
+    .argument("<id>", "Caplet Record ID")
+    .argument("<revision>", "revision key")
+    .requiredOption("--generation <n>", "observed record generation", parsePositiveInteger)
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(
+      async (
+        id: string,
+        revision: string,
+        options: StorageRemoteOptions & { generation: number },
+      ) => {
+        const remote = remoteClientForStorageOptions(context.io, options);
+        const record = remote
+          ? await remote.request("storage_records_restore", {
+              id,
+              revisionKey: revision,
+              expectedGeneration: options.generation,
+            })
+          : await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+              hostStorage.caplets.restoreRevision({
+                id,
+                revisionKey: revision,
+                expectedGeneration: options.generation,
+                operator,
+              }),
+            );
+        context.writeOut(`${JSON.stringify(record, null, 2)}\n`);
+      },
+    );
+
+  records
+    .command("delete-revision")
+    .description("Delete a retained revision.")
+    .argument("<id>", "Caplet Record ID")
+    .argument("<revision>", "revision key")
+    .requiredOption("--generation <n>", "observed record generation", parsePositiveInteger)
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(
+      async (
+        id: string,
+        revision: string,
+        options: StorageRemoteOptions & { generation: number },
+      ) => {
+        const remote = remoteClientForStorageOptions(context.io, options);
+        const result = remote
+          ? await remote.request("storage_records_delete_revision", {
+              id,
+              revisionKey: revision,
+              expectedGeneration: options.generation,
+            })
+          : {
+              deleted: true,
+              record: await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+                hostStorage.caplets.deleteRevision({
+                  id,
+                  revisionKey: revision,
+                  expectedGeneration: options.generation,
+                  operator,
+                }),
+              ),
+            };
+        context.writeOut(`${JSON.stringify(result, null, 2)}\n`);
+      },
+    );
+
+  records
+    .command("retention")
+    .description("Set retained revision count, or inherit the host default.")
+    .argument("<id>", "Caplet Record ID")
+    .argument("<limit>", "non-negative revision count or 'inherit'")
+    .requiredOption("--generation <n>", "observed record generation", parsePositiveInteger)
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(
+      async (id: string, limit: string, options: StorageRemoteOptions & { generation: number }) => {
+        const historyLimit = limit === "inherit" ? null : parseStorageNonNegativeInteger(limit);
+        const remote = remoteClientForStorageOptions(context.io, options);
+        const record = remote
+          ? await remote.request("storage_records_retention", {
+              id,
+              historyLimit,
+              expectedGeneration: options.generation,
+            })
+          : await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+              hostStorage.caplets.setRetention({
+                id,
+                historyLimit,
+                expectedGeneration: options.generation,
+                operator,
+              }),
+            );
+        context.writeOut(`${JSON.stringify(record, null, 2)}\n`);
+      },
+    );
+
+  records
+    .command("rename")
+    .description("Rename a Caplet Record.")
+    .argument("<id>", "current Caplet Record ID")
+    .argument("<new-id>", "new Caplet Record ID")
+    .requiredOption("--generation <n>", "observed record generation", parsePositiveInteger)
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(
+      async (id: string, newId: string, options: StorageRemoteOptions & { generation: number }) => {
+        const remote = remoteClientForStorageOptions(context.io, options);
+        const record = remote
+          ? await remote.request("storage_records_rename", {
+              id,
+              newId,
+              expectedGeneration: options.generation,
+            })
+          : await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+              hostStorage.caplets.rename({
+                id,
+                newId,
+                expectedGeneration: options.generation,
+                operator,
+              }),
+            );
+        context.writeOut(`${JSON.stringify(record, null, 2)}\n`);
+      },
+    );
+
+  records
+    .command("delete")
+    .description("Hard-delete a Caplet Record and all retained revisions.")
+    .argument("<id>", "Caplet Record ID")
+    .requiredOption("--generation <n>", "observed record generation", parsePositiveInteger)
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(async (id: string, options: StorageRemoteOptions & { generation: number }) => {
+      const remote = remoteClientForStorageOptions(context.io, options);
+      const result = remote
+        ? await remote.request("storage_records_delete", {
+            id,
+            expectedGeneration: options.generation,
+          })
+        : await useConfiguredHostStorage(context.configPath(), async (hostStorage) => {
+            await hostStorage.caplets.hardDelete({
+              id,
+              expectedGeneration: options.generation,
+              operator,
+            });
+            return { deleted: true, id };
+          });
+      context.writeOut(`${JSON.stringify(result, null, 2)}\n`);
+    });
+
+  const installation = records
+    .command("installation")
+    .description("Administer Caplet installation provenance.");
+
+  installation
+    .command("status")
+    .description("Inspect installation lifecycles and observations.")
+    .argument("<id>", "Caplet Record ID")
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(async (id: string, options: StorageRemoteOptions) => {
+      const remote = remoteClientForStorageOptions(context.io, options);
+      const result = remote
+        ? await remote.request("storage_records_installation_status", { id })
+        : await useConfiguredHostStorage(context.configPath(), async (hostStorage) => ({
+            installations: await hostStorage.installations.list(id),
+            observations: await hostStorage.installations.listObservations(id),
+          }));
+      context.writeOut(`${JSON.stringify(result, null, 2)}\n`);
+    });
+
+  installation
+    .command("detach")
+    .description("Detach the active installation lifecycle.")
+    .argument("<id>", "Caplet Record ID")
+    .requiredOption("--generation <n>", "observed installation generation", parsePositiveInteger)
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(async (id: string, options: StorageRemoteOptions & { generation: number }) => {
+      const remote = remoteClientForStorageOptions(context.io, options);
+      const result = remote
+        ? await remote.request("storage_records_installation_detach", {
+            id,
+            expectedGeneration: options.generation,
+          })
+        : await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+            hostStorage.installations.detach({
+              capletId: id,
+              expectedGeneration: options.generation,
+              operator,
+            }),
+          );
+      context.writeOut(`${JSON.stringify(result, null, 2)}\n`);
+    });
+
+  installation
+    .command("observe")
+    .description("Append an installation source observation.")
+    .argument("<id>", "Caplet Record ID")
+    .requiredOption("--generation <n>", "observed installation generation", parsePositiveInteger)
+    .requiredOption(
+      "--status <status>",
+      "current, metadata-only, or source-unavailable",
+      parseInstallationObservationStatus,
+    )
+    .option("--resolved-revision <revision>", "resolved source revision")
+    .option("--content-hash <hash>", "resolved source content hash")
+    .option("--risk-json <json>", "sanitized risk snapshot JSON")
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(
+      async (
+        id: string,
+        options: StorageRemoteOptions & {
+          generation: number;
+          status: "current" | "metadata-only" | "source-unavailable";
+          resolvedRevision?: string;
+          contentHash?: string;
+          riskJson?: string;
+        },
+      ) => {
+        const risk = options.riskJson ? parseStorageJsonObject(options.riskJson) : undefined;
+        const remote = remoteClientForStorageOptions(context.io, options);
+        const input = {
+          id,
+          expectedGeneration: options.generation,
+          status: options.status,
+          ...(options.resolvedRevision ? { resolvedRevision: options.resolvedRevision } : {}),
+          ...(options.contentHash ? { contentHash: options.contentHash } : {}),
+          ...(risk ? { risk } : {}),
+        };
+        const result = remote
+          ? await remote.request("storage_records_installation_observe", input)
+          : await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+              hostStorage.installations.appendObservation({
+                capletId: id,
+                expectedGeneration: options.generation,
+                status: options.status,
+                operator,
+                ...(options.resolvedRevision ? { resolvedRevision: options.resolvedRevision } : {}),
+                ...(options.contentHash ? { contentHash: options.contentHash } : {}),
+                ...(risk ? { risk } : {}),
+              }),
+            );
+        context.writeOut(`${JSON.stringify(result, null, 2)}\n`);
+      },
+    );
+
+  installation
+    .command("replace")
+    .description("Replace the latest detached installation with a new active lifecycle.")
+    .argument("<id>", "Caplet Record ID")
+    .requiredOption(
+      "--generation <n>",
+      "observed detached installation generation",
+      parsePositiveInteger,
+    )
+    .requiredOption("--source-kind <kind>", "replacement source kind")
+    .requiredOption("--source-identity <identity>", "replacement source identity")
+    .option("--channel <channel>", "replacement source channel")
+    .option("--detached-installation <key>", "expected detached installation key")
+    .option("--remote [server]", "administer the selected remote Host")
+    .action(
+      async (
+        id: string,
+        options: StorageRemoteOptions & {
+          generation: number;
+          sourceKind: string;
+          sourceIdentity: string;
+          channel?: string;
+          detachedInstallation?: string;
+        },
+      ) => {
+        const remote = remoteClientForStorageOptions(context.io, options);
+        const result = remote
+          ? await remote.request("storage_records_installation_replace", {
+              id,
+              expectedGeneration: options.generation,
+              sourceKind: options.sourceKind,
+              sourceIdentity: options.sourceIdentity,
+              ...(options.channel ? { channel: options.channel } : {}),
+              ...(options.detachedInstallation
+                ? { detachedInstallationKey: options.detachedInstallation }
+                : {}),
+            })
+          : await useConfiguredHostStorage(context.configPath(), async (hostStorage) =>
+              hostStorage.installations.replaceDetached({
+                capletId: id,
+                expectedGeneration: options.generation,
+                sourceKind: options.sourceKind,
+                sourceIdentity: options.sourceIdentity,
+                operator,
+                ...(options.channel ? { channel: options.channel } : {}),
+                ...(options.detachedInstallation
+                  ? { detachedInstallationKey: options.detachedInstallation }
+                  : {}),
+              }),
+            );
+        context.writeOut(`${JSON.stringify(result, null, 2)}\n`);
+      },
+    );
+}
+
+type StorageRemoteOptions = {
+  remote?: string | boolean | undefined;
+};
+
+function remoteClientForStorageOptions(
+  io: CliIO,
+  options: StorageRemoteOptions,
+): RemoteControlClient | undefined {
+  if (options.remote === undefined || options.remote === false) return undefined;
+  const remoteUrl = typeof options.remote === "string" ? options.remote : undefined;
+  return requireRemoteClientForTarget(io, remoteUrl, true);
+}
+
+function encodeRemoteCapletBundleFiles(files: CapletBundleInputFile[]): RemoteCapletBundleFile[] {
+  return files.map((file) => ({
+    path: file.path,
+    contentBase64: file.content.toString("base64"),
+    executable: file.executable,
+  }));
+}
+
+function parseRemoteCapletBundleResult(value: unknown): {
+  record: unknown;
+  files: CapletBundleInputFile[];
+} {
+  if (!isCliRecord(value) || !("record" in value) || !("files" in value)) {
+    throw new CapletsError("REQUEST_INVALID", "Remote Caplet bundle response is malformed.");
+  }
+  return { record: value.record, files: decodeRemoteCapletBundleFiles(value.files) };
+}
+
+function decodeRemoteCapletBundleFiles(value: unknown): CapletBundleInputFile[] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 2_049) {
+    throw new CapletsError("REQUEST_INVALID", "Remote Caplet bundle response is malformed.");
+  }
+  const files: CapletBundleInputFile[] = [];
+  let totalBytes = 0;
+  for (const item of value) {
+    if (
+      !isCliRecord(item) ||
+      Object.keys(item).some(
+        (key) => key !== "path" && key !== "contentBase64" && key !== "executable",
+      ) ||
+      typeof item.path !== "string" ||
+      !item.path ||
+      typeof item.contentBase64 !== "string" ||
+      typeof item.executable !== "boolean" ||
+      !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(item.contentBase64)
+    ) {
+      throw new CapletsError("REQUEST_INVALID", "Remote Caplet bundle response is malformed.");
+    }
+    const content = Buffer.from(item.contentBase64, "base64");
+    if (
+      content.byteLength > 64 * 1024 * 1024 ||
+      content.toString("base64") !== item.contentBase64
+    ) {
+      throw new CapletsError("REQUEST_INVALID", "Remote Caplet bundle response is malformed.");
+    }
+    totalBytes += content.byteLength;
+    if (totalBytes > 256 * 1024 * 1024) {
+      throw new CapletsError("REQUEST_INVALID", "Remote Caplet bundle response is too large.");
+    }
+    files.push({ path: item.path, content, executable: item.executable });
+  }
+  return files;
+}
+
+function isCliRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseStorageNonNegativeInteger(value: string): number {
+  return parseNonNegativeInteger(value, "Storage value");
+}
+
+function parseInstallationObservationStatus(
+  value: string,
+): "current" | "metadata-only" | "source-unavailable" {
+  if (value === "current" || value === "metadata-only" || value === "source-unavailable") {
+    return value;
+  }
+  throw new CapletsError(
+    "REQUEST_INVALID",
+    `Installation observation status must be current, metadata-only, or source-unavailable; got ${value}`,
+  );
+}
+
+function parseStorageJsonObject(value: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value) as unknown;
+  } catch {
+    throw new CapletsError("REQUEST_INVALID", "Storage risk JSON must be valid JSON.");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new CapletsError("REQUEST_INVALID", "Storage risk JSON must be an object.");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function installationSourceOptions(options: {
+  sourceKind?: string;
+  sourceIdentity?: string;
+  channel?: string;
+}):
+  | {
+      sourceKind: string;
+      sourceIdentity: string;
+      channel?: string;
+    }
+  | undefined {
+  if (options.sourceKind === undefined && options.sourceIdentity === undefined) return undefined;
+  if (!options.sourceKind || !options.sourceIdentity) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "--source-kind and --source-identity must be provided together.",
+    );
+  }
+  return {
+    sourceKind: options.sourceKind,
+    sourceIdentity: options.sourceIdentity,
+    ...(options.channel ? { channel: options.channel } : {}),
+  };
 }
 
 function formatDaemonStatus(status: Awaited<ReturnType<typeof daemonStatus>>): string {
@@ -3885,9 +4784,13 @@ function envConfigPath(
   return env.CAPLETS_CONFIG?.trim() || undefined;
 }
 
-function remoteClientForCli(io: CliIO): RemoteControlClient | undefined {
+function remoteClientForCli(
+  io: CliIO,
+  remoteUrl?: string | undefined,
+  forceRemote = false,
+): RemoteControlClient | undefined {
   const env = io.env ?? process.env;
-  if (resolveRemoteMode({}, env).mode !== "remote") {
+  if (!forceRemote && remoteUrl === undefined && resolveRemoteMode({}, env).mode !== "remote") {
     return undefined;
   }
   return new RemoteControlClient({
@@ -3895,16 +4798,14 @@ function remoteClientForCli(io: CliIO): RemoteControlClient | undefined {
       const selection = await resolveRemoteSelection(
         {
           mode: "remote",
+          ...(remoteUrl ? { remoteUrl } : {}),
           ...(io.authDir ? { authDir: io.authDir } : {}),
           ...(io.fetch ? { fetch: io.fetch } : {}),
         },
         env,
       );
       if (selection.kind !== "self_hosted_remote") {
-        throw new CapletsError(
-          "REQUEST_INVALID",
-          "--remote requires CAPLETS_MODE=remote and a self-hosted CAPLETS_REMOTE_URL",
-        );
+        throw new CapletsError("REQUEST_INVALID", "--remote requires a self-hosted remote Host");
       }
       return {
         baseUrl: selection.remote.baseUrl,
@@ -4223,36 +5124,48 @@ function assertVaultTransportValueSize(value: string): void {
   }
 }
 
-function resolveVaultAccessOrigin(capletId: string, io: CliIO): ConfigSource {
-  const env = io.env ?? process.env;
-  const configPath = envConfigPath(env);
-  const projectConfigPath = envProjectConfigPath(env);
-  const config = loadConfigWithSources(configPath, projectConfigPath, {
-    vaultResolver: vaultBootstrapResolver,
-  });
-  if (config.shadows[capletId]?.length) {
-    throw new CapletsError(
-      "REQUEST_INVALID",
-      `Caplet ${capletId} is shadowed in multiple config sources; resolve the active config before granting Vault access.`,
-    );
-  }
-  const origin = config.sources[capletId];
-  if (!origin) {
-    throw new CapletsError("SERVER_NOT_FOUND", `Caplet ${capletId} is not configured.`);
-  }
-  return origin;
+function storedVaultGrantForCli(grant: StoredVaultGrant) {
+  return {
+    storedKey: grant.vaultKey,
+    referenceName: grant.referenceName,
+    capletId: grant.capletId,
+    origin: {
+      kind: grant.originKind,
+      ...(grant.originPath === null ? {} : { path: grant.originPath }),
+    },
+    createdAt: grant.createdAt,
+    updatedAt: grant.createdAt,
+  };
 }
 
-function vaultAccessFilter(
-  storedKey?: string,
-  capletId?: string,
-  referenceName?: string,
-): VaultAccessGrantFilter {
-  return {
-    ...(storedKey ? { storedKey: validateVaultKeyName(storedKey) } : {}),
-    ...(capletId ? { capletId } : {}),
-    ...(referenceName ? { referenceName: validateVaultKeyName(referenceName) } : {}),
-  };
+type StoredCapletRow = CapletRecordView & {
+  shadowed: boolean;
+  shadowSource?: ConfigSource | undefined;
+};
+
+function formatStoredCapletRows(rows: StoredCapletRow[], format: CliOutputFormat): string {
+  if (rows.length === 0) return "No stored SQL Caplet Records.\n";
+  if (format === "markdown") {
+    return [
+      "| Caplet Record | Generation | Effective state |",
+      "| --- | ---: | --- |",
+      ...rows.map(
+        (row) =>
+          `| \`${row.id}\` | ${row.headGeneration} | ${
+            row.shadowed ? `shadowed by ${row.shadowSource?.kind ?? "higher layer"}` : "effective"
+          } |`,
+      ),
+      "",
+    ].join("\n");
+  }
+  return `${rows
+    .map(
+      (row) =>
+        `${row.id}\tgeneration ${row.headGeneration}\t${
+          row.shadowed ? `shadowed by ${row.shadowSource?.kind ?? "higher layer"}` : "effective"
+        }`,
+    )
+    .join("\n")}\n`;
 }
 
 function localMutationTargetLabel(target: Exclude<MutationTarget, "remote">, io: CliIO): string {
@@ -4462,12 +5375,15 @@ async function authListRowsForCli(
   if (target === "remote") {
     return remoteAuthRows(requireRemoteClientForTarget(io));
   }
-  const localRows = listLocalAuthRows({
-    ...(configPath ? { configPath } : {}),
-    ...(projectConfigPath ? { projectConfigPath } : {}),
-    ...(io.authDir ? { authDir: io.authDir } : {}),
-    ...(target ? { source: target } : {}),
-  });
+  const localRows = await useBackendAuthStore(configPath, async (authStore) =>
+    listLocalAuthRows({
+      authStore,
+      ...(configPath ? { configPath } : {}),
+      ...(projectConfigPath ? { projectConfigPath } : {}),
+      ...(io.authDir ? { authDir: io.authDir } : {}),
+      ...(target ? { source: target } : {}),
+    }),
+  );
   if (target) return localRows;
   const remote = remoteClientForCli(io);
   if (!remote) return localRows;
@@ -4508,8 +5424,12 @@ async function remoteAuthLogin(
   }
 }
 
-function requireRemoteClientForTarget(io: CliIO): RemoteControlClient {
-  const remote = remoteClientForCli(io);
+function requireRemoteClientForTarget(
+  io: CliIO,
+  remoteUrl?: string | undefined,
+  forceRemote = false,
+): RemoteControlClient {
+  const remote = remoteClientForCli(io, remoteUrl, forceRemote);
   if (!remote) {
     throw new CapletsError(
       "REQUEST_INVALID",
@@ -4614,13 +5534,17 @@ async function completeCliWordsLocally(
     config?: CapletsConfig | undefined;
   },
 ): Promise<string[]> {
-  const engine = new CapletsEngine({
-    ...(options.configPath ? { configPath: options.configPath } : {}),
-    ...(options.projectConfigPath ? { projectConfigPath: options.projectConfigPath } : {}),
-    ...(options.authDir ? { authDir: options.authDir } : {}),
-    watch: false,
-    ...(options.config ? { configLoader: () => options.config as CapletsConfig } : {}),
-  });
+  const engine = options.config
+    ? new CapletsEngine({
+        configLoader: () => options.config as CapletsConfig,
+        watch: false,
+      })
+    : await CapletsEngine.create({
+        ...(options.configPath ? { configPath: options.configPath } : {}),
+        ...(options.projectConfigPath ? { projectConfigPath: options.projectConfigPath } : {}),
+        ...(options.authDir ? { authDir: options.authDir } : {}),
+        watch: false,
+      });
   try {
     return await engine.completeCliWords(words);
   } finally {
@@ -4984,20 +5908,31 @@ async function executeLocalOperation(
   config?: CapletsConfig,
 ): Promise<void> {
   const configPath = envConfigPath(io.env ?? process.env);
-  const engine = new CapletsEngine({
-    ...(configPath ? { configPath } : {}),
-    projectConfigPath: envProjectConfigPath(io.env ?? process.env),
-    ...(io.authDir ? { authDir: io.authDir } : {}),
-    watch: false,
-    writeErr: io.writeErr,
-    telemetryEnv: io.env ?? process.env,
-    telemetryStateDir: io.telemetryStateDir ?? defaultTelemetryStateDir(io.env ?? process.env),
-    telemetrySurface: "cli",
-    telemetryVisibility: "visible",
-    telemetryRuntimeMode: runtimeModeForEnv(io.env ?? process.env),
-    telemetryDebugSink: io.telemetryDebugSink,
-    ...(config ? { configLoader: () => config } : {}),
-  });
+  const engine = config
+    ? new CapletsEngine({
+        configLoader: () => config,
+        watch: false,
+        writeErr: io.writeErr,
+        telemetryEnv: io.env ?? process.env,
+        telemetryStateDir: io.telemetryStateDir ?? defaultTelemetryStateDir(io.env ?? process.env),
+        telemetrySurface: "cli",
+        telemetryVisibility: "visible",
+        telemetryRuntimeMode: runtimeModeForEnv(io.env ?? process.env),
+        telemetryDebugSink: io.telemetryDebugSink,
+      })
+    : await CapletsEngine.create({
+        ...(configPath ? { configPath } : {}),
+        projectConfigPath: envProjectConfigPath(io.env ?? process.env),
+        ...(io.authDir ? { authDir: io.authDir } : {}),
+        watch: false,
+        writeErr: io.writeErr,
+        telemetryEnv: io.env ?? process.env,
+        telemetryStateDir: io.telemetryStateDir ?? defaultTelemetryStateDir(io.env ?? process.env),
+        telemetrySurface: "cli",
+        telemetryVisibility: "visible",
+        telemetryRuntimeMode: runtimeModeForEnv(io.env ?? process.env),
+        telemetryDebugSink: io.telemetryDebugSink,
+      });
   try {
     const result = await engine.execute(caplet, request);
     const output = cliOutputForOperation(result, { ...request, caplet }, io.format ?? "markdown");

--- a/packages/core/src/cli/auth.ts
+++ b/packages/core/src/cli/auth.ts
@@ -1,9 +1,7 @@
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import {
-  deleteTokenBundle,
   isTokenBundleExpired,
-  readTokenBundle,
   refreshOAuthTokenBundle,
   runGenericOAuthFlow,
   runOAuthFlow,
@@ -23,6 +21,7 @@ import {
 import { CapletsError, toSafeError } from "../errors";
 import { GoogleDiscoveryManager } from "../google-discovery";
 import { ServerRegistry } from "../registry";
+import type { BackendAuthStateStore } from "../storage/backend-auth";
 
 type AuthTarget = ReturnType<typeof authTargets>[number];
 type AuthListFormat = "plain" | "markdown" | "json";
@@ -44,17 +43,19 @@ export async function loginAuth(
     writeOut: (value: string) => void;
     writeErr: (value: string) => void;
     authDir?: string;
+    authStore: BackendAuthStateStore;
     config?: CapletsConfig;
   },
 ): Promise<void> {
   const config = options.config ?? loadAuthResolvedConfig(options);
-  const server = await resolveAuthTarget(serverId, config, options.authDir);
+  const server = await resolveAuthTarget(serverId, config, options.authStore);
   assertLoginTarget(server, serverId);
 
   try {
     const flowOptions = {
       noOpen: options.noOpen,
-      ...(options.authDir ? { authDir: options.authDir } : {}),
+      authStore: options.authStore,
+      operatorClientId: "local_cli",
       ...(options.noOpen ? { readManualInput: maybeReadManualInput } : {}),
       print: (line: string) => options.writeOut(`${line}\n`),
     };
@@ -70,16 +71,17 @@ export async function loginAuth(
   }
 }
 
-export function logoutAuth(
+export async function logoutAuth(
   serverId: string,
   options: {
     authDir?: string;
+    authStore: BackendAuthStateStore;
     configPath?: string;
     config?: CapletsConfig;
     writeOut: (value: string) => void;
   },
-): void {
-  const result = logoutAuthResult(serverId, options);
+): Promise<void> {
+  const result = await logoutAuthResult(serverId, options);
   if (result.deleted) {
     options.writeOut(`Deleted OAuth credentials for \`${serverId}\`.\n`);
   } else {
@@ -87,23 +89,38 @@ export function logoutAuth(
   }
 }
 
-export function logoutAuthResult(
+export async function logoutAuthResult(
   serverId: string,
-  options: { authDir?: string; configPath?: string; config?: CapletsConfig },
-): { server: string; deleted: boolean } {
+  options: {
+    authStore: BackendAuthStateStore;
+    authDir?: string;
+    configPath?: string;
+    config?: CapletsConfig;
+  },
+): Promise<{ server: string; deleted: boolean }> {
   const target = findAuthTarget(
     serverId,
     options.config ??
       loadConfig(options.configPath, undefined, { vaultResolver: vaultBootstrapResolver }),
   );
   assertLoginTarget(target, serverId);
-  return { server: serverId, deleted: deleteTokenBundle(serverId, options.authDir) };
+  const current = await options.authStore.readTokenBundle(serverId);
+  return {
+    server: serverId,
+    deleted: current
+      ? await options.authStore.deleteTokenBundle(serverId, {
+          expectedGeneration: current.generation,
+          operatorClientId: "local_cli",
+        })
+      : false,
+  };
 }
 
 export async function refreshAuth(
   serverId: string,
   options: {
     authDir?: string;
+    authStore: BackendAuthStateStore;
     configPath?: string;
     config?: CapletsConfig;
     writeOut: (value: string) => void;
@@ -115,25 +132,37 @@ export async function refreshAuth(
 
 export async function refreshAuthResult(
   serverId: string,
-  options: { authDir?: string; configPath?: string; config?: CapletsConfig },
+  options: {
+    authStore: BackendAuthStateStore;
+    authDir?: string;
+    configPath?: string;
+    config?: CapletsConfig;
+  },
 ): Promise<{ server: string }> {
   const target = await resolveAuthTarget(
     serverId,
     options.config ?? loadAuthResolvedConfig(options),
-    options.authDir,
+    options.authStore,
   );
   assertLoginTarget(target, serverId);
-  await refreshOAuthTokenBundle(target, options.authDir);
+  await refreshOAuthTokenBundle(target, options.authStore);
   return { server: serverId };
 }
 
-export function listAuth(options: {
+export async function listAuth(options: {
   authDir?: string;
+  authStore?: BackendAuthStateStore;
   configPath?: string;
   writeOut: (value: string) => void;
   format?: AuthListFormat;
-}): void {
-  const rows = listAuthRows(options);
+}): Promise<void> {
+  if (!options.authStore) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "Backend OAuth state requires Authoritative Host State storage.",
+    );
+  }
+  const rows = await listAuthRows({ ...options, authStore: options.authStore });
   const format = options.format ?? "plain";
   if (format === "json") {
     options.writeOut(`${JSON.stringify(rows, null, 2)}\n`);
@@ -142,11 +171,15 @@ export function listAuth(options: {
   options.writeOut(formatAuthRows(rows, format));
 }
 
-export function listAuthRows(options: { authDir?: string; configPath?: string }): AuthStatusRow[] {
+export async function listAuthRows(options: {
+  authStore: BackendAuthStateStore;
+  authDir?: string;
+  configPath?: string;
+}): Promise<AuthStatusRow[]> {
   const config = loadConfig(options.configPath, undefined, {
     vaultResolver: vaultBootstrapResolver,
   });
-  return authRowsForTargets(authTargets(config), options.authDir);
+  return await authRowsForTargets(authTargets(config), options.authStore);
 }
 
 function loadAuthResolvedConfig(options: {
@@ -158,13 +191,14 @@ function loadAuthResolvedConfig(options: {
   });
 }
 
-export function listLocalAuthRows(options: {
+export async function listLocalAuthRows(options: {
+  authStore: BackendAuthStateStore;
   authDir?: string;
   configPath?: string;
   projectConfigPath?: string;
   source?: Exclude<AuthSource, "remote">;
-}): AuthStatusRow[] {
-  return authRowsForTargets(localAuthTargets(options), options.authDir);
+}): Promise<AuthStatusRow[]> {
+  return await authRowsForTargets(localAuthTargets(options), options.authStore);
 }
 
 export function localAuthTargets(options: {
@@ -222,14 +256,17 @@ function loadConfigForSource(
   return loadProjectConfig(options.projectConfigPath, loadOptions);
 }
 
-function authRowsForTargets(
+async function authRowsForTargets(
   targets: (AuthTarget & { source?: AuthSource })[],
-  authDir?: string,
-): AuthStatusRow[] {
+  authStore: BackendAuthStateStore,
+): Promise<AuthStatusRow[]> {
+  const stored = new Map(
+    (await authStore.listTokenBundles()).map((state) => [state.bundle.server, state.bundle]),
+  );
   return targets
     .sort((left, right) => left.server.localeCompare(right.server))
     .map((server) => {
-      const bundle = readTokenBundle(server.server, authDir);
+      const bundle = stored.get(server.server);
       const status = !bundle
         ? "missing"
         : isTokenBundleExpired(bundle)
@@ -291,7 +328,7 @@ export function findAuthTarget(serverId: string, config = loadConfig()): AuthTar
 export async function resolveAuthTarget(
   serverId: string,
   config: CapletsConfig,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<AuthTarget | undefined> {
   const target = findAuthTarget(serverId, config);
   if (target?.backend !== "googleDiscovery") return target;
@@ -299,7 +336,7 @@ export async function resolveAuthTarget(
   if (!api || (api.auth.type !== "oauth2" && api.auth.type !== "oidc")) return target;
   const manager = new GoogleDiscoveryManager(
     new ServerRegistry(config),
-    authDir ? { authDir } : {},
+    authStore ? { backendAuth: authStore } : {},
   );
   const baseUrl =
     api.baseUrl ?? (await manager.resolveBaseUrl(api).catch(() => undefined)) ?? api.discoveryUrl;

--- a/packages/core/src/cli/code-mode.ts
+++ b/packages/core/src/cli/code-mode.ts
@@ -144,7 +144,7 @@ export async function codeModeTypesCli(
     | "writeOut"
   >,
 ): Promise<void> {
-  const engine = new CapletsEngine({
+  const engine = await CapletsEngine.create({
     ...(options.configPath ? { configPath: options.configPath } : {}),
     ...(options.projectConfigPath ? { projectConfigPath: options.projectConfigPath } : {}),
     ...(options.authDir ? { authDir: options.authDir } : {}),

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -35,6 +35,7 @@ export const cliCommands = {
   auth: "auth",
   vault: "vault",
   telemetry: "telemetry",
+  storage: "storage",
 } as const;
 
 export const topLevelCommandNames = [
@@ -68,6 +69,7 @@ export const topLevelCommandNames = [
   cliCommands.config,
   cliCommands.auth,
   cliCommands.vault,
+  cliCommands.storage,
   cliCommands.telemetry,
   cliCommands.completion,
 ] as const;
@@ -83,17 +85,37 @@ export const cliSubcommands = {
   [cliCommands.daemon]: ["install", "uninstall", "start", "restart", "stop", "status", "logs"],
   [cliCommands.setup]: ["codex", "claude-code", "opencode", "pi", "mcp-client"],
   [cliCommands.telemetry]: ["status", "enable", "disable", "delete-id", "rotate-id", "debug"],
+  [cliCommands.storage]: ["status", "schema-migrate", "migrate-legacy", "records"],
   [cliCommands.vault]: ["set", "get", "list", "delete", "access"],
 } as const satisfies Record<string, readonly string[]>;
 
-export const cliNestedSubcommands = {
+export const cliNestedSubcommands: Readonly<
+  Record<string, Readonly<Record<string, readonly string[]>>>
+> = {
   [cliCommands.remote]: {
     host: ["pair", "clients", "revoke"],
   },
   [cliCommands.vault]: {
     access: ["grant", "list", "revoke"],
   },
-} as const satisfies Record<string, Record<string, readonly string[]>>;
+  [cliCommands.storage]: {
+    records: [
+      "list",
+      "get",
+      "import",
+      "update",
+      "export",
+      "revisions",
+      "restore",
+      "delete-revision",
+      "retention",
+      "rename",
+      "delete",
+      "installation",
+    ],
+    "records installation": ["status", "detach", "observe", "replace"],
+  },
+};
 
 export const capletIdCommands = new Set<string>([
   cliCommands.inspect,

--- a/packages/core/src/cli/completion.ts
+++ b/packages/core/src/cli/completion.ts
@@ -111,8 +111,9 @@ export async function completeCliWords(
       return prefixFilter(cliSubcommands[command as keyof typeof cliSubcommands], current);
     }
 
-    const nestedStaticSubcommands = nestedSubcommandsFor(command, subcommand);
-    if (normalized.length === 3 && nestedStaticSubcommands) {
+    const nestedStaticSubcommands =
+      cliNestedSubcommands[command]?.[normalized.slice(1, -1).join(" ")];
+    if (nestedStaticSubcommands) {
       return prefixFilter(nestedStaticSubcommands, current);
     }
 
@@ -187,11 +188,6 @@ function suggestionsForOptionValue(
     optionValueSuggestions[command]?.[previous] ??
     optionValueSuggestions["*"]?.[previous]
   );
-}
-
-function nestedSubcommandsFor(command: string, subcommand: string): readonly string[] | undefined {
-  if (command !== cliCommands.remote || subcommand !== "host") return undefined;
-  return cliNestedSubcommands.remote.host;
 }
 
 const promptResourceCommands = new Set<string>([

--- a/packages/core/src/cli/setup-caplet.ts
+++ b/packages/core/src/cli/setup-caplet.ts
@@ -1,8 +1,13 @@
-import { loadConfigWithSources, resolveConfigPath, resolveProjectConfigPath } from "../config";
+import {
+  loadConfigWithHostStorage,
+  loadHostStorageConfig,
+  resolveConfigPath,
+  resolveProjectConfigPath,
+} from "../config";
 import { CapletsError } from "../errors";
 import { capletSetupContentHash } from "../setup/hash";
-import { LocalSetupStore } from "../setup/local-store";
 import { runCapletSetup, type SetupSpawn } from "../setup/runner";
+import { createHostStorage, createHostStorageVaultResolver, type HostStorage } from "../storage";
 import type { SetupActor, SetupTargetKind } from "../setup/types";
 
 export type CapletSetupCliOptions = {
@@ -11,7 +16,7 @@ export type CapletSetupCliOptions = {
   remote?: boolean;
   configPath?: string | undefined;
   projectConfigPath?: string | undefined;
-  baseDir?: string | undefined;
+  hostStorage?: HostStorage | undefined;
   spawn?: SetupSpawn;
 };
 
@@ -29,78 +34,91 @@ export async function runCapletSetupCli(
 
   const configPath = options.configPath ?? resolveConfigPath();
   const projectConfigPath = options.projectConfigPath ?? resolveProjectConfigPath();
-  const loaded = loadConfigWithSources(configPath, projectConfigPath);
-  const config = loaded.config;
-  const caplet = Object.values({
-    ...config.mcpServers,
-    ...config.openapiEndpoints,
-    ...config.googleDiscoveryApis,
-    ...config.graphqlEndpoints,
-    ...config.httpApis,
-    ...config.cliTools,
-    ...config.capletSets,
-  }).find((entry) => entry.server === capletId);
-  if (!caplet) throw new CapletsError("CONFIG_INVALID", `Unknown Caplet ID: ${capletId}`);
-  if (!caplet.setup || (!caplet.setup.commands?.length && !caplet.setup.verify?.length)) {
-    return `No setup metadata is defined for ${caplet.name} (${caplet.server}).\n`;
-  }
+  const storage =
+    options.hostStorage ?? (await createHostStorage(loadHostStorageConfig(configPath)));
+  const ownsStorage = options.hostStorage === undefined;
+  try {
+    const loaded = await loadConfigWithHostStorage(storage, configPath, projectConfigPath, {
+      vaultResolver: await createHostStorageVaultResolver(storage),
+    });
+    const config = loaded.config;
+    const caplet = Object.values({
+      ...config.mcpServers,
+      ...config.openapiEndpoints,
+      ...config.googleDiscoveryApis,
+      ...config.graphqlEndpoints,
+      ...config.httpApis,
+      ...config.cliTools,
+      ...config.capletSets,
+    }).find((entry) => entry.server === capletId);
+    if (!caplet) throw new CapletsError("CONFIG_INVALID", `Unknown Caplet ID: ${capletId}`);
+    if (!caplet.setup || (!caplet.setup.commands?.length && !caplet.setup.verify?.length)) {
+      return `No setup metadata is defined for ${caplet.name} (${caplet.server}).\n`;
+    }
 
-  const runtimeFingerprint = loaded.runtimeFingerprint?.caplets[caplet.server];
-  const contentHash = capletSetupContentHash(runtimeFingerprint);
-  const projectFingerprint = "default";
-  const store = new LocalSetupStore(options.baseDir ? { baseDir: options.baseDir } : {});
-  const existingApproval =
-    runtimeFingerprint?.persistenceEligible === false
-      ? undefined
-      : await store.getApproval(projectFingerprint, caplet.server, contentHash, targetKind);
-  const actor: SetupActor = options.yes ? "cli-yes" : "cli-interactive";
-  if (!existingApproval && !options.yes) {
-    return [
-      `Setup approval required for ${caplet.name} (${caplet.server}).`,
-      `Content hash: ${contentHash}`,
-      `Target: ${targetKind}`,
-      "",
-      "Commands:",
-      ...formatCommands(caplet.setup.commands ?? []),
-      "Verify:",
-      ...formatCommands(caplet.setup.verify ?? []),
-      "",
-      `Run caplets setup ${caplet.server} --yes to approve and execute these exact steps.`,
-      "",
-    ].join("\n");
-  }
+    const runtimeFingerprint = loaded.runtimeFingerprint?.caplets[caplet.server];
+    const contentHash = capletSetupContentHash(runtimeFingerprint);
+    const projectFingerprint = "default";
+    const store = storage.setupState;
+    const existingApproval =
+      runtimeFingerprint?.persistenceEligible === false
+        ? undefined
+        : await store.getApproval(projectFingerprint, caplet.server, contentHash, targetKind);
+    const actor: SetupActor = options.yes ? "cli-yes" : "cli-interactive";
+    if (!existingApproval && !options.yes) {
+      return [
+        `Setup approval required for ${caplet.name} (${caplet.server}).`,
+        `Content hash: ${contentHash}`,
+        `Target: ${targetKind}`,
+        "",
+        "Commands:",
+        ...formatCommands(caplet.setup.commands ?? []),
+        "Verify:",
+        ...formatCommands(caplet.setup.verify ?? []),
+        "",
+        `Run caplets setup ${caplet.server} --yes to approve and execute these exact steps.`,
+        "",
+      ].join("\n");
+    }
 
-  if (options.yes && !existingApproval && runtimeFingerprint?.persistenceEligible !== false) {
-    await store.approve({
+    if (options.yes && !existingApproval && runtimeFingerprint?.persistenceEligible !== false) {
+      await store.approve(
+        {
+          projectFingerprint,
+          capletId: caplet.server,
+          contentHash,
+          targetKind,
+          approvedAt: new Date().toISOString(),
+          actor,
+        },
+        { operatorClientId: "local_cli" },
+      );
+    }
+
+    const attempts = await runCapletSetup({
       projectFingerprint,
       capletId: caplet.server,
       contentHash,
       targetKind,
-      approvedAt: new Date().toISOString(),
+      setup: caplet.setup,
       actor,
+      approved: true,
+      store,
+      operatorClientId: "local_cli",
+      ...(options.spawn ? { spawn: options.spawn } : {}),
     });
+    const failed = attempts.find((attempt) => attempt.status === "failed");
+    if (failed) {
+      throw new CapletsError(
+        "SERVER_UNAVAILABLE",
+        `Setup failed for ${caplet.server}: ${failed.commandLabel}`,
+        { attempts },
+      );
+    }
+    return `Completed setup for ${caplet.name} (${caplet.server}).\n`;
+  } finally {
+    if (ownsStorage) await storage.close();
   }
-
-  const attempts = await runCapletSetup({
-    projectFingerprint,
-    capletId: caplet.server,
-    contentHash,
-    targetKind,
-    setup: caplet.setup,
-    actor,
-    approved: true,
-    store,
-    ...(options.spawn ? { spawn: options.spawn } : {}),
-  });
-  const failed = attempts.find((attempt) => attempt.status === "failed");
-  if (failed) {
-    throw new CapletsError(
-      "SERVER_UNAVAILABLE",
-      `Setup failed for ${caplet.server}: ${failed.commandLabel}`,
-      { attempts },
-    );
-  }
-  return `Completed setup for ${caplet.name} (${caplet.server}).\n`;
 }
 
 function resolveSetupTarget(options: CapletSetupCliOptions): SetupTargetKind {

--- a/packages/core/src/cli/vault.ts
+++ b/packages/core/src/cli/vault.ts
@@ -1,5 +1,9 @@
 import type { VaultAccessGrant, VaultDeleteStatus, VaultValueStatus } from "../vault";
 
+type VaultAccessGrantDisplay = Omit<VaultAccessGrant, "origin"> & {
+  origin?: { kind: string; path?: string | undefined } | undefined;
+};
+
 export function formatVaultValueStatus(status: VaultValueStatus, json = false): string {
   if (json) return `${JSON.stringify(status, null, 2)}\n`;
   if (!status.present) return `Vault key ${status.key} is not set.\n`;
@@ -26,17 +30,19 @@ export function formatVaultDeleteStatus(status: VaultDeleteStatus, json = false)
     : `No Vault key ${status.key} found.\n`;
 }
 
-export function formatVaultAccessGrant(grant: VaultAccessGrant, json = false): string {
+export function formatVaultAccessGrant(grant: VaultAccessGrantDisplay, json = false): string {
   if (json) return `${JSON.stringify(grant, null, 2)}\n`;
   return `Granted Vault key ${grant.storedKey} to ${grant.capletId} as ${grant.referenceName}.\n`;
 }
 
-export function formatVaultAccessList(grants: VaultAccessGrant[], json = false): string {
+export function formatVaultAccessList(grants: VaultAccessGrantDisplay[], json = false): string {
   if (json) return `${JSON.stringify(grants, null, 2)}\n`;
   if (grants.length === 0) return "No Vault access grants.\n";
   return `${grants
     .map((grant) => {
-      const origin = grant.origin ? ` (${grant.origin.kind} ${grant.origin.path})` : "";
+      const origin = grant.origin
+        ? ` (${grant.origin.kind}${grant.origin.path ? ` ${grant.origin.path}` : ""})`
+        : "";
       return `${grant.storedKey} -> ${grant.capletId}:${grant.referenceName}${origin}`;
     })
     .join("\n")}\n`;

--- a/packages/core/src/config-runtime.ts
+++ b/packages/core/src/config-runtime.ts
@@ -193,8 +193,41 @@ export type NamespaceAliasesConfig = {
   upstreams: Record<string, string>;
 };
 
+export type AssetStorageConfig =
+  | { type: "sql" }
+  | {
+      type: "s3";
+      endpoint?: string | undefined;
+      region: string;
+      bucket: string;
+      prefix?: string | undefined;
+      forcePathStyle?: boolean | undefined;
+      accessKeyId?: string | undefined;
+      secretAccessKey?: string | undefined;
+    };
+
+type HostStorageCommonConfig = {
+  assets?: AssetStorageConfig | undefined;
+  bundleLimits?:
+    | {
+        maxFiles?: number | undefined;
+        maxFileBytes?: number | undefined;
+        maxTotalBytes?: number | undefined;
+      }
+    | undefined;
+};
+
+export type HostStorageConfig =
+  | ({ type: "sqlite"; path?: string | undefined } & HostStorageCommonConfig)
+  | ({
+      type: "postgres";
+      connectionString: string;
+      schema?: string | undefined;
+    } & HostStorageCommonConfig);
+
 export type CapletsConfig = {
   version: 1;
+  storage: HostStorageConfig;
   options: {
     defaultSearchLimit: number;
     maxSearchLimit: number;
@@ -499,9 +532,60 @@ const namespaceAliasesSchema = z
     }
   });
 
+const assetStorageSchema = z
+  .discriminatedUnion("type", [
+    z.object({ type: z.literal("sql") }).strict(),
+    z
+      .object({
+        type: z.literal("s3"),
+        endpoint: z.string().url().optional(),
+        region: z.string().min(1),
+        bucket: z.string().min(1),
+        prefix: z.string().optional(),
+        forcePathStyle: z.boolean().optional(),
+        accessKeyId: z.string().min(1).optional(),
+        secretAccessKey: z.string().min(1).optional(),
+      })
+      .strict(),
+  ])
+  .optional();
+
+const bundleLimitsSchema = z
+  .object({
+    maxFiles: z.number().int().positive().max(100_000).optional(),
+    maxFileBytes: z.number().int().positive().optional(),
+    maxTotalBytes: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 const configSchema = z
   .object({
     version: z.literal(1).default(1),
+    storage: z
+      .discriminatedUnion("type", [
+        z
+          .object({
+            type: z.literal("sqlite"),
+            path: z.string().min(1).optional(),
+            assets: assetStorageSchema,
+            bundleLimits: bundleLimitsSchema,
+          })
+          .strict(),
+        z
+          .object({
+            type: z.literal("postgres"),
+            connectionString: z.string().min(1),
+            schema: z
+              .string()
+              .regex(/^[a-z_][a-z0-9_]{0,62}$/u)
+              .optional(),
+            assets: assetStorageSchema,
+            bundleLimits: bundleLimitsSchema,
+          })
+          .strict(),
+      ])
+      .default({ type: "sqlite" }),
     defaultSearchLimit: z.number().int().positive().default(20),
     maxSearchLimit: z.number().int().positive().max(50).default(50),
     completion: z
@@ -565,6 +649,7 @@ export function parseConfig(input: unknown): CapletsConfig {
   const config = parsed.data;
   return {
     version: 1,
+    storage: config.storage,
     options: {
       defaultSearchLimit: config.defaultSearchLimit,
       maxSearchLimit: config.maxSearchLimit,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { z } from "zod";
 import {
@@ -20,6 +21,7 @@ import {
 } from "./config-runtime";
 import {
   defaultConfigPath,
+  defaultStateBaseDir,
   resolveCapletsRoot,
   resolveConfigPath,
   resolveProjectConfigPath,
@@ -348,6 +350,38 @@ export type CapletsOptions = {
   completion: CompletionConfig;
 };
 
+export type AssetStorageConfig =
+  | { type: "sql" }
+  | {
+      type: "s3";
+      endpoint?: string | undefined;
+      region: string;
+      bucket: string;
+      prefix?: string | undefined;
+      forcePathStyle?: boolean | undefined;
+      accessKeyId?: string | undefined;
+      secretAccessKey?: string | undefined;
+    };
+
+type HostStorageCommonConfig = {
+  assets?: AssetStorageConfig | undefined;
+  bundleLimits?:
+    | {
+        maxFiles?: number | undefined;
+        maxFileBytes?: number | undefined;
+        maxTotalBytes?: number | undefined;
+      }
+    | undefined;
+};
+
+export type HostStorageConfig =
+  | ({ type: "sqlite"; path?: string | undefined } & HostStorageCommonConfig)
+  | ({
+      type: "postgres";
+      connectionString: string;
+      schema?: string | undefined;
+    } & HostStorageCommonConfig);
+
 export type ServeConfig = {
   host?: string | undefined;
   port?: number | undefined;
@@ -370,6 +404,7 @@ export type CapletsConfig = {
   version: 1;
   telemetry?: boolean | undefined;
   serve?: ServeConfig | undefined;
+  storage: HostStorageConfig;
   options: CapletsOptions;
   namespaceAliases: NamespaceAliasesConfig;
   mcpServers: Record<string, CapletServerConfig>;
@@ -381,7 +416,12 @@ export type CapletsConfig = {
   capletSets: Record<string, CapletSetConfig>;
 };
 
-export type ConfigSourceKind = "global-config" | "global-file" | "project-config" | "project-file";
+export type ConfigSourceKind =
+  | "stored-record"
+  | "global-config"
+  | "global-file"
+  | "project-config"
+  | "project-file";
 
 export type ConfigSource = {
   kind: ConfigSourceKind;
@@ -1177,6 +1217,7 @@ type ConfigSchemaCapletSetValue = z.infer<typeof normalizedCapletSetSchema>;
 type ConfigInput = {
   telemetry?: unknown;
   serve?: unknown;
+  storage?: unknown;
   namespaceAliases?: unknown;
   mcpServers?: Record<string, unknown>;
   openapiEndpoints?: Record<string, unknown>;
@@ -1251,6 +1292,62 @@ const serveConfigSchema = z
   })
   .strict();
 
+const assetStorageConfigSchema = z
+  .discriminatedUnion("type", [
+    z.object({ type: z.literal("sql") }).strict(),
+    z
+      .object({
+        type: z.literal("s3"),
+        endpoint: z.string().url().optional(),
+        region: z.string().trim().min(1),
+        bucket: z.string().trim().min(1),
+        prefix: z.string().trim().optional(),
+        forcePathStyle: z.boolean().optional(),
+        accessKeyId: z.string().min(1).optional(),
+        secretAccessKey: z.string().min(1).optional(),
+      })
+      .strict()
+      .refine(
+        (value) => Boolean(value.accessKeyId) === Boolean(value.secretAccessKey),
+        "S3 accessKeyId and secretAccessKey must be configured together",
+      ),
+  ])
+  .optional();
+
+const bundleLimitsSchema = z
+  .object({
+    maxFiles: z.number().int().positive().max(100_000).optional(),
+    maxFileBytes: z.number().int().positive().optional(),
+    maxTotalBytes: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
+const storageConfigSchema = z
+  .discriminatedUnion("type", [
+    z
+      .object({
+        type: z.literal("sqlite"),
+        path: z.string().trim().min(1).optional(),
+        assets: assetStorageConfigSchema,
+        bundleLimits: bundleLimitsSchema,
+      })
+      .strict(),
+    z
+      .object({
+        type: z.literal("postgres"),
+        connectionString: z.string().trim().min(1),
+        schema: z
+          .string()
+          .regex(/^[a-z_][a-z0-9_]{0,62}$/u, "invalid PostgreSQL schema name")
+          .optional(),
+        assets: assetStorageConfigSchema,
+        bundleLimits: bundleLimitsSchema,
+      })
+      .strict(),
+  ])
+  .default({ type: "sqlite" });
+
 const serveDefaultsFileSchema = z.object({ serve: serveConfigSchema.optional() }).passthrough();
 
 type MissingEnvReference = {
@@ -1288,6 +1385,9 @@ function configSchemaFor(
         .boolean()
         .optional()
         .describe("Set false to disable anonymous Caplets telemetry for this user config."),
+      storage: storageConfigSchema.describe(
+        "Authoritative Host State backend. SQLite is used when omitted.",
+      ),
       serve: serveConfigSchema
         .optional()
         .describe("User-owned HTTP serve defaults. Ignored from project config for security."),
@@ -1788,6 +1888,90 @@ export function loadConfigWithSources(
     "Caplets config must define at least one MCP server, OpenAPI endpoint, Google Discovery API, GraphQL endpoint, HTTP API, CLI tools backend, or Caplet set",
     options,
   );
+}
+
+export function loadHostStorageConfig(path = resolveConfigPath()): HostStorageConfig {
+  if (!existsSync(path)) return { type: "sqlite" };
+  const input = readPublicConfigInput(path) as ConfigInput;
+  return storageConfigSchema.parse(input.storage ?? { type: "sqlite" });
+}
+
+type StoredCapletSource = {
+  caplets: {
+    list(): Promise<Array<{ id: string }>>;
+    materializeRuntimeBundle(id: string, destination: string): Promise<void>;
+  };
+};
+
+export async function loadConfigWithHostStorage(
+  storage: StoredCapletSource,
+  path = resolveConfigPath(),
+  projectPath = resolveProjectConfigPath(),
+  options: Pick<ConfigParseOptions, "vaultResolver"> & {
+    recordCacheRoot?: string | undefined;
+  } = {},
+): Promise<ConfigWithSources> {
+  const recordCacheRoot = options.recordCacheRoot ?? join(defaultStateBaseDir(), "record-caplets");
+  await materializeStoredCaplets(storage, recordCacheRoot);
+  const storedCaplets = loadCapletFilesWithPaths(recordCacheRoot);
+  const userConfig = existsSync(path) ? readPublicConfigInput(path) : undefined;
+  const userCaplets = loadCapletFilesWithPaths(resolveCapletsRoot(path));
+  const projectConfig = existsSync(projectPath)
+    ? rejectProjectConfigExecutableBackendMaps(
+        stripProjectServeConfig(readPublicConfigInput(projectPath), projectPath),
+        projectPath,
+      )
+    : undefined;
+  const projectCapletsRoot = resolveProjectCapletsRootForConfigPath(projectPath);
+  const projectCaplets = projectCapletsRoot
+    ? loadCapletFilesWithPaths(projectCapletsRoot)
+    : undefined;
+  return buildConfigWithSources(
+    [
+      storedCaplets
+        ? {
+            input: storedCaplets.config,
+            source: { kind: "stored-record", path: storedCaplets.paths },
+          }
+        : undefined,
+      { input: userConfig, source: { kind: "global-config", path } },
+      userCaplets
+        ? { input: userCaplets.config, source: { kind: "global-file", path: userCaplets.paths } }
+        : undefined,
+      { input: projectConfig, source: { kind: "project-config", path: projectPath } },
+      projectCaplets
+        ? {
+            input: projectCaplets.config,
+            source: { kind: "project-file", path: projectCaplets.paths },
+          }
+        : undefined,
+    ],
+    `Caplets config not found at ${path} or ${projectPath}`,
+    "Caplets config must define at least one MCP server, OpenAPI endpoint, Google Discovery API, GraphQL endpoint, HTTP API, CLI tools backend, or Caplet set",
+    options,
+  );
+}
+
+async function materializeStoredCaplets(
+  storage: StoredCapletSource,
+  destination: string,
+): Promise<void> {
+  const parent = dirname(destination);
+  const staging = join(parent, `.${basename(destination)}.tmp-${randomUUID()}`);
+  const backup = join(parent, `.${basename(destination)}.backup-${randomUUID()}`);
+  mkdirSync(staging, { recursive: true, mode: 0o700 });
+  try {
+    for (const record of await storage.caplets.list()) {
+      await storage.caplets.materializeRuntimeBundle(record.id, join(staging, record.id));
+    }
+    if (existsSync(destination)) renameSync(destination, backup);
+    renameSync(staging, destination);
+    rmSync(backup, { recursive: true, force: true });
+  } catch (error) {
+    rmSync(staging, { recursive: true, force: true });
+    if (!existsSync(destination) && existsSync(backup)) renameSync(backup, destination);
+    throw error;
+  }
 }
 
 export function loadGlobalConfig(
@@ -3056,7 +3240,7 @@ function mergeConfigInputsWithSources(...inputs: Array<ConfigInputWithSource | u
 }
 
 function stripUserOnlyConfig(input: ConfigInput): ConfigInput {
-  const { telemetry: _telemetry, serve: _serve, ...rest } = input;
+  const { telemetry: _telemetry, serve: _serve, storage: _storage, ...rest } = input;
   return rest;
 }
 
@@ -3212,6 +3396,7 @@ export function parseConfig(input: unknown, options: ConfigParseOptions = {}): C
     version: parsed.data.version,
     telemetry: parsed.data.telemetry,
     ...(parsed.data.serve ? { serve: normalizeServeConfig(parsed.data.serve) } : {}),
+    storage: parsed.data.storage,
     options: {
       defaultSearchLimit: parsed.data.defaultSearchLimit,
       maxSearchLimit: parsed.data.maxSearchLimit,

--- a/packages/core/src/current-host/catalog-operations.ts
+++ b/packages/core/src/current-host/catalog-operations.ts
@@ -5,8 +5,9 @@ import {
   installCaplets,
   restoreCapletsFromLockfile,
   updateCapletsFromLockfile,
-} from "./../cli/install";
+} from "../install";
 import { CapletsError } from "../errors";
+import { installSqlCatalogCaplets, updateSqlCatalogCaplets } from "../storage/catalog-lifecycle";
 import {
   currentHostCatalogDetail,
   currentHostCatalogIndex,
@@ -93,8 +94,6 @@ async function catalogInstallOutcome(
     );
   }
   try {
-    const control = requireControlContext(dependencies.control, "Catalog actions");
-    const target = globalCatalogTarget(control);
     let repo = operation.repo;
     if (operation.source !== undefined) {
       if (!operation.entryKey) {
@@ -121,15 +120,10 @@ async function catalogInstallOutcome(
       capletIds = [detail.entry.id];
       repo = currentHostCatalogInstallSource(operation.source, detail.entry.resolvedRevision);
     }
-    const installOptions = {
-      ...target,
-      ...(capletIds === undefined ? {} : { capletIds }),
-      ...(operation.force === undefined ? {} : { force: operation.force }),
-    };
-    const installed = repo
-      ? installCaplets(repo, installOptions).installed
-      : restoreCapletsFromLockfile(installOptions).installed;
-    await attachCatalogIndexing(installed, operation.disableCatalogIndexing ?? false);
+    const installed = dependencies.catalogStorage
+      ? await installCatalogRecords(dependencies, principal, repo, capletIds, operation)
+      : await installCatalogFiles(dependencies, repo, capletIds, operation);
+    await dependencies.activateConfig?.();
     for (const entry of installed) {
       dependencies.activityLog.append({
         actorClientId: principal.clientId,
@@ -152,16 +146,23 @@ async function catalogUpdateOutcome(
 ): Promise<CatalogUpdateOutcome> {
   const capletIds = optionalCapletIds(operation.capletIds);
   try {
-    const control = requireControlContext(dependencies.control, "Catalog actions");
-    const installed = updateCapletsFromLockfile({
-      ...globalCatalogTarget(control),
-      ...(capletIds === undefined ? {} : { capletIds }),
-      ...(operation.force === undefined ? {} : { force: operation.force }),
-      ...(operation.allowRiskIncrease === undefined
-        ? {}
-        : { allowRiskIncrease: operation.allowRiskIncrease }),
-    }).installed;
-    await attachCatalogIndexing(installed, operation.disableCatalogIndexing ?? false);
+    const installed = dependencies.catalogStorage
+      ? (
+          await updateSqlCatalogCaplets({
+            storage: dependencies.catalogStorage,
+            operator: operator(principal),
+            ...(capletIds === undefined ? {} : { capletIds }),
+            ...(operation.force === undefined ? {} : { force: operation.force }),
+            ...(operation.allowRiskIncrease === undefined
+              ? {}
+              : { allowRiskIncrease: operation.allowRiskIncrease }),
+            ...(operation.disableCatalogIndexing === undefined
+              ? {}
+              : { disableCatalogIndexing: operation.disableCatalogIndexing }),
+          })
+        ).installed
+      : await updateCatalogFiles(dependencies, capletIds, operation);
+    await dependencies.activateConfig?.();
     for (const entry of installed) {
       dependencies.activityLog.append({
         actorClientId: principal.clientId,
@@ -178,6 +179,74 @@ async function catalogUpdateOutcome(
     appendCatalogFailureActivities(dependencies, principal, "catalog_updated", capletIds);
     throw error;
   }
+}
+
+async function installCatalogRecords(
+  dependencies: CurrentHostOperationsDependencies,
+  principal: CurrentHostOperatorPrincipal,
+  source: string | undefined,
+  capletIds: string[] | undefined,
+  operation: CatalogInstallOperation,
+) {
+  if (!source) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "SQL catalog install requires a source; tracked SQL installations are updated with catalog update.",
+    );
+  }
+  return (
+    await installSqlCatalogCaplets({
+      storage: dependencies.catalogStorage!,
+      operator: operator(principal),
+      source,
+      ...(capletIds === undefined ? {} : { capletIds }),
+      ...(operation.force === undefined ? {} : { force: operation.force }),
+      ...(operation.disableCatalogIndexing === undefined
+        ? {}
+        : { disableCatalogIndexing: operation.disableCatalogIndexing }),
+    })
+  ).installed;
+}
+
+async function installCatalogFiles(
+  dependencies: CurrentHostOperationsDependencies,
+  repo: string | undefined,
+  capletIds: string[] | undefined,
+  operation: CatalogInstallOperation,
+) {
+  const control = requireControlContext(dependencies.control, "Catalog actions");
+  const installOptions = {
+    ...globalCatalogTarget(control),
+    ...(capletIds === undefined ? {} : { capletIds }),
+    ...(operation.force === undefined ? {} : { force: operation.force }),
+  };
+  const installed = repo
+    ? installCaplets(repo, installOptions).installed
+    : restoreCapletsFromLockfile(installOptions).installed;
+  await attachCatalogIndexing(installed, operation.disableCatalogIndexing ?? false);
+  return installed;
+}
+
+async function updateCatalogFiles(
+  dependencies: CurrentHostOperationsDependencies,
+  capletIds: string[] | undefined,
+  operation: CatalogUpdateOperation,
+) {
+  const control = requireControlContext(dependencies.control, "Catalog actions");
+  const installed = updateCapletsFromLockfile({
+    ...globalCatalogTarget(control),
+    ...(capletIds === undefined ? {} : { capletIds }),
+    ...(operation.force === undefined ? {} : { force: operation.force }),
+    ...(operation.allowRiskIncrease === undefined
+      ? {}
+      : { allowRiskIncrease: operation.allowRiskIncrease }),
+  }).installed;
+  await attachCatalogIndexing(installed, operation.disableCatalogIndexing ?? false);
+  return installed;
+}
+
+function operator(principal: CurrentHostOperatorPrincipal) {
+  return { role: "operator" as const, clientId: principal.clientId };
 }
 
 function appendCatalogFailureActivities(

--- a/packages/core/src/current-host/client-operations.ts
+++ b/packages/core/src/current-host/client-operations.ts
@@ -1,5 +1,7 @@
 import { roleChangeMetadata } from "../dashboard/activity-log";
 import { CapletsError } from "../errors";
+import { RemoteServerCredentialStore } from "../remote/server-credential-store";
+import { RemoteSecurityStore } from "../storage/remote-security";
 import type {
   CurrentHostOperation,
   CurrentHostOperationOutcome,
@@ -32,45 +34,48 @@ type SummaryOutcome = Extract<CurrentHostOperationOutcome, { kind: "summary" }>;
 /** Current Host client and Pending Remote Login administration behind the facade. */
 export function createCurrentHostClientOperations(dependencies: CurrentHostOperationsDependencies) {
   return {
-    summary: (vaultCount: number, operation: SummaryOperation): SummaryOutcome =>
-      summaryOutcome(dependencies, vaultCount, operation),
-    listClients: (): ClientsListOutcome => ({
+    summary: async (vaultCount: number, operation: SummaryOperation): Promise<SummaryOutcome> =>
+      await summaryOutcome(dependencies, vaultCount, operation),
+    listClients: async (): Promise<ClientsListOutcome> => ({
       kind: "clients_list",
-      clients: dependencies.remoteCredentialStore?.listClients() ?? [],
+      clients: (await dependencies.remoteCredentialStore?.listClients()) ?? [],
     }),
-    listPendingLogins: (): PendingLoginsListOutcome => ({
+    listPendingLogins: async (): Promise<PendingLoginsListOutcome> => ({
       kind: "pending_logins_list",
-      pendingLogins: (dependencies.remoteCredentialStore?.listPendingLogins() ?? []).filter(
+      pendingLogins: ((await dependencies.remoteCredentialStore?.listPendingLogins()) ?? []).filter(
         (login) => login.status === "pending" || login.status === "approved",
       ),
     }),
-    approvePendingLogin: (
+    approvePendingLogin: async (
       principal: CurrentHostOperatorPrincipal,
       operation: PendingLoginApproveOperation,
-    ): PendingLoginApproveOutcome =>
-      pendingLoginApprovalOutcome(dependencies, principal, operation),
-    denyPendingLogin: (
+    ): Promise<PendingLoginApproveOutcome> =>
+      await pendingLoginApprovalOutcome(dependencies, principal, operation),
+    denyPendingLogin: async (
       principal: CurrentHostOperatorPrincipal,
       operation: PendingLoginDenyOperation,
-    ): PendingLoginDenyOutcome => pendingLoginDenialOutcome(dependencies, principal, operation),
-    revokeClient: (
+    ): Promise<PendingLoginDenyOutcome> =>
+      await pendingLoginDenialOutcome(dependencies, principal, operation),
+    revokeClient: async (
       principal: CurrentHostOperatorPrincipal,
       operation: ClientRevokeOperation,
-    ): ClientRevokeOutcome => clientRevokeOutcome(dependencies, principal, operation),
-    changeClientRole: (
+    ): Promise<ClientRevokeOutcome> =>
+      await clientRevokeOutcome(dependencies, principal, operation),
+    changeClientRole: async (
       principal: CurrentHostOperatorPrincipal,
       operation: ClientChangeRoleOperation,
-    ): ClientChangeRoleOutcome => clientRoleOutcome(dependencies, principal, operation),
+    ): Promise<ClientChangeRoleOutcome> =>
+      await clientRoleOutcome(dependencies, principal, operation),
   };
 }
 
-function summaryOutcome(
+async function summaryOutcome(
   dependencies: CurrentHostOperationsDependencies,
   vaultCount: number,
   operation: SummaryOperation,
-): SummaryOutcome {
-  const pendingLogins = dependencies.remoteCredentialStore?.listPendingLogins() ?? [];
-  const clients = dependencies.remoteCredentialStore?.listClients() ?? [];
+): Promise<SummaryOutcome> {
+  const pendingLogins = (await dependencies.remoteCredentialStore?.listPendingLogins()) ?? [];
+  const clients = (await dependencies.remoteCredentialStore?.listClients()) ?? [];
   const pending = pendingLogins.filter((login) => login.status === "pending");
   return {
     kind: "summary",
@@ -114,11 +119,11 @@ function summaryOutcome(
   };
 }
 
-function pendingLoginApprovalOutcome(
+async function pendingLoginApprovalOutcome(
   dependencies: CurrentHostOperationsDependencies,
   principal: CurrentHostOperatorPrincipal,
   operation: PendingLoginApproveOperation,
-): PendingLoginApproveOutcome {
+): Promise<PendingLoginApproveOutcome> {
   const flowId = requiredPendingLoginFlowId(operation.flowId);
   if (operation.grantedRole !== undefined) assertRemoteClientRole(operation.grantedRole);
   const store = dependencies.remoteCredentialStore;
@@ -130,10 +135,17 @@ function pendingLoginApprovalOutcome(
     return { kind: "pending_login_approve", status: "credential_store_unavailable" };
   }
   try {
-    const pendingLogin = store.approvePendingLoginFlow({
-      flowId,
-      ...(operation.grantedRole === undefined ? {} : { grantedRole: operation.grantedRole }),
-    });
+    const pendingLogin =
+      store instanceof RemoteSecurityStore
+        ? await store.approvePendingLoginFlow({
+            operatorClientId: principal.clientId,
+            flowId,
+            ...(operation.grantedRole === undefined ? {} : { grantedRole: operation.grantedRole }),
+          })
+        : store.approvePendingLoginFlow({
+            flowId,
+            ...(operation.grantedRole === undefined ? {} : { grantedRole: operation.grantedRole }),
+          });
     dependencies.activityLog.append({
       actorClientId: principal.clientId,
       action: "pending_login_approved",
@@ -153,11 +165,11 @@ function pendingLoginApprovalOutcome(
   }
 }
 
-function pendingLoginDenialOutcome(
+async function pendingLoginDenialOutcome(
   dependencies: CurrentHostOperationsDependencies,
   principal: CurrentHostOperatorPrincipal,
   operation: PendingLoginDenyOperation,
-): PendingLoginDenyOutcome {
+): Promise<PendingLoginDenyOutcome> {
   const flowId = requiredPendingLoginFlowId(operation.flowId);
   const store = dependencies.remoteCredentialStore;
   if (!store) {
@@ -168,7 +180,10 @@ function pendingLoginDenialOutcome(
     return { kind: "pending_login_deny", status: "credential_store_unavailable" };
   }
   try {
-    const pendingLogin = store.denyPendingLoginFlow({ flowId });
+    const pendingLogin =
+      store instanceof RemoteSecurityStore
+        ? await store.denyPendingLoginFlow({ operatorClientId: principal.clientId, flowId })
+        : store.denyPendingLoginFlow({ flowId });
     dependencies.activityLog.append({
       actorClientId: principal.clientId,
       action: "pending_login_denied",
@@ -185,11 +200,11 @@ function pendingLoginDenialOutcome(
   }
 }
 
-function clientRevokeOutcome(
+async function clientRevokeOutcome(
   dependencies: CurrentHostOperationsDependencies,
   principal: CurrentHostOperatorPrincipal,
   operation: ClientRevokeOperation,
-): ClientRevokeOutcome {
+): Promise<ClientRevokeOutcome> {
   const clientId = requiredRemoteClientId(operation.clientId);
   const store = dependencies.remoteCredentialStore;
   if (!store) {
@@ -200,8 +215,11 @@ function clientRevokeOutcome(
     return { kind: "client_revoke", status: "credential_store_unavailable", clientId };
   }
   try {
-    const client = store.listClients().find((candidate) => candidate.clientId === clientId);
-    const revoked = store.revokeClient(clientId);
+    const client = (await store.listClients()).find((candidate) => candidate.clientId === clientId);
+    const revoked =
+      store instanceof RemoteServerCredentialStore
+        ? store.revokeClient(clientId)
+        : await store.revokeClient({ operatorClientId: principal.clientId, clientId });
     if (revoked && !client?.revokedAt) {
       dependencies.activityLog.append({
         actorClientId: principal.clientId,
@@ -225,11 +243,11 @@ function clientRevokeOutcome(
   }
 }
 
-function clientRoleOutcome(
+async function clientRoleOutcome(
   dependencies: CurrentHostOperationsDependencies,
   principal: CurrentHostOperatorPrincipal,
   operation: ClientChangeRoleOperation,
-): ClientChangeRoleOutcome {
+): Promise<ClientChangeRoleOutcome> {
   const clientId = requiredRemoteClientId(operation.clientId);
   assertRemoteClientRole(operation.role);
   const store = dependencies.remoteCredentialStore;
@@ -241,8 +259,15 @@ function clientRoleOutcome(
     return { kind: "client_change_role", status: "credential_store_unavailable", clientId };
   }
   try {
-    const before = store.listClients().find((candidate) => candidate.clientId === clientId);
-    const client = store.changeClientRole(clientId, operation.role);
+    const before = (await store.listClients()).find((candidate) => candidate.clientId === clientId);
+    const client =
+      store instanceof RemoteServerCredentialStore
+        ? store.changeClientRole(clientId, operation.role)
+        : await store.changeClientRole({
+            operatorClientId: principal.clientId,
+            clientId,
+            role: operation.role,
+          });
     if (!client) {
       return { kind: "client_change_role", status: "not_found", clientId, sessionEnded: false };
     }

--- a/packages/core/src/current-host/operations.ts
+++ b/packages/core/src/current-host/operations.ts
@@ -1,12 +1,18 @@
 import type { CatalogCompactEntry, CatalogEntry } from "../catalog";
-import {
-  DashboardActivityLog,
-  type DashboardActivityAction,
-  type DashboardActivityEntry,
+import type {
+  AppendDashboardActivityInput,
+  DashboardActivityAction,
+  ListDashboardActivityInput,
 } from "../dashboard/activity-log";
 import type { CapletsEngine } from "../engine";
 import { CapletsError, toSafeError, type SafeErrorSummary } from "../errors";
 import type { RemoteServerCredentialStore } from "../remote/server-credential-store";
+import type { VaultGrantStore } from "../storage/vault-grants";
+import type { OperatorActivityEntry } from "../storage/operator-activity";
+import type { VaultValueRepository } from "../storage/vault-values";
+import type { RemoteSecurityStore } from "../storage/remote-security";
+import type { CapletRecordStore, CapletRecordView } from "../storage/caplet-records";
+import type { HostStorage } from "../storage/database";
 import type {
   RemoteClientRole,
   RemoteClientStatus,
@@ -21,6 +27,7 @@ import {
 } from "./catalog";
 import { createCurrentHostCatalogOperations } from "./catalog-operations";
 import { createCurrentHostClientOperations } from "./client-operations";
+import { createCurrentHostRecordOperations } from "./record-operations";
 import { createCurrentHostVaultOperations } from "./vault-operations";
 
 const TRUSTED_DEVELOPMENT_PRINCIPAL = Symbol("trusted-development-principal");
@@ -167,6 +174,34 @@ export type CurrentHostOperation =
       storedKey?: string | undefined;
       capletId?: string | undefined;
     }
+  | { kind: "stored_caplets_list" }
+  | { kind: "stored_caplet_get"; id: string; revisionKey?: string | undefined }
+  | {
+      kind: "stored_caplet_import";
+      id: string;
+      document: string;
+      historyLimit?: number | undefined;
+    }
+  | {
+      kind: "stored_caplet_update";
+      id: string;
+      document: string;
+      expectedGeneration: number;
+    }
+  | { kind: "stored_caplet_delete"; id: string; expectedGeneration: number }
+  | { kind: "stored_caplet_revisions"; id: string }
+  | {
+      kind: "stored_caplet_restore_revision";
+      id: string;
+      revisionKey: string;
+      expectedGeneration: number;
+    }
+  | {
+      kind: "stored_caplet_delete_revision";
+      id: string;
+      revisionKey: string;
+      expectedGeneration: number;
+    }
   | {
       kind: "runtime";
       baseUrl: string;
@@ -224,7 +259,7 @@ export type CurrentHostSummary = {
 };
 
 export type CurrentHostActivityPage = {
-  entries: DashboardActivityEntry[];
+  entries: OperatorActivityEntry[];
   nextCursor?: string | undefined;
 };
 
@@ -295,6 +330,24 @@ export type CurrentHostOperationOutcome =
   | { kind: "vault_access_grant"; grant: CurrentHostVaultAccessGrant }
   | { kind: "vault_access_revoke"; revoked: CurrentHostVaultAccessGrant[] }
   | { kind: "vault_access_list"; grants: CurrentHostVaultAccessGrant[] }
+  | { kind: "stored_caplets_list"; records: CapletRecordView[] }
+  | {
+      kind: "stored_caplet_get";
+      record: CapletRecordView;
+      document: string;
+    }
+  | { kind: "stored_caplet_import"; record: CapletRecordView }
+  | { kind: "stored_caplet_update"; record: CapletRecordView }
+  | { kind: "stored_caplet_delete"; deleted: true; id: string }
+  | {
+      kind: "stored_caplet_revisions";
+      revisions: Array<{ revisionKey: string; sequence: number; name: string }>;
+    }
+  | { kind: "stored_caplet_restore_revision"; record: CapletRecordView }
+  | {
+      kind: "stored_caplet_delete_revision";
+      record?: CapletRecordView | undefined;
+    }
   | {
       kind: "runtime";
       runtime: {
@@ -348,11 +401,24 @@ export interface CurrentHostOperations {
   ): Promise<CurrentHostOperationOutcomeFor<TOperation>>;
 }
 
+export type CurrentHostActivityStore = {
+  append(input: AppendDashboardActivityInput): unknown | Promise<unknown>;
+  list(
+    input?: ListDashboardActivityInput,
+  ): CurrentHostActivityPage | Promise<CurrentHostActivityPage>;
+};
+
 export type CurrentHostOperationsDependencies = {
   engine: Pick<CapletsEngine, "enabledServers">;
   control?: CurrentHostControlContext | undefined;
-  activityLog: DashboardActivityLog;
-  remoteCredentialStore?: RemoteServerCredentialStore | undefined;
+  activityLog: CurrentHostActivityStore;
+  remoteCredentialStore?: RemoteServerCredentialStore | RemoteSecurityStore | undefined;
+  capletRecords?: CapletRecordStore | undefined;
+  invalidateConfig?: ((operatorClientId: string) => Promise<void>) | undefined;
+  activateConfig?: (() => Promise<void>) | undefined;
+  catalogStorage?: HostStorage | undefined;
+  vaultGrants?: VaultGrantStore | undefined;
+  vaultValues?: VaultValueRepository | undefined;
   version: string;
 };
 
@@ -362,6 +428,7 @@ export function createCurrentHostOperations(
   const catalog = createCurrentHostCatalogOperations(dependencies);
   const clients = createCurrentHostClientOperations(dependencies);
   const vault = createCurrentHostVaultOperations(dependencies);
+  const records = createCurrentHostRecordOperations(dependencies);
 
   return {
     async execute<const TOperation extends CurrentHostOperation>(
@@ -374,6 +441,7 @@ export function createCurrentHostOperations(
         catalog,
         clients,
         vault,
+        records,
         principal,
         operation,
       );
@@ -387,12 +455,13 @@ async function executeCurrentHostOperation(
   catalog: ReturnType<typeof createCurrentHostCatalogOperations>,
   clients: ReturnType<typeof createCurrentHostClientOperations>,
   vault: ReturnType<typeof createCurrentHostVaultOperations>,
+  records: ReturnType<typeof createCurrentHostRecordOperations>,
   principal: CurrentHostOperatorPrincipal,
   operation: CurrentHostOperation,
 ): Promise<CurrentHostOperationOutcome> {
   switch (operation.kind) {
     case "summary":
-      return clients.summary(vault.valueCount(), operation);
+      return clients.summary(await vault.valueCount(), operation);
     case "caplets_list":
       return catalog.capletsList(operation);
     case "catalog_search":
@@ -408,33 +477,49 @@ async function executeCurrentHostOperation(
     case "catalog_update":
       return await catalog.update(principal, operation);
     case "clients_list":
-      return clients.listClients();
+      return await clients.listClients();
     case "pending_logins_list":
-      return clients.listPendingLogins();
+      return await clients.listPendingLogins();
     case "pending_login_approve":
-      return clients.approvePendingLogin(principal, operation);
+      return await clients.approvePendingLogin(principal, operation);
     case "pending_login_deny":
-      return clients.denyPendingLogin(principal, operation);
+      return await clients.denyPendingLogin(principal, operation);
     case "client_revoke":
-      return clients.revokeClient(principal, operation);
+      return await clients.revokeClient(principal, operation);
     case "client_change_role":
-      return clients.changeClientRole(principal, operation);
+      return await clients.changeClientRole(principal, operation);
     case "activity_list":
-      return { kind: "activity_list", activity: dependencies.activityLog.list(operation) };
+      return { kind: "activity_list", activity: await dependencies.activityLog.list(operation) };
     case "vault_set":
-      return vault.set(principal, operation);
+      return await vault.set(principal, operation);
     case "vault_list":
-      return vault.list(operation);
+      return await vault.list(operation);
     case "vault_get":
-      return vault.get(operation);
+      return await vault.get(operation);
     case "vault_delete":
-      return vault.delete(principal, operation);
+      return await vault.delete(principal, operation);
     case "vault_access_grant":
-      return vault.grant(principal, operation);
+      return await vault.grant(principal, operation);
     case "vault_access_revoke":
-      return vault.revoke(principal, operation);
+      return await vault.revoke(principal, operation);
     case "vault_access_list":
-      return vault.listAccess(operation);
+      return await vault.listAccess(operation);
+    case "stored_caplets_list":
+      return await records.list(principal);
+    case "stored_caplet_get":
+      return await records.get(principal, operation);
+    case "stored_caplet_import":
+      return await records.import(principal, operation);
+    case "stored_caplet_update":
+      return await records.update(principal, operation);
+    case "stored_caplet_delete":
+      return await records.delete(principal, operation);
+    case "stored_caplet_revisions":
+      return await records.revisions(principal, operation);
+    case "stored_caplet_restore_revision":
+      return await records.restoreRevision(principal, operation);
+    case "stored_caplet_delete_revision":
+      return await records.deleteRevision(principal, operation);
     case "runtime":
       return {
         kind: "runtime",
@@ -448,7 +533,7 @@ async function executeCurrentHostOperation(
         daemon: { restartAvailable: false, stopAvailable: false, uninstallAvailable: false },
       };
     case "runtime_restart":
-      dependencies.activityLog.append({
+      await dependencies.activityLog.append({
         actorClientId: principal.clientId,
         action: "runtime_restart_requested",
         outcome: "failure",

--- a/packages/core/src/current-host/record-operations.ts
+++ b/packages/core/src/current-host/record-operations.ts
@@ -1,0 +1,165 @@
+import { Buffer } from "node:buffer";
+import { CapletsError } from "../errors";
+import type {
+  CurrentHostOperation,
+  CurrentHostOperationOutcome,
+  CurrentHostOperatorPrincipal,
+  CurrentHostOperationsDependencies,
+} from "./operations";
+
+type GetOperation = Extract<CurrentHostOperation, { kind: "stored_caplet_get" }>;
+type ImportOperation = Extract<CurrentHostOperation, { kind: "stored_caplet_import" }>;
+type UpdateOperation = Extract<CurrentHostOperation, { kind: "stored_caplet_update" }>;
+type DeleteOperation = Extract<CurrentHostOperation, { kind: "stored_caplet_delete" }>;
+type RevisionsOperation = Extract<CurrentHostOperation, { kind: "stored_caplet_revisions" }>;
+type RestoreRevisionOperation = Extract<
+  CurrentHostOperation,
+  { kind: "stored_caplet_restore_revision" }
+>;
+type DeleteRevisionOperation = Extract<
+  CurrentHostOperation,
+  { kind: "stored_caplet_delete_revision" }
+>;
+
+type ListOutcome = Extract<CurrentHostOperationOutcome, { kind: "stored_caplets_list" }>;
+type GetOutcome = Extract<CurrentHostOperationOutcome, { kind: "stored_caplet_get" }>;
+type ImportOutcome = Extract<CurrentHostOperationOutcome, { kind: "stored_caplet_import" }>;
+type UpdateOutcome = Extract<CurrentHostOperationOutcome, { kind: "stored_caplet_update" }>;
+type DeleteOutcome = Extract<CurrentHostOperationOutcome, { kind: "stored_caplet_delete" }>;
+type RevisionsOutcome = Extract<CurrentHostOperationOutcome, { kind: "stored_caplet_revisions" }>;
+type RestoreRevisionOutcome = Extract<
+  CurrentHostOperationOutcome,
+  { kind: "stored_caplet_restore_revision" }
+>;
+type DeleteRevisionOutcome = Extract<
+  CurrentHostOperationOutcome,
+  { kind: "stored_caplet_delete_revision" }
+>;
+
+export function createCurrentHostRecordOperations(dependencies: CurrentHostOperationsDependencies) {
+  const records = dependencies.capletRecords;
+  const requiredRecords = () => {
+    if (!records) {
+      throw new CapletsError(
+        "SERVER_UNAVAILABLE",
+        "Authoritative Caplet Record storage is unavailable.",
+      );
+    }
+    return records;
+  };
+  const activate = async (): Promise<void> => {
+    await dependencies.activateConfig?.();
+  };
+
+  return {
+    list: async (principal: CurrentHostOperatorPrincipal): Promise<ListOutcome> => ({
+      kind: "stored_caplets_list",
+      records: await requiredRecords().listStored(operator(principal)),
+    }),
+    get: async (
+      principal: CurrentHostOperatorPrincipal,
+      operation: GetOperation,
+    ): Promise<GetOutcome> => {
+      const bundle = await requiredRecords().readBundle(operation.id, {
+        operator: operator(principal),
+        ...(operation.revisionKey === undefined ? {} : { revisionKey: operation.revisionKey }),
+      });
+      const document = bundle.files.find((file) => file.path === "CAPLET.md");
+      if (!document) {
+        throw new CapletsError("INTERNAL_ERROR", "Stored Caplet bundle has no CAPLET.md document.");
+      }
+      return {
+        kind: "stored_caplet_get",
+        record: bundle.record,
+        document: document.content.toString("utf8"),
+      };
+    },
+    import: async (
+      principal: CurrentHostOperatorPrincipal,
+      operation: ImportOperation,
+    ): Promise<ImportOutcome> => {
+      const record = await requiredRecords().importBundle({
+        id: operation.id,
+        files: [documentFile(operation.document)],
+        operator: operator(principal),
+        ...(operation.historyLimit === undefined ? {} : { historyLimit: operation.historyLimit }),
+      });
+      await activate();
+      return { kind: "stored_caplet_import", record };
+    },
+    update: async (
+      principal: CurrentHostOperatorPrincipal,
+      operation: UpdateOperation,
+    ): Promise<UpdateOutcome> => {
+      const store = requiredRecords();
+      const current = await store.readBundle(operation.id, { operator: operator(principal) });
+      const files = current.files.map((file) =>
+        file.path === "CAPLET.md" ? documentFile(operation.document) : file,
+      );
+      const record = await store.updateBundle({
+        id: operation.id,
+        files,
+        expectedGeneration: operation.expectedGeneration,
+        operator: operator(principal),
+      });
+      await activate();
+      return { kind: "stored_caplet_update", record };
+    },
+    delete: async (
+      principal: CurrentHostOperatorPrincipal,
+      operation: DeleteOperation,
+    ): Promise<DeleteOutcome> => {
+      await requiredRecords().hardDelete({
+        id: operation.id,
+        expectedGeneration: operation.expectedGeneration,
+        operator: operator(principal),
+      });
+      await activate();
+      return { kind: "stored_caplet_delete", deleted: true, id: operation.id };
+    },
+    revisions: async (
+      principal: CurrentHostOperatorPrincipal,
+      operation: RevisionsOperation,
+    ): Promise<RevisionsOutcome> => ({
+      kind: "stored_caplet_revisions",
+      revisions: await requiredRecords().listRevisions(operation.id, operator(principal)),
+    }),
+    restoreRevision: async (
+      principal: CurrentHostOperatorPrincipal,
+      operation: RestoreRevisionOperation,
+    ): Promise<RestoreRevisionOutcome> => {
+      const record = await requiredRecords().restoreRevision({
+        id: operation.id,
+        revisionKey: operation.revisionKey,
+        expectedGeneration: operation.expectedGeneration,
+        operator: operator(principal),
+      });
+      await activate();
+      return { kind: "stored_caplet_restore_revision", record };
+    },
+    deleteRevision: async (
+      principal: CurrentHostOperatorPrincipal,
+      operation: DeleteRevisionOperation,
+    ): Promise<DeleteRevisionOutcome> => {
+      const record = await requiredRecords().deleteRevision({
+        id: operation.id,
+        revisionKey: operation.revisionKey,
+        expectedGeneration: operation.expectedGeneration,
+        operator: operator(principal),
+      });
+      await activate();
+      return {
+        kind: "stored_caplet_delete_revision",
+        ...(record === undefined ? {} : { record }),
+      };
+    },
+  };
+}
+
+function operator(principal: CurrentHostOperatorPrincipal) {
+  return { role: "operator" as const, clientId: principal.clientId };
+}
+
+function documentFile(document: string) {
+  return { path: "CAPLET.md", content: Buffer.from(document), executable: false };
+}

--- a/packages/core/src/current-host/vault-operations.ts
+++ b/packages/core/src/current-host/vault-operations.ts
@@ -6,6 +6,8 @@ import {
 import { SERVER_ID_PATTERN } from "../config/validation";
 import { CapletsError } from "../errors";
 import { FileVaultStore, validateVaultKeyName, type VaultAccessGrantInput } from "../vault";
+import type { StoredVaultGrant, VaultGrantStore } from "../storage/vault-grants";
+import type { VaultValueRepository } from "../storage/vault-values";
 import type {
   CurrentHostOperation,
   CurrentHostOperationOutcome,
@@ -34,47 +36,236 @@ type VaultAccessListOutcome = Extract<CurrentHostOperationOutcome, { kind: "vaul
 
 /** Safe Vault administration implementation. Raw value reveal remains in the dashboard adapter. */
 export function createCurrentHostVaultOperations(dependencies: CurrentHostOperationsDependencies) {
-  const vault = vaultStoreForAuthDir(dependencies.control?.authDir);
+  const sqlValues = dependencies.vaultValues;
+  const sqlGrants = dependencies.vaultGrants;
+  if (Boolean(sqlValues) !== Boolean(sqlGrants)) {
+    throw new CapletsError(
+      "INTERNAL_ERROR",
+      "SQL Vault values and grants must be configured together.",
+    );
+  }
+  const fileVault = sqlValues ? undefined : vaultStoreForAuthDir(dependencies.control?.authDir);
 
   return {
-    valueCount: (): number => vault.listValues().length,
-    list: (_operation: VaultListOperation): VaultListOutcome => ({
+    valueCount: async (): Promise<number> =>
+      sqlValues ? (await sqlValues.listValues()).length : fileVault!.listValues().length,
+    list: async (_operation: VaultListOperation): Promise<VaultListOutcome> => ({
       kind: "vault_list",
-      values: vault.listValues(),
-      grants: vault.listAccess().map(redactedVaultGrant),
+      values: sqlValues ? await sqlValues.listValues() : fileVault!.listValues(),
+      grants:
+        sqlGrants && sqlValues
+          ? (await sqlGrants.list()).map(redactedSqlVaultGrant)
+          : fileVault!.listAccess().map(redactedVaultGrant),
     }),
-    get: (operation: VaultGetOperation): VaultGetOutcome => ({
+    get: async (operation: VaultGetOperation): Promise<VaultGetOutcome> => ({
       kind: "vault_get",
-      status: vault.getStatus(validateVaultKeyName(operation.name)),
+      status: sqlValues
+        ? await sqlValues.getStatus(validateVaultKeyName(operation.name))
+        : fileVault!.getStatus(validateVaultKeyName(operation.name)),
     }),
-    set: (principal: CurrentHostOperatorPrincipal, operation: VaultSetOperation): VaultSetOutcome =>
-      vaultSetOutcome(dependencies, vault, principal, operation),
-    delete: (
+    set: async (
+      principal: CurrentHostOperatorPrincipal,
+      operation: VaultSetOperation,
+    ): Promise<VaultSetOutcome> =>
+      sqlValues && sqlGrants
+        ? await sqlVaultSetOutcome(dependencies, sqlValues, sqlGrants, principal, operation)
+        : vaultSetOutcome(dependencies, fileVault!, principal, operation),
+    delete: async (
       principal: CurrentHostOperatorPrincipal,
       operation: VaultDeleteOperation,
-    ): VaultDeleteOutcome => vaultDeleteOutcome(dependencies, vault, principal, operation),
-    grant: (
+    ): Promise<VaultDeleteOutcome> =>
+      sqlValues && sqlGrants
+        ? await sqlVaultDeleteOutcome(dependencies, sqlValues, sqlGrants, principal, operation)
+        : vaultDeleteOutcome(dependencies, fileVault!, principal, operation),
+    grant: async (
       principal: CurrentHostOperatorPrincipal,
       operation: VaultAccessGrantOperation,
-    ): VaultAccessGrantOutcome => vaultGrantOutcome(dependencies, vault, principal, operation),
-    revoke: (
+    ): Promise<VaultAccessGrantOutcome> =>
+      sqlGrants
+        ? await sqlVaultGrantOutcome(dependencies, sqlGrants, principal, operation)
+        : vaultGrantOutcome(dependencies, fileVault!, principal, operation),
+    revoke: async (
       principal: CurrentHostOperatorPrincipal,
       operation: VaultAccessRevokeOperation,
-    ): VaultAccessRevokeOutcome => vaultRevokeOutcome(dependencies, vault, principal, operation),
-    listAccess: (operation: VaultAccessListOperation): VaultAccessListOutcome => ({
+    ): Promise<VaultAccessRevokeOutcome> =>
+      sqlGrants
+        ? await sqlVaultRevokeOutcome(dependencies, sqlGrants, principal, operation)
+        : vaultRevokeOutcome(dependencies, fileVault!, principal, operation),
+    listAccess: async (operation: VaultAccessListOperation): Promise<VaultAccessListOutcome> => ({
       kind: "vault_access_list",
-      grants: vault
-        .listAccess({
-          ...(operation.storedKey === undefined
-            ? {}
-            : { storedKey: validateVaultKeyName(operation.storedKey) }),
-          ...(operation.capletId === undefined
-            ? {}
-            : { capletId: requiredCapletId(operation.capletId) }),
-        })
-        .map(redactedVaultGrant),
+      grants: sqlGrants
+        ? (await sqlGrants.list(operation.capletId))
+            .filter((grant) => sqlGrantMatches(grant, operation))
+            .map(redactedSqlVaultGrant)
+        : fileVault!
+            .listAccess({
+              ...(operation.storedKey === undefined
+                ? {}
+                : { storedKey: validateVaultKeyName(operation.storedKey) }),
+              ...(operation.capletId === undefined
+                ? {}
+                : { capletId: requiredCapletId(operation.capletId) }),
+            })
+            .map(redactedVaultGrant),
     }),
   };
+}
+
+async function sqlVaultSetOutcome(
+  dependencies: CurrentHostOperationsDependencies,
+  values: VaultValueRepository,
+  grants: VaultGrantStore,
+  principal: CurrentHostOperatorPrincipal,
+  operation: VaultSetOperation,
+): Promise<VaultSetOutcome> {
+  const storedKey = validateVaultKeyName(operation.name);
+  const capletId = operation.grant === undefined ? undefined : requiredCapletId(operation.grant);
+  const referenceName =
+    capletId === undefined ? undefined : validateVaultKeyName(operation.referenceName ?? storedKey);
+  const previousStatus = await values.getStatus(storedKey);
+  const previousValue =
+    previousStatus.present && capletId !== undefined
+      ? await values.resolveValue(storedKey)
+      : undefined;
+  const status = await values.set(storedKey, operation.value, {
+    force: operation.force ?? false,
+    operatorClientId: principal.clientId,
+  });
+  if (capletId === undefined || referenceName === undefined) {
+    await dependencies.invalidateConfig?.(principal.clientId);
+    return { kind: "vault_set", status };
+  }
+  try {
+    const origin = vaultAccessOrigin(capletId, dependencies);
+    await grants.grant({
+      capletId,
+      vaultKey: storedKey,
+      referenceName,
+      originKind: origin.kind,
+      originPath: origin.path,
+      operator: sqlOperator(principal),
+    });
+    await dependencies.invalidateConfig?.(principal.clientId);
+    return { kind: "vault_set", status };
+  } catch (error) {
+    if (previousStatus.present && previousValue !== undefined) {
+      await values.set(storedKey, previousValue, {
+        force: true,
+        expectedGeneration: status.generation,
+        operatorClientId: principal.clientId,
+      });
+    } else {
+      await values.delete(storedKey, {
+        expectedGeneration: status.generation,
+        operatorClientId: principal.clientId,
+      });
+    }
+    throw error;
+  }
+}
+
+async function sqlVaultDeleteOutcome(
+  dependencies: CurrentHostOperationsDependencies,
+  values: VaultValueRepository,
+  grants: VaultGrantStore,
+  principal: CurrentHostOperatorPrincipal,
+  operation: VaultDeleteOperation,
+): Promise<VaultDeleteOutcome> {
+  const storedKey = validateVaultKeyName(operation.name);
+  const retained = (await grants.list()).filter((grant) => grant.vaultKey === storedKey).length;
+  const deleted = await values.delete(storedKey, { operatorClientId: principal.clientId });
+  if (deleted.deleted) await dependencies.invalidateConfig?.(principal.clientId);
+  return {
+    kind: "vault_delete",
+    deleted: { key: storedKey, deleted: deleted.deleted, grantsRetained: retained },
+  };
+}
+
+async function sqlVaultGrantOutcome(
+  dependencies: CurrentHostOperationsDependencies,
+  grants: VaultGrantStore,
+  principal: CurrentHostOperatorPrincipal,
+  operation: VaultAccessGrantOperation,
+): Promise<VaultAccessGrantOutcome> {
+  const storedKey = validateVaultKeyName(operation.storedKey);
+  const referenceName = validateVaultKeyName(operation.referenceName);
+  const capletId = requiredCapletId(operation.capletId);
+  const origin = vaultAccessOrigin(capletId, dependencies);
+  await grants.grant({
+    capletId,
+    vaultKey: storedKey,
+    referenceName,
+    originKind: origin.kind,
+    originPath: origin.path,
+    operator: sqlOperator(principal),
+  });
+  const grant = (await grants.list(capletId)).find(
+    (candidate) => candidate.vaultKey === storedKey && candidate.referenceName === referenceName,
+  );
+  if (!grant) {
+    throw new CapletsError("INTERNAL_ERROR", "Stored Vault access grant could not be reloaded.");
+  }
+  await dependencies.invalidateConfig?.(principal.clientId);
+  return { kind: "vault_access_grant", grant: redactedSqlVaultGrant(grant) };
+}
+
+async function sqlVaultRevokeOutcome(
+  dependencies: CurrentHostOperationsDependencies,
+  grants: VaultGrantStore,
+  principal: CurrentHostOperatorPrincipal,
+  operation: VaultAccessRevokeOperation,
+): Promise<VaultAccessRevokeOutcome> {
+  const storedKey = validateVaultKeyName(operation.storedKey);
+  const referenceName =
+    operation.referenceName === undefined
+      ? undefined
+      : validateVaultKeyName(operation.referenceName);
+  const capletId =
+    operation.capletId === undefined ? undefined : requiredCapletId(operation.capletId);
+  const candidates = (await grants.list(capletId)).filter(
+    (grant) =>
+      grant.vaultKey === storedKey &&
+      (referenceName === undefined || grant.referenceName === referenceName),
+  );
+  const revoked: StoredVaultGrant[] = [];
+  for (const grant of candidates) {
+    const removed = await grants.revoke({
+      capletId: grant.capletId,
+      vaultKey: grant.vaultKey,
+      referenceName: grant.referenceName,
+      operator: sqlOperator(principal),
+    });
+    if (removed) revoked.push(grant);
+  }
+  if (revoked.length > 0) await dependencies.invalidateConfig?.(principal.clientId);
+  return { kind: "vault_access_revoke", revoked: revoked.map(redactedSqlVaultGrant) };
+}
+
+function redactedSqlVaultGrant(grant: StoredVaultGrant): CurrentHostVaultAccessGrant {
+  return {
+    storedKey: grant.vaultKey,
+    referenceName: grant.referenceName,
+    capletId: grant.capletId,
+    origin: { kind: grant.originKind },
+    createdAt: grant.createdAt,
+    updatedAt: grant.createdAt,
+  };
+}
+
+function sqlGrantMatches(grant: StoredVaultGrant, operation: VaultAccessListOperation): boolean {
+  if (
+    operation.storedKey !== undefined &&
+    grant.vaultKey !== validateVaultKeyName(operation.storedKey)
+  ) {
+    return false;
+  }
+  return (
+    operation.capletId === undefined || grant.capletId === requiredCapletId(operation.capletId)
+  );
+}
+
+function sqlOperator(principal: CurrentHostOperatorPrincipal) {
+  return { role: "operator" as const, clientId: principal.clientId };
 }
 
 function vaultSetOutcome(

--- a/packages/core/src/dashboard/activity-log.ts
+++ b/packages/core/src/dashboard/activity-log.ts
@@ -8,6 +8,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { CapletsError } from "../errors";
 import { randomToken } from "../remote/pairing";
 import type { RemoteClientRole } from "../remote/server-credentials";
 
@@ -110,6 +111,27 @@ export class DashboardActivityLog {
     return { entries: page, ...(nextCursor ? { nextCursor } : {}) };
   }
 
+  exportForMigration(): {
+    entries: DashboardActivityEntry[];
+    sourcePaths: string[];
+  } {
+    const path = this.path();
+    if (!existsSync(path)) return { entries: [], sourcePaths: [] };
+    const raw = readFileSync(path, "utf8");
+    const entries = raw
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map(parseActivityEntryForMigration);
+    const ids = new Set<string>();
+    for (const entry of entries) {
+      if (ids.has(entry.id) || !Number.isFinite(Date.parse(entry.createdAt))) {
+        throw new CapletsError("CONFIG_INVALID", "Legacy Operator Activity is invalid.");
+      }
+      ids.add(entry.id);
+    }
+    return { entries, sourcePaths: [path] };
+  }
+
   private readEntries(): DashboardActivityEntry[] {
     const path = this.path();
     if (!existsSync(path)) return [];
@@ -165,6 +187,14 @@ function parseActivityEntry(line: string): DashboardActivityEntry[] {
     return [sanitizeActivityEntry(JSON.parse(line) as Partial<DashboardActivityEntry>)];
   } catch {
     return [];
+  }
+}
+
+function parseActivityEntryForMigration(line: string): DashboardActivityEntry {
+  try {
+    return sanitizeActivityEntry(JSON.parse(line) as Partial<DashboardActivityEntry>);
+  } catch {
+    throw new CapletsError("CONFIG_INVALID", "Legacy Operator Activity is invalid.");
   }
 }
 

--- a/packages/core/src/dashboard/session-store.ts
+++ b/packages/core/src/dashboard/session-store.ts
@@ -1,53 +1,38 @@
 import { Buffer } from "node:buffer";
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
-import { join } from "node:path";
 import { CapletsError } from "../errors";
-import type { RemoteServerCredentialStore } from "../remote/server-credential-store";
+import type { DashboardSessionRepository } from "../storage/dashboard-sessions";
 import {
   DASHBOARD_SESSION_COOKIE,
+  DASHBOARD_SESSION_ABSOLUTE_TIMEOUT_MS,
+  DASHBOARD_SESSION_IDLE_TIMEOUT_MS,
   type DashboardSessionRecord,
   type DashboardSessionView,
 } from "./types";
 
+export type DashboardOperatorClientValidator = (operatorClientId: string) => Promise<boolean>;
+
 export type DashboardSessionStoreOptions = {
-  dir: string;
+  repository: DashboardSessionRepository;
+  validateOperatorClient: DashboardOperatorClientValidator;
 };
-
-type DashboardSessionState = {
-  version: 1;
-  sessions: DashboardSessionRecord[];
-};
-
-const STATE_FILE = "dashboard-sessions.json";
-const LOCK_DIR = "dashboard-sessions.lock";
-const LOCK_TIMEOUT_MS = 100;
-const LOCK_STALE_MS = 30_000;
-const ABSOLUTE_TIMEOUT_MS = 12 * 60 * 60_000;
-const IDLE_TIMEOUT_MS = 60 * 60_000;
 
 export class DashboardSessionStore {
-  readonly dir: string;
+  private readonly repository: DashboardSessionRepository;
+  private readonly validateOperatorClient: DashboardOperatorClientValidator;
 
   constructor(options: DashboardSessionStoreOptions) {
-    this.dir = options.dir;
+    this.repository = options.repository;
+    this.validateOperatorClient = options.validateOperatorClient;
   }
 
-  create(input: { operatorClientId: string; now?: Date | undefined }): {
+  async create(input: { operatorClientId: string; now?: Date | undefined }): Promise<{
     cookieValue: string;
     session: DashboardSessionView;
-  } {
-    return this.withStateLock(() => {
-      const now = input.now ?? new Date();
+  }> {
+    const now = input.now ?? new Date();
+    await this.repository.cleanupExpired(now);
+    while (true) {
       const secret = `dash_secret_${randomToken(32)}`;
       const session: DashboardSessionRecord = {
         sessionId: `dash_${randomToken(12)}`,
@@ -56,189 +41,58 @@ export class DashboardSessionStore {
         role: "operator",
         csrfToken: `csrf_${randomToken(32)}`,
         createdAt: now.toISOString(),
-        expiresAt: new Date(now.getTime() + ABSOLUTE_TIMEOUT_MS).toISOString(),
+        expiresAt: new Date(now.getTime() + DASHBOARD_SESSION_ABSOLUTE_TIMEOUT_MS).toISOString(),
         lastUsedAt: now.toISOString(),
       };
-      const state = this.loadState();
-      cleanupSessions(state, now);
-      state.sessions.push(session);
-      this.saveState(state);
-      return { cookieValue: `${session.sessionId}.${secret}`, session: sessionView(session) };
-    });
+      if (await this.repository.create(session)) {
+        return { cookieValue: `${session.sessionId}.${secret}`, session: sessionView(session) };
+      }
+    }
   }
 
-  validate(input: {
+  async validate(input: {
     cookieHeader?: string | undefined;
-    credentialStore: RemoteServerCredentialStore;
     csrfToken?: string | undefined;
     requireCsrf?: boolean | undefined;
     now?: Date | undefined;
-  }): DashboardSessionView {
-    return this.withStateLock(() => {
-      const now = input.now ?? new Date();
-      const state = this.loadState();
-      cleanupSessions(state, now);
-      const parsed = parseDashboardCookie(input.cookieHeader);
-      if (!parsed) {
-        this.saveState(state);
-        throw new CapletsError("AUTH_FAILED", "Dashboard session is required.");
-      }
-      const session = state.sessions.find((candidate) => candidate.sessionId === parsed.sessionId);
-      if (!session || !safeHashEqual(hashSecret(parsed.secret), session.secretHash)) {
-        this.saveState(state);
-        throw new CapletsError("AUTH_FAILED", "Dashboard session is invalid.");
-      }
-      const expired = Date.parse(session.expiresAt) <= now.getTime();
-      const idleExpired = now.getTime() - Date.parse(session.lastUsedAt) > IDLE_TIMEOUT_MS;
-      if (expired || idleExpired) {
-        state.sessions = state.sessions.filter(
-          (candidate) => candidate.sessionId !== session.sessionId,
-        );
-        this.saveState(state);
-        throw new CapletsError("AUTH_FAILED", "Dashboard session has expired.");
-      }
-      const operator = input.credentialStore
-        .listClients()
-        .find((client) => client.clientId === session.operatorClientId);
-      if (!operator || operator.revokedAt || operator.role !== "operator") {
-        state.sessions = state.sessions.filter(
-          (candidate) => candidate.sessionId !== session.sessionId,
-        );
-        this.saveState(state);
-        throw new CapletsError("AUTH_FAILED", "Dashboard operator client is no longer authorized.");
-      }
-      if (input.requireCsrf && input.csrfToken !== session.csrfToken) {
-        this.saveState(state);
-        throw new CapletsError("REQUEST_INVALID", "Dashboard CSRF token is invalid.");
-      }
-      session.lastUsedAt = now.toISOString();
-      this.saveState(state);
-      return sessionView(session);
-    });
-  }
-
-  delete(cookieHeader?: string | undefined): boolean {
-    return this.withStateLock(() => {
-      const parsed = parseDashboardCookie(cookieHeader);
-      if (!parsed) return false;
-      const state = this.loadState();
-      const before = state.sessions.length;
-      state.sessions = state.sessions.filter((session) => session.sessionId !== parsed.sessionId);
-      this.saveState(state);
-      return state.sessions.length !== before;
-    });
-  }
-
-  private loadState(): DashboardSessionState {
-    const path = this.statePath();
-    if (!existsSync(path)) return { version: 1, sessions: [] };
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<DashboardSessionState>;
-    return {
-      version: 1,
-      sessions: (parsed.sessions ?? []).flatMap((session) => parseSessionRecord(session)),
-    };
-  }
-
-  private saveState(state: DashboardSessionState): void {
-    mkdirSync(this.dir, { recursive: true, mode: 0o700 });
-    try {
-      chmodSync(this.dir, 0o700);
-    } catch {
-      // Best effort on platforms without POSIX permissions.
+  }): Promise<DashboardSessionView> {
+    const now = input.now ?? new Date();
+    const parsed = parseDashboardCookie(input.cookieHeader);
+    const session = parsed ? await this.repository.get(parsed.sessionId) : undefined;
+    await this.repository.cleanupExpired(now);
+    if (!parsed) {
+      throw new CapletsError("AUTH_FAILED", "Dashboard session is required.");
     }
-    const path = this.statePath();
-    const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
-    writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
-    try {
-      chmodSync(tempPath, 0o600);
-    } catch {
-      // Best effort on platforms without POSIX permissions.
+    if (!session || !safeHashEqual(hashSecret(parsed.secret), session.secretHash)) {
+      throw new CapletsError("AUTH_FAILED", "Dashboard session is invalid.");
     }
-    renameSync(tempPath, path);
-  }
-
-  private statePath(): string {
-    return join(this.dir, STATE_FILE);
-  }
-
-  private lockPath(): string {
-    return join(this.dir, LOCK_DIR);
-  }
-
-  private withStateLock<T>(operation: () => T): T {
-    this.acquireLock();
-    try {
-      return operation();
-    } finally {
-      this.releaseLock();
+    const expired = Date.parse(session.expiresAt) <= now.getTime();
+    const idleExpired =
+      now.getTime() - Date.parse(session.lastUsedAt) > DASHBOARD_SESSION_IDLE_TIMEOUT_MS;
+    if (expired || idleExpired) {
+      throw new CapletsError("AUTH_FAILED", "Dashboard session has expired.");
     }
-  }
-
-  private acquireLock(): void {
-    mkdirSync(this.dir, { recursive: true, mode: 0o700 });
-    const started = Date.now();
-    while (true) {
-      try {
-        mkdirSync(this.lockPath(), { mode: 0o700 });
-        return;
-      } catch (error) {
-        if (isFileExistsError(error) && this.clearStaleLock()) continue;
-        if (!isFileExistsError(error) || Date.now() - started >= LOCK_TIMEOUT_MS) {
-          throw new CapletsError("SERVER_UNAVAILABLE", "Dashboard session state is locked.");
-        }
-        sleepSync(10);
-      }
+    if (!(await this.validateOperatorClient(session.operatorClientId))) {
+      await this.repository.delete(session.sessionId, {
+        expectedSecretHash: session.secretHash,
+      });
+      throw new CapletsError("AUTH_FAILED", "Dashboard operator client is no longer authorized.");
     }
-  }
-
-  private releaseLock(): void {
-    rmSync(this.lockPath(), { recursive: true, force: true });
-  }
-
-  private clearStaleLock(): boolean {
-    try {
-      if (Date.now() - statSync(this.lockPath()).mtimeMs < LOCK_STALE_MS) return false;
-      rmSync(this.lockPath(), { recursive: true, force: true });
-      return true;
-    } catch {
-      return false;
+    if (input.requireCsrf && input.csrfToken !== session.csrfToken) {
+      throw new CapletsError("REQUEST_INVALID", "Dashboard CSRF token is invalid.");
     }
+    const touched = await this.repository.touch(session.sessionId, session.secretHash, now);
+    if (!touched) {
+      throw new CapletsError("AUTH_FAILED", "Dashboard session has expired.");
+    }
+    return sessionView(touched);
   }
-}
 
-function parseSessionRecord(value: unknown): DashboardSessionRecord[] {
-  if (!value || typeof value !== "object") return [];
-  const record = value as Partial<DashboardSessionRecord>;
-  if (
-    typeof record.sessionId !== "string" ||
-    typeof record.secretHash !== "string" ||
-    typeof record.operatorClientId !== "string" ||
-    typeof record.csrfToken !== "string" ||
-    typeof record.createdAt !== "string" ||
-    typeof record.expiresAt !== "string" ||
-    typeof record.lastUsedAt !== "string"
-  ) {
-    return [];
+  async delete(cookieHeader?: string | undefined): Promise<boolean> {
+    const parsed = parseDashboardCookie(cookieHeader);
+    if (!parsed) return false;
+    return await this.repository.delete(parsed.sessionId, { operatorInitiated: true });
   }
-  return [
-    {
-      sessionId: record.sessionId,
-      secretHash: record.secretHash,
-      operatorClientId: record.operatorClientId,
-      role: "operator",
-      csrfToken: record.csrfToken,
-      createdAt: record.createdAt,
-      expiresAt: record.expiresAt,
-      lastUsedAt: record.lastUsedAt,
-    },
-  ];
-}
-
-function cleanupSessions(state: DashboardSessionState, now: Date): void {
-  state.sessions = state.sessions.filter((session) => {
-    if (Date.parse(session.expiresAt) <= now.getTime()) return false;
-    return now.getTime() - Date.parse(session.lastUsedAt) <= IDLE_TIMEOUT_MS;
-  });
 }
 
 function sessionView(session: DashboardSessionRecord): DashboardSessionView {
@@ -279,13 +133,4 @@ function safeHashEqual(left: string, right: string): boolean {
 
 function randomToken(bytes: number): string {
   return randomBytes(bytes).toString("base64url");
-}
-
-function sleepSync(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function isFileExistsError(error: unknown): boolean {
-  if (!error || typeof error !== "object" || !("code" in error)) return false;
-  return error.code === "EEXIST";
 }

--- a/packages/core/src/dashboard/types.ts
+++ b/packages/core/src/dashboard/types.ts
@@ -1,6 +1,8 @@
 import type { RemoteClientRole } from "../remote/server-credentials";
 
 export const DASHBOARD_SESSION_COOKIE = "caplets_dashboard_session";
+export const DASHBOARD_SESSION_ABSOLUTE_TIMEOUT_MS = 12 * 60 * 60_000;
+export const DASHBOARD_SESSION_IDLE_TIMEOUT_MS = 60 * 60_000;
 
 export type DashboardSessionRecord = {
   sessionId: string;

--- a/packages/core/src/downstream.ts
+++ b/packages/core/src/downstream.ts
@@ -16,12 +16,7 @@ import {
   ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types";
 import type { CapletServerConfig } from "./config";
-import {
-  classifyRemoteAuthError,
-  FileOAuthProvider,
-  readTokenBundle,
-  staticRemoteHeaders,
-} from "./auth";
+import { classifyRemoteAuthError, FileOAuthProvider, staticRemoteHeaders } from "./auth";
 import { CapletsError, toSafeError, type CapletsErrorCode, type SafeErrorSummary } from "./errors";
 import {
   projectBindingConnectionKey,
@@ -29,6 +24,7 @@ import {
   type ProjectBindingExecutionContext,
 } from "./project-binding/execution-context";
 import type { ServerRegistry } from "./registry";
+import type { BackendAuthStateStore } from "./storage/backend-auth";
 import { searchToolList } from "./tool-search";
 
 export type CompactTool = {
@@ -87,6 +83,11 @@ type ManagedConnection = {
   closing?: boolean;
 };
 
+type ConnectionAttempt = {
+  configFingerprint: string;
+  promise: Promise<ManagedConnection>;
+};
+
 type PendingConnection = {
   connection: ManagedConnection;
   promise: Promise<ManagedConnection>;
@@ -96,10 +97,12 @@ export class DownstreamManager {
   private readonly connections = new Map<string, ManagedConnection>();
   private readonly connecting = new Map<string, PendingConnection>();
   private readonly restartState = new Map<string, { restartUsed: boolean; backoffUntil: number }>();
+  private readonly connectionAttempts = new Map<string, ConnectionAttempt>();
 
   constructor(
     private registry: ServerRegistry,
     private readonly options: {
+      backendAuth?: BackendAuthStateStore | undefined;
       authDir?: string | undefined;
       projectBindingContext?: ProjectBindingExecutionContext | undefined;
     } = {},
@@ -563,6 +566,27 @@ export class DownstreamManager {
   private async connect(server: CapletServerConfig): Promise<ManagedConnection> {
     const expectedFingerprint = this.currentServerFingerprint(server);
     const connectionKey = this.connectionKey(server);
+    const existingAttempt = this.connectionAttempts.get(connectionKey);
+    if (existingAttempt?.configFingerprint === expectedFingerprint) {
+      return existingAttempt.promise;
+    }
+
+    const promise = this.connectUnshared(server, expectedFingerprint, connectionKey);
+    this.connectionAttempts.set(connectionKey, { configFingerprint: expectedFingerprint, promise });
+    try {
+      return await promise;
+    } finally {
+      if (this.connectionAttempts.get(connectionKey)?.promise === promise) {
+        this.connectionAttempts.delete(connectionKey);
+      }
+    }
+  }
+
+  private async connectUnshared(
+    server: CapletServerConfig,
+    expectedFingerprint: string,
+    connectionKey: string,
+  ): Promise<ManagedConnection> {
     const existing = this.connections.get(connectionKey);
     if (existing) {
       if (existing.configFingerprint !== expectedFingerprint) {
@@ -607,7 +631,7 @@ export class DownstreamManager {
     this.registry.setStatus(server.server, "starting");
     try {
       const client = new Client({ name: "caplets", version: "1.0.0" }, { capabilities: {} });
-      const transport = this.createTransport(server);
+      const transport = await this.createTransport(server);
       const connection: ManagedConnection = {
         client,
         transport,
@@ -727,7 +751,7 @@ export class DownstreamManager {
     }
   }
 
-  private createTransport(server: CapletServerConfig): any {
+  private async createTransport(server: CapletServerConfig): Promise<any> {
     if (server.transport === "stdio") {
       const cwd = resolveProjectBoundCwd({
         caplet: server,
@@ -757,7 +781,7 @@ export class DownstreamManager {
 
     const headers = staticRemoteHeaders(server);
     const requestInit = Object.keys(headers).length ? { headers } : undefined;
-    const authProvider = this.oauthProvider(server);
+    const authProvider = await this.oauthProvider(server);
     const fetchWithAuthClassification = async (
       input: Parameters<typeof fetch>[0],
       init?: RequestInit,
@@ -800,11 +824,19 @@ export class DownstreamManager {
     throw new CapletsError("UNSUPPORTED_TRANSPORT", `Unsupported transport for ${server.server}`);
   }
 
-  private oauthProvider(server: CapletServerConfig): FileOAuthProvider | undefined {
+  private async oauthProvider(server: CapletServerConfig): Promise<FileOAuthProvider | undefined> {
     if (server.auth?.type !== "oauth2" && server.auth?.type !== "oidc") {
       return undefined;
     }
-    const bundle = readTokenBundle(server.server, this.options.authDir);
+    const authStore = this.options.backendAuth;
+    if (!authStore) {
+      throw new CapletsError(
+        "SERVER_UNAVAILABLE",
+        "Authoritative backend auth storage is unavailable.",
+      );
+    }
+    const state = await authStore.readTokenBundle(server.server);
+    const bundle = state?.bundle;
     if (!bundle?.accessToken && !bundle?.refreshToken) {
       throw new CapletsError("AUTH_REQUIRED", `OAuth credentials required for ${server.server}`, {
         server: server.server,
@@ -822,7 +854,8 @@ export class DownstreamManager {
           nextAction: "run_caplets_auth_login",
         });
       },
-      this.options.authDir,
+      authStore,
+      state,
     );
   }
 

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1,4 +1,5 @@
-import { existsSync, readdirSync, statSync, watch, type FSWatcher } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, statSync, watch, type FSWatcher } from "node:fs";
 import { dirname, join, parse } from "node:path";
 import {
   createBackendOperationRuntime,
@@ -11,6 +12,8 @@ import {
   type CapletConfig,
   type CapletsConfig,
   loadLocalRuntimeConfig,
+  loadConfigWithHostStorage,
+  loadHostStorageConfig,
   type LocalOverlayConfigWarning,
   resolveCapletsRoot,
   resolveConfigPath,
@@ -18,7 +21,7 @@ import {
   runtimeFingerprintForConfig,
   vaultResolverForAuthDir,
 } from "./config";
-import { DEFAULT_OBSERVED_OUTPUT_SHAPE_CACHE_DIR } from "./config/paths";
+import { DEFAULT_OBSERVED_OUTPUT_SHAPE_CACHE_DIR, defaultStateBaseDir } from "./config/paths";
 import {
   resolvedExecutionFingerprintForConfig,
   type DeclaredInputReader,
@@ -36,6 +39,7 @@ import {
 } from "./observed-output-shapes";
 import type { ProjectBindingExecutionContext } from "./project-binding/execution-context";
 import { ServerRegistry } from "./registry";
+import { createHostStorage, createHostStorageVaultResolver, type HostStorage } from "./storage";
 import { extractArtifacts, handleServerTool } from "./tools";
 import { discoverExposureSnapshot, type ExposureSnapshot } from "./exposure/discovery";
 import { buildExposureProjection, type ExposureProjection } from "./exposure/projection";
@@ -79,6 +83,16 @@ export type CapletsEngineOptions = {
     projectConfigPath: string,
     options?: { writeWarning?: ((warning: LocalOverlayConfigWarning) => void) | undefined },
   ) => CapletsConfig;
+  asyncConfigLoader?: (
+    configPath: string,
+    projectConfigPath: string,
+    options?: { writeWarning?: ((warning: LocalOverlayConfigWarning) => void) | undefined },
+  ) => Promise<CapletsConfig>;
+  initialConfig?: CapletsConfig | undefined;
+  hostStorage?: HostStorage | undefined;
+  hostNodeId?: string | undefined;
+  hostConfigGeneration?: number | undefined;
+  hostRuntimeFingerprint?: string | undefined;
   declaredInputReader?: DeclaredInputReader | undefined;
   observedOutputShapeStore?: ObservedOutputShapeStore | undefined;
   observedOutputShapeScope?: ObservedOutputShapeKey["scope"] | undefined;
@@ -127,6 +141,14 @@ export class CapletsEngine {
   private readonly watchEnabled: boolean;
   private readonly writeErr: (value: string) => void;
   private readonly configLoader: NonNullable<CapletsEngineOptions["configLoader"]>;
+  private readonly asyncConfigLoader: CapletsEngineOptions["asyncConfigLoader"];
+  private readonly hostStorage: HostStorage | undefined;
+  private readonly hostNodeId: string | undefined;
+  private hostConfigGeneration: number;
+  private readonly hostRuntimeFingerprint: string;
+  private coordinationTimer: NodeJS.Timeout | undefined;
+  private coordinationAbortController: AbortController | undefined;
+  private coordinationTask: Promise<void> | undefined;
   private readonly declaredInputReader: DeclaredInputReader | undefined;
   private readonly requireValidCustomFingerprint: boolean;
   private readonly observedOutputShapeStore: ObservedOutputShapeStore | undefined;
@@ -146,6 +168,70 @@ export class CapletsEngine {
   private stableHostConfigurationFingerprint: string;
   private resolvedExecutionFingerprint: string;
 
+  static async create(options: CapletsEngineOptions = {}): Promise<CapletsEngine> {
+    const configPath = resolveConfigPath(options.configPath);
+    const projectConfigPath = options.projectConfigPath ?? resolveProjectConfigPath();
+    const storage = await createHostStorage(loadHostStorageConfig(configPath), {
+      vaultRoot: options.authDir ? join(options.authDir, "vault") : undefined,
+    });
+    const recordCacheRoot = join(defaultStateBaseDir(), "record-caplets");
+    const load = async (
+      path: string,
+      projectPath: string,
+      _loaderOptions?: {
+        writeWarning?: ((warning: LocalOverlayConfigWarning) => void) | undefined;
+      },
+    ): Promise<CapletsConfig> =>
+      (
+        await loadConfigWithHostStorage(storage, path, projectPath, {
+          recordCacheRoot,
+          vaultResolver: await createHostStorageVaultResolver(storage),
+        })
+      ).config;
+    try {
+      const loaded = await loadConfigWithHostStorage(storage, configPath, projectConfigPath, {
+        vaultResolver: await createHostStorageVaultResolver(storage),
+        recordCacheRoot,
+      });
+      const initialConfig = loaded.config;
+      const parityConfig = await load(
+        configPath,
+        join(recordCacheRoot, ".cluster-parity", "config.json"),
+      );
+      const hostRuntimeFingerprint =
+        runtimeFingerprintForConfig(parityConfig).hostConfigurationFingerprint;
+      const hostNodeId = randomUUID();
+      const registration = await storage.coordination.registerNode({
+        nodeId: hostNodeId,
+        globalFileManifest: globalFileManifest(configPath),
+        runtimeFingerprint: hostRuntimeFingerprint,
+      });
+      if (!registration.ready) {
+        throw new CapletsError(
+          "SERVER_UNAVAILABLE",
+          `Host Node configuration conflicts with another active node (${registration.conflict}).`,
+          { conflict: registration.conflict },
+        );
+      }
+      const hostConfigGeneration = await storage.coordination.publishConfigGeneration(
+        resolvedExecutionFingerprintForConfig(parityConfig),
+        hostNodeId,
+      );
+      return new CapletsEngine({
+        ...options,
+        initialConfig,
+        asyncConfigLoader: load,
+        hostRuntimeFingerprint,
+        hostStorage: storage,
+        hostNodeId,
+        hostConfigGeneration,
+      });
+    } catch (error) {
+      await storage.close();
+      throw error;
+    }
+  }
+
   constructor(options: CapletsEngineOptions = {}) {
     this.paths = {
       configPath: resolveConfigPath(options.configPath),
@@ -154,9 +240,17 @@ export class CapletsEngine {
     this.writeErr = options.writeErr ?? ((value: string) => process.stderr.write(value));
     this.configLoader =
       options.configLoader ?? runtimeConfigLoader(options.authDir, options.vaultRecoveryTarget);
+    this.asyncConfigLoader = options.asyncConfigLoader;
+    this.hostStorage = options.hostStorage;
     this.declaredInputReader = options.declaredInputReader;
-    this.requireValidCustomFingerprint = options.configLoader !== undefined;
-    const config = this.loadConfigWithWarnings();
+    this.requireValidCustomFingerprint =
+      options.configLoader !== undefined || options.asyncConfigLoader !== undefined;
+    const config = options.initialConfig ?? this.loadConfigWithWarnings();
+    this.hostNodeId = options.hostNodeId;
+    this.hostConfigGeneration = options.hostConfigGeneration ?? 0;
+    this.hostRuntimeFingerprint =
+      options.hostRuntimeFingerprint ??
+      runtimeFingerprintForConfig(config).hostConfigurationFingerprint;
     this.stableHostConfigurationFingerprint =
       runtimeFingerprintForConfig(config).hostConfigurationFingerprint;
     this.resolvedExecutionFingerprint = resolvedExecutionFingerprintForConfig(config);
@@ -176,6 +270,7 @@ export class CapletsEngine {
       options.telemetrySurface === "code_mode" ? "code_mode" : "progressive";
     this.downstream = new DownstreamManager(this.registry, {
       ...selectAuthOptions(options.authDir),
+      ...(options.hostStorage ? { backendAuth: options.hostStorage.backendAuth } : {}),
       projectBindingContext: options.projectBindingContext,
     });
     this.openapi = new OpenApiManager(this.registry, selectHttpLikeOptions(options));
@@ -211,6 +306,50 @@ export class CapletsEngine {
     if (this.watchEnabled) {
       this.resetWatchers();
     }
+    if (this.hostStorage && this.hostNodeId) {
+      this.coordinationAbortController = new AbortController();
+      this.coordinationTask = this.watchConfigGenerations(this.coordinationAbortController.signal);
+      this.coordinationTimer = setInterval(() => {
+        void this.refreshCoordinationHeartbeat();
+      }, 1_000);
+      this.coordinationTimer.unref();
+    }
+  }
+
+  async readiness(): Promise<{
+    ready: boolean;
+    backend?: "sqlite" | "postgres" | undefined;
+    reason?: string | undefined;
+  }> {
+    try {
+      await this.assertHostStorageReady();
+      return {
+        ready: true,
+        ...(this.hostStorage ? { backend: this.hostStorage.backend } : {}),
+      };
+    } catch (error) {
+      let reason = "host_not_ready";
+      if (
+        error instanceof CapletsError &&
+        error.details &&
+        typeof error.details === "object" &&
+        "reason" in error.details &&
+        typeof error.details.reason === "string"
+      ) {
+        reason = error.details.reason;
+      }
+      return {
+        ready: false,
+        ...(this.hostStorage ? { backend: this.hostStorage.backend } : {}),
+        reason,
+      };
+    }
+  }
+  authoritativeStorage(): HostStorage | undefined {
+    return this.hostStorage;
+  }
+  hostNodeIdentity(): string | undefined {
+    return this.hostNodeId;
   }
 
   currentConfig(): CapletsConfig {
@@ -306,6 +445,7 @@ export class CapletsEngine {
     const started = Date.now();
     let caplet: CapletConfig | undefined;
     try {
+      await this.assertHostStorageReady();
       caplet = this.registry.require(serverId);
       this.assertProjectBindingCallable(caplet);
       const result = await handleServerTool(caplet, request, this.registry, this.backendRuntime, {
@@ -347,6 +487,7 @@ export class CapletsEngine {
     const started = Date.now();
     let caplet: CapletConfig | undefined;
     try {
+      await this.assertHostStorageReady();
       caplet = this.registry.require(serverId);
       this.assertProjectBindingCallable(caplet);
       const result = await this.backendRuntime.operations.callTool(caplet, toolName, args);
@@ -370,6 +511,7 @@ export class CapletsEngine {
     const started = Date.now();
     let caplet: CapletConfig | undefined;
     try {
+      await this.assertHostStorageReady();
       caplet = this.registry.require(serverId);
       this.assertProjectBindingCallable(caplet);
       if (caplet.backend !== "mcp") throw new Error(`Caplet ${serverId} has no MCP completions`);
@@ -392,6 +534,7 @@ export class CapletsEngine {
     const started = Date.now();
     let caplet: CapletConfig | undefined;
     try {
+      await this.assertHostStorageReady();
       caplet = this.registry.require(serverId);
       this.assertProjectBindingCallable(caplet);
       if (caplet.backend !== "mcp") throw new Error(`Caplet ${serverId} has no MCP resources`);
@@ -415,6 +558,7 @@ export class CapletsEngine {
     const started = Date.now();
     let caplet: CapletConfig | undefined;
     try {
+      await this.assertHostStorageReady();
       caplet = this.registry.require(serverId);
       this.assertProjectBindingCallable(caplet);
       if (caplet.backend !== "mcp") throw new Error(`Caplet ${serverId} has no MCP prompts`);
@@ -476,6 +620,12 @@ export class CapletsEngine {
 
   async close(): Promise<void> {
     this.closed = true;
+    this.coordinationAbortController?.abort();
+    this.coordinationAbortController = undefined;
+    if (this.coordinationTimer) {
+      clearInterval(this.coordinationTimer);
+      this.coordinationTimer = undefined;
+    }
     try {
       if (this.reloadTimer) {
         clearTimeout(this.reloadTimer);
@@ -485,14 +635,22 @@ export class CapletsEngine {
         clearTimeout(this.watcherRefreshTimer);
         this.watcherRefreshTimer = undefined;
       }
+      if (this.coordinationTask) {
+        await this.coordinationTask;
+        this.coordinationTask = undefined;
+      }
       if (this.reloading) {
         await this.reloading;
+      }
+      if (this.hostStorage && this.hostNodeId) {
+        await this.hostStorage.coordination.unregisterNode(this.hostNodeId);
       }
     } finally {
       this.closeWatchers();
       await this.downstream.close();
       await this.capletSets.close();
       await this.telemetry.dispatcher.shutdown();
+      await this.hostStorage?.close();
       this.reloadListeners.clear();
     }
   }
@@ -554,7 +712,7 @@ export class CapletsEngine {
     }
     let nextConfig: CapletsConfig;
     try {
-      nextConfig = this.loadConfigWithWarnings();
+      nextConfig = await this.loadConfigWithWarningsAsync();
     } catch (error) {
       this.writeErr(`Caplets config reload failed; keeping last known-good config.\n`);
       this.writeErr(`${JSON.stringify(toSafeError(error, "CONFIG_INVALID"), null, 2)}\n`);
@@ -606,12 +764,82 @@ export class CapletsEngine {
     return invalidated;
   }
 
+  private async assertHostStorageReady(): Promise<void> {
+    if (!this.hostStorage) return;
+    if (this.hostNodeId && !(await this.hostStorage.coordination.nodeReady(this.hostNodeId))) {
+      throw new CapletsError("SERVER_UNAVAILABLE", "Host Node configuration parity is not ready.");
+    }
+    const health = await this.hostStorage.health();
+    if (!health.ready) {
+      throw new CapletsError(
+        "SERVER_UNAVAILABLE",
+        "Authoritative Host State storage is unavailable.",
+        { backend: health.backend, reason: health.reason },
+      );
+    }
+  }
+
+  private async refreshCoordinationHeartbeat(): Promise<void> {
+    if (!this.hostStorage || !this.hostNodeId || this.closed) return;
+    try {
+      await this.hostStorage.coordination.heartbeat({
+        nodeId: this.hostNodeId,
+        globalFileManifest: globalFileManifest(this.paths.configPath),
+        runtimeFingerprint: this.hostRuntimeFingerprint,
+      });
+    } catch {
+      // Request-time storage and node-readiness checks fail closed while coordination recovers.
+    }
+  }
+
+  private async watchConfigGenerations(signal: AbortSignal): Promise<void> {
+    if (!this.hostStorage) return;
+    let observedGeneration = this.hostConfigGeneration;
+    while (!this.closed && !signal.aborted) {
+      try {
+        const generation = await this.hostStorage.coordination.waitForConfigGeneration(
+          observedGeneration,
+          { signal },
+        );
+        if (this.closed || signal.aborted) return;
+        observedGeneration = Math.max(observedGeneration, generation);
+        if (generation > this.hostConfigGeneration && (await this.reload())) {
+          this.hostConfigGeneration = generation;
+        }
+      } catch {
+        if (this.closed || signal.aborted) return;
+        await coordinationRetryDelay(signal);
+      }
+    }
+  }
+
   private loadConfigWithWarnings(): CapletsConfig {
     const config = this.configLoader(this.paths.configPath, this.paths.projectConfigPath, {
       writeWarning: (warning) => {
         this.writeErr(`Warning: ${warning.kind} at ${warning.path}: ${warning.message}\n`);
       },
     });
+    const runtimeFingerprint = runtimeFingerprintForConfig(config, this.declaredInputReader);
+    if (this.requireValidCustomFingerprint && !runtimeFingerprint.valid) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        "Caplets runtime references must be present and readable.",
+      );
+    }
+    return config;
+  }
+
+  private async loadConfigWithWarningsAsync(): Promise<CapletsConfig> {
+    if (!this.asyncConfigLoader) return this.loadConfigWithWarnings();
+    const config = await this.asyncConfigLoader(
+      this.paths.configPath,
+      this.paths.projectConfigPath,
+      {
+        writeWarning: (warning) => {
+          this.writeErr(`Warning: ${warning.kind} at ${warning.path}: ${warning.message}\n`);
+        },
+      },
+    );
     const runtimeFingerprint = runtimeFingerprintForConfig(config, this.declaredInputReader);
     if (this.requireValidCustomFingerprint && !runtimeFingerprint.valid) {
       throw new CapletsError(
@@ -797,6 +1025,20 @@ export class CapletsEngine {
   }
 }
 
+function coordinationRetryDelay(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const finish = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, 1_000);
+    timer.unref();
+    signal.addEventListener("abort", finish, { once: true });
+  });
+}
+
 function runtimeConfigLoader(
   authDir: string | undefined,
   vaultRecoveryTarget: CapletsEngineOptions["vaultRecoveryTarget"],
@@ -816,6 +1058,7 @@ function selectAuthOptions(authDir: string | undefined): { authDir?: string } {
 
 function selectHttpLikeOptions(options: CapletsEngineOptions): {
   authDir?: string;
+  backendAuth?: HostStorage["backendAuth"];
   artifactDir?: string;
   exposeLocalArtifactPaths?: boolean;
   mediaInlineThresholdBytes?: number;
@@ -823,6 +1066,7 @@ function selectHttpLikeOptions(options: CapletsEngineOptions): {
 } {
   return {
     ...selectAuthOptions(options.authDir),
+    ...(options.hostStorage ? { backendAuth: options.hostStorage.backendAuth } : {}),
     ...(options.artifactDir ? { artifactDir: options.artifactDir } : {}),
     ...(options.exposeLocalArtifactPaths === false ? { exposeLocalArtifactPaths: false } : {}),
     ...(options.mediaInlineThresholdBytes === undefined
@@ -949,6 +1193,43 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function operationFromRequest(request: unknown): unknown {
   return isRecord(request) ? request.operation : undefined;
+}
+
+function globalFileManifest(configPath: string): string {
+  const root = resolveCapletsRoot(configPath);
+  const hash = createHash("sha256");
+  if (existsSync(configPath)) {
+    hash.update("config.json");
+    hash.update("\0");
+    hash.update(readFileSync(configPath));
+    hash.update("\0");
+  }
+  if (!existsSync(root)) return hash.digest("hex");
+  const appendFile = (path: string, relativePath: string): void => {
+    hash.update(relativePath);
+    hash.update("\0");
+    hash.update(readFileSync(path));
+    hash.update("\0");
+  };
+  const visitBundle = (directory: string, relativeRoot: string): void => {
+    for (const name of readdirSync(directory).sort()) {
+      const path = join(directory, name);
+      const relativePath = join(relativeRoot, name);
+      const stat = statSync(path);
+      if (stat.isDirectory()) visitBundle(path, relativePath);
+      else if (stat.isFile()) appendFile(path, relativePath);
+    }
+  };
+  for (const name of readdirSync(root).sort()) {
+    const path = join(root, name);
+    const stat = statSync(path);
+    if (stat.isFile() && name.toLowerCase().endsWith(".md")) {
+      appendFile(path, name);
+    } else if (stat.isDirectory() && existsSync(join(path, "CAPLET.md"))) {
+      visitBundle(path, name);
+    }
+  }
+  return hash.digest("hex");
 }
 
 function runtimeModeFromEnv(env: NodeJS.ProcessEnv | undefined): RuntimeMode {

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -60,6 +60,8 @@ import type {
   TelemetryVisibility,
 } from "./telemetry";
 
+const HOST_RUNTIME_FINGERPRINT_PATTERN = /^hmac-sha256:[a-f0-9]{64}$/u;
+
 type ToolSummary = { name: string; description?: string };
 
 export type ResolvedExposureProjection = {
@@ -93,6 +95,7 @@ export type CapletsEngineOptions = {
   hostNodeId?: string | undefined;
   hostConfigGeneration?: number | undefined;
   hostRuntimeFingerprint?: string | undefined;
+  parityConfigLoader?: (() => Promise<CapletsConfig>) | undefined;
   declaredInputReader?: DeclaredInputReader | undefined;
   observedOutputShapeStore?: ObservedOutputShapeStore | undefined;
   observedOutputShapeScope?: ObservedOutputShapeKey["scope"] | undefined;
@@ -142,10 +145,11 @@ export class CapletsEngine {
   private readonly writeErr: (value: string) => void;
   private readonly configLoader: NonNullable<CapletsEngineOptions["configLoader"]>;
   private readonly asyncConfigLoader: CapletsEngineOptions["asyncConfigLoader"];
+  private readonly parityConfigLoader: CapletsEngineOptions["parityConfigLoader"];
   private readonly hostStorage: HostStorage | undefined;
   private readonly hostNodeId: string | undefined;
   private hostConfigGeneration: number;
-  private readonly hostRuntimeFingerprint: string;
+  private hostRuntimeFingerprint: string;
   private coordinationTimer: NodeJS.Timeout | undefined;
   private coordinationAbortController: AbortController | undefined;
   private coordinationTask: Promise<void> | undefined;
@@ -188,18 +192,18 @@ export class CapletsEngine {
           vaultResolver: await createHostStorageVaultResolver(storage),
         })
       ).config;
+    const parityConfigLoader = async (): Promise<CapletsConfig> =>
+      await load(configPath, join(recordCacheRoot, ".cluster-parity", "config.json"));
     try {
       const loaded = await loadConfigWithHostStorage(storage, configPath, projectConfigPath, {
         vaultResolver: await createHostStorageVaultResolver(storage),
         recordCacheRoot,
       });
       const initialConfig = loaded.config;
-      const parityConfig = await load(
-        configPath,
-        join(recordCacheRoot, ".cluster-parity", "config.json"),
+      const parityConfig = await parityConfigLoader();
+      const hostRuntimeFingerprint = storage.vaultValues.hostRuntimeFingerprint(
+        clusterHostConfigurationFingerprint(parityConfig),
       );
-      const hostRuntimeFingerprint =
-        runtimeFingerprintForConfig(parityConfig).hostConfigurationFingerprint;
       const hostNodeId = randomUUID();
       const registration = await storage.coordination.registerNode({
         nodeId: hostNodeId,
@@ -222,6 +226,7 @@ export class CapletsEngine {
         initialConfig,
         asyncConfigLoader: load,
         hostRuntimeFingerprint,
+        parityConfigLoader,
         hostStorage: storage,
         hostNodeId,
         hostConfigGeneration,
@@ -241,6 +246,7 @@ export class CapletsEngine {
     this.configLoader =
       options.configLoader ?? runtimeConfigLoader(options.authDir, options.vaultRecoveryTarget);
     this.asyncConfigLoader = options.asyncConfigLoader;
+    this.parityConfigLoader = options.parityConfigLoader;
     this.hostStorage = options.hostStorage;
     this.declaredInputReader = options.declaredInputReader;
     this.requireValidCustomFingerprint =
@@ -248,11 +254,20 @@ export class CapletsEngine {
     const config = options.initialConfig ?? this.loadConfigWithWarnings();
     this.hostNodeId = options.hostNodeId;
     this.hostConfigGeneration = options.hostConfigGeneration ?? 0;
-    this.hostRuntimeFingerprint =
-      options.hostRuntimeFingerprint ??
-      runtimeFingerprintForConfig(config).hostConfigurationFingerprint;
     this.stableHostConfigurationFingerprint =
       runtimeFingerprintForConfig(config).hostConfigurationFingerprint;
+    if (
+      this.hostStorage &&
+      this.hostNodeId &&
+      !HOST_RUNTIME_FINGERPRINT_PATTERN.test(options.hostRuntimeFingerprint ?? "")
+    ) {
+      throw new CapletsError(
+        "INTERNAL_ERROR",
+        "Host Node keyed parity state must be initialized before runtime startup.",
+      );
+    }
+    this.hostRuntimeFingerprint =
+      options.hostRuntimeFingerprint ?? this.stableHostConfigurationFingerprint;
     this.resolvedExecutionFingerprint = resolvedExecutionFingerprintForConfig(config);
     this.registry = new ServerRegistry(config);
     this.telemetry = createRuntimeTelemetryContext({
@@ -711,8 +726,15 @@ export class CapletsEngine {
       return false;
     }
     let nextConfig: CapletsConfig;
+    let nextHostRuntimeFingerprint = this.hostRuntimeFingerprint;
     try {
       nextConfig = await this.loadConfigWithWarningsAsync();
+      if (this.parityConfigLoader && this.hostStorage && this.hostNodeId) {
+        const parityConfig = await this.parityConfigLoader();
+        nextHostRuntimeFingerprint = this.hostStorage.vaultValues.hostRuntimeFingerprint(
+          clusterHostConfigurationFingerprint(parityConfig),
+        );
+      }
     } catch (error) {
       this.writeErr(`Caplets config reload failed; keeping last known-good config.\n`);
       this.writeErr(`${JSON.stringify(toSafeError(error, "CONFIG_INVALID"), null, 2)}\n`);
@@ -720,6 +742,11 @@ export class CapletsEngine {
     }
     if (this.closed) {
       return false;
+    }
+
+    if (nextHostRuntimeFingerprint !== this.hostRuntimeFingerprint) {
+      this.hostRuntimeFingerprint = nextHostRuntimeFingerprint;
+      await this.refreshCoordinationHeartbeat();
     }
 
     const nextStableHostConfigurationFingerprint =
@@ -1195,15 +1222,14 @@ function operationFromRequest(request: unknown): unknown {
   return isRecord(request) ? request.operation : undefined;
 }
 
+function clusterHostConfigurationFingerprint(config: CapletsConfig): string {
+  const { serve: _serve, telemetry: _telemetry, ...clusterConfig } = config;
+  return runtimeFingerprintForConfig(clusterConfig).hostConfigurationFingerprint;
+}
+
 function globalFileManifest(configPath: string): string {
   const root = resolveCapletsRoot(configPath);
   const hash = createHash("sha256");
-  if (existsSync(configPath)) {
-    hash.update("config.json");
-    hash.update("\0");
-    hash.update(readFileSync(configPath));
-    hash.update("\0");
-  }
   if (!existsSync(root)) return hash.digest("hex");
   const appendFile = (path: string, relativePath: string): void => {
     hash.update(relativePath);

--- a/packages/core/src/google-discovery/manager.ts
+++ b/packages/core/src/google-discovery/manager.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sdk/types";
-import { genericOAuthHeaders, readTokenBundle } from "../auth";
+import { genericOAuthHeaders } from "../auth";
 import type { GoogleDiscoveryApiConfig } from "../config";
 import {
   compactToolSafetyHints,
@@ -15,6 +15,7 @@ import { DEFAULT_MAX_RESPONSE_BYTES, isAbortError, readLimitedText } from "../ht
 import { readMediaInput, type ResolvedMediaInput } from "../media";
 import type { ServerRegistry } from "../registry";
 import { markdownStructuredContent } from "../result-content";
+import type { BackendAuthStateStore } from "../storage/backend-auth";
 import { searchToolList } from "../tool-search";
 import {
   discoveryOperations,
@@ -45,6 +46,7 @@ export class GoogleDiscoveryManager {
   constructor(
     private registry: ServerRegistry,
     private readonly options: {
+      backendAuth?: BackendAuthStateStore;
       authDir?: string;
       artifactDir?: string;
       exposeLocalArtifactPaths?: boolean;
@@ -113,7 +115,7 @@ export class GoogleDiscoveryManager {
       : args;
     const url = buildGoogleDiscoveryUrl(requestApi, operation, requestArgs);
     const headers = new Headers(
-      await authHeaders(requestApi, this.options.authDir, operation.scopes),
+      await authHeaders(requestApi, this.options.backendAuth, operation.scopes),
     );
     const init = buildJsonRequestInit(operation, args, headers);
     const controller = new AbortController();
@@ -188,7 +190,7 @@ export class GoogleDiscoveryManager {
     if (this.options.artifactDir) mediaOptions.artifactRoot = this.options.artifactDir;
     if (this.options.exposeLocalArtifactPaths === false) mediaOptions.allowLocalPaths = false;
     const media = await readMediaInput(args.media, mediaOptions);
-    const headers = new Headers(await authHeaders(api, this.options.authDir, operation.scopes));
+    const headers = new Headers(await authHeaders(api, this.options.backendAuth, operation.scopes));
     const protocol = selectUploadProtocol(operation, media, args);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), api.requestTimeoutMs);
@@ -392,7 +394,7 @@ export class GoogleDiscoveryManager {
     if (!force && isFresh) return cached.operations ?? [];
 
     try {
-      const document = await loadGoogleDiscoveryDocument(api, this.options.authDir);
+      const document = await loadGoogleDiscoveryDocument(api, this.options.backendAuth);
       const baseUrl = googleDiscoveryBaseUrl(api, document);
       const operations = discoveryOperations({
         server: api.server,
@@ -588,9 +590,9 @@ async function fetchGoogleRequest(
 
 async function loadGoogleDiscoveryDocument(
   api: GoogleDiscoveryApiConfig,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<GoogleDiscoveryDocument> {
-  const source = await loadGoogleDiscoverySource(api, authDir);
+  const source = await loadGoogleDiscoverySource(api, authStore);
   let parsed: unknown;
   try {
     parsed = JSON.parse(source);
@@ -611,7 +613,7 @@ async function loadGoogleDiscoveryDocument(
 
 async function loadGoogleDiscoverySource(
   api: GoogleDiscoveryApiConfig,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<string> {
   if (api.discoveryPath) {
     return readFile(api.discoveryPath, "utf8");
@@ -622,7 +624,7 @@ async function loadGoogleDiscoverySource(
       `${api.server} is missing Google Discovery document source`,
     );
   }
-  return fetchDiscoverySource(api, await discoveryAuthHeaders(api, authDir));
+  return fetchDiscoverySource(api, await discoveryAuthHeaders(api, authStore));
 }
 
 async function fetchDiscoverySource(
@@ -666,23 +668,24 @@ async function fetchDiscoverySource(
 
 async function discoveryAuthHeaders(
   api: GoogleDiscoveryApiConfig,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<Record<string, string>> {
   if (api.auth.type === "none") return {};
   if (api.auth.type === "oauth2" || api.auth.type === "oidc") {
-    const protectedOrigin = discoveryProtectedResourceOrigin(api, authDir);
+    const protectedOrigin = await discoveryProtectedResourceOrigin(api, authStore);
     if (!protectedOrigin || !shouldSendDiscoveryAuth(api, protectedOrigin)) return {};
-    const bundle = readTokenBundle(api.server, authDir);
-    if (!bundle?.accessToken && !bundle?.refreshToken) return {};
-    return genericOAuthHeaders({ ...api, baseUrl: protectedOrigin }, authDir);
+    if (!authStore) return {};
+    const state = await authStore.readTokenBundle(api.server);
+    if (!state?.bundle.accessToken && !state?.bundle.refreshToken) return {};
+    return genericOAuthHeaders({ ...api, baseUrl: protectedOrigin }, authStore);
   }
   if (!api.baseUrl || !shouldSendDiscoveryAuth(api, new URL(api.baseUrl).origin)) return {};
-  return authHeaders(api, authDir);
+  return authHeaders(api, authStore);
 }
 
 async function authHeaders(
   api: GoogleDiscoveryApiConfig,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
   resolvedScopes?: string[],
 ): Promise<Record<string, string>> {
   switch (api.auth.type) {
@@ -694,17 +697,23 @@ async function authHeaders(
       return api.auth.headers;
     case "oauth2":
     case "oidc":
-      return genericOAuthHeaders({ ...api, resolvedScopes }, authDir);
+      if (!authStore) {
+        throw new CapletsError(
+          "SERVER_UNAVAILABLE",
+          "Authoritative backend auth storage is unavailable.",
+        );
+      }
+      return genericOAuthHeaders({ ...api, resolvedScopes }, authStore);
   }
 }
 
-function discoveryProtectedResourceOrigin(
+async function discoveryProtectedResourceOrigin(
   api: GoogleDiscoveryApiConfig,
-  authDir?: string,
-): string | undefined {
+  authStore?: BackendAuthStateStore,
+): Promise<string | undefined> {
   if (api.baseUrl) return new URL(api.baseUrl).origin;
-  const bundle = readTokenBundle(api.server, authDir);
-  return bundle?.protectedResourceOrigin;
+  if (!authStore) return undefined;
+  return (await authStore.readTokenBundle(api.server))?.bundle.protectedResourceOrigin;
 }
 
 function copySessionAuthorization(

--- a/packages/core/src/graphql.ts
+++ b/packages/core/src/graphql.ts
@@ -30,6 +30,7 @@ import {
 import { genericOAuthHeaders } from "./auth";
 import type { GraphQlEndpointConfig } from "./config";
 import { isAllowedRemoteUrl } from "./config/validation";
+import type { BackendAuthStateStore } from "./storage/backend-auth";
 import {
   compactToolSafetyHints,
   compactToolSchemaHints,
@@ -77,7 +78,7 @@ export class GraphQLManager {
   constructor(
     private registry: ServerRegistry,
     private readonly options: {
-      authDir?: string;
+      backendAuth?: BackendAuthStateStore;
       artifactDir?: string;
       exposeLocalArtifactPaths?: boolean;
       mediaInlineThresholdBytes?: number;
@@ -152,7 +153,7 @@ export class GraphQLManager {
             auth: endpoint.auth,
             requestTimeoutMs: endpoint.requestTimeoutMs,
           },
-          this.options.authDir,
+          this.options.backendAuth,
         )),
       });
       const response = await fetch(endpoint.endpointUrl, {
@@ -300,7 +301,7 @@ export class GraphQLManager {
 
     try {
       validateEndpointUrl(endpoint.endpointUrl);
-      const schema = await loadSchema(endpoint, this.options.authDir);
+      const schema = await loadSchema(endpoint, this.options.backendAuth);
       const operations =
         endpoint.operations && Object.keys(endpoint.operations).length > 0
           ? loadConfiguredOperations(endpoint, schema)
@@ -334,7 +335,7 @@ export class GraphQLManager {
 
 async function loadSchema(
   endpoint: GraphQlEndpointConfig,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<GraphQLSchema> {
   if (endpoint.schemaPath) {
     return parseSchemaSource(readFileSync(endpoint.schemaPath, "utf8"));
@@ -344,7 +345,7 @@ async function loadSchema(
     const source = await fetchGraphQlText(
       endpoint,
       endpoint.schemaUrl,
-      authDir,
+      authStore,
       shouldSendSchemaAuth(endpoint),
     );
     return parseSchemaSource(source);
@@ -353,7 +354,7 @@ async function loadSchema(
     endpoint,
     endpoint.endpointUrl,
     { query: getIntrospectionQuery() },
-    authDir,
+    authStore,
   );
   if (!response.ok) {
     throw new CapletsError("DOWNSTREAM_PROTOCOL_ERROR", "GraphQL introspection request failed", {
@@ -614,7 +615,7 @@ async function postGraphQl(
   endpoint: GraphQlEndpointConfig,
   url: string,
   payload: Record<string, unknown>,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), endpoint.requestTimeoutMs);
@@ -634,7 +635,7 @@ async function postGraphQl(
             auth: endpoint.auth,
             requestTimeoutMs: endpoint.requestTimeoutMs,
           },
-          authDir,
+          authStore,
         )),
       },
       body: JSON.stringify(payload),
@@ -652,7 +653,7 @@ async function postGraphQl(
 async function fetchGraphQlText(
   endpoint: GraphQlEndpointConfig,
   url: string,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
   sendAuth = true,
 ): Promise<string> {
   const controller = new AbortController();
@@ -663,7 +664,7 @@ async function fetchGraphQlText(
       redirect: "manual",
       signal: controller.signal,
       headers: {
-        ...(sendAuth ? await schemaAuthHeaders(endpoint, authDir) : {}),
+        ...(sendAuth ? await schemaAuthHeaders(endpoint, authStore) : {}),
       },
     });
   } catch (error) {
@@ -690,7 +691,7 @@ async function fetchGraphQlText(
 
 async function schemaAuthHeaders(
   endpoint: GraphQlEndpointConfig,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<Record<string, string>> {
   return {
     ...staticHeaders(endpoint),
@@ -702,7 +703,7 @@ async function schemaAuthHeaders(
         auth: endpoint.auth,
         requestTimeoutMs: endpoint.requestTimeoutMs,
       },
-      authDir,
+      authStore,
     )),
   };
 }

--- a/packages/core/src/http-actions.ts
+++ b/packages/core/src/http-actions.ts
@@ -2,6 +2,7 @@ import type { CompatibilityCallToolResult, Tool } from "@modelcontextprotocol/sd
 import { genericOAuthHeaders } from "./auth";
 import type { HttpActionConfig, HttpApiConfig } from "./config";
 import { FORBIDDEN_HEADERS, isAllowedRemoteUrl } from "./config/validation";
+import type { BackendAuthStateStore } from "./storage/backend-auth";
 import {
   compactToolSafetyHints,
   compactToolSchemaHints,
@@ -23,7 +24,7 @@ export class HttpActionManager {
   constructor(
     private registry: ServerRegistry,
     private readonly options: {
-      authDir?: string;
+      backendAuth?: BackendAuthStateStore;
       artifactDir?: string;
       exposeLocalArtifactPaths?: boolean;
       mediaInlineThresholdBytes?: number;
@@ -47,7 +48,7 @@ export class HttpActionManager {
     try {
       const operations = operationsFor(api);
       validateBaseUrl(api);
-      await authHeaders(api, this.options.authDir);
+      await authHeaders(api, this.options.backendAuth);
       for (const operation of operations) {
         validateAction(api, operation);
       }
@@ -85,7 +86,7 @@ export class HttpActionManager {
   ): Promise<CompatibilityCallToolResult> {
     const operation = getOperation(api, toolName);
     const startedAt = Date.now();
-    const request = await buildRequest(api, operation, args, this.options.authDir);
+    const request = await buildRequest(api, operation, args, this.options.backendAuth);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), api.requestTimeoutMs);
     try {
@@ -209,7 +210,7 @@ async function buildRequest(
   api: HttpApiConfig,
   operation: HttpActionOperation,
   args: Record<string, unknown>,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<{ url: URL; headers: Headers; body?: string }> {
   validateBaseUrl(api);
   validateAction(api, operation);
@@ -223,7 +224,7 @@ async function buildRequest(
     }
   }
   const headers = new Headers();
-  await applyAuth(headers, api, authDir);
+  await applyAuth(headers, api, authStore);
   const resolvedHeaders = resolveMappingToRecord(operation.headers, args, "headers");
   for (const [key, value] of Object.entries(resolvedHeaders)) {
     if (value !== undefined && value !== null) {
@@ -359,13 +360,20 @@ function serializeHttpValue(
   }
 }
 
-async function applyAuth(headers: Headers, api: HttpApiConfig, authDir?: string): Promise<void> {
-  for (const [key, value] of Object.entries(await authHeaders(api, authDir))) {
+async function applyAuth(
+  headers: Headers,
+  api: HttpApiConfig,
+  authStore?: BackendAuthStateStore,
+): Promise<void> {
+  for (const [key, value] of Object.entries(await authHeaders(api, authStore))) {
     headers.set(key, value);
   }
 }
 
-async function authHeaders(api: HttpApiConfig, authDir?: string): Promise<Record<string, string>> {
+async function authHeaders(
+  api: HttpApiConfig,
+  authStore?: BackendAuthStateStore,
+): Promise<Record<string, string>> {
   switch (api.auth.type) {
     case "none":
       return {};
@@ -383,7 +391,7 @@ async function authHeaders(api: HttpApiConfig, authDir?: string): Promise<Record
           auth: api.auth,
           requestTimeoutMs: api.requestTimeoutMs,
         },
-        authDir,
+        authStore,
       );
   }
 }

--- a/packages/core/src/install.ts
+++ b/packages/core/src/install.ts
@@ -29,19 +29,19 @@ import {
   loadCapletFilesFromMap,
   loadCapletFilesWithPaths,
   validateCapletFile,
-} from "../caplet-files";
-import type { CapletFileConfig } from "../caplet-files";
+} from "./caplet-files";
+import type { CapletFileConfig } from "./caplet-files";
 import {
   createMemoryDeclaredInputReader,
   createRuntimeFingerprintSnapshot,
   type RuntimeFingerprintSnapshot,
-} from "../caplet-source";
-import { parseConfig } from "../config-runtime";
-import { resolveProjectCapletsRoot } from "../config";
-import { SERVER_ID_PATTERN } from "../config/validation";
-import { CapletsError, toSafeError } from "../errors";
-import type { CatalogIndexingResult } from "../catalog-indexing/payload";
-import { catalogIndexingPayloadForLockEntry } from "../catalog-indexing/eligibility";
+} from "./caplet-source";
+import { parseConfig } from "./config-runtime";
+import { resolveProjectCapletsRoot } from "./config";
+import { SERVER_ID_PATTERN } from "./config/validation";
+import { CapletsError, toSafeError } from "./errors";
+import type { CatalogIndexingResult } from "./catalog-indexing/payload";
+import { catalogIndexingPayloadForLockEntry } from "./catalog-indexing/eligibility";
 import {
   catalogAuthRequiredFromFrontmatter,
   catalogIconFromFrontmatter,
@@ -58,7 +58,7 @@ import {
   type CatalogEntry,
   type CatalogEntryChild,
   type CatalogWorkflowSummary,
-} from "../catalog";
+} from "./catalog";
 import {
   replaceCapletsLockfileTemporary,
   parseCapletsLockfile,
@@ -476,7 +476,7 @@ function updateCapletsFromLockfileUnlocked(
         if (
           status === "updated" &&
           !allowRiskIncrease &&
-          riskIncrease(entry.risk, candidate.risk)
+          capletRiskIncreases(entry.risk, candidate.risk)
         ) {
           throw new CapletsError(
             "REQUEST_INVALID",
@@ -1671,7 +1671,10 @@ function riskSummaryForSourcePath(sourcePath: string): CapletsLockEntry["risk"] 
   };
 }
 
-function riskIncrease(current: CapletsLockEntry["risk"], next: CapletsLockEntry["risk"]): boolean {
+export function capletRiskIncreases(
+  current: CapletsLockEntry["risk"],
+  next: CapletsLockEntry["risk"],
+): boolean {
   if (current.safety === "unknown" || next.safety === "unknown") return true;
   if (riskRank(next.safety) > riskRank(current.safety)) return true;
   if (!current.projectBindingRequired && next.projectBindingRequired) return true;

--- a/packages/core/src/lockfile.ts
+++ b/packages/core/src/lockfile.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
-import { CapletsError, toSafeError } from "../errors";
+import { CapletsError, toSafeError } from "./errors";
 
 export const CAPLETS_LOCKFILE_VERSION = 1;
 

--- a/packages/core/src/openapi.ts
+++ b/packages/core/src/openapi.ts
@@ -4,6 +4,7 @@ import { parse as parseYaml } from "yaml";
 import { genericOAuthHeaders } from "./auth";
 import type { OpenApiEndpointConfig } from "./config";
 import { isAllowedRemoteUrl } from "./config/validation";
+import type { BackendAuthStateStore } from "./storage/backend-auth";
 import {
   compactToolSafetyHints,
   compactToolSchemaHints,
@@ -64,6 +65,7 @@ export class OpenApiManager {
   constructor(
     private registry: ServerRegistry,
     private readonly options: {
+      backendAuth?: BackendAuthStateStore;
       authDir?: string;
       artifactDir?: string;
       exposeLocalArtifactPaths?: boolean;
@@ -124,7 +126,7 @@ export class OpenApiManager {
     args: Record<string, unknown>,
   ): Promise<CompatibilityCallToolResult> {
     const operation = await this.getOperation(endpoint, toolName);
-    const request = await buildRequest(endpoint, operation, args, this.options.authDir);
+    const request = await buildRequest(endpoint, operation, args, this.options.backendAuth);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), endpoint.requestTimeoutMs);
     try {
@@ -264,7 +266,7 @@ export class OpenApiManager {
     }
 
     try {
-      const document = await loadOpenApiDocument(endpoint, this.options.authDir);
+      const document = await loadOpenApiDocument(endpoint, this.options.backendAuth);
       const operations = extractOperations(endpoint, document);
       this.cache.set(endpoint.server, { operations, fetchedAt: Date.now(), cacheKey });
       this.registry.setStatus(endpoint.server, "available");
@@ -300,9 +302,9 @@ export class OpenApiManager {
 
 async function loadOpenApiDocument(
   endpoint: OpenApiEndpointConfig,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<OpenApiDocument> {
-  const source = await loadOpenApiSource(endpoint, authDir);
+  const source = await loadOpenApiSource(endpoint, authStore);
   return (await SwaggerParser.validate(source as any, {
     resolve: {
       external: false,
@@ -313,7 +315,7 @@ async function loadOpenApiDocument(
 
 async function loadOpenApiSource(
   endpoint: OpenApiEndpointConfig,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<string | OpenApiDocument> {
   if (endpoint.specPath) {
     return endpoint.specPath;
@@ -330,7 +332,7 @@ async function loadOpenApiSource(
   const response = await fetchWithLimit(
     endpoint.specUrl,
     endpoint.requestTimeoutMs,
-    shouldSendSpecAuth(endpoint) ? await authHeaders(endpoint, authDir) : {},
+    shouldSendSpecAuth(endpoint) ? await authHeaders(endpoint, authStore) : {},
   );
   return parseOpenApiSourceText(response);
 }
@@ -601,7 +603,7 @@ async function buildRequest(
   endpoint: OpenApiEndpointConfig,
   operation: OpenApiOperation,
   args: Record<string, unknown>,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<{ url: URL; headers: Headers; body?: string }> {
   const base = endpoint.baseUrl ?? operation.baseUrl;
   validateOperationBaseUrl(endpoint, base);
@@ -615,7 +617,7 @@ async function buildRequest(
     }
   }
   const headers = new Headers();
-  await applyAuth(headers, endpoint, authDir);
+  await applyAuth(headers, endpoint, authStore);
   const configuredHeaderNames = configuredAuthHeaderNames(endpoint);
   for (const [key, value] of Object.entries(operation.staticHeaders ?? {})) {
     if (!headers.has(key) && !configuredHeaderNames.has(key.toLowerCase())) {
@@ -696,9 +698,9 @@ function asRecord(value: unknown): Record<string, unknown> {
 async function applyAuth(
   headers: Headers,
   endpoint: OpenApiEndpointConfig,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<void> {
-  for (const [key, value] of Object.entries(await authHeaders(endpoint, authDir))) {
+  for (const [key, value] of Object.entries(await authHeaders(endpoint, authStore))) {
     headers.set(key, value);
   }
 }
@@ -711,7 +713,7 @@ function configuredAuthHeaderNames(endpoint: OpenApiEndpointConfig): Set<string>
 
 async function authHeaders(
   endpoint: OpenApiEndpointConfig,
-  authDir?: string,
+  authStore?: BackendAuthStateStore,
 ): Promise<Record<string, string>> {
   switch (endpoint.auth.type) {
     case "none":
@@ -722,7 +724,13 @@ async function authHeaders(
       return endpoint.auth.headers;
     case "oauth2":
     case "oidc":
-      return await genericOAuthHeaders(endpoint, authDir);
+      if (!authStore) {
+        throw new CapletsError(
+          "SERVER_UNAVAILABLE",
+          "Authoritative backend auth storage is unavailable.",
+        );
+      }
+      return await genericOAuthHeaders(endpoint, authStore);
   }
 }
 

--- a/packages/core/src/project-binding/types.ts
+++ b/packages/core/src/project-binding/types.ts
@@ -23,6 +23,10 @@ export const PROJECT_BINDING_STATES: readonly ProjectBindingState[] = [
   "expired",
 ];
 
+export function isProjectBindingState(value: unknown): value is ProjectBindingState {
+  return typeof value === "string" && PROJECT_BINDING_STATES.includes(value as ProjectBindingState);
+}
+
 export const PROJECT_BINDING_SYNC_STATES = [
   "not_started",
   "pending",
@@ -32,6 +36,24 @@ export const PROJECT_BINDING_SYNC_STATES = [
 ] as const;
 
 export type ProjectBindingSyncState = (typeof PROJECT_BINDING_SYNC_STATES)[number];
+
+export function isProjectBindingSyncState(value: unknown): value is ProjectBindingSyncState {
+  return (
+    typeof value === "string" &&
+    PROJECT_BINDING_SYNC_STATES.includes(value as ProjectBindingSyncState)
+  );
+}
+
+export const PROJECT_BINDING_READINESS_STATES = ["not_ready", "ready", "quarantined"] as const;
+
+export type ProjectBindingReadiness = (typeof PROJECT_BINDING_READINESS_STATES)[number];
+
+export function isProjectBindingReadiness(value: unknown): value is ProjectBindingReadiness {
+  return (
+    typeof value === "string" &&
+    PROJECT_BINDING_READINESS_STATES.includes(value as ProjectBindingReadiness)
+  );
+}
 
 export const PROJECT_BINDING_HIDDEN_REASONS = [
   "missing_context",
@@ -114,6 +136,30 @@ export type ProjectBindingLease = {
   updatedAt: string;
   expiresAt?: string;
   diagnosticCode?: string;
+};
+
+export type ProjectBindingAuthoritativeMetadata = {
+  bindingId: string;
+  sessionId: string;
+  projectFingerprint: string;
+  projectRoot: string;
+  serverProjectRoot: string;
+  ownerNodeId: string;
+  revision: number;
+  state: ProjectBindingState;
+  syncState: ProjectBindingSyncState;
+  readiness: ProjectBindingReadiness;
+  active: boolean;
+  lastHeartbeatAt: string;
+  expiresAt: string;
+  createdAt: string;
+  updatedAt: string;
+  quarantinedAt?: string | undefined;
+  quarantineReason?: "owner_lost" | undefined;
+};
+
+export type ProjectBindingAuthoritativeView = ProjectBindingAuthoritativeMetadata & {
+  generation: number;
 };
 
 export type ProjectBindingWorkspaceMetadata = {

--- a/packages/core/src/remote-control/dispatch.ts
+++ b/packages/core/src/remote-control/dispatch.ts
@@ -27,7 +27,11 @@ import {
   type CurrentHostOperatorPrincipal,
   type CurrentHostOperations,
 } from "../current-host/operations";
-import type { RemoteCliRequest, RemoteCliResponse } from "./types";
+import type { RemoteCapletBundleFile, RemoteCliRequest, RemoteCliResponse } from "./types";
+import type { BackendAuthStateStore } from "../storage/backend-auth";
+import type { HostStorage } from "../storage/database";
+import { createHostStorageVaultResolver } from "../storage/vault-resolver";
+import type { CapletBundleInputFile } from "../storage/caplet-records";
 
 export type RemoteControlDispatchContext = CapletsEngineOptions & {
   projectCapletsRoot: string;
@@ -35,6 +39,7 @@ export type RemoteControlDispatchContext = CapletsEngineOptions & {
   globalLockfilePath?: string | undefined;
   authFlowStore?: RemoteAuthFlowStore;
   controlCallbackBaseUrl?: string;
+  backendAuthStore?: BackendAuthStateStore;
 };
 
 type AddKind =
@@ -63,9 +68,17 @@ const ENGINE_COMMANDS = new Set<RemoteCliRequest["command"]>([
   "complete",
 ]);
 
+const STORAGE_RECORD_COMMAND_PREFIX = "storage_records_";
+const MAX_REMOTE_BUNDLE_FILES = 2_049;
+const MAX_REMOTE_BUNDLE_FILE_BYTES = 64 * 1024 * 1024;
+const MAX_REMOTE_BUNDLE_TOTAL_BYTES = 256 * 1024 * 1024;
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u;
+
 type CurrentHostRemoteAdministration = {
   operations: CurrentHostOperations;
   principal: CurrentHostOperatorPrincipal;
+  storage?: HostStorage | undefined;
+  activateConfig?: (() => Promise<void>) | undefined;
 };
 
 export async function dispatchRemoteCliRequest(
@@ -111,7 +124,7 @@ async function dispatch(
   if (ENGINE_COMMANDS.has(request.command)) {
     const caplet = requiredString(request.arguments, "caplet");
     const toolRequest = requiredEngineRequest(request.arguments, request.command);
-    const engine = new CapletsEngine(context);
+    const engine = await CapletsEngine.create(context);
     try {
       return await engine.execute(caplet, toolRequest);
     } finally {
@@ -167,7 +180,7 @@ async function dispatch(
   if (request.command === "complete_cli") {
     const shell = optionalString(request.arguments, "shell") ?? "bash";
     if (!completionShells.includes(shell as CompletionShell)) return [];
-    const engine = new CapletsEngine(context);
+    const engine = await CapletsEngine.create(context);
     try {
       return await engine.completeCliWords(optionalStringArray(request.arguments, "words") ?? [""]);
     } finally {
@@ -177,9 +190,17 @@ async function dispatch(
 
   if (request.command === "auth_list") {
     return listAuthRows({
+      authStore: requireBackendAuthStore(context),
       ...optionalProp("configPath", context.configPath),
       ...optionalProp("authDir", context.authDir),
     });
+  }
+
+  if (request.command.startsWith(STORAGE_RECORD_COMMAND_PREFIX)) {
+    return await dispatchCurrentHostStorage(
+      request,
+      requireCurrentHostAdministration(currentHostAdministration),
+    );
   }
 
   if (request.command.startsWith("vault_")) {
@@ -200,6 +221,7 @@ async function dispatch(
 
   if (request.command === "auth_logout") {
     return logoutAuthResult(requiredString(request.arguments, "server"), {
+      authStore: requireBackendAuthStore(context),
       ...optionalProp("configPath", context.configPath),
       ...optionalProp("authDir", context.authDir),
     });
@@ -207,6 +229,7 @@ async function dispatch(
 
   if (request.command === "auth_refresh") {
     return refreshAuthResult(requiredString(request.arguments, "server"), {
+      authStore: requireBackendAuthStore(context),
       ...optionalProp("configPath", context.configPath),
       ...optionalProp("authDir", context.authDir),
     });
@@ -231,13 +254,20 @@ async function dispatch(
 }
 
 function isCurrentHostAdministrationCommand(command: unknown): boolean {
-  return command === "install" || command === "update" || String(command).startsWith("vault_");
+  return (
+    command === "install" ||
+    command === "update" ||
+    String(command).startsWith("vault_") ||
+    String(command).startsWith(STORAGE_RECORD_COMMAND_PREFIX)
+  );
 }
 
 function requireCurrentHostAdministration(
   administration: CurrentHostRemoteAdministration | undefined,
 ): CurrentHostRemoteAdministration {
-  if (administration) return administration;
+  if (administration?.principal.role === "operator" && administration.principal.clientId.trim()) {
+    return administration;
+  }
   throw new CapletsError(
     "AUTH_FAILED",
     "Current Host administration requires an Operator principal.",
@@ -315,14 +345,236 @@ async function dispatchCurrentHostVault(
   }
 }
 
+async function dispatchCurrentHostStorage(
+  request: RemoteCliRequest,
+  administration: CurrentHostRemoteAdministration,
+) {
+  const storage = administration.storage;
+  if (!storage) {
+    throw new CapletsError(
+      "SERVER_UNAVAILABLE",
+      "Authoritative Host State storage is unavailable.",
+    );
+  }
+  const operator = {
+    role: "operator" as const,
+    clientId: administration.principal.clientId,
+  };
+  const args = request.arguments;
+  const activate = async (): Promise<void> => {
+    await administration.activateConfig?.();
+  };
+
+  switch (request.command) {
+    case "storage_records_list":
+      assertOnlyKeys(args, []);
+      return await storage.caplets.listStored(operator);
+    case "storage_records_get": {
+      assertOnlyKeys(args, ["id"]);
+      return encodeBundleResult(
+        await storage.caplets.readBundle(requiredString(args, "id"), { operator }),
+      );
+    }
+    case "storage_records_import": {
+      assertOnlyKeys(args, [
+        "id",
+        "files",
+        "historyLimit",
+        "sourceKind",
+        "sourceIdentity",
+        "channel",
+      ]);
+      const sourceKind = optionalString(args, "sourceKind");
+      const sourceIdentity = optionalString(args, "sourceIdentity");
+      const installation =
+        sourceKind === undefined && sourceIdentity === undefined
+          ? undefined
+          : {
+              sourceKind: requirePairedString(
+                sourceKind,
+                "sourceKind",
+                sourceIdentity,
+                "sourceIdentity",
+              ),
+              sourceIdentity: requirePairedString(
+                sourceIdentity,
+                "sourceIdentity",
+                sourceKind,
+                "sourceKind",
+              ),
+              ...optionalProp("channel", optionalString(args, "channel")),
+            };
+      const record = await storage.caplets.importBundle({
+        id: requiredString(args, "id"),
+        files: decodeBundleFiles(args.files),
+        operator,
+        ...optionalProp("historyLimit", optionalNonNegativeInteger(args, "historyLimit")),
+        ...(installation ? { installation } : {}),
+      });
+      await activate();
+      return record;
+    }
+    case "storage_records_update": {
+      assertOnlyKeys(args, ["id", "files", "expectedGeneration", "detachInstallation"]);
+      const record = await storage.caplets.updateBundle({
+        id: requiredString(args, "id"),
+        files: decodeBundleFiles(args.files),
+        expectedGeneration: requiredPositiveInteger(args, "expectedGeneration"),
+        operator,
+        ...optionalProp("detachInstallation", optionalBoolean(args, "detachInstallation")),
+      });
+      await activate();
+      return record;
+    }
+    case "storage_records_export": {
+      assertOnlyKeys(args, ["id", "revisionKey"]);
+      return encodeBundleResult(
+        await storage.caplets.readBundle(requiredString(args, "id"), {
+          operator,
+          ...optionalProp("revisionKey", optionalString(args, "revisionKey")),
+        }),
+      );
+    }
+    case "storage_records_revisions":
+      assertOnlyKeys(args, ["id"]);
+      return await storage.caplets.listRevisions(requiredString(args, "id"), operator);
+    case "storage_records_restore": {
+      assertOnlyKeys(args, ["id", "revisionKey", "expectedGeneration"]);
+      const record = await storage.caplets.restoreRevision({
+        id: requiredString(args, "id"),
+        revisionKey: requiredString(args, "revisionKey"),
+        expectedGeneration: requiredPositiveInteger(args, "expectedGeneration"),
+        operator,
+      });
+      await activate();
+      return record;
+    }
+    case "storage_records_delete_revision": {
+      assertOnlyKeys(args, ["id", "revisionKey", "expectedGeneration"]);
+      const record = await storage.caplets.deleteRevision({
+        id: requiredString(args, "id"),
+        revisionKey: requiredString(args, "revisionKey"),
+        expectedGeneration: requiredPositiveInteger(args, "expectedGeneration"),
+        operator,
+      });
+      await activate();
+      return { deleted: true, record };
+    }
+    case "storage_records_retention": {
+      assertOnlyKeys(args, ["id", "historyLimit", "expectedGeneration"]);
+      const record = await storage.caplets.setRetention({
+        id: requiredString(args, "id"),
+        historyLimit: requiredNullableNonNegativeInteger(args, "historyLimit"),
+        expectedGeneration: requiredPositiveInteger(args, "expectedGeneration"),
+        operator,
+      });
+      await activate();
+      return record;
+    }
+    case "storage_records_rename": {
+      assertOnlyKeys(args, ["id", "newId", "expectedGeneration"]);
+      const record = await storage.caplets.rename({
+        id: requiredString(args, "id"),
+        newId: requiredString(args, "newId"),
+        expectedGeneration: requiredPositiveInteger(args, "expectedGeneration"),
+        operator,
+      });
+      await activate();
+      return record;
+    }
+    case "storage_records_delete": {
+      assertOnlyKeys(args, ["id", "expectedGeneration"]);
+      const id = requiredString(args, "id");
+      await storage.caplets.hardDelete({
+        id,
+        expectedGeneration: requiredPositiveInteger(args, "expectedGeneration"),
+        operator,
+      });
+      await activate();
+      return { deleted: true, id };
+    }
+    case "storage_records_installation_status": {
+      assertOnlyKeys(args, ["id"]);
+      const id = requiredString(args, "id");
+      return {
+        installations: await storage.installations.list(id),
+        observations: await storage.installations.listObservations(id),
+      };
+    }
+    case "storage_records_installation_detach":
+      assertOnlyKeys(args, ["id", "expectedGeneration"]);
+      return await storage.installations.detach({
+        capletId: requiredString(args, "id"),
+        expectedGeneration: requiredPositiveInteger(args, "expectedGeneration"),
+        operator,
+      });
+    case "storage_records_installation_observe":
+      assertOnlyKeys(args, [
+        "id",
+        "expectedGeneration",
+        "status",
+        "resolvedRevision",
+        "contentHash",
+        "risk",
+      ]);
+      return await storage.installations.appendObservation({
+        capletId: requiredString(args, "id"),
+        expectedGeneration: requiredPositiveInteger(args, "expectedGeneration"),
+        status: requiredInstallationObservationStatus(args, "status"),
+        operator,
+        ...optionalProp("resolvedRevision", optionalString(args, "resolvedRevision")),
+        ...optionalProp("contentHash", optionalString(args, "contentHash")),
+        ...optionalProp("risk", optionalRecord(args, "risk")),
+      });
+    case "storage_records_installation_replace":
+      assertOnlyKeys(args, [
+        "id",
+        "expectedGeneration",
+        "sourceKind",
+        "sourceIdentity",
+        "channel",
+        "detachedInstallationKey",
+      ]);
+      return await storage.installations.replaceDetached({
+        capletId: requiredString(args, "id"),
+        expectedGeneration: requiredPositiveInteger(args, "expectedGeneration"),
+        sourceKind: requiredString(args, "sourceKind"),
+        sourceIdentity: requiredString(args, "sourceIdentity"),
+        operator,
+        ...optionalProp("channel", optionalString(args, "channel")),
+        ...optionalProp("detachedInstallationKey", optionalString(args, "detachedInstallationKey")),
+      });
+    default:
+      throw new CapletsError(
+        "UNKNOWN_OPERATION",
+        `Unsupported remote control command ${request.command}`,
+      );
+  }
+}
+
+function requireBackendAuthStore(context: RemoteControlDispatchContext) {
+  const authStore = context.backendAuthStore ?? context.hostStorage?.backendAuth;
+  if (!authStore) {
+    throw new CapletsError(
+      "SERVER_UNAVAILABLE",
+      "Authoritative backend auth storage is unavailable.",
+    );
+  }
+  return authStore;
+}
+
 async function startRemoteAuthLogin(serverId: string, context: RemoteControlDispatchContext) {
   if (!context.authFlowStore || !context.controlCallbackBaseUrl) {
     throw new CapletsError("REQUEST_INVALID", "Remote auth login is not available on this server");
   }
+  const vaultResolver = context.hostStorage
+    ? await createHostStorageVaultResolver(context.hostStorage)
+    : vaultResolverForAuthDir(context.authDir);
   const config = loadConfigWithSources(context.configPath, context.projectConfigPath, {
-    vaultResolver: vaultResolverForAuthDir(context.authDir),
+    vaultResolver,
   }).config;
-  const target = await resolveAuthTarget(serverId, config, context.authDir);
+  const authStore = requireBackendAuthStore(context);
+  const target = await resolveAuthTarget(serverId, config, authStore);
   assertLoginTarget(target, serverId);
   const flowId = randomUUID();
   const baseUrl = context.controlCallbackBaseUrl.endsWith("/")
@@ -333,11 +585,13 @@ async function startRemoteAuthLogin(serverId: string, context: RemoteControlDisp
     target.backend === "mcp"
       ? await startOAuthFlow(target, {
           redirectUri,
-          ...optionalProp("authDir", context.authDir),
+          authStore,
+          operatorClientId: "remote_cli",
         })
       : await startGenericOAuthFlow(target, {
           redirectUri,
-          ...optionalProp("authDir", context.authDir),
+          authStore,
+          operatorClientId: "remote_cli",
         });
   if (!started.authorizationUrl) {
     return { server: serverId, authenticated: true };
@@ -471,6 +725,134 @@ function optionalString(args: Record<string, unknown>, key: string): string | un
     throw new CapletsError("REQUEST_INVALID", `${key} must be a string`);
   }
   return value;
+}
+
+function assertOnlyKeys(args: Record<string, unknown>, allowed: readonly string[]): void {
+  for (const key of Object.keys(args)) {
+    if (!allowed.includes(key)) {
+      throw new CapletsError("REQUEST_INVALID", `Unexpected remote storage argument ${key}.`);
+    }
+  }
+}
+
+function requiredPositiveInteger(args: Record<string, unknown>, key: string): number {
+  const value = args[key];
+  if (!Number.isInteger(value) || (value as number) < 1) {
+    throw new CapletsError("REQUEST_INVALID", `${key} must be a positive integer`);
+  }
+  return value as number;
+}
+
+function optionalNonNegativeInteger(
+  args: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = args[key];
+  if (value === undefined) return undefined;
+  if (!Number.isInteger(value) || (value as number) < 0) {
+    throw new CapletsError("REQUEST_INVALID", `${key} must be a non-negative integer`);
+  }
+  return value as number;
+}
+
+function requiredNullableNonNegativeInteger(
+  args: Record<string, unknown>,
+  key: string,
+): number | null {
+  if (args[key] === null) return null;
+  const value = optionalNonNegativeInteger(args, key);
+  if (value === undefined) {
+    throw new CapletsError("REQUEST_INVALID", `${key} is required`);
+  }
+  return value;
+}
+
+function optionalRecord(
+  args: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = args[key];
+  if (value === undefined) return undefined;
+  assertObject(value, key);
+  return value;
+}
+
+function requirePairedString(
+  value: string | undefined,
+  key: string,
+  paired: string | undefined,
+  pairedKey: string,
+): string {
+  if (value !== undefined && paired !== undefined) return value;
+  throw new CapletsError("REQUEST_INVALID", `${key} and ${pairedKey} must be provided together`);
+}
+
+function requiredInstallationObservationStatus(
+  args: Record<string, unknown>,
+  key: string,
+): "current" | "metadata-only" | "source-unavailable" {
+  const value = requiredString(args, key);
+  if (value === "current" || value === "metadata-only" || value === "source-unavailable") {
+    return value;
+  }
+  throw new CapletsError(
+    "REQUEST_INVALID",
+    `${key} must be current, metadata-only, or source-unavailable`,
+  );
+}
+
+function decodeBundleFiles(value: unknown): CapletBundleInputFile[] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_REMOTE_BUNDLE_FILES) {
+    throw new CapletsError("REQUEST_INVALID", "Remote Caplet bundle file list is invalid.");
+  }
+  const files: CapletBundleInputFile[] = [];
+  let totalBytes = 0;
+  for (const item of value) {
+    assertObject(item, "Remote Caplet bundle file");
+    assertOnlyKeys(item, ["path", "contentBase64", "executable"]);
+    const path = requiredString(item, "path");
+    const contentBase64 = item.contentBase64;
+    if (
+      typeof contentBase64 !== "string" ||
+      contentBase64.length > Math.ceil(MAX_REMOTE_BUNDLE_FILE_BYTES / 3) * 4 ||
+      !BASE64_PATTERN.test(contentBase64)
+    ) {
+      throw new CapletsError("REQUEST_INVALID", "Remote Caplet bundle file content is invalid.");
+    }
+    const content = Buffer.from(contentBase64, "base64");
+    if (
+      content.byteLength > MAX_REMOTE_BUNDLE_FILE_BYTES ||
+      content.toString("base64") !== contentBase64
+    ) {
+      throw new CapletsError("REQUEST_INVALID", "Remote Caplet bundle file content is invalid.");
+    }
+    totalBytes += content.byteLength;
+    if (totalBytes > MAX_REMOTE_BUNDLE_TOTAL_BYTES) {
+      throw new CapletsError("REQUEST_INVALID", "Remote Caplet bundle exceeds the byte limit.");
+    }
+    if (typeof item.executable !== "boolean") {
+      throw new CapletsError(
+        "REQUEST_INVALID",
+        "Remote Caplet bundle executable intent must be boolean.",
+      );
+    }
+    files.push({ path, content, executable: item.executable });
+  }
+  return files;
+}
+
+function encodeBundleResult(result: { record: unknown; files: CapletBundleInputFile[] }): {
+  record: unknown;
+  files: RemoteCapletBundleFile[];
+} {
+  return {
+    record: result.record,
+    files: result.files.map((file) => ({
+      path: file.path,
+      contentBase64: file.content.toString("base64"),
+      executable: file.executable,
+    })),
+  };
 }
 
 function optionalObject(args: Record<string, unknown>, key: string): Record<string, unknown> {

--- a/packages/core/src/remote-control/types.ts
+++ b/packages/core/src/remote-control/types.ts
@@ -32,7 +32,28 @@ export type RemoteCliCommand =
   | "vault_delete"
   | "vault_access_grant"
   | "vault_access_revoke"
-  | "vault_access_list";
+  | "vault_access_list"
+  | "storage_records_list"
+  | "storage_records_get"
+  | "storage_records_import"
+  | "storage_records_update"
+  | "storage_records_export"
+  | "storage_records_revisions"
+  | "storage_records_restore"
+  | "storage_records_delete_revision"
+  | "storage_records_retention"
+  | "storage_records_rename"
+  | "storage_records_delete"
+  | "storage_records_installation_status"
+  | "storage_records_installation_detach"
+  | "storage_records_installation_observe"
+  | "storage_records_installation_replace";
+
+export type RemoteCapletBundleFile = {
+  path: string;
+  contentBase64: string;
+  executable: boolean;
+};
 
 /**
  * Parsed wire input. `command` stays open so the adapter can safely envelope

--- a/packages/core/src/remote/server-credential-store.ts
+++ b/packages/core/src/remote/server-credential-store.ts
@@ -12,7 +12,12 @@ import { Buffer } from "node:buffer";
 import { createHash, timingSafeEqual, randomUUID } from "node:crypto";
 import { join } from "node:path";
 import { CapletsError } from "../errors";
-import { decryptVaultValue, encryptVaultValue, type VaultEncryptedRecord } from "../vault/crypto";
+import {
+  decryptVaultValue,
+  encryptVaultValue,
+  parseEncryptedRecord,
+  type VaultEncryptedRecord,
+} from "../vault/crypto";
 import { normalizeRemoteProfileHostUrl } from "./options";
 import { createPairingCode, parsePairingCode, randomToken } from "./pairing";
 import type {
@@ -92,7 +97,7 @@ export type CompletePendingLoginInput = PendingLoginPossessionInput & {
   requiredRole?: RemoteClientRole | undefined;
 };
 
-type StoredPairingCode = {
+export type StoredPairingCode = {
   codeId: string;
   hostUrl: string;
   secretHash: string;
@@ -104,7 +109,7 @@ type StoredPairingCode = {
   usedAt?: string | undefined;
 };
 
-type StoredRemoteClient = {
+export type StoredRemoteClient = {
   clientId: string;
   clientLabel: string;
   role: RemoteClientRole;
@@ -121,7 +126,7 @@ type StoredRemoteClient = {
 
 type PendingLoginStatus = RemotePendingLoginState;
 
-type StoredPendingLogin = {
+export type StoredPendingLogin = {
   flowId: string;
   hostUrl: string;
   hostIdentity?: string | undefined;
@@ -147,23 +152,23 @@ type StoredPendingLogin = {
   exchangedAt?: string | undefined;
 };
 
-type SupersededRefreshToken = {
+export type SupersededRefreshToken = {
   hash: string;
   supersededAt: string;
 };
 
-type PendingRefreshReplay = {
+export type PendingRefreshReplay = {
   refreshHash: string;
   expiresAt: string;
   encryptedResponse: VaultEncryptedRecord;
 };
 
-type CompletionReplay = {
+export type CompletionReplay = {
   expiresAt: string;
   encryptedCredentials: VaultEncryptedRecord;
 };
 
-type RemoteServerCredentialState = {
+export type RemoteServerCredentialState = {
   version: 1;
   pairingCodes: StoredPairingCode[];
   pendingLogins: StoredPendingLogin[];
@@ -713,6 +718,26 @@ export class RemoteServerCredentialStore {
     });
   }
 
+  exportForMigration(): {
+    state: RemoteServerCredentialState;
+    sourcePaths: string[];
+  } {
+    const path = this.statePath();
+    if (!existsSync(path)) {
+      return {
+        state: { version: 1, pairingCodes: [], pendingLogins: [], clients: [] },
+        sourcePaths: [],
+      };
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    } catch {
+      throw new CapletsError("CONFIG_INVALID", "Legacy remote security state is invalid.");
+    }
+    return { state: parseRemoteServerCredentialState(parsed), sourcePaths: [path] };
+  }
+
   dumpForTest(): RemoteServerCredentialState {
     return this.loadState();
   }
@@ -826,6 +851,291 @@ export class RemoteServerCredentialStore {
     }
     return flow;
   }
+}
+
+export function parseRemoteServerCredentialState(value: unknown): RemoteServerCredentialState {
+  if (
+    !isLegacyRemoteRecord(value) ||
+    value.version !== 1 ||
+    !Array.isArray(value.pairingCodes) ||
+    !Array.isArray(value.pendingLogins) ||
+    !Array.isArray(value.clients)
+  ) {
+    throw invalidLegacyRemoteState();
+  }
+  const pairingCodes = value.pairingCodes.map((entry): StoredPairingCode => {
+    if (
+      !isLegacyRemoteRecord(entry) ||
+      !legacyRemoteStrings(entry, "codeId", "hostUrl", "secretHash", "createdAt", "expiresAt") ||
+      !validLegacyRemoteDate(entry.createdAt) ||
+      !validLegacyRemoteDate(entry.expiresAt) ||
+      !Number.isSafeInteger(entry.attempts) ||
+      (entry.attempts as number) < 0 ||
+      !Number.isSafeInteger(entry.maxAttempts) ||
+      (entry.maxAttempts as number) < 1 ||
+      !optionalLegacyRemoteString(entry.clientLabel) ||
+      !optionalLegacyRemoteString(entry.usedAt) ||
+      (entry.usedAt !== undefined && !validLegacyRemoteDate(entry.usedAt))
+    ) {
+      throw invalidLegacyRemoteState();
+    }
+    return {
+      codeId: entry.codeId as string,
+      hostUrl: normalizeRemoteProfileHostUrl(entry.hostUrl as string),
+      secretHash: entry.secretHash as string,
+      ...(entry.clientLabel === undefined ? {} : { clientLabel: entry.clientLabel as string }),
+      createdAt: entry.createdAt as string,
+      expiresAt: entry.expiresAt as string,
+      attempts: entry.attempts as number,
+      maxAttempts: entry.maxAttempts as number,
+      ...(entry.usedAt === undefined ? {} : { usedAt: entry.usedAt as string }),
+    };
+  });
+  const clients = value.clients.map((entry): StoredRemoteClient => {
+    if (
+      !isLegacyRemoteRecord(entry) ||
+      !legacyRemoteStrings(
+        entry,
+        "clientId",
+        "clientLabel",
+        "hostUrl",
+        "accessTokenHash",
+        "accessExpiresAt",
+        "refreshTokenHash",
+        "refreshFamilyId",
+        "createdAt",
+      ) ||
+      (entry.role !== undefined && entry.role !== "access" && entry.role !== "operator") ||
+      !Array.isArray(entry.supersededRefreshTokenHashes) ||
+      !validLegacyRemoteDate(entry.accessExpiresAt) ||
+      !validLegacyRemoteDate(entry.createdAt) ||
+      !optionalLegacyRemoteString(entry.lastUsedAt) ||
+      !optionalLegacyRemoteString(entry.revokedAt) ||
+      (entry.lastUsedAt !== undefined && !validLegacyRemoteDate(entry.lastUsedAt)) ||
+      (entry.revokedAt !== undefined && !validLegacyRemoteDate(entry.revokedAt))
+    ) {
+      throw invalidLegacyRemoteState();
+    }
+    return {
+      clientId: entry.clientId as string,
+      clientLabel: entry.clientLabel as string,
+      role: entry.role === "operator" ? "operator" : "access",
+      hostUrl: normalizeRemoteProfileHostUrl(entry.hostUrl as string),
+      accessTokenHash: entry.accessTokenHash as string,
+      accessExpiresAt: entry.accessExpiresAt as string,
+      refreshTokenHash: entry.refreshTokenHash as string,
+      supersededRefreshTokenHashes: parseLegacySupersededRefreshTokens(
+        entry.supersededRefreshTokenHashes,
+      ),
+      refreshFamilyId: entry.refreshFamilyId as string,
+      createdAt: entry.createdAt as string,
+      ...(entry.lastUsedAt === undefined ? {} : { lastUsedAt: entry.lastUsedAt as string }),
+      ...(entry.revokedAt === undefined ? {} : { revokedAt: entry.revokedAt as string }),
+    };
+  });
+  const pendingLogins = value.pendingLogins.map((entry): StoredPendingLogin => {
+    if (
+      !isLegacyRemoteRecord(entry) ||
+      !legacyRemoteStrings(
+        entry,
+        "flowId",
+        "hostUrl",
+        "operatorCodeHash",
+        "pendingRefreshHash",
+        "pendingCompletionHash",
+        "clientLabel",
+        "createdAt",
+        "codeExpiresAt",
+        "flowExpiresAt",
+      ) ||
+      !Array.isArray(entry.supersededPendingRefreshHashes) ||
+      (entry.requestedRole !== undefined &&
+        entry.requestedRole !== "access" &&
+        entry.requestedRole !== "operator") ||
+      (entry.grantedRole !== undefined &&
+        entry.grantedRole !== "access" &&
+        entry.grantedRole !== "operator") ||
+      !isLegacyPendingStatus(entry.status) ||
+      !validLegacyRemoteDate(entry.createdAt) ||
+      !validLegacyRemoteDate(entry.codeExpiresAt) ||
+      !validLegacyRemoteDate(entry.flowExpiresAt) ||
+      !optionalLegacyRemoteString(entry.hostIdentity) ||
+      !optionalLegacyRemoteString(entry.clientFingerprint) ||
+      !optionalLegacyRemoteString(entry.sourceHint) ||
+      !optionalLegacyRemoteString(entry.operatorCodeFingerprint) ||
+      !optionalLegacyRemoteDate(entry.approvedAt) ||
+      !optionalLegacyRemoteDate(entry.deniedAt) ||
+      !optionalLegacyRemoteDate(entry.cancelledAt) ||
+      !optionalLegacyRemoteDate(entry.exchangedAt)
+    ) {
+      throw invalidLegacyRemoteState();
+    }
+    return {
+      flowId: entry.flowId as string,
+      hostUrl: normalizeRemoteProfileHostUrl(entry.hostUrl as string),
+      ...(entry.hostIdentity === undefined ? {} : { hostIdentity: entry.hostIdentity as string }),
+      operatorCodeHash: entry.operatorCodeHash as string,
+      pendingRefreshHash: entry.pendingRefreshHash as string,
+      supersededPendingRefreshHashes: parseLegacySupersededRefreshTokens(
+        entry.supersededPendingRefreshHashes,
+      ),
+      ...(entry.pendingRefreshReplay === undefined
+        ? {}
+        : { pendingRefreshReplay: parseLegacyPendingRefreshReplay(entry.pendingRefreshReplay) }),
+      pendingCompletionHash: entry.pendingCompletionHash as string,
+      ...(entry.completionReplay === undefined
+        ? {}
+        : { completionReplay: parseLegacyCompletionReplay(entry.completionReplay) }),
+      clientLabel: entry.clientLabel as string,
+      requestedRole: entry.requestedRole === "operator" ? "operator" : "access",
+      ...(entry.grantedRole === undefined
+        ? {}
+        : { grantedRole: entry.grantedRole as RemoteClientRole }),
+      ...(entry.clientFingerprint === undefined
+        ? {}
+        : { clientFingerprint: entry.clientFingerprint as string }),
+      ...(entry.sourceHint === undefined ? {} : { sourceHint: entry.sourceHint as string }),
+      createdAt: entry.createdAt as string,
+      codeExpiresAt: entry.codeExpiresAt as string,
+      flowExpiresAt: entry.flowExpiresAt as string,
+      status: entry.status,
+      ...(entry.operatorCodeFingerprint === undefined
+        ? {}
+        : { operatorCodeFingerprint: entry.operatorCodeFingerprint as string }),
+      ...(entry.approvedAt === undefined ? {} : { approvedAt: entry.approvedAt as string }),
+      ...(entry.deniedAt === undefined ? {} : { deniedAt: entry.deniedAt as string }),
+      ...(entry.cancelledAt === undefined ? {} : { cancelledAt: entry.cancelledAt as string }),
+      ...(entry.exchangedAt === undefined ? {} : { exchangedAt: entry.exchangedAt as string }),
+    };
+  });
+  const state = { version: 1 as const, pairingCodes, pendingLogins, clients };
+  assertUniqueLegacyRemoteState(state);
+  return state;
+}
+
+function parseLegacySupersededRefreshTokens(value: unknown[]): SupersededRefreshToken[] {
+  return value.map((entry) => {
+    if (typeof entry === "string" && entry.length > 0) {
+      return { hash: entry, supersededAt: new Date(0).toISOString() };
+    }
+    if (
+      !isLegacyRemoteRecord(entry) ||
+      !legacyRemoteStrings(entry, "hash", "supersededAt") ||
+      !validLegacyRemoteDate(entry.supersededAt)
+    ) {
+      throw invalidLegacyRemoteState();
+    }
+    return { hash: entry.hash as string, supersededAt: entry.supersededAt as string };
+  });
+}
+
+function parseLegacyPendingRefreshReplay(value: unknown): PendingRefreshReplay {
+  if (
+    !isLegacyRemoteRecord(value) ||
+    !legacyRemoteStrings(value, "refreshHash", "expiresAt") ||
+    !validLegacyRemoteDate(value.expiresAt)
+  ) {
+    throw invalidLegacyRemoteState();
+  }
+  return {
+    refreshHash: value.refreshHash as string,
+    expiresAt: value.expiresAt as string,
+    encryptedResponse: parseLegacyReplayEnvelope(value.encryptedResponse),
+  };
+}
+
+function parseLegacyCompletionReplay(value: unknown): CompletionReplay {
+  if (
+    !isLegacyRemoteRecord(value) ||
+    !legacyRemoteStrings(value, "expiresAt") ||
+    !validLegacyRemoteDate(value.expiresAt)
+  ) {
+    throw invalidLegacyRemoteState();
+  }
+  return {
+    expiresAt: value.expiresAt as string,
+    encryptedCredentials: parseLegacyReplayEnvelope(value.encryptedCredentials),
+  };
+}
+
+function parseLegacyReplayEnvelope(value: unknown): VaultEncryptedRecord {
+  try {
+    const record = parseEncryptedRecord(value);
+    if (
+      !Number.isSafeInteger(record.valueBytes) ||
+      record.valueBytes < 0 ||
+      !validLegacyRemoteDate(record.createdAt) ||
+      !validLegacyRemoteDate(record.updatedAt)
+    ) {
+      throw invalidLegacyRemoteState();
+    }
+    return record;
+  } catch {
+    throw invalidLegacyRemoteState();
+  }
+}
+
+function assertUniqueLegacyRemoteState(state: RemoteServerCredentialState): void {
+  assertUniqueLegacyRemoteValues(state.pairingCodes.map((entry) => entry.codeId));
+  assertUniqueLegacyRemoteValues(state.clients.map((entry) => entry.clientId));
+  assertUniqueLegacyRemoteValues(state.clients.map((entry) => entry.accessTokenHash));
+  assertUniqueLegacyRemoteValues(state.clients.map((entry) => entry.refreshFamilyId));
+  assertUniqueLegacyRemoteValues([
+    ...state.clients.map((entry) => entry.refreshTokenHash),
+    ...state.clients.flatMap((entry) =>
+      entry.supersededRefreshTokenHashes.map((token) => token.hash),
+    ),
+  ]);
+  assertUniqueLegacyRemoteValues(state.pendingLogins.map((entry) => entry.flowId));
+  assertUniqueLegacyRemoteValues(state.pendingLogins.map((entry) => entry.operatorCodeHash));
+  assertUniqueLegacyRemoteValues(state.pendingLogins.map((entry) => entry.pendingCompletionHash));
+  assertUniqueLegacyRemoteValues([
+    ...state.pendingLogins.map((entry) => entry.pendingRefreshHash),
+    ...state.pendingLogins.flatMap((entry) =>
+      entry.supersededPendingRefreshHashes.map((token) => token.hash),
+    ),
+  ]);
+}
+
+function assertUniqueLegacyRemoteValues(values: string[]): void {
+  if (new Set(values).size !== values.length || values.some((value) => value.length === 0)) {
+    throw invalidLegacyRemoteState();
+  }
+}
+
+function isLegacyPendingStatus(value: unknown): value is RemotePendingLoginState {
+  return (
+    value === "pending" ||
+    value === "approved" ||
+    value === "denied" ||
+    value === "cancelled" ||
+    value === "exchanged" ||
+    value === "expired"
+  );
+}
+
+function optionalLegacyRemoteDate(value: unknown): boolean {
+  return value === undefined || (typeof value === "string" && validLegacyRemoteDate(value));
+}
+
+function optionalLegacyRemoteString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function validLegacyRemoteDate(value: unknown): boolean {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+function legacyRemoteStrings(value: Record<string, unknown>, ...keys: string[]): boolean {
+  return keys.every((key) => typeof value[key] === "string" && value[key] !== "");
+}
+
+function isLegacyRemoteRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function invalidLegacyRemoteState(): CapletsError {
+  return new CapletsError("CONFIG_INVALID", "Legacy remote security state is invalid.");
 }
 
 function sleepSync(ms: number): void {

--- a/packages/core/src/remote/server-credential-store.ts
+++ b/packages/core/src/remote/server-credential-store.ts
@@ -20,13 +20,14 @@ import {
 } from "../vault/crypto";
 import { normalizeRemoteProfileHostUrl } from "./options";
 import { createPairingCode, parsePairingCode, randomToken } from "./pairing";
-import type {
-  IssuedRemoteClientCredentials,
-  RemoteClientRole,
-  RemoteClientStatus,
-  RemotePendingLoginStatus,
-  RemotePendingLoginState,
-  ValidatedRemoteClient,
+import {
+  remoteClientRoleSatisfies,
+  type IssuedRemoteClientCredentials,
+  type RemoteClientRole,
+  type RemoteClientStatus,
+  type RemotePendingLoginStatus,
+  type RemotePendingLoginState,
+  type ValidatedRemoteClient,
 } from "./server-credentials";
 
 export type RemoteServerCredentialStoreOptions = {
@@ -489,7 +490,10 @@ export class RemoteServerCredentialStore {
       }
 
       const role = flow.grantedRole ?? flow.requestedRole;
-      if (input.requiredRole !== undefined && role !== input.requiredRole) {
+      if (
+        input.requiredRole !== undefined &&
+        !remoteClientRoleSatisfies(role, input.requiredRole)
+      ) {
         throw new CapletsError("AUTH_FAILED", `${input.requiredRole} role is required.`);
       }
 

--- a/packages/core/src/remote/server-credentials.ts
+++ b/packages/core/src/remote/server-credentials.ts
@@ -1,5 +1,12 @@
 export type RemoteClientRole = "access" | "operator";
 
+export function remoteClientRoleSatisfies(
+  role: RemoteClientRole,
+  requiredRole: RemoteClientRole,
+): boolean {
+  return role === "operator" || role === requiredRole;
+}
+
 export type IssuedRemoteClientCredentials = {
   hostUrl: string;
   clientId: string;

--- a/packages/core/src/serve/http.ts
+++ b/packages/core/src/serve/http.ts
@@ -61,7 +61,11 @@ import { RemoteServerCredentialStore } from "../remote/server-credential-store";
 import type { RemoteSecurityStore } from "../storage/remote-security";
 import type { BackendAuthStateStore } from "../storage/backend-auth";
 import type { HostStorage } from "../storage/database";
-import type { RemoteClientRole, ValidatedRemoteClient } from "../remote/server-credentials";
+import {
+  remoteClientRoleSatisfies,
+  type RemoteClientRole,
+  type ValidatedRemoteClient,
+} from "../remote/server-credentials";
 import { isLoopbackHost } from "../server/options";
 import type { HttpServeOptions } from "./options";
 import { CapletsMcpSession } from "./session";
@@ -2057,7 +2061,11 @@ export function createHttpServeApp(
     const client = (await remoteCredentialStore.listClients()).find(
       (candidate) => candidate.clientId === ownerKey,
     );
-    return client?.role === "access" && client.revokedAt === undefined;
+    return (
+      client !== undefined &&
+      remoteClientRoleSatisfies(client.role, "access") &&
+      client.revokedAt === undefined
+    );
   }
 
   async function terminalizeProjectBindingRecordInQueue(
@@ -3288,7 +3296,7 @@ function routeAuth(
         ),
         accessToken: token,
       });
-      if (requiredRole !== undefined && client.role !== requiredRole) {
+      if (requiredRole !== undefined && !remoteClientRoleSatisfies(client.role, requiredRole)) {
         return c.text(`Forbidden: ${requiredRole} role required`, 403);
       }
       retainAuthenticatedClient?.(c.req.raw, client);

--- a/packages/core/src/serve/http.ts
+++ b/packages/core/src/serve/http.ts
@@ -58,10 +58,15 @@ import {
 import { RemoteAuthFlowStore } from "../remote-control/auth-flow";
 import type { RemoteCliRequest } from "../remote-control/types";
 import { RemoteServerCredentialStore } from "../remote/server-credential-store";
+import type { RemoteSecurityStore } from "../storage/remote-security";
+import type { BackendAuthStateStore } from "../storage/backend-auth";
+import type { HostStorage } from "../storage/database";
 import type { RemoteClientRole, ValidatedRemoteClient } from "../remote/server-credentials";
 import { isLoopbackHost } from "../server/options";
 import type { HttpServeOptions } from "./options";
 import { CapletsMcpSession } from "./session";
+
+type RemoteCredentialStore = RemoteServerCredentialStore | RemoteSecurityStore;
 
 type HttpServeIo = {
   writeErr?: (value: string) => void;
@@ -71,8 +76,10 @@ type HttpServeIo = {
   attachSessionFactory?: HttpAttachSessionFactory;
   defaultAttachSessionFactory?: HttpAttachSessionFactory;
   exposeAttach?: boolean;
-  remoteCredentialStore?: RemoteServerCredentialStore;
+  remoteCredentialStore?: RemoteCredentialStore;
+  backendAuthStore?: BackendAuthStateStore;
   dashboardSessionStore?: DashboardSessionStore;
+  authoritativeStorage?: HostStorage;
   dashboardDistDir?: string;
   projectBindingWorkspaceStore?: ProjectBindingWorkspaceStore;
 };
@@ -134,6 +141,7 @@ type ProjectBindingHttpRecord = {
   expiresAt: string;
   active: boolean;
   generation: number;
+  authoritativeGeneration?: number | undefined;
   mutationTail: Promise<void>;
   terminal: boolean;
   ownerlessCleanup: Promise<boolean> | undefined;
@@ -183,13 +191,42 @@ export function createHttpServeApp(
   const authFlowStore = io.authFlowStore ?? new RemoteAuthFlowStore();
   const exposeAttach = io.exposeAttach ?? true;
   const exposeAttachSessions = exposeAttach && Boolean(io.attachSessionFactory);
-  const remoteCredentialStore = remoteCredentialStoreForOptions(options, io.remoteCredentialStore);
-  const dashboardStateDir =
-    options.remoteCredentialStateDir ?? io.dashboardSessionStore?.dir ?? ".";
-  const dashboardSessionStore = new DashboardSessionStore({
-    dir: dashboardStateDir,
-  });
-  const dashboardActivityLog = new DashboardActivityLog({ dir: dashboardStateDir });
+  const authoritativeStorage =
+    io.authoritativeStorage ??
+    (typeof engine.authoritativeStorage === "function" ? engine.authoritativeStorage() : undefined);
+  const remoteCredentialStore =
+    options.auth.type === "remote_credentials"
+      ? (io.remoteCredentialStore ?? authoritativeStorage?.remoteSecurity)
+      : undefined;
+  const backendAuthStore = io.backendAuthStore ?? authoritativeStorage?.backendAuth;
+  const projectBindingRepository = authoritativeStorage?.projectBindings;
+  const hostNodeId =
+    typeof engine.hostNodeIdentity === "function" ? engine.hostNodeIdentity() : undefined;
+  const dashboardSessionStore =
+    io.dashboardSessionStore ??
+    (authoritativeStorage && remoteCredentialStore
+      ? new DashboardSessionStore({
+          repository: authoritativeStorage.dashboardSessions,
+          validateOperatorClient: async (clientId) =>
+            (await remoteCredentialStore.listClients()).some(
+              (client) =>
+                client.clientId === clientId &&
+                client.role === "operator" &&
+                client.revokedAt === undefined,
+            ),
+        })
+      : undefined);
+  const dashboardActivityLog =
+    authoritativeStorage?.operatorActivity ??
+    new DashboardActivityLog({ dir: options.remoteCredentialStateDir ?? "." });
+  const activateCommittedConfig = async (): Promise<void> => {
+    if (!(await engine.reload())) {
+      throw new CapletsError(
+        "SERVER_UNAVAILABLE",
+        "Committed host configuration could not be activated on this Host Node.",
+      );
+    }
+  };
   const currentHostOperations = createCurrentHostOperations({
     engine,
     ...(io.control === undefined
@@ -204,7 +241,20 @@ export function createHttpServeApp(
           },
         }),
     activityLog: dashboardActivityLog,
+    capletRecords: authoritativeStorage?.caplets,
+    catalogStorage: authoritativeStorage,
+    ...(authoritativeStorage
+      ? {
+          activateConfig: activateCommittedConfig,
+          invalidateConfig: async (operatorClientId: string) => {
+            await authoritativeStorage.invalidateConfig(operatorClientId);
+            await activateCommittedConfig();
+          },
+        }
+      : {}),
     remoteCredentialStore,
+    vaultGrants: authoritativeStorage?.vaultGrants,
+    vaultValues: authoritativeStorage?.vaultValues,
     version: packageJsonVersion,
   });
   const authenticatedRemoteClients = new WeakMap<Request, ValidatedRemoteClient>();
@@ -274,11 +324,16 @@ export function createHttpServeApp(
     return c.json(versionDiscovery(paths, { exposeAttach, exposeAttachSessions }, remote));
   });
 
-  app.get(paths.health, (c) =>
-    c.json({
-      status: "ok",
-    }),
-  );
+  app.get(paths.health, async (c) => {
+    const readiness = await engine.readiness();
+    return c.json(
+      {
+        status: readiness.ready ? "ok" : "unavailable",
+        ...readiness,
+      },
+      readiness.ready ? 200 : 503,
+    );
+  });
 
   app.get(
     routePath(paths.base, "_astro/*"),
@@ -307,7 +362,7 @@ export function createHttpServeApp(
       const hostUrl = remoteCredentialHostUrl(c.req.url, paths.base, options, (name) =>
         c.req.header(name),
       );
-      const pending = remoteCredentialStore.createPendingLogin({
+      const pending = await remoteCredentialStore.createPendingLogin({
         hostUrl,
         hostIdentity: hostUrl,
         requestedRole: "operator",
@@ -320,7 +375,7 @@ export function createHttpServeApp(
         requestedRole: "operator",
         approvalCommand: pendingLoginApprovalCommand(
           pending.operatorCode,
-          remoteCredentialStore.dir,
+          remoteCredentialStatePath(remoteCredentialStore),
         ),
       });
     } catch (error) {
@@ -333,7 +388,7 @@ export function createHttpServeApp(
     try {
       const parsed = await parseJsonObject(c.req.json(), "Dashboard login poll request");
       return c.json(
-        remoteCredentialStore.pollPendingLogin({
+        await remoteCredentialStore.pollPendingLogin({
           flowId: stringField(parsed, "flowId"),
           pendingCompletionSecret: stringField(parsed, "pendingCompletionSecret"),
         }),
@@ -347,7 +402,7 @@ export function createHttpServeApp(
     if (!remoteCredentialStore) return c.json({ error: "dashboard_auth_unavailable" }, 404);
     try {
       const parsed = await parseJsonObject(c.req.json(), "Dashboard login complete request");
-      const credentials = remoteCredentialStore.completePendingLogin({
+      const credentials = await remoteCredentialStore.completePendingLogin({
         hostUrl: remoteCredentialHostUrl(c.req.url, paths.base, options, (name) =>
           c.req.header(name),
         ),
@@ -355,8 +410,13 @@ export function createHttpServeApp(
         flowId: stringField(parsed, "flowId"),
         pendingCompletionSecret: stringField(parsed, "pendingCompletionSecret"),
       });
-      const created = dashboardSessionStore.create({ operatorClientId: credentials.clientId });
-      dashboardActivityLog.append({
+      if (!dashboardSessionStore) {
+        return c.json({ error: "dashboard_auth_unavailable" }, 503);
+      }
+      const created = await dashboardSessionStore.create({
+        operatorClientId: credentials.clientId,
+      });
+      await dashboardActivityLog.append({
         actorClientId: credentials.clientId,
         action: "dashboard_login_completed",
         target: { type: "dashboard_session", id: created.session.sessionId },
@@ -374,14 +434,14 @@ export function createHttpServeApp(
     }
   });
 
-  app.get(paths.dashboardSession, (c) => {
-    const session = dashboardSessionForRequest(c);
+  app.get(paths.dashboardSession, async (c) => {
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     return c.json({ authenticated: true, session: session.session });
   });
 
   app.get(paths.dashboardSummary, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const baseUrl = remoteCredentialHostUrl(c.req.url, paths.base, options, (name) =>
@@ -403,7 +463,7 @@ export function createHttpServeApp(
   });
 
   app.get(paths.dashboardCaplets, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const outcome = await currentHostOperations.execute(
@@ -417,8 +477,176 @@ export function createHttpServeApp(
     }
   });
 
+  app.get(paths.dashboardStoredCaplets, async (c) => {
+    const session = await dashboardSessionForRequest(c);
+    if (!session.ok) return session.response;
+    try {
+      const outcome = await currentHostOperations.execute(
+        dashboardPrincipalForSession(c, session.session),
+        { kind: "stored_caplets_list" },
+      );
+      return c.json({ records: outcome.records });
+    } catch (error) {
+      return currentHostErrorResponse(error);
+    }
+  });
+
+  app.post(paths.dashboardStoredCaplets, async (c) => {
+    const session = await dashboardSessionForRequest(c, {
+      requireCsrf: true,
+      csrfToken: c.req.header("x-caplets-csrf"),
+    });
+    if (!session.ok) return session.response;
+    try {
+      const parsed = await parseJsonObject(c.req.json(), "Stored Caplet import request");
+      const historyLimit = optionalIntegerField(parsed, "historyLimit");
+      const outcome = await currentHostOperations.execute(
+        dashboardPrincipalForSession(c, session.session),
+        {
+          kind: "stored_caplet_import",
+          id: stringField(parsed, "id"),
+          document: opaqueStringField(parsed, "document"),
+          ...(historyLimit === undefined ? {} : { historyLimit }),
+        },
+      );
+      return c.json({ record: outcome.record }, 201);
+    } catch (error) {
+      return currentHostErrorResponse(error);
+    }
+  });
+
+  app.get(routePath(paths.dashboardStoredCaplets, ":id"), async (c) => {
+    const session = await dashboardSessionForRequest(c);
+    if (!session.ok) return session.response;
+    try {
+      const revisionKey = optionalQueryParam(c.req.query("revision"));
+      const outcome = await currentHostOperations.execute(
+        dashboardPrincipalForSession(c, session.session),
+        {
+          kind: "stored_caplet_get",
+          id: requiredRouteParam(c.req.param("id")),
+          ...(revisionKey === undefined ? {} : { revisionKey }),
+        },
+      );
+      return c.json({ record: outcome.record, document: outcome.document });
+    } catch (error) {
+      return currentHostErrorResponse(error);
+    }
+  });
+
+  app.put(routePath(paths.dashboardStoredCaplets, ":id"), async (c) => {
+    const session = await dashboardSessionForRequest(c, {
+      requireCsrf: true,
+      csrfToken: c.req.header("x-caplets-csrf"),
+    });
+    if (!session.ok) return session.response;
+    try {
+      const parsed = await parseJsonObject(c.req.json(), "Stored Caplet update request");
+      const outcome = await currentHostOperations.execute(
+        dashboardPrincipalForSession(c, session.session),
+        {
+          kind: "stored_caplet_update",
+          id: requiredRouteParam(c.req.param("id")),
+          document: opaqueStringField(parsed, "document"),
+          expectedGeneration: integerField(parsed, "expectedGeneration"),
+        },
+      );
+      return c.json({ record: outcome.record });
+    } catch (error) {
+      return currentHostErrorResponse(error);
+    }
+  });
+
+  app.delete(routePath(paths.dashboardStoredCaplets, ":id"), async (c) => {
+    const session = await dashboardSessionForRequest(c, {
+      requireCsrf: true,
+      csrfToken: c.req.header("x-caplets-csrf"),
+    });
+    if (!session.ok) return session.response;
+    try {
+      const parsed = await parseJsonObject(c.req.json(), "Stored Caplet delete request");
+      const outcome = await currentHostOperations.execute(
+        dashboardPrincipalForSession(c, session.session),
+        {
+          kind: "stored_caplet_delete",
+          id: requiredRouteParam(c.req.param("id")),
+          expectedGeneration: integerField(parsed, "expectedGeneration"),
+        },
+      );
+      return c.json({ deleted: outcome.deleted, id: outcome.id });
+    } catch (error) {
+      return currentHostErrorResponse(error);
+    }
+  });
+
+  app.get(routePath(paths.dashboardStoredCaplets, ":id/revisions"), async (c) => {
+    const session = await dashboardSessionForRequest(c);
+    if (!session.ok) return session.response;
+    try {
+      const outcome = await currentHostOperations.execute(
+        dashboardPrincipalForSession(c, session.session),
+        {
+          kind: "stored_caplet_revisions",
+          id: requiredRouteParam(c.req.param("id")),
+        },
+      );
+      return c.json({ revisions: outcome.revisions });
+    } catch (error) {
+      return currentHostErrorResponse(error);
+    }
+  });
+
+  app.post(
+    routePath(paths.dashboardStoredCaplets, ":id/revisions/:revisionKey/restore"),
+    async (c) => {
+      const session = await dashboardSessionForRequest(c, {
+        requireCsrf: true,
+        csrfToken: c.req.header("x-caplets-csrf"),
+      });
+      if (!session.ok) return session.response;
+      try {
+        const parsed = await parseJsonObject(c.req.json(), "Stored Caplet restore request");
+        const outcome = await currentHostOperations.execute(
+          dashboardPrincipalForSession(c, session.session),
+          {
+            kind: "stored_caplet_restore_revision",
+            id: requiredRouteParam(c.req.param("id")),
+            revisionKey: requiredRouteParam(c.req.param("revisionKey")),
+            expectedGeneration: integerField(parsed, "expectedGeneration"),
+          },
+        );
+        return c.json({ record: outcome.record });
+      } catch (error) {
+        return currentHostErrorResponse(error);
+      }
+    },
+  );
+
+  app.delete(routePath(paths.dashboardStoredCaplets, ":id/revisions/:revisionKey"), async (c) => {
+    const session = await dashboardSessionForRequest(c, {
+      requireCsrf: true,
+      csrfToken: c.req.header("x-caplets-csrf"),
+    });
+    if (!session.ok) return session.response;
+    try {
+      const parsed = await parseJsonObject(c.req.json(), "Stored Caplet revision delete request");
+      const outcome = await currentHostOperations.execute(
+        dashboardPrincipalForSession(c, session.session),
+        {
+          kind: "stored_caplet_delete_revision",
+          id: requiredRouteParam(c.req.param("id")),
+          revisionKey: requiredRouteParam(c.req.param("revisionKey")),
+          expectedGeneration: integerField(parsed, "expectedGeneration"),
+        },
+      );
+      return c.json({ record: outcome.record ?? null });
+    } catch (error) {
+      return currentHostErrorResponse(error);
+    }
+  });
+
   app.get(paths.dashboardCatalogSearch, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const query = new URL(c.req.url).searchParams;
@@ -443,7 +671,7 @@ export function createHttpServeApp(
   });
 
   app.get(paths.dashboardCatalogDetail, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const query = new URL(c.req.url).searchParams;
@@ -467,7 +695,7 @@ export function createHttpServeApp(
   });
 
   app.get(paths.dashboardCatalogUpdates, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const outcome = await currentHostOperations.execute(
@@ -482,7 +710,7 @@ export function createHttpServeApp(
   });
 
   app.post(paths.dashboardCatalogInstall, async (c) => {
-    const session = dashboardSessionForRequest(c, {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
@@ -507,7 +735,7 @@ export function createHttpServeApp(
   });
 
   app.post(paths.dashboardCatalogUpdate, async (c) => {
-    const session = dashboardSessionForRequest(c, {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
@@ -532,7 +760,7 @@ export function createHttpServeApp(
   });
 
   app.get(paths.dashboardAccessClients, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const outcome = await currentHostOperations.execute(
@@ -547,7 +775,7 @@ export function createHttpServeApp(
   });
 
   app.get(paths.dashboardAccessPendingLogins, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const outcome = await currentHostOperations.execute(
@@ -562,7 +790,7 @@ export function createHttpServeApp(
   });
 
   app.post(routePath(paths.dashboardAccessPendingLogins, ":flowId/approve"), async (c) => {
-    const session = dashboardSessionForRequest(c, {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
@@ -589,7 +817,7 @@ export function createHttpServeApp(
   });
 
   app.post(routePath(paths.dashboardAccessPendingLogins, ":flowId/deny"), async (c) => {
-    const session = dashboardSessionForRequest(c, {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
@@ -608,7 +836,7 @@ export function createHttpServeApp(
   });
 
   app.post(routePath(paths.dashboardAccessClients, ":clientId/revoke"), async (c) => {
-    const session = dashboardSessionForRequest(c, {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
@@ -621,7 +849,7 @@ export function createHttpServeApp(
 
       if ("status" in outcome) return c.json({ error: "dashboard_auth_unavailable" }, 404);
       if (outcome.sessionEnded) {
-        dashboardSessionStore.delete(c.req.header("cookie"));
+        await dashboardSessionStore?.delete(c.req.header("cookie"));
         c.header("set-cookie", expiredDashboardSessionCookie(paths.dashboard));
       }
       return c.json({
@@ -635,7 +863,7 @@ export function createHttpServeApp(
   });
 
   app.post(routePath(paths.dashboardAccessClients, ":clientId/role"), async (c) => {
-    const session = dashboardSessionForRequest(c, {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
@@ -656,7 +884,7 @@ export function createHttpServeApp(
       }
       if (outcome.status === "not_found") return c.json({ error: "client_not_found" }, 404);
       if (outcome.sessionEnded) {
-        dashboardSessionStore.delete(c.req.header("cookie"));
+        await dashboardSessionStore?.delete(c.req.header("cookie"));
         c.header("set-cookie", expiredDashboardSessionCookie(paths.dashboard));
       }
       return c.json({ client: outcome.client, sessionEnded: outcome.sessionEnded });
@@ -666,7 +894,7 @@ export function createHttpServeApp(
   });
 
   app.get(paths.dashboardActivity, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const query = new URL(c.req.url).searchParams;
@@ -687,7 +915,7 @@ export function createHttpServeApp(
   });
 
   app.get(paths.dashboardVault, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const outcome = await currentHostOperations.execute(
@@ -702,7 +930,7 @@ export function createHttpServeApp(
   });
 
   app.post(paths.dashboardVaultSet, async (c) => {
-    const session = dashboardSessionForRequest(c, {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
@@ -726,7 +954,7 @@ export function createHttpServeApp(
   });
 
   app.post(routePath(paths.dashboardVaultValues, ":key/delete"), async (c) => {
-    const session = dashboardSessionForRequest(c, {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
@@ -744,7 +972,7 @@ export function createHttpServeApp(
   });
 
   app.post(paths.dashboardVaultGrant, async (c) => {
-    const session = dashboardSessionForRequest(c, {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
@@ -768,7 +996,7 @@ export function createHttpServeApp(
   });
 
   app.post(paths.dashboardVaultRevoke, async (c) => {
-    const session = dashboardSessionForRequest(c, {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
@@ -792,7 +1020,7 @@ export function createHttpServeApp(
   });
 
   app.post(paths.dashboardVaultReveal, async (c) => {
-    const session = dashboardSessionForRequest(c, {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
@@ -803,8 +1031,10 @@ export function createHttpServeApp(
       if (stringField(parsed, "confirmation") !== `reveal ${key}`) {
         throw new CapletsError("REQUEST_INVALID", "Vault reveal confirmation is invalid.");
       }
-      const value = vaultStoreForAuthDir(io.control?.authDir).resolveValue(key);
-      dashboardActivityLog.append({
+      const value = authoritativeStorage
+        ? await authoritativeStorage.vaultValues.resolveValue(key)
+        : vaultStoreForAuthDir(io.control?.authDir).resolveValue(key);
+      await dashboardActivityLog.append({
         actorClientId: session.session.operatorClientId,
         action: "vault_value_revealed",
         target: { type: "vault", id: key },
@@ -817,7 +1047,7 @@ export function createHttpServeApp(
   });
 
   app.get(paths.dashboardRuntime, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const outcome = await currentHostOperations.execute(
@@ -839,7 +1069,7 @@ export function createHttpServeApp(
   });
 
   app.post(paths.dashboardRuntimeRestart, async (c) => {
-    const session = dashboardSessionForRequest(c, {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
@@ -857,7 +1087,7 @@ export function createHttpServeApp(
   });
 
   app.get(paths.dashboardLogs, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const outcome = await currentHostOperations.execute(
@@ -876,7 +1106,7 @@ export function createHttpServeApp(
   });
 
   app.get(paths.dashboardDiagnostics, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const outcome = await currentHostOperations.execute(
@@ -895,7 +1125,7 @@ export function createHttpServeApp(
   });
 
   app.get(paths.dashboardEvents, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const outcome = await currentHostOperations.execute(
@@ -919,7 +1149,7 @@ export function createHttpServeApp(
   });
 
   app.get(paths.dashboardProjectBinding, async (c) => {
-    const session = dashboardSessionForRequest(c);
+    const session = await dashboardSessionForRequest(c);
     if (!session.ok) return session.response;
     try {
       const outcome = await currentHostOperations.execute(
@@ -933,18 +1163,18 @@ export function createHttpServeApp(
     }
   });
 
-  app.post(paths.dashboardLogout, (c) => {
-    const session = dashboardSessionForRequest(c, {
+  app.post(paths.dashboardLogout, async (c) => {
+    const session = await dashboardSessionForRequest(c, {
       requireCsrf: true,
       csrfToken: c.req.header("x-caplets-csrf"),
     });
     if (!session.ok) return session.response;
-    dashboardActivityLog.append({
+    await dashboardActivityLog.append({
       actorClientId: session.session.operatorClientId,
       action: "dashboard_logout",
       target: { type: "dashboard_session", id: session.session.sessionId },
     });
-    dashboardSessionStore.delete(c.req.header("cookie"));
+    await dashboardSessionStore?.delete(c.req.header("cookie"));
     c.header("set-cookie", expiredDashboardSessionCookie(paths.dashboard));
     return c.json({ ok: true });
   });
@@ -967,7 +1197,7 @@ export function createHttpServeApp(
         const hostUrl = remoteCredentialHostUrl(c.req.url, paths.base, options, (name) =>
           c.req.header(name),
         );
-        const pending = remoteCredentialStore.createPendingLogin({
+        const pending = await remoteCredentialStore.createPendingLogin({
           hostUrl,
           hostIdentity: hostUrl,
           ...(clientLabel ? { clientLabel } : {}),
@@ -978,7 +1208,7 @@ export function createHttpServeApp(
           ...pending,
           approvalCommand: pendingLoginApprovalCommand(
             pending.operatorCode,
-            remoteCredentialStore.dir,
+            remoteCredentialStatePath(remoteCredentialStore),
           ),
         });
       } catch (error) {
@@ -990,7 +1220,7 @@ export function createHttpServeApp(
       try {
         const parsed = await parseJsonObject(c.req.json(), "Pending remote login poll request");
         return c.json(
-          remoteCredentialStore.pollPendingLogin({
+          await remoteCredentialStore.pollPendingLogin({
             flowId: stringField(parsed, "flowId"),
             pendingCompletionSecret: stringField(parsed, "pendingCompletionSecret"),
           }),
@@ -1004,7 +1234,7 @@ export function createHttpServeApp(
       try {
         const parsed = await parseJsonObject(c.req.json(), "Pending remote login refresh request");
         return c.json(
-          remoteCredentialStore.refreshPendingLogin({
+          await remoteCredentialStore.refreshPendingLogin({
             flowId: stringField(parsed, "flowId"),
             pendingRefreshSecret: stringField(parsed, "pendingRefreshSecret"),
             pendingCompletionSecret: stringField(parsed, "pendingCompletionSecret"),
@@ -1018,7 +1248,7 @@ export function createHttpServeApp(
     app.post(paths.remoteLoginComplete, attachHostProtection, async (c) => {
       try {
         const parsed = await parseJsonObject(c.req.json(), "Pending remote login complete request");
-        const credentials = remoteCredentialStore.completePendingLogin({
+        const credentials = await remoteCredentialStore.completePendingLogin({
           hostUrl: remoteCredentialHostUrl(c.req.url, paths.base, options, (name) =>
             c.req.header(name),
           ),
@@ -1035,7 +1265,7 @@ export function createHttpServeApp(
       try {
         const parsed = await parseJsonObject(c.req.json(), "Pending remote login cancel request");
         return c.json(
-          remoteCredentialStore.cancelPendingLogin({
+          await remoteCredentialStore.cancelPendingLogin({
             flowId: stringField(parsed, "flowId"),
             pendingCompletionSecret: stringField(parsed, "pendingCompletionSecret"),
           }),
@@ -1053,7 +1283,7 @@ export function createHttpServeApp(
       try {
         const parsed = await parseJsonObject(c.req.json(), "Remote refresh request");
         const refreshToken = stringField(parsed, "refreshToken");
-        const credentials = remoteCredentialStore.refreshClientCredentials({
+        const credentials = await remoteCredentialStore.refreshClientCredentials({
           hostUrl: remoteCredentialHostUrl(c.req.url, paths.base, options, (name) =>
             c.req.header(name),
           ),
@@ -1073,12 +1303,18 @@ export function createHttpServeApp(
       }
     });
 
-    app.delete(paths.remoteClient, authenticatedClientRouteAuth, (c) => {
+    app.delete(paths.remoteClient, authenticatedClientRouteAuth, async (c) => {
       const client = authenticatedRemoteClients.get(c.req.raw);
       if (!client) return c.text("Unauthorized", 401);
       try {
         return c.json({
-          revoked: remoteCredentialStore.revokeClient(client.clientId),
+          revoked:
+            remoteCredentialStore instanceof RemoteServerCredentialStore
+              ? remoteCredentialStore.revokeClient(client.clientId)
+              : await remoteCredentialStore.revokeClient({
+                  operatorClientId: client.clientId,
+                  clientId: client.clientId,
+                }),
           clientId: client.clientId,
         });
       } catch (error) {
@@ -1335,6 +1571,8 @@ export function createHttpServeApp(
       io,
       writeErr,
       authFlowStore,
+      backendAuthStore,
+      authoritativeStorage,
       c.req.url,
       paths.control,
       options.publicOrigin,
@@ -1345,6 +1583,9 @@ export function createHttpServeApp(
       await dispatchRemoteCliRequest(request, context, {
         operations: currentHostOperations,
         principal: controlOperatorPrincipal(c),
+        ...(authoritativeStorage
+          ? { storage: authoritativeStorage, activateConfig: activateCommittedConfig }
+          : {}),
       }),
     );
   });
@@ -1427,11 +1668,14 @@ export function createHttpServeApp(
     }),
   );
 
-  app.get(routePath(paths.projectBindings, ":bindingId/status"), accessRouteAuth, (c) =>
-    projectBindingStatusResponse(
-      requiredRouteParam(c.req.param("bindingId")),
-      projectBindingOwnerKey(c),
-    ),
+  app.get(
+    routePath(paths.projectBindings, ":bindingId/status"),
+    accessRouteAuth,
+    async (c) =>
+      await projectBindingStatusResponse(
+        requiredRouteParam(c.req.param("bindingId")),
+        projectBindingOwnerKey(c),
+      ),
   );
 
   app.post(routePath(paths.projectBindings, "sessions"), accessRouteAuth, async (c) => {
@@ -1480,11 +1724,59 @@ export function createHttpServeApp(
         heartbeatInFlight: undefined,
         pendingHeartbeat: undefined,
       };
-      await projectBindingWorkspaceStore.writeLease(projectBindingLease(record));
+      if (projectBindingRepository) {
+        if (!hostNodeId) {
+          throw new CapletsError(
+            "SERVER_UNAVAILABLE",
+            "Project Binding requires a registered Host Node identity.",
+          );
+        }
+        const authoritative = await projectBindingRepository.create({
+          bindingId,
+          sessionId,
+          projectFingerprint,
+          projectRoot,
+          serverProjectRoot: paths.project,
+          ownerNodeId: hostNodeId,
+          state: record.state,
+          syncState: record.syncState,
+          leaseTtlMs: PROJECT_BINDING_LEASE_TTL_MS,
+        });
+        record.authoritativeGeneration = authoritative.generation;
+        record.expiresAt = authoritative.expiresAt;
+        record.updatedAt = authoritative.updatedAt;
+      }
+      try {
+        await projectBindingWorkspaceStore.writeLease(projectBindingLease(record));
+      } catch (error) {
+        if (
+          projectBindingRepository &&
+          hostNodeId &&
+          record.authoritativeGeneration !== undefined
+        ) {
+          await projectBindingRepository.end({
+            bindingId,
+            ownerNodeId: hostNodeId,
+            expectedGeneration: record.authoritativeGeneration,
+          });
+        }
+        throw error;
+      }
       if (projectBindingSessionsClosing) {
         await projectBindingWorkspaceStore.writeLease(
           projectBindingLease(terminalProjectBindingCandidate(record)),
         );
+        if (
+          projectBindingRepository &&
+          hostNodeId &&
+          record.authoritativeGeneration !== undefined
+        ) {
+          await projectBindingRepository.end({
+            bindingId,
+            ownerNodeId: hostNodeId,
+            expectedGeneration: record.authoritativeGeneration,
+          });
+        }
         return c.json({ ok: false, error: { code: "SERVER_UNAVAILABLE" } }, 503);
       }
       projectBindingSessions.set(bindingId, record);
@@ -1628,7 +1920,7 @@ export function createHttpServeApp(
     }
 
     const heartbeat = enqueueProjectBindingMutation(record, async () => {
-      if (!canMutateProjectBindingRecord(record, ownerKey)) {
+      if (!(await canMutateProjectBindingRecord(record, ownerKey))) {
         await terminalizeProjectBindingRecordInQueue(record);
         return false;
       }
@@ -1644,9 +1936,44 @@ export function createHttpServeApp(
         expiresAt: new Date(Date.parse(updatedAt) + PROJECT_BINDING_LEASE_TTL_MS).toISOString(),
         generation: generation + 1,
       };
-      await projectBindingWorkspaceStore.writeLease(projectBindingLease(candidate));
+      if (projectBindingRepository) {
+        if (!hostNodeId || record.authoritativeGeneration === undefined) {
+          throw new CapletsError(
+            "SERVER_UNAVAILABLE",
+            "Project Binding authoritative ownership is unavailable.",
+          );
+        }
+        const authoritative = await projectBindingRepository.heartbeat({
+          bindingId: record.bindingId,
+          ownerNodeId: hostNodeId,
+          sessionId: record.sessionId,
+          expectedGeneration: record.authoritativeGeneration,
+          state: candidate.state,
+          syncState: candidate.syncState,
+          leaseTtlMs: PROJECT_BINDING_LEASE_TTL_MS,
+        });
+        candidate.authoritativeGeneration = authoritative.generation;
+        candidate.expiresAt = authoritative.expiresAt;
+        candidate.updatedAt = authoritative.updatedAt;
+      }
+      try {
+        await projectBindingWorkspaceStore.writeLease(projectBindingLease(candidate));
+      } catch (error) {
+        if (
+          projectBindingRepository &&
+          hostNodeId &&
+          candidate.authoritativeGeneration !== undefined
+        ) {
+          await projectBindingRepository.quarantineOwnerLoss({
+            bindingId: record.bindingId,
+            ownerNodeId: hostNodeId,
+            expectedGeneration: candidate.authoritativeGeneration,
+          });
+        }
+        throw error;
+      }
 
-      if (!canCommitProjectBindingHeartbeat(record, ownerKey, generation, expiresAt)) {
+      if (!(await canCommitProjectBindingHeartbeat(record, ownerKey, generation, expiresAt))) {
         await terminalizeProjectBindingRecordInQueue(record, candidate);
         return false;
       }
@@ -1656,6 +1983,7 @@ export function createHttpServeApp(
       record.updatedAt = candidate.updatedAt;
       record.expiresAt = candidate.expiresAt;
       record.generation = candidate.generation;
+      record.authoritativeGeneration = candidate.authoritativeGeneration;
       return true;
     });
     record.heartbeatInFlight = heartbeat;
@@ -1693,42 +2021,42 @@ export function createHttpServeApp(
     return queued;
   }
 
-  function canMutateProjectBindingRecord(
+  async function canMutateProjectBindingRecord(
     record: ProjectBindingHttpRecord,
     ownerKey: string,
-  ): boolean {
+  ): Promise<boolean> {
     return (
       !projectBindingSessionsClosing &&
       projectBindingSessions.get(record.bindingId) === record &&
       record.active &&
       !record.terminal &&
       Date.parse(record.expiresAt) > Date.now() &&
-      isCurrentProjectBindingAccessOwner(record, ownerKey)
+      (await isCurrentProjectBindingAccessOwner(record, ownerKey))
     );
   }
 
-  function canCommitProjectBindingHeartbeat(
+  async function canCommitProjectBindingHeartbeat(
     record: ProjectBindingHttpRecord,
     ownerKey: string,
     generation: number,
     expiresAt: string,
-  ): boolean {
+  ): Promise<boolean> {
     return (
-      canMutateProjectBindingRecord(record, ownerKey) &&
+      (await canMutateProjectBindingRecord(record, ownerKey)) &&
       record.generation === generation &&
       record.expiresAt === expiresAt
     );
   }
 
-  function isCurrentProjectBindingAccessOwner(
+  async function isCurrentProjectBindingAccessOwner(
     record: ProjectBindingHttpRecord,
     ownerKey: string,
-  ): boolean {
+  ): Promise<boolean> {
     if (record.ownerKey !== ownerKey) return false;
     if (!remoteCredentialStore) return ownerKey === "development_unauthenticated";
-    const client = remoteCredentialStore
-      .listClients()
-      .find((candidate) => candidate.clientId === ownerKey);
+    const client = (await remoteCredentialStore.listClients()).find(
+      (candidate) => candidate.clientId === ownerKey,
+    );
     return client?.role === "access" && client.revokedAt === undefined;
   }
 
@@ -1740,6 +2068,20 @@ export function createHttpServeApp(
     const current = projectBindingSessions.get(record.bindingId) === record;
     const target = current ? record : candidate;
     if (!target) return;
+    if (current && !record.terminal && projectBindingRepository) {
+      if (!hostNodeId || record.authoritativeGeneration === undefined) {
+        throw new CapletsError(
+          "SERVER_UNAVAILABLE",
+          "Project Binding authoritative ownership is unavailable.",
+        );
+      }
+      const ended = await projectBindingRepository.end({
+        bindingId: record.bindingId,
+        ownerNodeId: hostNodeId,
+        expectedGeneration: record.authoritativeGeneration,
+      });
+      record.authoritativeGeneration = ended.generation;
+    }
     if (current && !record.terminal) terminalizeProjectBindingRecord(record);
     const terminal = current ? record : terminalProjectBindingCandidate(target);
 
@@ -1817,7 +2159,7 @@ export function createHttpServeApp(
     return await enqueueProjectBindingMutation(record, async () => {
       const generation = record.generation;
       const expiresAt = record.expiresAt;
-      if (!canMutateProjectBindingRecord(record, ownerKey)) {
+      if (!(await canMutateProjectBindingRecord(record, ownerKey))) {
         await terminalizeProjectBindingRecordInQueue(record);
         return false;
       }
@@ -1830,7 +2172,7 @@ export function createHttpServeApp(
         record.generation === generation + 1 &&
         record.expiresAt === expiresAt &&
         Date.parse(expiresAt) > Date.now() &&
-        isCurrentProjectBindingAccessOwner(record, ownerKey);
+        (await isCurrentProjectBindingAccessOwner(record, ownerKey));
       if (projectBindingSessions.get(record.bindingId) === record) {
         projectBindingSessions.delete(record.bindingId);
       }
@@ -1867,15 +2209,58 @@ export function createHttpServeApp(
     return record;
   }
 
-  function projectBindingStatusResponse(bindingId: string, ownerKey: string): Response {
+  async function projectBindingStatusResponse(
+    bindingId: string,
+    ownerKey: string,
+  ): Promise<Response> {
     const record = projectBindingRecordFor(bindingId, ownerKey);
-    if (!record) {
-      return new Response(JSON.stringify({ bindingId, state: "not_attached" }), {
+    if (record) {
+      return new Response(JSON.stringify(projectBindingResponse(record)), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
     }
-    return new Response(JSON.stringify(projectBindingResponse(record)), {
+    let authoritative = await projectBindingRepository?.get(bindingId);
+    if (authoritative?.active && Date.parse(authoritative.expiresAt) <= Date.now()) {
+      authoritative = await projectBindingRepository!.quarantineOwnerLoss({
+        bindingId,
+        ownerNodeId: authoritative.ownerNodeId,
+        expectedGeneration: authoritative.generation,
+      });
+    }
+    if (authoritative?.active) {
+      return new Response(
+        JSON.stringify({
+          bindingId,
+          state: authoritative.state,
+          syncState: authoritative.syncState,
+          readiness: authoritative.readiness,
+          active: true,
+          expiresAt: authoritative.expiresAt,
+          affinity: {
+            ownerNodeId: authoritative.ownerNodeId,
+            currentNode: authoritative.ownerNodeId === hostNodeId,
+            required: authoritative.ownerNodeId !== hostNodeId,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (authoritative?.readiness === "quarantined") {
+      return new Response(
+        JSON.stringify({
+          bindingId,
+          state: authoritative.state,
+          syncState: authoritative.syncState,
+          readiness: authoritative.readiness,
+          active: false,
+          requiresOperatorRebind: true,
+          ownerNodeId: authoritative.ownerNodeId,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response(JSON.stringify({ bindingId, state: "not_attached" }), {
       status: 200,
       headers: { "content-type": "application/json" },
     });
@@ -1924,11 +2309,11 @@ export function createHttpServeApp(
     return value as ProjectBindingState;
   }
 
-  function dashboardSessionForRequest(
+  async function dashboardSessionForRequest(
     c: Parameters<MiddlewareHandler>[0],
     csrf: { requireCsrf?: boolean; csrfToken?: string | undefined } = {},
-  ): { ok: true; session: DashboardSessionView } | { ok: false; response: Response } {
-    return validateDashboardSession(c.req.header("cookie"), csrf, c.req.url, (name) =>
+  ): Promise<{ ok: true; session: DashboardSessionView } | { ok: false; response: Response }> {
+    return await validateDashboardSession(c.req.header("cookie"), csrf, c.req.url, (name) =>
       c.req.header(name),
     );
   }
@@ -1982,12 +2367,12 @@ export function createHttpServeApp(
     );
   }
 
-  function validateDashboardSession(
+  async function validateDashboardSession(
     cookieHeader: string | undefined,
     csrf: { requireCsrf?: boolean; csrfToken?: string | undefined },
     requestUrl: string,
     header: (name: string) => string | undefined,
-  ): { ok: true; session: DashboardSessionView } | { ok: false; response: Response } {
+  ): Promise<{ ok: true; session: DashboardSessionView } | { ok: false; response: Response }> {
     if (!remoteCredentialStore && options.auth.type === "development_unauthenticated") {
       if (!isVerifiedLoopbackDevelopmentRequest(options, requestUrl, header)) {
         return { ok: false, response: new Response("Forbidden", { status: 403 }) };
@@ -2009,7 +2394,7 @@ export function createHttpServeApp(
         },
       };
     }
-    if (!remoteCredentialStore) {
+    if (!remoteCredentialStore || !dashboardSessionStore) {
       return {
         ok: false,
         response: new Response(JSON.stringify({ error: "not_found" }), { status: 404 }),
@@ -2018,9 +2403,8 @@ export function createHttpServeApp(
     try {
       return {
         ok: true,
-        session: dashboardSessionStore.validate({
+        session: await dashboardSessionStore.validate({
           cookieHeader,
-          credentialStore: remoteCredentialStore,
           ...csrf,
         }),
       };
@@ -2028,10 +2412,13 @@ export function createHttpServeApp(
       if (error instanceof CapletsError && error.code === "REQUEST_INVALID") {
         return { ok: false, response: new Response("Forbidden", { status: 403 }) };
       }
+      if (error instanceof CapletsError && error.code === "AUTH_FAILED") {
+        return { ok: false, response: new Response("Unauthorized", { status: 401 }) };
+      }
       if (error instanceof CapletsError && error.code === "SERVER_UNAVAILABLE") {
         return { ok: false, response: new Response("Service Unavailable", { status: 503 }) };
       }
-      return { ok: false, response: new Response("Unauthorized", { status: 401 }) };
+      return { ok: false, response: new Response("Service Unavailable", { status: 503 }) };
     }
   }
 
@@ -2056,6 +2443,8 @@ export function createHttpServeApp(
         io,
         writeErr,
         authFlowStore,
+        backendAuthStore,
+        authoritativeStorage,
         c.req.url,
         paths.control,
         options.publicOrigin,
@@ -2108,6 +2497,8 @@ function controlContext(
   io: HttpServeIo,
   writeErr: (value: string) => void,
   authFlowStore: RemoteAuthFlowStore,
+  backendAuthStore: BackendAuthStateStore | undefined,
+  authoritativeStorage: HostStorage | undefined,
   requestUrl: string,
   controlPath: string,
   publicOrigin: string | undefined,
@@ -2120,6 +2511,8 @@ function controlContext(
     globalCapletsRoot: io.control?.globalCapletsRoot ?? resolveCapletsRoot(io.control?.configPath),
     globalLockfilePath: io.control?.globalLockfilePath ?? defaultCapletsLockfilePath(),
     authFlowStore,
+    ...(backendAuthStore ? { backendAuthStore } : {}),
+    ...(authoritativeStorage ? { hostStorage: authoritativeStorage } : {}),
     controlCallbackBaseUrl: new URL(
       controlPath,
       publicOrigin ?? publicRequestOrigin(requestUrl, trustProxy, header),
@@ -2556,7 +2949,7 @@ export async function serveHttp(
   writeErr: (value: string) => void = (value) => process.stderr.write(value),
 ): Promise<void> {
   const remoteEngineOptions = sanitizeRemoteEngineOptions(engineOptions);
-  const engine = new CapletsEngine(remoteEngineOptions);
+  const engine = await CapletsEngine.create(remoteEngineOptions);
   const app = createHttpServeApp(options, engine, {
     writeErr,
     control: {
@@ -2600,7 +2993,7 @@ export async function serveHttpWithSessionFactory(
   engineOptions: CapletsEngineOptions = {},
 ): Promise<void> {
   const remoteEngineOptions = sanitizeRemoteEngineOptions(engineOptions);
-  const engine = new CapletsEngine(remoteEngineOptions);
+  const engine = await CapletsEngine.create(remoteEngineOptions);
   const app = createHttpServeApp(options, engine, {
     writeErr,
     exposeAttach: io.exposeAttach ?? false,
@@ -2692,6 +3085,7 @@ export function servicePaths(base: string): {
   dashboardLogout: string;
   dashboardSummary: string;
   dashboardCaplets: string;
+  dashboardStoredCaplets: string;
   dashboardCatalogSearch: string;
   dashboardCatalogDetail: string;
   dashboardCatalogInstall: string;
@@ -2747,6 +3141,7 @@ export function servicePaths(base: string): {
     dashboardLogout: routePath(dashboardApi, "logout"),
     dashboardSummary: routePath(dashboardApi, "summary"),
     dashboardCaplets: routePath(dashboardApi, "caplets"),
+    dashboardStoredCaplets: routePath(dashboardApi, "stored-caplets"),
     dashboardCatalogSearch: routePath(dashboardApi, "catalog/search"),
     dashboardCatalogDetail: routePath(dashboardApi, "catalog/detail"),
     dashboardCatalogInstall: routePath(dashboardApi, "catalog/install"),
@@ -2791,6 +3186,23 @@ function requiredQueryParam(params: URLSearchParams, key: string): string {
   const value = params.get(key);
   if (!value) throw new CapletsError("REQUEST_INVALID", `${key} is required.`);
   return value;
+}
+
+function optionalQueryParam(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function integerField(input: Record<string, unknown>, key: string): number {
+  const value = input[key];
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new CapletsError("REQUEST_INVALID", `${key} must be a non-negative integer.`);
+  }
+  return value;
+}
+
+function optionalIntegerField(input: Record<string, unknown>, key: string): number | undefined {
+  return input[key] === undefined ? undefined : integerField(input, key);
 }
 
 function optionalBooleanField(input: Record<string, unknown>, key: string): boolean | undefined {
@@ -2848,7 +3260,7 @@ function isDashboardActivityAction(value: string): value is DashboardActivityAct
 
 function routeAuth(
   options: HttpServeOptions,
-  remoteCredentialStore: RemoteServerCredentialStore | undefined,
+  remoteCredentialStore: RemoteCredentialStore | undefined,
   basePath: string,
   requiredRole: RemoteClientRole | undefined,
   retainAuthenticatedClient:
@@ -2861,10 +3273,7 @@ function routeAuth(
     };
   }
   if (!remoteCredentialStore) {
-    throw new CapletsError(
-      "REQUEST_INVALID",
-      "Remote credential auth requires a server credential store.",
-    );
+    return async (c) => c.text("Unauthorized", 401);
   }
   return async (c, next) => {
     const header = authorizationHeaderForRequest(c);
@@ -2873,7 +3282,7 @@ function routeAuth(
       return c.text("Unauthorized", 401);
     }
     try {
-      const client = remoteCredentialStore.validateAccessToken({
+      const client = await remoteCredentialStore.validateAccessToken({
         hostUrl: remoteCredentialHostUrl(c.req.url, basePath, options, (name) =>
           c.req.header(name),
         ),
@@ -2926,19 +3335,8 @@ function isVerifiedLoopbackDevelopmentRequest(
   }
 }
 
-function remoteCredentialStoreForOptions(
-  options: HttpServeOptions,
-  store: RemoteServerCredentialStore | undefined,
-): RemoteServerCredentialStore | undefined {
-  if (options.auth.type !== "remote_credentials") return undefined;
-  if (store) return store;
-  if (!options.remoteCredentialStateDir) {
-    throw new CapletsError(
-      "REQUEST_INVALID",
-      "Remote credential auth requires a server credential state directory.",
-    );
-  }
-  return new RemoteServerCredentialStore({ dir: options.remoteCredentialStateDir });
+function remoteCredentialStatePath(store: RemoteCredentialStore): string | undefined {
+  return store instanceof RemoteServerCredentialStore ? store.dir : undefined;
 }
 
 function bearerToken(header: string): string | undefined {

--- a/packages/core/src/serve/stdio.ts
+++ b/packages/core/src/serve/stdio.ts
@@ -7,7 +7,7 @@ export type ServeStdioOptions = CapletsEngineOptions & {
 };
 
 export async function serveStdio(options: ServeStdioOptions = {}): Promise<void> {
-  const engine = new CapletsEngine(options);
+  const engine = await CapletsEngine.create(options);
   const session = new CapletsMcpSession(engine);
   let closing = false;
 

--- a/packages/core/src/setup/local-store.ts
+++ b/packages/core/src/setup/local-store.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { defaultCacheBaseDir } from "../config/paths";
 import { CapletsError } from "../errors";
@@ -9,7 +9,7 @@ import {
   type SetupTargetKind,
 } from "./types";
 
-type SetupApprovalInput = Omit<SetupApproval, "projectFingerprint"> & {
+export type SetupApprovalInput = Omit<SetupApproval, "projectFingerprint"> & {
   projectFingerprint?: string | undefined;
 };
 
@@ -20,6 +20,12 @@ export type LocalSetupStoreOptions = {
   now?: () => Date;
   maxAttempts?: number;
   retentionDays?: number;
+};
+
+export type LegacySetupMigrationSnapshot = {
+  approvals: SetupApproval[];
+  attempts: SetupAttempt[];
+  sourcePaths: string[];
 };
 
 export class LocalSetupStore {
@@ -62,11 +68,8 @@ export class LocalSetupStore {
   }
 
   async approve(input: SetupApprovalInput): Promise<SetupApproval> {
-    const approval = {
-      ...input,
-      projectFingerprint: input.projectFingerprint ?? DEFAULT_PROJECT_FINGERPRINT,
-    };
-    assertSetupTargetKind(approval.targetKind);
+    assertSetupTargetKind(input.targetKind);
+    const approval = parseSetupApproval(input);
     const approvals = this.approvals().filter(
       (existing) =>
         existing.projectFingerprint !== approval.projectFingerprint ||
@@ -84,14 +87,15 @@ export class LocalSetupStore {
 
   async recordAttempt(attempt: SetupAttempt): Promise<void> {
     assertSetupTargetKind(attempt.targetKind);
-    const projectFingerprint = attempt.projectFingerprint ?? DEFAULT_PROJECT_FINGERPRINT;
+    const parsedAttempt = parseSetupAttempt(attempt);
+    const projectFingerprint = parsedAttempt.projectFingerprint ?? DEFAULT_PROJECT_FINGERPRINT;
     const attempts = this.prunedAttempts([
-      ...this.attempts(projectFingerprint, attempt.capletId),
-      { ...attempt, projectFingerprint },
+      ...this.attempts(projectFingerprint, parsedAttempt.capletId),
+      { ...parsedAttempt, projectFingerprint },
     ]);
     mkdirSync(this.attemptsDir(projectFingerprint), { recursive: true });
     writeFileSync(
-      this.attemptsPath(projectFingerprint, attempt.capletId),
+      this.attemptsPath(projectFingerprint, parsedAttempt.capletId),
       attempts.map((entry) => JSON.stringify(entry)).join("\n") + "\n",
       { mode: 0o600 },
     );
@@ -109,14 +113,46 @@ export class LocalSetupStore {
     return { maxAttempts: this.maxAttempts, days: this.retentionDays };
   }
 
+  exportForMigration(): LegacySetupMigrationSnapshot {
+    const approvals = this.approvals();
+    const sourcePaths = existsSync(this.approvalsPath()) ? [this.approvalsPath()] : [];
+    const attempts: SetupAttempt[] = [];
+    const projectsRoot = join(this.root, "projects");
+    if (existsSync(projectsRoot)) {
+      for (const project of readdirSync(projectsRoot, { withFileTypes: true })) {
+        if (!project.isDirectory()) continue;
+        const attemptsRoot = join(projectsRoot, project.name, "attempts");
+        if (!existsSync(attemptsRoot)) continue;
+        for (const entry of readdirSync(attemptsRoot, { withFileTypes: true })
+          .filter((candidate) => candidate.name.endsWith(".jsonl"))
+          .sort((left, right) => left.name.localeCompare(right.name))) {
+          if (!entry.isFile()) {
+            throw invalidPersistedSetupState("attempt artifact");
+          }
+          const path = join(attemptsRoot, entry.name);
+          let lines: string[];
+          try {
+            lines = readFileSync(path, "utf8")
+              .split("\n")
+              .filter((line) => line.length > 0);
+            attempts.push(...lines.map((line) => parseSetupAttempt(JSON.parse(line) as unknown)));
+          } catch {
+            throw invalidPersistedSetupState("attempt list");
+          }
+          sourcePaths.push(path);
+        }
+      }
+    }
+    assertUniqueSetupSnapshot(approvals, attempts);
+    return { approvals, attempts, sourcePaths: sourcePaths.sort() };
+  }
+
   private approvals(): SetupApproval[] {
     const path = this.approvalsPath();
     if (!existsSync(path)) return [];
-    const approvals = JSON.parse(readFileSync(path, "utf8")) as SetupApprovalInput[];
-    return approvals.map((approval) => ({
-      ...approval,
-      projectFingerprint: approval.projectFingerprint ?? DEFAULT_PROJECT_FINGERPRINT,
-    }));
+    const approvals: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (!Array.isArray(approvals)) throw invalidPersistedSetupState("approval list");
+    return approvals.map(parseSetupApproval);
   }
 
   private prunedAttempts(attempts: SetupAttempt[]): SetupAttempt[] {
@@ -136,7 +172,7 @@ export class LocalSetupStore {
     return readFileSync(path, "utf8")
       .split("\n")
       .filter(Boolean)
-      .map((line) => JSON.parse(line) as SetupAttempt);
+      .map((line) => parseSetupAttempt(JSON.parse(line) as unknown));
   }
 
   private attemptsDir(projectFingerprint: string): string {
@@ -145,6 +181,38 @@ export class LocalSetupStore {
 
   private attemptsPath(projectFingerprint: string, capletId: string): string {
     return join(this.attemptsDir(projectFingerprint), `${safeFileName(capletId)}.jsonl`);
+  }
+}
+
+function assertUniqueSetupSnapshot(approvals: SetupApproval[], attempts: SetupAttempt[]): void {
+  const approvalKeys = new Set<string>();
+  for (const approval of approvals) {
+    const identity = JSON.stringify([
+      approval.projectFingerprint,
+      approval.capletId,
+      approval.contentHash,
+      approval.targetKind,
+    ]);
+    if (approvalKeys.has(identity) || !Number.isFinite(Date.parse(approval.approvedAt))) {
+      throw invalidPersistedSetupState("approval list");
+    }
+    approvalKeys.add(identity);
+  }
+  const attemptKeys = new Set<string>();
+  for (const attempt of attempts) {
+    const identity = JSON.stringify([
+      attempt.projectFingerprint,
+      attempt.capletId,
+      attempt.attemptId,
+    ]);
+    if (
+      attemptKeys.has(identity) ||
+      !Number.isFinite(Date.parse(attempt.startedAt)) ||
+      !Number.isFinite(Date.parse(attempt.finishedAt))
+    ) {
+      throw invalidPersistedSetupState("attempt list");
+    }
+    attemptKeys.add(identity);
   }
 }
 
@@ -159,4 +227,116 @@ function assertSetupTargetKind(value: string): asserts value is SetupTargetKind 
       "setup target must be one of: local_host, remote_host, hosted_sandbox",
     );
   }
+}
+
+export function parseSetupApproval(value: unknown): SetupApproval {
+  if (
+    !isRecord(value) ||
+    typeof value.capletId !== "string" ||
+    typeof value.contentHash !== "string" ||
+    !isSetupTargetKindValue(value.targetKind) ||
+    typeof value.approvedAt !== "string" ||
+    !isSetupActor(value.actor) ||
+    (value.projectFingerprint !== undefined && typeof value.projectFingerprint !== "string")
+  ) {
+    throw invalidPersistedSetupState("approval");
+  }
+  return {
+    projectFingerprint: value.projectFingerprint ?? DEFAULT_PROJECT_FINGERPRINT,
+    capletId: value.capletId,
+    contentHash: value.contentHash,
+    targetKind: value.targetKind,
+    approvedAt: value.approvedAt,
+    actor: value.actor,
+  };
+}
+
+export function parseSetupAttempt(value: unknown): SetupAttempt {
+  if (
+    !isRecord(value) ||
+    typeof value.attemptId !== "string" ||
+    typeof value.projectFingerprint !== "string" ||
+    typeof value.capletId !== "string" ||
+    typeof value.contentHash !== "string" ||
+    (value.setupHash !== undefined && typeof value.setupHash !== "string") ||
+    !isSetupTargetKindValue(value.targetKind) ||
+    !isRuntimeFeatures(value.runtimeFeatures) ||
+    !isSetupActor(value.actor) ||
+    !isSetupAttemptStatus(value.status) ||
+    (value.phase !== "commands" && value.phase !== "verify") ||
+    typeof value.commandLabel !== "string" ||
+    !isStringArray(value.argv) ||
+    (value.exitCode !== undefined && typeof value.exitCode !== "number") ||
+    (value.signal !== undefined && typeof value.signal !== "string") ||
+    typeof value.durationMs !== "number" ||
+    typeof value.startedAt !== "string" ||
+    typeof value.finishedAt !== "string" ||
+    typeof value.stdout !== "string" ||
+    typeof value.stderr !== "string" ||
+    typeof value.redacted !== "boolean" ||
+    !isRetention(value.retention)
+  ) {
+    throw invalidPersistedSetupState("attempt");
+  }
+  return {
+    attemptId: value.attemptId,
+    projectFingerprint: value.projectFingerprint,
+    capletId: value.capletId,
+    contentHash: value.contentHash,
+    ...(value.setupHash === undefined ? {} : { setupHash: value.setupHash }),
+    targetKind: value.targetKind,
+    ...(value.runtimeFeatures === undefined ? {} : { runtimeFeatures: value.runtimeFeatures }),
+    actor: value.actor,
+    status: value.status,
+    phase: value.phase,
+    commandLabel: value.commandLabel,
+    argv: value.argv,
+    ...(value.exitCode === undefined ? {} : { exitCode: value.exitCode }),
+    ...(value.signal === undefined ? {} : { signal: value.signal }),
+    durationMs: value.durationMs,
+    startedAt: value.startedAt,
+    finishedAt: value.finishedAt,
+    stdout: value.stdout,
+    stderr: value.stderr,
+    redacted: value.redacted,
+    retention: value.retention,
+  };
+}
+
+function isSetupTargetKindValue(value: unknown): value is SetupTargetKind {
+  return typeof value === "string" && isSetupTargetKind(value);
+}
+
+function isSetupActor(value: unknown): value is SetupApproval["actor"] {
+  return (
+    value === "cli-interactive" || value === "cli-yes" || value === "ui" || value === "automation"
+  );
+}
+
+function isSetupAttemptStatus(value: unknown): value is SetupAttempt["status"] {
+  return value === "running" || value === "succeeded" || value === "failed";
+}
+
+function isRuntimeFeatures(value: unknown): value is SetupAttempt["runtimeFeatures"] {
+  return (
+    value === undefined ||
+    (Array.isArray(value) &&
+      value.every((feature) => feature === "docker" || feature === "browser"))
+  );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isRetention(value: unknown): value is SetupAttempt["retention"] {
+  return isRecord(value) && typeof value.maxAttempts === "number" && typeof value.days === "number";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function invalidPersistedSetupState(kind: string): CapletsError {
+  return new CapletsError("INTERNAL_ERROR", `Persisted setup ${kind} is invalid.`);
 }

--- a/packages/core/src/setup/runner.ts
+++ b/packages/core/src/setup/runner.ts
@@ -4,7 +4,6 @@ import { isAbsolute, resolve } from "node:path";
 import type { CapletSetupCommandConfig, CapletSetupConfig } from "../config";
 import type { RuntimeFeature } from "../config-runtime";
 import { CapletsError } from "../errors";
-import type { LocalSetupStore } from "./local-store";
 import {
   isSetupTargetKind,
   type SetupActor,
@@ -31,6 +30,14 @@ export type SetupSpawn = (
   },
 ) => Promise<SpawnResult>;
 
+export type SetupAttemptStore = {
+  recordAttempt(
+    attempt: SetupAttempt,
+    options?: { operatorClientId?: string | undefined },
+  ): Promise<void>;
+  retention(): { maxAttempts: number; days: number };
+};
+
 export type RunCapletSetupOptions = {
   projectFingerprint?: string;
   capletId: string;
@@ -43,7 +50,8 @@ export type RunCapletSetupOptions = {
   setup: CapletSetupConfig;
   actor: SetupActor;
   approved: boolean;
-  store: Pick<LocalSetupStore, "recordAttempt" | "retention">;
+  store: SetupAttemptStore;
+  operatorClientId?: string | undefined;
   spawn?: SetupSpawn;
   now?: () => Date;
 };
@@ -64,7 +72,12 @@ export async function runCapletSetup(options: RunCapletSetupOptions): Promise<Se
     for (const command of phase === "commands" ? commands : verify) {
       const attempt = await runSetupCommand(options, phase, command);
       attempts.push(attempt);
-      await options.store.recordAttempt(attempt);
+      await options.store.recordAttempt(
+        attempt,
+        options.operatorClientId === undefined
+          ? {}
+          : { operatorClientId: options.operatorClientId },
+      );
       if (attempt.status !== "succeeded") {
         return attempts;
       }

--- a/packages/core/src/storage/asset-store.ts
+++ b/packages/core/src/storage/asset-store.ts
@@ -1,0 +1,128 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import type { AssetStorageConfig } from "../config";
+import { CapletsError } from "../errors";
+
+export interface AssetObjectStore {
+  putVerified(hash: string, payload: Buffer): Promise<string>;
+  get(key: string): Promise<Buffer>;
+  delete(key: string): Promise<void>;
+  list(): Promise<Array<{ key: string; modifiedAt: Date }>>;
+  health(): Promise<boolean>;
+  close(): void;
+}
+
+export function createAssetObjectStore(
+  config: AssetStorageConfig | undefined,
+): AssetObjectStore | undefined {
+  if (!config || config.type === "sql") return undefined;
+  return new S3AssetObjectStore(config);
+}
+
+class S3AssetObjectStore implements AssetObjectStore {
+  private readonly client: S3Client;
+  private readonly prefix: string;
+
+  constructor(private readonly config: Extract<AssetStorageConfig, { type: "s3" }>) {
+    this.prefix = config.prefix?.replace(/^\/+|\/+$/gu, "") ?? "caplets";
+    this.client = new S3Client({
+      region: config.region,
+      ...(config.endpoint ? { endpoint: config.endpoint } : {}),
+      ...(config.forcePathStyle === undefined ? {} : { forcePathStyle: config.forcePathStyle }),
+      ...(config.accessKeyId && config.secretAccessKey
+        ? {
+            credentials: {
+              accessKeyId: config.accessKeyId,
+              secretAccessKey: config.secretAccessKey,
+            },
+          }
+        : {}),
+    });
+  }
+
+  async putVerified(hash: string, payload: Buffer): Promise<string> {
+    const actualHash = sha256(payload);
+    if (actualHash !== hash) {
+      throw new CapletsError("INTERNAL_ERROR", `Caplet asset ${hash} has invalid staged content.`);
+    }
+    const key = `${this.prefix}/assets/sha256/${hash.slice(0, 2)}/${hash}-${randomUUID()}`;
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.config.bucket,
+        Key: key,
+        Body: payload,
+        ContentLength: payload.byteLength,
+        Metadata: { sha256: hash },
+      }),
+    );
+    const stored = await this.get(key);
+    if (stored.byteLength !== payload.byteLength || sha256(stored) !== hash) {
+      throw new CapletsError("SERVER_UNAVAILABLE", `Caplet asset ${hash} failed S3 verification.`);
+    }
+    return key;
+  }
+
+  async get(key: string): Promise<Buffer> {
+    const response = await this.client.send(
+      new GetObjectCommand({ Bucket: this.config.bucket, Key: key }),
+    );
+    if (!response.Body) {
+      throw new CapletsError("SERVER_UNAVAILABLE", `Caplet asset object ${key} has no payload.`);
+    }
+    return Buffer.from(await response.Body.transformToByteArray());
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.send(new DeleteObjectCommand({ Bucket: this.config.bucket, Key: key }));
+  }
+
+  async list(): Promise<Array<{ key: string; modifiedAt: Date }>> {
+    const objects: Array<{ key: string; modifiedAt: Date }> = [];
+    let continuationToken: string | undefined;
+    do {
+      const response = await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.config.bucket,
+          Prefix: `${this.prefix}/assets/sha256/`,
+          ...(continuationToken ? { ContinuationToken: continuationToken } : {}),
+        }),
+      );
+      for (const object of response.Contents ?? []) {
+        if (object.Key && object.LastModified) {
+          objects.push({ key: object.Key, modifiedAt: object.LastModified });
+        }
+      }
+      continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined;
+    } while (continuationToken);
+    return objects;
+  }
+
+  async health(): Promise<boolean> {
+    try {
+      await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.config.bucket,
+          Prefix: `${this.prefix}/assets/`,
+          MaxKeys: 1,
+        }),
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  close(): void {
+    this.client.destroy();
+  }
+}
+
+function sha256(payload: Buffer): string {
+  return createHash("sha256").update(payload).digest("hex");
+}

--- a/packages/core/src/storage/asset-store.ts
+++ b/packages/core/src/storage/asset-store.ts
@@ -11,7 +11,7 @@ import { CapletsError } from "../errors";
 
 export interface AssetObjectStore {
   putVerified(hash: string, payload: Buffer): Promise<string>;
-  get(key: string): Promise<Buffer>;
+  getVerified(key: string, expected: { hash: string; size: number }): Promise<Buffer>;
   delete(key: string): Promise<void>;
   list(): Promise<Array<{ key: string; modifiedAt: Date }>>;
   health(): Promise<boolean>;
@@ -61,21 +61,35 @@ class S3AssetObjectStore implements AssetObjectStore {
         Metadata: { sha256: hash },
       }),
     );
-    const stored = await this.get(key);
-    if (stored.byteLength !== payload.byteLength || sha256(stored) !== hash) {
-      throw new CapletsError("SERVER_UNAVAILABLE", `Caplet asset ${hash} failed S3 verification.`);
-    }
+    await this.getVerified(key, { hash, size: payload.byteLength });
     return key;
   }
 
-  async get(key: string): Promise<Buffer> {
-    const response = await this.client.send(
-      new GetObjectCommand({ Bucket: this.config.bucket, Key: key }),
-    );
+  async getVerified(key: string, expected: { hash: string; size: number }): Promise<Buffer> {
+    let response;
+    try {
+      response = await this.client.send(
+        new GetObjectCommand({ Bucket: this.config.bucket, Key: key }),
+      );
+    } catch {
+      throw new CapletsError("SERVER_UNAVAILABLE", `Caplet asset object ${key} is unavailable.`);
+    }
     if (!response.Body) {
       throw new CapletsError("SERVER_UNAVAILABLE", `Caplet asset object ${key} has no payload.`);
     }
-    return Buffer.from(await response.Body.transformToByteArray());
+    const payload = Buffer.from(await response.Body.transformToByteArray());
+    if (
+      response.ContentLength !== expected.size ||
+      response.Metadata?.sha256 !== expected.hash ||
+      payload.byteLength !== expected.size ||
+      sha256(payload) !== expected.hash
+    ) {
+      throw new CapletsError(
+        "INTERNAL_ERROR",
+        `Caplet asset object ${key} failed integrity verification.`,
+      );
+    }
+    return payload;
   }
 
   async delete(key: string): Promise<void> {

--- a/packages/core/src/storage/backend-auth.ts
+++ b/packages/core/src/storage/backend-auth.ts
@@ -1,0 +1,471 @@
+import { randomUUID } from "node:crypto";
+import { asc, eq, sql } from "drizzle-orm";
+import {
+  isStoredOAuthTokenBundle,
+  type StoredOAuthTokenBundle,
+  type StoredOAuthTokenBundleView,
+} from "../auth/store";
+import { CapletsError } from "../errors";
+import { stableJsonStringify } from "../stable-json";
+import * as postgres from "./schema/postgres";
+import * as sqlite from "./schema/sqlite";
+import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+
+export type BackendAuthMutationOptions = {
+  expectedGeneration?: number | undefined;
+  operatorClientId?: string | undefined;
+};
+
+type BackendAuthRow = {
+  server: string;
+  generation: number;
+  tokenBundle: unknown;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export class BackendAuthStateStore {
+  constructor(private readonly database: HostDatabase) {}
+
+  async readTokenBundle(server: string): Promise<StoredOAuthTokenBundleView | undefined> {
+    validateServer(server);
+    const row =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select()
+            .from(sqlite.backendAuthStates)
+            .where(eq(sqlite.backendAuthStates.server, server))
+            .get()
+        : (
+            await this.database.db
+              .select()
+              .from(postgres.backendAuthStates)
+              .where(eq(postgres.backendAuthStates.server, server))
+              .limit(1)
+          )[0];
+    return row ? tokenBundleView(row, server) : undefined;
+  }
+
+  async listTokenBundles(): Promise<StoredOAuthTokenBundleView[]> {
+    const rows =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select()
+            .from(sqlite.backendAuthStates)
+            .orderBy(asc(sqlite.backendAuthStates.server))
+            .all()
+        : await this.database.db
+            .select()
+            .from(postgres.backendAuthStates)
+            .orderBy(asc(postgres.backendAuthStates.server));
+    return rows.map((row) => tokenBundleView(row, row.server));
+  }
+
+  async writeTokenBundle(
+    bundle: StoredOAuthTokenBundle,
+    options: BackendAuthMutationOptions = {},
+  ): Promise<StoredOAuthTokenBundleView> {
+    const server = bundle.server;
+    validateServer(server);
+    const validatedBundle: unknown = bundle;
+    if (!isStoredOAuthTokenBundle(validatedBundle)) {
+      throw new CapletsError("REQUEST_INVALID", `Invalid OAuth token bundle for ${server}.`);
+    }
+    validateMutationOptions(options);
+    return this.database.dialect === "sqlite"
+      ? writeSqlite(this.database.db, validatedBundle, options)
+      : await writePostgres(this.database.db, validatedBundle, options);
+  }
+
+  async assertLegacyBundlesImportable(bundles: StoredOAuthTokenBundle[]): Promise<void> {
+    const validated = validateLegacyBundles(bundles);
+    if (this.database.dialect === "sqlite") {
+      assertLegacyBundlesMatchSqlite(this.database.db, validated);
+    } else {
+      await assertLegacyBundlesMatchPostgres(this.database.db, validated);
+    }
+  }
+
+  async importLegacyBundles(bundles: StoredOAuthTokenBundle[]): Promise<void> {
+    const validated = validateLegacyBundles(bundles);
+    if (validated.length === 0) return;
+    const timestamp = new Date().toISOString();
+    if (this.database.dialect === "sqlite") {
+      this.database.db.transaction((transaction) => {
+        assertLegacyBundlesMatchSqlite(transaction, validated);
+        const values = validated
+          .filter(
+            (bundle) =>
+              !transaction
+                .select({ server: sqlite.backendAuthStates.server })
+                .from(sqlite.backendAuthStates)
+                .where(eq(sqlite.backendAuthStates.server, bundle.server))
+                .get(),
+          )
+          .map((bundle) => ({
+            server: bundle.server,
+            generation: 1,
+            tokenBundle: bundle,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          }));
+        if (values.length > 0) {
+          transaction.insert(sqlite.backendAuthStates).values(values).run();
+        }
+      });
+      return;
+    }
+    await this.database.db.transaction(async (transaction) => {
+      for (const bundle of validated) await lockPostgresState(transaction, bundle.server);
+      await assertLegacyBundlesMatchPostgres(transaction, validated);
+      const existing = await transaction
+        .select({ server: postgres.backendAuthStates.server })
+        .from(postgres.backendAuthStates);
+      const existingServers = new Set(existing.map((row) => row.server));
+      const values = validated
+        .filter((bundle) => !existingServers.has(bundle.server))
+        .map((bundle) => ({
+          server: bundle.server,
+          generation: 1,
+          tokenBundle: bundle,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        }));
+      if (values.length > 0) await transaction.insert(postgres.backendAuthStates).values(values);
+    });
+  }
+
+  async verifyLegacyBundles(bundles: StoredOAuthTokenBundle[]): Promise<void> {
+    for (const bundle of validateLegacyBundles(bundles)) {
+      const stored = await this.readTokenBundle(bundle.server);
+      if (!stored || stableJsonStringify(stored.bundle) !== stableJsonStringify(bundle)) {
+        throw new CapletsError(
+          "INTERNAL_ERROR",
+          `Backend auth state for ${bundle.server} failed post-migration verification.`,
+        );
+      }
+    }
+  }
+
+  async deleteTokenBundle(
+    server: string,
+    options: BackendAuthMutationOptions = {},
+  ): Promise<boolean> {
+    validateServer(server);
+    validateMutationOptions(options);
+    return this.database.dialect === "sqlite"
+      ? deleteSqlite(this.database.db, server, options)
+      : await deletePostgres(this.database.db, server, options);
+  }
+}
+
+type SqliteBackendAuthDatabase =
+  | SqliteHostDatabase
+  | Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0];
+type PostgresBackendAuthDatabase =
+  | PostgresHostDatabase
+  | Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0];
+
+function validateLegacyBundles(bundles: StoredOAuthTokenBundle[]): StoredOAuthTokenBundle[] {
+  const servers = new Set<string>();
+  const validated = bundles.map((bundle) => {
+    const candidate: unknown = bundle;
+    if (!isStoredOAuthTokenBundle(candidate)) {
+      throw new CapletsError("CONFIG_INVALID", "A legacy OAuth token bundle is invalid.");
+    }
+    validateServer(candidate.server);
+    if (servers.has(candidate.server)) {
+      throw new CapletsError("CONFIG_INVALID", "Legacy OAuth token bundles contain duplicates.");
+    }
+    servers.add(candidate.server);
+    return candidate;
+  });
+  return validated.sort((left, right) => left.server.localeCompare(right.server));
+}
+
+function assertLegacyBundlesMatchSqlite(
+  database: SqliteBackendAuthDatabase,
+  bundles: StoredOAuthTokenBundle[],
+): void {
+  for (const bundle of bundles) {
+    const row = database
+      .select()
+      .from(sqlite.backendAuthStates)
+      .where(eq(sqlite.backendAuthStates.server, bundle.server))
+      .get();
+    if (
+      row &&
+      stableJsonStringify(tokenBundleView(row, bundle.server).bundle) !==
+        stableJsonStringify(bundle)
+    ) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        `Backend auth state for ${bundle.server} conflicts with the legacy snapshot.`,
+      );
+    }
+  }
+}
+
+async function assertLegacyBundlesMatchPostgres(
+  database: PostgresBackendAuthDatabase,
+  bundles: StoredOAuthTokenBundle[],
+): Promise<void> {
+  for (const bundle of bundles) {
+    const [row] = await database
+      .select()
+      .from(postgres.backendAuthStates)
+      .where(eq(postgres.backendAuthStates.server, bundle.server))
+      .limit(1);
+    if (
+      row &&
+      stableJsonStringify(tokenBundleView(row, bundle.server).bundle) !==
+        stableJsonStringify(bundle)
+    ) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        `Backend auth state for ${bundle.server} conflicts with the legacy snapshot.`,
+      );
+    }
+  }
+}
+
+function writeSqlite(
+  db: SqliteHostDatabase,
+  bundle: StoredOAuthTokenBundle,
+  options: BackendAuthMutationOptions,
+): StoredOAuthTokenBundleView {
+  return db.transaction((transaction) => {
+    const current = transaction
+      .select()
+      .from(sqlite.backendAuthStates)
+      .where(eq(sqlite.backendAuthStates.server, bundle.server))
+      .get();
+    if (current) tokenBundleView(current, bundle.server);
+    assertExpectedGeneration(current, options.expectedGeneration);
+    const generation = (current?.generation ?? 0) + 1;
+    const now = new Date().toISOString();
+    transaction
+      .insert(sqlite.backendAuthStates)
+      .values({
+        server: bundle.server,
+        generation,
+        tokenBundle: bundle,
+        createdAt: current?.createdAt ?? now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: sqlite.backendAuthStates.server,
+        set: { generation, tokenBundle: bundle, updatedAt: now },
+      })
+      .run();
+    if (options.operatorClientId) {
+      transaction
+        .insert(sqlite.operatorActivity)
+        .values(
+          activityValues(
+            options.operatorClientId,
+            "backend_auth_written",
+            bundle.server,
+            generation,
+            now,
+          ),
+        )
+        .run();
+    }
+    return { bundle, generation };
+  });
+}
+
+async function writePostgres(
+  db: PostgresHostDatabase,
+  bundle: StoredOAuthTokenBundle,
+  options: BackendAuthMutationOptions,
+): Promise<StoredOAuthTokenBundleView> {
+  return await db.transaction(async (transaction) => {
+    await lockPostgresState(transaction, bundle.server);
+    const [current] = await transaction
+      .select()
+      .from(postgres.backendAuthStates)
+      .where(eq(postgres.backendAuthStates.server, bundle.server))
+      .for("update")
+      .limit(1);
+    if (current) tokenBundleView(current, bundle.server);
+    assertExpectedGeneration(current, options.expectedGeneration);
+    const generation = (current?.generation ?? 0) + 1;
+    const now = new Date().toISOString();
+    await transaction
+      .insert(postgres.backendAuthStates)
+      .values({
+        server: bundle.server,
+        generation,
+        tokenBundle: bundle,
+        createdAt: current?.createdAt ?? now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: postgres.backendAuthStates.server,
+        set: { generation, tokenBundle: bundle, updatedAt: now },
+      });
+    if (options.operatorClientId) {
+      await transaction
+        .insert(postgres.operatorActivity)
+        .values(
+          activityValues(
+            options.operatorClientId,
+            "backend_auth_written",
+            bundle.server,
+            generation,
+            now,
+          ),
+        );
+    }
+    return { bundle, generation };
+  });
+}
+
+function deleteSqlite(
+  db: SqliteHostDatabase,
+  server: string,
+  options: BackendAuthMutationOptions,
+): boolean {
+  return db.transaction((transaction) => {
+    const current = transaction
+      .select()
+      .from(sqlite.backendAuthStates)
+      .where(eq(sqlite.backendAuthStates.server, server))
+      .get();
+    if (current) tokenBundleView(current, server);
+    assertExpectedGeneration(current, options.expectedGeneration);
+    if (!current) return false;
+    const now = new Date().toISOString();
+    transaction
+      .delete(sqlite.backendAuthStates)
+      .where(eq(sqlite.backendAuthStates.server, server))
+      .run();
+    if (options.operatorClientId) {
+      transaction
+        .insert(sqlite.operatorActivity)
+        .values(
+          activityValues(
+            options.operatorClientId,
+            "backend_auth_deleted",
+            server,
+            current.generation,
+            now,
+          ),
+        )
+        .run();
+    }
+    return true;
+  });
+}
+
+async function deletePostgres(
+  db: PostgresHostDatabase,
+  server: string,
+  options: BackendAuthMutationOptions,
+): Promise<boolean> {
+  return await db.transaction(async (transaction) => {
+    await lockPostgresState(transaction, server);
+    const [current] = await transaction
+      .select()
+      .from(postgres.backendAuthStates)
+      .where(eq(postgres.backendAuthStates.server, server))
+      .for("update")
+      .limit(1);
+    if (current) tokenBundleView(current, server);
+    assertExpectedGeneration(current, options.expectedGeneration);
+    if (!current) return false;
+    const now = new Date().toISOString();
+    await transaction
+      .delete(postgres.backendAuthStates)
+      .where(eq(postgres.backendAuthStates.server, server));
+    if (options.operatorClientId) {
+      await transaction
+        .insert(postgres.operatorActivity)
+        .values(
+          activityValues(
+            options.operatorClientId,
+            "backend_auth_deleted",
+            server,
+            current.generation,
+            now,
+          ),
+        );
+    }
+    return true;
+  });
+}
+
+async function lockPostgresState(
+  transaction: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  server: string,
+): Promise<void> {
+  await transaction.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify(["backend-auth", server])}, 0))`,
+  );
+}
+
+function tokenBundleView(row: BackendAuthRow, expectedServer: string): StoredOAuthTokenBundleView {
+  if (
+    row.server !== expectedServer ||
+    !Number.isInteger(row.generation) ||
+    row.generation < 1 ||
+    !isStoredOAuthTokenBundle(row.tokenBundle) ||
+    row.tokenBundle.server !== expectedServer
+  ) {
+    throw new CapletsError(
+      "INTERNAL_ERROR",
+      `Stored backend auth state for ${expectedServer} is invalid.`,
+    );
+  }
+  return { bundle: row.tokenBundle, generation: row.generation };
+}
+
+function assertExpectedGeneration(
+  current: Pick<BackendAuthRow, "generation"> | undefined,
+  expectedGeneration: number | undefined,
+): void {
+  if (expectedGeneration === undefined) return;
+  if (current?.generation === expectedGeneration) return;
+  throw new CapletsError(
+    "REQUEST_INVALID",
+    "Authoritative Host State changed after it was read; reload and retry.",
+    {
+      kind: "stale_generation",
+      expectedGeneration,
+      currentGeneration: current?.generation ?? 0,
+    },
+  );
+}
+
+function activityValues(
+  operatorClientId: string,
+  action: "backend_auth_written" | "backend_auth_deleted",
+  server: string,
+  generation: number,
+  createdAt: string,
+) {
+  return {
+    activityKey: randomUUID(),
+    operatorClientId,
+    action,
+    targetKind: "backend_auth",
+    targetKey: server,
+    outcome: "succeeded",
+    metadata: { generation },
+    createdAt,
+  };
+}
+
+function validateServer(server: string): void {
+  if (!server.trim() || server.includes("/") || server.includes("\\") || server.includes("..")) {
+    throw new CapletsError("REQUEST_INVALID", `Invalid auth store server name ${server}`);
+  }
+}
+
+function validateMutationOptions(options: BackendAuthMutationOptions): void {
+  if (options.operatorClientId !== undefined && !options.operatorClientId.trim()) {
+    throw new CapletsError("REQUEST_INVALID", "Operator client ID is required when provided.");
+  }
+}

--- a/packages/core/src/storage/backend-auth.ts
+++ b/packages/core/src/storage/backend-auth.ts
@@ -9,7 +9,12 @@ import { CapletsError } from "../errors";
 import { stableJsonStringify } from "../stable-json";
 import * as postgres from "./schema/postgres";
 import * as sqlite from "./schema/sqlite";
-import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+import type {
+  HostDatabase,
+  HostDatabaseTransaction,
+  PostgresHostDatabase,
+  SqliteHostDatabase,
+} from "./types";
 
 export type BackendAuthMutationOptions = {
   expectedGeneration?: number | undefined;
@@ -91,48 +96,26 @@ export class BackendAuthStateStore {
     if (validated.length === 0) return;
     const timestamp = new Date().toISOString();
     if (this.database.dialect === "sqlite") {
-      this.database.db.transaction((transaction) => {
-        assertLegacyBundlesMatchSqlite(transaction, validated);
-        const values = validated
-          .filter(
-            (bundle) =>
-              !transaction
-                .select({ server: sqlite.backendAuthStates.server })
-                .from(sqlite.backendAuthStates)
-                .where(eq(sqlite.backendAuthStates.server, bundle.server))
-                .get(),
-          )
-          .map((bundle) => ({
-            server: bundle.server,
-            generation: 1,
-            tokenBundle: bundle,
-            createdAt: timestamp,
-            updatedAt: timestamp,
-          }));
-        if (values.length > 0) {
-          transaction.insert(sqlite.backendAuthStates).values(values).run();
-        }
-      });
+      this.database.db.transaction((transaction) =>
+        importLegacyBundlesSqlite(transaction, validated, timestamp),
+      );
       return;
     }
-    await this.database.db.transaction(async (transaction) => {
-      for (const bundle of validated) await lockPostgresState(transaction, bundle.server);
-      await assertLegacyBundlesMatchPostgres(transaction, validated);
-      const existing = await transaction
-        .select({ server: postgres.backendAuthStates.server })
-        .from(postgres.backendAuthStates);
-      const existingServers = new Set(existing.map((row) => row.server));
-      const values = validated
-        .filter((bundle) => !existingServers.has(bundle.server))
-        .map((bundle) => ({
-          server: bundle.server,
-          generation: 1,
-          tokenBundle: bundle,
-          createdAt: timestamp,
-          updatedAt: timestamp,
-        }));
-      if (values.length > 0) await transaction.insert(postgres.backendAuthStates).values(values);
-    });
+    await this.database.db.transaction(
+      async (transaction) => await importLegacyBundlesPostgres(transaction, validated, timestamp),
+    );
+  }
+
+  importLegacyBundlesInTransaction(
+    bundles: StoredOAuthTokenBundle[],
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    const validated = validateLegacyBundles(bundles);
+    if (validated.length === 0) return;
+    const timestamp = new Date().toISOString();
+    return transaction.dialect === "sqlite"
+      ? importLegacyBundlesSqlite(transaction.db, validated, timestamp)
+      : importLegacyBundlesPostgres(transaction.db, validated, timestamp);
   }
 
   async verifyLegacyBundles(bundles: StoredOAuthTokenBundle[]): Promise<void> {
@@ -145,6 +128,15 @@ export class BackendAuthStateStore {
         );
       }
     }
+  }
+  verifyLegacyBundlesInTransaction(
+    bundles: StoredOAuthTokenBundle[],
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    const validated = validateLegacyBundles(bundles);
+    return transaction.dialect === "sqlite"
+      ? verifyLegacyBundlesSqlite(transaction.db, validated)
+      : verifyLegacyBundlesPostgres(transaction.db, validated);
   }
 
   async deleteTokenBundle(
@@ -165,6 +157,100 @@ type SqliteBackendAuthDatabase =
 type PostgresBackendAuthDatabase =
   | PostgresHostDatabase
   | Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0];
+function importLegacyBundlesSqlite(
+  database: SqliteBackendAuthDatabase,
+  bundles: StoredOAuthTokenBundle[],
+  timestamp: string,
+): void {
+  assertLegacyBundlesMatchSqlite(database, bundles);
+  const values = bundles
+    .filter(
+      (bundle) =>
+        !database
+          .select({ server: sqlite.backendAuthStates.server })
+          .from(sqlite.backendAuthStates)
+          .where(eq(sqlite.backendAuthStates.server, bundle.server))
+          .get(),
+    )
+    .map((bundle) => ({
+      server: bundle.server,
+      generation: 1,
+      tokenBundle: bundle,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }));
+  if (values.length > 0) database.insert(sqlite.backendAuthStates).values(values).run();
+}
+
+async function importLegacyBundlesPostgres(
+  database: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  bundles: StoredOAuthTokenBundle[],
+  timestamp: string,
+): Promise<void> {
+  for (const bundle of bundles) await lockPostgresState(database, bundle.server);
+  await assertLegacyBundlesMatchPostgres(database, bundles);
+  const existing = await database
+    .select({ server: postgres.backendAuthStates.server })
+    .from(postgres.backendAuthStates);
+  const existingServers = new Set(existing.map((row) => row.server));
+  const values = bundles
+    .filter((bundle) => !existingServers.has(bundle.server))
+    .map((bundle) => ({
+      server: bundle.server,
+      generation: 1,
+      tokenBundle: bundle,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }));
+  if (values.length > 0) await database.insert(postgres.backendAuthStates).values(values);
+}
+
+function verifyLegacyBundlesSqlite(
+  database: SqliteBackendAuthDatabase,
+  bundles: StoredOAuthTokenBundle[],
+): void {
+  for (const bundle of bundles) {
+    const row = database
+      .select()
+      .from(sqlite.backendAuthStates)
+      .where(eq(sqlite.backendAuthStates.server, bundle.server))
+      .get();
+    if (
+      !row ||
+      stableJsonStringify(tokenBundleView(row, bundle.server).bundle) !==
+        stableJsonStringify(bundle)
+    ) {
+      throw legacyBundleVerificationError(bundle.server);
+    }
+  }
+}
+
+async function verifyLegacyBundlesPostgres(
+  database: PostgresBackendAuthDatabase,
+  bundles: StoredOAuthTokenBundle[],
+): Promise<void> {
+  for (const bundle of bundles) {
+    const [row] = await database
+      .select()
+      .from(postgres.backendAuthStates)
+      .where(eq(postgres.backendAuthStates.server, bundle.server))
+      .limit(1);
+    if (
+      !row ||
+      stableJsonStringify(tokenBundleView(row, bundle.server).bundle) !==
+        stableJsonStringify(bundle)
+    ) {
+      throw legacyBundleVerificationError(bundle.server);
+    }
+  }
+}
+
+function legacyBundleVerificationError(server: string): CapletsError {
+  return new CapletsError(
+    "INTERNAL_ERROR",
+    `Backend auth state for ${server} failed post-migration verification.`,
+  );
+}
 
 function validateLegacyBundles(bundles: StoredOAuthTokenBundle[]): StoredOAuthTokenBundle[] {
   const servers = new Set<string>();

--- a/packages/core/src/storage/caplet-records.ts
+++ b/packages/core/src/storage/caplet-records.ts
@@ -1,0 +1,2752 @@
+import { chmodSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { basename, dirname, extname, join, posix } from "node:path";
+import { and, asc, count, desc, eq, inArray } from "drizzle-orm";
+import { stringify as stringifyYaml } from "yaml";
+import { parseCapletFileDocument, type CapletFileFrontmatter } from "../caplet-files-bundle";
+import { CapletsError } from "../errors";
+import { advancePostgresConfigGeneration, advanceSqliteConfigGeneration } from "./coordination";
+import type { AssetObjectStore } from "./asset-store";
+import {
+  requireOperator,
+  type CapletInstallationObservationStatus,
+  type OperatorPrincipal,
+} from "./installations";
+import * as postgres from "./schema/postgres";
+import * as sqlite from "./schema/sqlite";
+import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+
+export type CapletBundleInputFile = {
+  path: string;
+  content: Buffer;
+  executable: boolean;
+};
+export type ReadCapletBundleResult = {
+  record: CapletRecordView;
+  files: CapletBundleInputFile[];
+};
+
+export type UpdateCapletBundleInput = ImportCapletBundleInput & {
+  expectedGeneration: number;
+  detachInstallation?: boolean | undefined;
+};
+
+export type UpdateCapletFromSourceInput = {
+  id: string;
+  files: CapletBundleInputFile[];
+  expectedGeneration: number;
+  expectedInstallationGeneration: number;
+  sourceRevision: string;
+  sourceContentHash: string;
+  observationStatus: Exclude<CapletInstallationObservationStatus, "source-unavailable">;
+  risk?: Record<string, unknown> | null | undefined;
+  operator: OperatorPrincipal;
+};
+
+export type DeleteCapletRevisionInput = {
+  id: string;
+  revisionKey: string;
+  expectedGeneration: number;
+  operator: OperatorPrincipal;
+};
+
+export type RestoreCapletRevisionInput = DeleteCapletRevisionInput;
+
+export type RenameCapletRecordInput = {
+  id: string;
+  newId: string;
+  expectedGeneration: number;
+  operator: OperatorPrincipal;
+};
+
+export type SetCapletRetentionInput = {
+  id: string;
+  historyLimit: number | null;
+  expectedGeneration: number;
+  operator: OperatorPrincipal;
+};
+
+export type HardDeleteCapletRecordInput = {
+  id: string;
+  expectedGeneration: number;
+  operator: OperatorPrincipal;
+};
+export type ImportCapletBundleInput = {
+  id: string;
+  files: CapletBundleInputFile[];
+  operator: OperatorPrincipal;
+  historyLimit?: number | undefined;
+  sourceRevision?: string | undefined;
+  sourceContentHash?: string | undefined;
+  installation?:
+    | {
+        sourceKind: string;
+        sourceIdentity: string;
+        channel?: string | undefined;
+        risk?: Record<string, unknown> | null | undefined;
+      }
+    | undefined;
+};
+
+export type CapletBackendView = {
+  family: string;
+  childId: string | null;
+  config: Record<string, unknown>;
+};
+
+export type CapletBundleEntryView = {
+  path: string;
+  hash: string;
+  mediaType: string;
+  size: number;
+  executable: boolean;
+};
+
+export type CapletRevisionView = {
+  revisionKey: string;
+  sequence: number;
+  name: string;
+  description: string;
+  body: string;
+  schemaUrl: string | null;
+  content: Record<string, unknown>;
+  contentHash: string;
+  sourceRevision: string | null;
+  sourceContentHash: string | null;
+  createdAt: string;
+  actor: string;
+  tags: string[];
+  backends: CapletBackendView[];
+  bundle: CapletBundleEntryView[];
+};
+
+export type CapletRecordView = {
+  recordKey: string;
+  id: string;
+  headGeneration: number;
+  historyLimit: number | null;
+  createdAt: string;
+  updatedAt: string;
+  currentRevision: CapletRevisionView;
+};
+
+export type AssetGarbageCollectionResult = {
+  blobRowsDeleted: number;
+  objectsDeleted: number;
+};
+
+type PreparedBundle = {
+  id: string;
+  recordKey: string;
+  revisionKey: string;
+  now: string;
+  actor: string;
+  historyLimit: number | null;
+  name: string;
+  description: string;
+  body: string;
+  schemaUrl: string | null;
+  content: Record<string, unknown>;
+  contentHash: string;
+  sourceRevision: string | null;
+  sourceContentHash: string | null;
+  installation:
+    | {
+        installationKey: string;
+        sourceKind: string;
+        sourceIdentity: string;
+        channel: string | null;
+        risk: Record<string, unknown> | null;
+      }
+    | undefined;
+  tags: string[];
+  backends: CapletBackendView[];
+  entries: Array<
+    CapletBundleEntryView & {
+      payload: Buffer;
+      sqlPayload: Buffer | null;
+      objectKey: string | null;
+      assetWasExisting: boolean;
+    }
+  >;
+};
+
+const MAX_BUNDLE_FILES = 2_048;
+const MAX_BUNDLE_FILE_BYTES = 64 * 1024 * 1024;
+const MAX_BUNDLE_TOTAL_BYTES = 256 * 1024 * 1024;
+
+type BundleLimits = {
+  maxFiles: number;
+  maxFileBytes: number;
+  maxTotalBytes: number;
+};
+
+type CapletRecordStoreOptions = {
+  objectStore?: AssetObjectStore | undefined;
+  limits?:
+    | {
+        maxFiles?: number | undefined;
+        maxFileBytes?: number | undefined;
+        maxTotalBytes?: number | undefined;
+      }
+    | undefined;
+};
+
+export class CapletRecordStore {
+  private readonly objectStore: AssetObjectStore | undefined;
+  private readonly limits: BundleLimits;
+
+  constructor(
+    private readonly database: HostDatabase,
+    options: CapletRecordStoreOptions = {},
+  ) {
+    this.objectStore = options.objectStore;
+    this.limits = {
+      maxFiles: options.limits?.maxFiles ?? MAX_BUNDLE_FILES,
+      maxFileBytes: options.limits?.maxFileBytes ?? MAX_BUNDLE_FILE_BYTES,
+      maxTotalBytes: options.limits?.maxTotalBytes ?? MAX_BUNDLE_TOTAL_BYTES,
+    };
+  }
+
+  async importBundle(input: ImportCapletBundleInput): Promise<CapletRecordView> {
+    requireOperator(input.operator);
+    const prepared = prepareBundle(input, this.limits);
+    await this.prepareAssetStorage([prepared]);
+    if (this.database.dialect === "sqlite") {
+      importSqlite(this.database.db, prepared);
+    } else {
+      await importPostgres(this.database.db, prepared);
+    }
+    const result = await this.get(input.id);
+    if (!result)
+      throw new CapletsError("INTERNAL_ERROR", `Imported Caplet ${input.id} was not found.`);
+    return result;
+  }
+
+  async importBundles(inputs: ImportCapletBundleInput[]): Promise<CapletRecordView[]> {
+    for (const input of inputs) requireOperator(input.operator);
+    const bundles = inputs.map((input) => prepareBundle(input, this.limits));
+    await this.prepareAssetStorage(bundles);
+    if (this.database.dialect === "sqlite") {
+      importManySqlite(this.database.db, bundles);
+    } else {
+      await importManyPostgres(this.database.db, bundles);
+    }
+    const records = await Promise.all(inputs.map(async (input) => await this.get(input.id)));
+    return records.map((record, index) => {
+      if (!record) {
+        throw new CapletsError(
+          "INTERNAL_ERROR",
+          `Imported Caplet ${inputs[index]!.id} was not found.`,
+        );
+      }
+      return record;
+    });
+  }
+
+  async get(id: string): Promise<CapletRecordView | undefined> {
+    return this.database.dialect === "sqlite"
+      ? getSqlite(this.database.db, id)
+      : await getPostgres(this.database.db, id);
+  }
+
+  async list(): Promise<CapletRecordView[]> {
+    const ids =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select({ id: sqlite.capletRecords.capletId })
+            .from(sqlite.capletRecords)
+            .orderBy(asc(sqlite.capletRecords.capletId))
+            .all()
+        : await this.database.db
+            .select({ id: postgres.capletRecords.capletId })
+            .from(postgres.capletRecords)
+            .orderBy(asc(postgres.capletRecords.capletId));
+    const records = await Promise.all(ids.map(async ({ id }) => await this.get(id)));
+    return records.filter((record): record is CapletRecordView => record !== undefined);
+  }
+
+  async collectAssetGarbage(input: {
+    graceMs: number;
+    now?: Date | undefined;
+  }): Promise<AssetGarbageCollectionResult> {
+    if (!Number.isFinite(input.graceMs) || input.graceMs < 0) {
+      throw new CapletsError("REQUEST_INVALID", "Asset cleanup grace period must be non-negative.");
+    }
+    const cutoff = (input.now ?? new Date()).getTime() - input.graceMs;
+    const blobs =
+      this.database.dialect === "sqlite"
+        ? this.database.db.select().from(sqlite.capletAssetBlobs).all()
+        : await this.database.db.select().from(postgres.capletAssetBlobs);
+    const candidates = blobs.filter((blob) => Date.parse(blob.createdAt) <= cutoff);
+    const deletedKeys: string[] = [];
+    let blobRowsDeleted = 0;
+    for (const candidate of candidates) {
+      const objectKey =
+        this.database.dialect === "sqlite"
+          ? deleteUnreferencedSqliteBlob(this.database.db, candidate.hash)
+          : await deleteUnreferencedPostgresBlob(this.database.db, candidate.hash);
+      if (objectKey === undefined) continue;
+      blobRowsDeleted += 1;
+      if (objectKey) deletedKeys.push(objectKey);
+    }
+    let objectsDeleted = 0;
+    if (this.objectStore) {
+      for (const key of deletedKeys) {
+        await this.objectStore.delete(key);
+        objectsDeleted += 1;
+      }
+      const remaining =
+        this.database.dialect === "sqlite"
+          ? this.database.db
+              .select({ objectKey: sqlite.capletAssetBlobs.objectKey })
+              .from(sqlite.capletAssetBlobs)
+              .all()
+          : await this.database.db
+              .select({ objectKey: postgres.capletAssetBlobs.objectKey })
+              .from(postgres.capletAssetBlobs);
+      const referencedKeys = new Set(
+        remaining.flatMap((row) => (row.objectKey ? [row.objectKey] : [])),
+      );
+      for (const object of await this.objectStore.list()) {
+        if (object.modifiedAt.getTime() > cutoff || referencedKeys.has(object.key)) continue;
+        await this.objectStore.delete(object.key);
+        objectsDeleted += 1;
+      }
+    }
+    return { blobRowsDeleted, objectsDeleted };
+  }
+  async assetStats(): Promise<{ blobs: number; entries: number }> {
+    if (this.database.dialect === "sqlite") {
+      const blobs = this.database.db.select({ count: count() }).from(sqlite.capletAssetBlobs).get();
+      const entries = this.database.db
+        .select({ count: count() })
+        .from(sqlite.capletBundleEntries)
+        .get();
+      return { blobs: blobs?.count ?? 0, entries: entries?.count ?? 0 };
+    }
+    const [[blobs], [entries]] = await Promise.all([
+      this.database.db.select({ count: count() }).from(postgres.capletAssetBlobs),
+      this.database.db.select({ count: count() }).from(postgres.capletBundleEntries),
+    ]);
+    return { blobs: blobs?.count ?? 0, entries: entries?.count ?? 0 };
+  }
+
+  async updateBundle(input: UpdateCapletBundleInput): Promise<CapletRecordView> {
+    requireOperator(input.operator);
+    const prepared = prepareBundle(input, this.limits);
+    await this.prepareAssetStorage([prepared]);
+    if (this.database.dialect === "sqlite") {
+      updateSqlite(
+        this.database.db,
+        prepared,
+        input.expectedGeneration,
+        input.detachInstallation === true,
+      );
+    } else {
+      await updatePostgres(
+        this.database.db,
+        prepared,
+        input.expectedGeneration,
+        input.detachInstallation === true,
+      );
+    }
+    const result = await this.get(input.id);
+    if (!result)
+      throw new CapletsError("INTERNAL_ERROR", `Updated Caplet ${input.id} was not found.`);
+    return result;
+  }
+
+  async updateFromSource(input: UpdateCapletFromSourceInput): Promise<CapletRecordView> {
+    requireOperator(input.operator);
+    if (
+      (input.observationStatus !== "current" && input.observationStatus !== "metadata-only") ||
+      !input.sourceRevision.trim() ||
+      !input.sourceContentHash.trim() ||
+      (input.risk !== undefined &&
+        input.risk !== null &&
+        (typeof input.risk !== "object" || Array.isArray(input.risk)))
+    ) {
+      throw new CapletsError("REQUEST_INVALID", "Source update provenance is invalid.");
+    }
+    const prepared = prepareBundle(input, this.limits);
+    await this.prepareAssetStorage([prepared]);
+    if (this.database.dialect === "sqlite") {
+      updateFromSourceSqlite(this.database.db, prepared, input);
+    } else {
+      await updateFromSourcePostgres(this.database.db, prepared, input);
+    }
+    const result = await this.get(input.id);
+    if (!result) {
+      throw new CapletsError("INTERNAL_ERROR", `Source-updated Caplet ${input.id} was not found.`);
+    }
+    return result;
+  }
+
+  async getStored(id: string, operator: OperatorPrincipal): Promise<CapletRecordView | undefined> {
+    const actor = requireOperator(operator);
+    const record = await this.get(id);
+    if (record) {
+      await this.appendOperatorActivity(actor, "caplet.stored_get", record.recordKey, {
+        capletId: id,
+      });
+    }
+    return record;
+  }
+
+  async listStored(operator: OperatorPrincipal): Promise<CapletRecordView[]> {
+    const actor = requireOperator(operator);
+    const records = await this.list();
+    await this.appendOperatorActivity(actor, "caplet.stored_list", "all", {
+      count: records.length,
+    });
+    return records;
+  }
+
+  async listRevisions(
+    id: string,
+    operator: OperatorPrincipal,
+  ): Promise<Array<{ revisionKey: string; sequence: number; name: string }>> {
+    const actor = requireOperator(operator);
+    let recordKey: string | undefined;
+    let revisions: Array<{ revisionKey: string; sequence: number; name: string }>;
+    if (this.database.dialect === "sqlite") {
+      const record = this.database.db
+        .select({ recordKey: sqlite.capletRecords.recordKey })
+        .from(sqlite.capletRecords)
+        .where(eq(sqlite.capletRecords.capletId, id))
+        .get();
+      if (!record) return [];
+      recordKey = record.recordKey;
+      revisions = this.database.db
+        .select({
+          revisionKey: sqlite.capletRevisions.revisionKey,
+          sequence: sqlite.capletRevisions.sequence,
+          name: sqlite.capletRevisions.name,
+        })
+        .from(sqlite.capletRevisions)
+        .where(eq(sqlite.capletRevisions.recordKey, record.recordKey))
+        .orderBy(desc(sqlite.capletRevisions.sequence))
+        .all();
+    } else {
+      const [record] = await this.database.db
+        .select({ recordKey: postgres.capletRecords.recordKey })
+        .from(postgres.capletRecords)
+        .where(eq(postgres.capletRecords.capletId, id))
+        .limit(1);
+      if (!record) return [];
+      recordKey = record.recordKey;
+      revisions = await this.database.db
+        .select({
+          revisionKey: postgres.capletRevisions.revisionKey,
+          sequence: postgres.capletRevisions.sequence,
+          name: postgres.capletRevisions.name,
+        })
+        .from(postgres.capletRevisions)
+        .where(eq(postgres.capletRevisions.recordKey, record.recordKey))
+        .orderBy(desc(postgres.capletRevisions.sequence));
+    }
+    await this.appendOperatorActivity(actor, "caplet.revisions_list", recordKey, {
+      capletId: id,
+      count: revisions.length,
+    });
+    return revisions;
+  }
+
+  async deleteRevision(input: DeleteCapletRevisionInput): Promise<CapletRecordView | undefined> {
+    requireOperator(input.operator);
+    if (this.database.dialect === "sqlite") {
+      deleteRevisionSqlite(this.database.db, input);
+    } else {
+      await deleteRevisionPostgres(this.database.db, input);
+    }
+    return await this.get(input.id);
+  }
+
+  async restoreRevision(input: RestoreCapletRevisionInput): Promise<CapletRecordView> {
+    requireOperator(input.operator);
+    if (this.database.dialect === "sqlite") {
+      restoreRevisionSqlite(this.database.db, input);
+    } else {
+      await restoreRevisionPostgres(this.database.db, input);
+    }
+    const restored = await this.get(input.id);
+    if (!restored)
+      throw new CapletsError("INTERNAL_ERROR", `Restored Caplet ${input.id} was not found.`);
+    return restored;
+  }
+
+  async rename(input: RenameCapletRecordInput): Promise<CapletRecordView> {
+    requireOperator(input.operator);
+    validateCapletRecordId(input.newId);
+    if (this.database.dialect === "sqlite") renameSqlite(this.database.db, input);
+    else await renamePostgres(this.database.db, input);
+    const record = await this.get(input.newId);
+    if (!record)
+      throw new CapletsError("INTERNAL_ERROR", `Renamed Caplet ${input.newId} was not found.`);
+    return record;
+  }
+
+  async setRetention(input: SetCapletRetentionInput): Promise<CapletRecordView> {
+    requireOperator(input.operator);
+    validateHistoryLimit(input.historyLimit);
+    if (this.database.dialect === "sqlite") setRetentionSqlite(this.database.db, input);
+    else await setRetentionPostgres(this.database.db, input);
+    const record = await this.get(input.id);
+    if (!record) throw new CapletsError("INTERNAL_ERROR", `Caplet ${input.id} was not found.`);
+    return record;
+  }
+
+  async hardDelete(input: HardDeleteCapletRecordInput): Promise<void> {
+    requireOperator(input.operator);
+    if (this.database.dialect === "sqlite") hardDeleteSqlite(this.database.db, input);
+    else await hardDeletePostgres(this.database.db, input);
+  }
+
+  async readBundle(
+    id: string,
+    options: {
+      operator: OperatorPrincipal;
+      revisionKey?: string | undefined;
+    },
+  ): Promise<ReadCapletBundleResult> {
+    const actor = requireOperator(options.operator);
+    let record = await this.get(id);
+    if (!record) throw new CapletsError("CONFIG_INVALID", `Caplet Record ${id} was not found.`);
+    if (options.revisionKey) {
+      const revision = await getRevisionByKey(this.database, record.recordKey, options.revisionKey);
+      if (!revision) {
+        throw new CapletsError(
+          "CONFIG_INVALID",
+          `Caplet Revision ${options.revisionKey} was not found.`,
+        );
+      }
+      record = { ...record, currentRevision: revision };
+    }
+    const payloads = await this.bundlePayloads(record.currentRevision);
+    const files: CapletBundleInputFile[] = [
+      {
+        path: "CAPLET.md",
+        content: Buffer.from(renderCapletDocument(record.currentRevision)),
+        executable: false,
+      },
+    ];
+    for (const entry of record.currentRevision.bundle) {
+      const content = payloads.get(entry.hash);
+      if (!content) {
+        throw new CapletsError(
+          "SERVER_UNAVAILABLE",
+          `Caplet bundle asset ${entry.path} is unavailable.`,
+        );
+      }
+      files.push({ path: entry.path, content, executable: entry.executable });
+    }
+    await this.appendOperatorActivity(actor, "caplet.bundle_read", record.recordKey, {
+      capletId: id,
+      revisionKey: record.currentRevision.revisionKey,
+    });
+    return { record, files };
+  }
+
+  async exportBundle(
+    id: string,
+    destination: string,
+    options: {
+      operator: OperatorPrincipal;
+      replace?: boolean | undefined;
+      revisionKey?: string | undefined;
+    },
+  ): Promise<void> {
+    const actor = requireOperator(options.operator);
+    await this.materializeRuntimeBundle(id, destination, options);
+    const record = await this.get(id);
+    if (record) {
+      await this.appendOperatorActivity(actor, "caplet.export", record.recordKey, {
+        capletId: id,
+        revisionKey: options.revisionKey ?? record.currentRevision.revisionKey,
+      });
+    }
+  }
+
+  async materializeRuntimeBundle(
+    id: string,
+    destination: string,
+    options: { replace?: boolean | undefined; revisionKey?: string | undefined } = {},
+  ): Promise<void> {
+    if (existsSync(destination) && !options.replace) {
+      throw new CapletsError(
+        "REQUEST_INVALID",
+        `Export destination ${destination} already exists.`,
+      );
+    }
+    let record = await this.get(id);
+    if (!record) throw new CapletsError("CONFIG_INVALID", `Caplet Record ${id} was not found.`);
+    if (options.revisionKey) {
+      const revision = await getRevisionByKey(this.database, record.recordKey, options.revisionKey);
+      if (!revision) {
+        throw new CapletsError(
+          "CONFIG_INVALID",
+          `Caplet Revision ${options.revisionKey} was not found.`,
+        );
+      }
+      record = { ...record, currentRevision: revision };
+    }
+    const payloads = await this.bundlePayloads(record.currentRevision);
+    const files: CapletBundleInputFile[] = [
+      {
+        path: "CAPLET.md",
+        content: Buffer.from(renderCapletDocument(record.currentRevision)),
+        executable: false,
+      },
+      ...record.currentRevision.bundle.map((entry) => ({
+        path: entry.path,
+        content: payloads.get(entry.hash)!,
+        executable: entry.executable,
+      })),
+    ];
+    materializeCapletBundleFiles(files, destination, options);
+  }
+
+  private async appendOperatorActivity(
+    operatorClientId: string,
+    action: string,
+    targetKey: string,
+    metadata: Record<string, unknown>,
+  ): Promise<void> {
+    await appendOperatorActivity(this.database, {
+      operatorClientId,
+      action,
+      targetKind: "caplet_record",
+      targetKey,
+      metadata,
+    });
+  }
+
+  private async prepareAssetStorage(bundles: PreparedBundle[]): Promise<void> {
+    if (!this.objectStore) return;
+    const entries = bundles.flatMap((bundle) => bundle.entries);
+    const hashes = [...new Set(entries.map((entry) => entry.hash))];
+    if (hashes.length === 0) return;
+    const rows =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select()
+            .from(sqlite.capletAssetBlobs)
+            .where(inArray(sqlite.capletAssetBlobs.hash, hashes))
+            .all()
+        : await this.database.db
+            .select()
+            .from(postgres.capletAssetBlobs)
+            .where(inArray(postgres.capletAssetBlobs.hash, hashes));
+    const existing = new Map(rows.map((row) => [row.hash, row]));
+    for (const entry of entries) {
+      const row = existing.get(entry.hash);
+      if (row) {
+        if (row.size !== entry.size || row.verificationStatus !== "verified") {
+          throw new CapletsError(
+            "INTERNAL_ERROR",
+            `Caplet asset ${entry.hash} has invalid stored metadata.`,
+          );
+        }
+        entry.sqlPayload = row.payload ? entry.payload : null;
+        entry.objectKey = row.objectKey;
+        entry.assetWasExisting = true;
+        continue;
+      }
+      entry.objectKey = await this.objectStore.putVerified(entry.hash, entry.payload);
+      entry.sqlPayload = null;
+      existing.set(entry.hash, {
+        hash: entry.hash,
+        size: entry.size,
+        payload: null,
+        objectKey: entry.objectKey,
+        verificationStatus: "verified",
+        createdAt: bundles[0]?.now ?? new Date().toISOString(),
+      });
+    }
+  }
+
+  private async bundlePayloads(revision: CapletRevisionView): Promise<Map<string, Buffer>> {
+    const hashes = [...new Set(revision.bundle.map((entry) => entry.hash))];
+    if (hashes.length === 0) return new Map();
+    const rows =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select()
+            .from(sqlite.capletAssetBlobs)
+            .where(inArray(sqlite.capletAssetBlobs.hash, hashes))
+            .all()
+        : await this.database.db
+            .select()
+            .from(postgres.capletAssetBlobs)
+            .where(inArray(postgres.capletAssetBlobs.hash, hashes));
+    const payloads = new Map<string, Buffer>();
+    for (const row of rows) {
+      const payload = row.payload
+        ? Buffer.from(row.payload)
+        : row.objectKey && this.objectStore
+          ? await this.objectStore.get(row.objectKey)
+          : undefined;
+      if (!payload) {
+        throw new CapletsError("SERVER_UNAVAILABLE", `Caplet asset ${row.hash} is unavailable.`);
+      }
+      const actualHash = createHash("sha256").update(payload).digest("hex");
+      if (actualHash !== row.hash || payload.byteLength !== row.size) {
+        throw new CapletsError(
+          "INTERNAL_ERROR",
+          `Caplet asset ${row.hash} failed integrity verification.`,
+        );
+      }
+      payloads.set(row.hash, payload);
+    }
+    for (const hash of hashes) {
+      if (!payloads.has(hash)) {
+        throw new CapletsError("INTERNAL_ERROR", `Caplet asset ${hash} is missing.`);
+      }
+    }
+    return payloads;
+  }
+}
+
+export function materializeCapletBundleFiles(
+  files: CapletBundleInputFile[],
+  destination: string,
+  options: { replace?: boolean | undefined } = {},
+): void {
+  if (existsSync(destination) && !options.replace) {
+    throw new CapletsError("REQUEST_INVALID", `Export destination ${destination} already exists.`);
+  }
+  const normalizedFiles: CapletBundleInputFile[] = [];
+  const paths = new Set<string>();
+  for (const file of files) {
+    if (
+      !file ||
+      typeof file.path !== "string" ||
+      !Buffer.isBuffer(file.content) ||
+      typeof file.executable !== "boolean"
+    ) {
+      throw new CapletsError("REQUEST_INVALID", "Caplet bundle contains a malformed file.");
+    }
+    const path = normalizedBundlePath(file.path);
+    if (paths.has(path)) {
+      throw new CapletsError("REQUEST_INVALID", `Duplicate Caplet bundle path ${path}.`);
+    }
+    paths.add(path);
+    normalizedFiles.push({ ...file, path });
+  }
+  if (!paths.has("CAPLET.md")) {
+    throw new CapletsError("REQUEST_INVALID", "Caplet bundle must contain CAPLET.md.");
+  }
+
+  const parent = dirname(destination);
+  const staging = join(parent, `.${basename(destination)}.tmp-${randomUUID()}`);
+  const backup = join(parent, `.${basename(destination)}.backup-${randomUUID()}`);
+  mkdirSync(parent, { recursive: true });
+  try {
+    mkdirSync(staging, { mode: 0o700 });
+    for (const file of normalizedFiles) {
+      const path = join(staging, ...file.path.split("/"));
+      mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+      writeFileSync(path, file.content, { mode: file.executable ? 0o700 : 0o600 });
+      if (file.executable) chmodSync(path, 0o700);
+    }
+    if (existsSync(destination)) renameSync(destination, backup);
+    renameSync(staging, destination);
+    rmSync(backup, { recursive: true, force: true });
+  } catch (error) {
+    rmSync(staging, { recursive: true, force: true });
+    if (!existsSync(destination) && existsSync(backup)) renameSync(backup, destination);
+    throw error;
+  }
+}
+
+function prepareBundle(input: ImportCapletBundleInput, limits: BundleLimits): PreparedBundle {
+  if (!/^[A-Za-z0-9_-]+$/u.test(input.id)) {
+    throw new CapletsError("CONFIG_INVALID", `Invalid Caplet ID ${input.id}.`);
+  }
+  if (
+    input.historyLimit !== undefined &&
+    (!Number.isInteger(input.historyLimit) || input.historyLimit < 0)
+  ) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "Caplet history limit must be a non-negative integer.",
+    );
+  }
+  if (
+    input.installation?.risk !== undefined &&
+    input.installation.risk !== null &&
+    (typeof input.installation.risk !== "object" || Array.isArray(input.installation.risk))
+  ) {
+    throw new CapletsError("REQUEST_INVALID", "Caplet installation risk provenance is invalid.");
+  }
+
+  const paths = new Set<string>();
+  let document: CapletBundleInputFile | undefined;
+  const assets: CapletBundleInputFile[] = [];
+  for (const file of input.files) {
+    const path = normalizedBundlePath(file.path);
+    if (paths.has(path))
+      throw new CapletsError("CONFIG_INVALID", `Duplicate Caplet bundle path ${path}.`);
+    paths.add(path);
+    if (path === "CAPLET.md") {
+      document = { ...file, path };
+    } else {
+      assets.push({ ...file, path });
+    }
+  }
+  if (assets.length > limits.maxFiles) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      `Caplet bundle exceeds the ${limits.maxFiles} auxiliary file limit.`,
+    );
+  }
+  let totalBytes = 0;
+  for (const file of assets) {
+    if (file.content.byteLength > limits.maxFileBytes) {
+      throw new CapletsError(
+        "REQUEST_INVALID",
+        `Caplet bundle file ${file.path} exceeds the ${limits.maxFileBytes} byte limit.`,
+      );
+    }
+    totalBytes += file.content.byteLength;
+  }
+  if (totalBytes > limits.maxTotalBytes) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      `Caplet bundle exceeds the ${limits.maxTotalBytes} auxiliary byte limit.`,
+    );
+  }
+  if (!document) throw new CapletsError("CONFIG_INVALID", "Caplet bundle must contain CAPLET.md.");
+  const { frontmatter, body } = parseCapletFileDocument(
+    "CAPLET.md",
+    document.content.toString("utf8"),
+  );
+  const projected = projectFrontmatter(frontmatter);
+  const entries = assets
+    .sort((left, right) => left.path.localeCompare(right.path))
+    .map((file) => ({
+      path: file.path,
+      payload: file.content,
+      sqlPayload: file.content,
+      objectKey: null,
+      hash: createHash("sha256").update(file.content).digest("hex"),
+      assetWasExisting: false,
+      mediaType: mediaTypeForPath(file.path),
+      size: file.content.byteLength,
+      executable: file.executable,
+    }));
+  const contentHash = createHash("sha256")
+    .update(
+      JSON.stringify({
+        frontmatter,
+        body,
+        entries: entries.map(({ path, hash, mediaType, size, executable }) => ({
+          path,
+          hash,
+          mediaType,
+          size,
+          executable,
+        })),
+      }),
+    )
+    .digest("hex");
+  return {
+    id: input.id,
+    recordKey: randomUUID(),
+    revisionKey: randomUUID(),
+    now: new Date().toISOString(),
+    actor: requireOperator(input.operator),
+    historyLimit: input.historyLimit ?? null,
+    name: frontmatter.name,
+    description: frontmatter.description,
+    body,
+    schemaUrl: frontmatter.$schema ?? null,
+    content: projected.content,
+    contentHash,
+    sourceRevision: input.sourceRevision ?? null,
+    sourceContentHash: input.sourceContentHash ?? null,
+    installation: input.installation
+      ? {
+          installationKey: randomUUID(),
+          sourceKind: input.installation.sourceKind,
+          sourceIdentity: input.installation.sourceIdentity,
+          channel: input.installation.channel ?? null,
+          risk: input.installation.risk ?? null,
+        }
+      : undefined,
+    tags: frontmatter.tags ?? [],
+    backends: projected.backends,
+    entries,
+  };
+}
+
+function normalizedBundlePath(value: string): string {
+  const normalized = posix.normalize(value.replaceAll("\\", "/"));
+  if (
+    !value ||
+    value.includes("\0") ||
+    normalized === "." ||
+    normalized.startsWith("../") ||
+    normalized.startsWith("/")
+  ) {
+    throw new CapletsError("CONFIG_INVALID", `Invalid Caplet bundle path ${value}.`);
+  }
+  return normalized;
+}
+
+function projectFrontmatter(frontmatter: CapletFileFrontmatter): {
+  content: Record<string, unknown>;
+  backends: CapletBackendView[];
+} {
+  const contentKeys = [
+    "exposure",
+    "shadowing",
+    "setup",
+    "projectBinding",
+    "runtime",
+    "auth",
+    "catalog",
+  ] as const;
+  const content = Object.fromEntries(
+    contentKeys.flatMap((key) => (frontmatter[key] === undefined ? [] : [[key, frontmatter[key]]])),
+  );
+  const backends: CapletBackendView[] = [];
+  const singular = [
+    ["mcpServer", frontmatter.mcpServer],
+    ["openapiEndpoint", frontmatter.openapiEndpoint],
+    ["googleDiscoveryApi", frontmatter.googleDiscoveryApi],
+    ["graphqlEndpoint", frontmatter.graphqlEndpoint],
+    ["httpApi", frontmatter.httpApi],
+    ["capletSet", frontmatter.capletSet],
+  ] as const;
+  for (const [family, config] of singular) {
+    if (config) backends.push({ family, childId: null, config });
+  }
+  if (frontmatter.cliTools && Object.hasOwn(frontmatter.cliTools, "actions")) {
+    backends.push({ family: "cliTools", childId: null, config: frontmatter.cliTools });
+  }
+  const plural = [
+    ["mcpServers", frontmatter.mcpServers],
+    ["openapiEndpoints", frontmatter.openapiEndpoints],
+    ["googleDiscoveryApis", frontmatter.googleDiscoveryApis],
+    ["graphqlEndpoints", frontmatter.graphqlEndpoints],
+    ["httpApis", frontmatter.httpApis],
+    ["capletSets", frontmatter.capletSets],
+    [
+      "cliTools",
+      frontmatter.cliTools && !Object.hasOwn(frontmatter.cliTools, "actions")
+        ? (frontmatter.cliTools as Record<string, Record<string, unknown>>)
+        : undefined,
+    ],
+  ] as const;
+  for (const [family, configurations] of plural) {
+    for (const [childId, config] of Object.entries(configurations ?? {})) {
+      backends.push({ family, childId, config });
+    }
+  }
+  return { content, backends };
+}
+
+function importSqlite(db: SqliteHostDatabase, bundle: PreparedBundle): void {
+  importManySqlite(db, [bundle]);
+}
+
+function importManySqlite(db: SqliteHostDatabase, bundles: PreparedBundle[]): void {
+  db.transaction((transaction) => {
+    for (const bundle of bundles) {
+      if (
+        transaction
+          .select()
+          .from(sqlite.capletRecords)
+          .where(eq(sqlite.capletRecords.capletId, bundle.id))
+          .get()
+      ) {
+        throw new CapletsError("CONFIG_INVALID", `Caplet Record ${bundle.id} already exists.`);
+      }
+      transaction.insert(sqlite.capletRecords).values(recordValues(bundle)).run();
+      transaction.insert(sqlite.capletRevisions).values(revisionValues(bundle)).run();
+      if (bundle.tags.length > 0) {
+        transaction.insert(sqlite.capletRevisionTags).values(tagValues(bundle)).run();
+      }
+      if (bundle.backends.length > 0) {
+        transaction.insert(sqlite.capletRevisionBackends).values(backendValues(bundle)).run();
+      }
+      for (const entry of bundle.entries) {
+        ensureSqliteBlob(transaction, bundle, entry);
+        transaction.insert(sqlite.capletBundleEntries).values(entryValues(bundle, entry)).run();
+      }
+      transaction
+        .update(sqlite.capletRecords)
+        .set({ currentRevisionKey: bundle.revisionKey })
+        .where(eq(sqlite.capletRecords.recordKey, bundle.recordKey))
+        .run();
+      insertSqliteInstallation(transaction, bundle);
+      transaction
+        .insert(sqlite.operatorActivity)
+        .values(recordActivityValues(bundle, "caplet.import"))
+        .run();
+    }
+    const generationHash = createHash("sha256")
+      .update(bundles.map((bundle) => bundle.contentHash).join("\0"))
+      .digest("hex");
+    advanceSqliteConfigGeneration(transaction, generationHash, bundles[0]!.actor);
+  });
+}
+
+async function importPostgres(db: PostgresHostDatabase, bundle: PreparedBundle): Promise<void> {
+  await importManyPostgres(db, [bundle]);
+}
+
+async function importManyPostgres(
+  db: PostgresHostDatabase,
+  bundles: PreparedBundle[],
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    for (const bundle of bundles) {
+      const [existing] = await transaction
+        .select()
+        .from(postgres.capletRecords)
+        .where(eq(postgres.capletRecords.capletId, bundle.id))
+        .limit(1);
+      if (existing) {
+        throw new CapletsError("CONFIG_INVALID", `Caplet Record ${bundle.id} already exists.`);
+      }
+      await transaction.insert(postgres.capletRecords).values(recordValues(bundle));
+      await transaction.insert(postgres.capletRevisions).values(revisionValues(bundle));
+      if (bundle.tags.length > 0) {
+        await transaction.insert(postgres.capletRevisionTags).values(tagValues(bundle));
+      }
+      if (bundle.backends.length > 0) {
+        await transaction.insert(postgres.capletRevisionBackends).values(backendValues(bundle));
+      }
+      for (const entry of bundle.entries) {
+        await ensurePostgresBlob(transaction, bundle, entry);
+        await transaction.insert(postgres.capletBundleEntries).values(entryValues(bundle, entry));
+      }
+      await transaction
+        .update(postgres.capletRecords)
+        .set({ currentRevisionKey: bundle.revisionKey })
+        .where(eq(postgres.capletRecords.recordKey, bundle.recordKey));
+      await insertPostgresInstallation(transaction, bundle);
+      await transaction
+        .insert(postgres.operatorActivity)
+        .values(recordActivityValues(bundle, "caplet.import"));
+    }
+    const generationHash = createHash("sha256")
+      .update(bundles.map((bundle) => bundle.contentHash).join("\0"))
+      .digest("hex");
+    await advancePostgresConfigGeneration(transaction, generationHash, bundles[0]!.actor);
+  });
+}
+
+function updateSqlite(
+  db: SqliteHostDatabase,
+  bundle: PreparedBundle,
+  expectedGeneration: number,
+  detachInstallation: boolean,
+): void {
+  db.transaction((transaction) => {
+    const record = transaction
+      .select()
+      .from(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.capletId, bundle.id))
+      .get();
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${bundle.id} was not found.`);
+    if (record.headGeneration !== expectedGeneration) {
+      throw staleGeneration(bundle.id, expectedGeneration, record.headGeneration);
+    }
+    const activeInstallation = transaction
+      .select()
+      .from(sqlite.capletInstallations)
+      .where(
+        and(
+          eq(sqlite.capletInstallations.recordKey, record.recordKey),
+          eq(sqlite.capletInstallations.status, "active"),
+        ),
+      )
+      .get();
+    if (activeInstallation && !detachInstallation) throw trackedInstallation(bundle.id);
+    if (activeInstallation) {
+      transaction
+        .update(sqlite.capletInstallations)
+        .set({
+          status: "detached",
+          generation: activeInstallation.generation + 1,
+          detachedAt: bundle.now,
+          detachedBy: bundle.actor,
+          updatedAt: bundle.now,
+        })
+        .where(eq(sqlite.capletInstallations.installationKey, activeInstallation.installationKey))
+        .run();
+      transaction
+        .insert(sqlite.operatorActivity)
+        .values({
+          activityKey: randomUUID(),
+          operatorClientId: bundle.actor,
+          action: "caplet.detach_for_overwrite",
+          targetKind: "installation",
+          targetKey: activeInstallation.installationKey,
+          outcome: "succeeded",
+          metadata: { capletId: bundle.id },
+          createdAt: bundle.now,
+        })
+        .run();
+    }
+    const sequence = record.headGeneration + 1;
+    bundle.recordKey = record.recordKey;
+    transaction.insert(sqlite.capletRevisions).values(revisionValues(bundle, sequence)).run();
+    if (bundle.tags.length > 0) {
+      transaction.insert(sqlite.capletRevisionTags).values(tagValues(bundle)).run();
+    }
+    if (bundle.backends.length > 0) {
+      transaction.insert(sqlite.capletRevisionBackends).values(backendValues(bundle)).run();
+    }
+    for (const entry of bundle.entries) {
+      ensureSqliteBlob(transaction, bundle, entry);
+      transaction.insert(sqlite.capletBundleEntries).values(entryValues(bundle, entry)).run();
+    }
+    transaction
+      .update(sqlite.capletRecords)
+      .set({
+        currentRevisionKey: bundle.revisionKey,
+        headGeneration: sequence,
+        updatedAt: bundle.now,
+      })
+      .where(eq(sqlite.capletRecords.recordKey, record.recordKey))
+      .run();
+    const retained = Math.max(1, record.historyLimit ?? 1);
+    const revisions = transaction
+      .select({ revisionKey: sqlite.capletRevisions.revisionKey })
+      .from(sqlite.capletRevisions)
+      .where(eq(sqlite.capletRevisions.recordKey, record.recordKey))
+      .orderBy(desc(sqlite.capletRevisions.sequence))
+      .all();
+    const expired = revisions.slice(retained).map((revision) => revision.revisionKey);
+    if (expired.length > 0) {
+      transaction
+        .delete(sqlite.capletRevisions)
+        .where(inArray(sqlite.capletRevisions.revisionKey, expired))
+        .run();
+    }
+    insertSqliteInstallation(transaction, bundle);
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values(recordActivityValues(bundle, "caplet.update"))
+      .run();
+    advanceSqliteConfigGeneration(transaction, bundle.contentHash, bundle.actor);
+  });
+}
+
+async function updatePostgres(
+  db: PostgresHostDatabase,
+  bundle: PreparedBundle,
+  expectedGeneration: number,
+  detachInstallation: boolean,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const [record] = await transaction
+      .select()
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.capletId, bundle.id))
+      .for("update")
+      .limit(1);
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${bundle.id} was not found.`);
+    if (record.headGeneration !== expectedGeneration) {
+      throw staleGeneration(bundle.id, expectedGeneration, record.headGeneration);
+    }
+    const [activeInstallation] = await transaction
+      .select()
+      .from(postgres.capletInstallations)
+      .where(
+        and(
+          eq(postgres.capletInstallations.recordKey, record.recordKey),
+          eq(postgres.capletInstallations.status, "active"),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (activeInstallation && !detachInstallation) throw trackedInstallation(bundle.id);
+    if (activeInstallation) {
+      await transaction
+        .update(postgres.capletInstallations)
+        .set({
+          status: "detached",
+          generation: activeInstallation.generation + 1,
+          detachedAt: bundle.now,
+          detachedBy: bundle.actor,
+          updatedAt: bundle.now,
+        })
+        .where(
+          eq(postgres.capletInstallations.installationKey, activeInstallation.installationKey),
+        );
+      await transaction.insert(postgres.operatorActivity).values({
+        activityKey: randomUUID(),
+        operatorClientId: bundle.actor,
+        action: "caplet.detach_for_overwrite",
+        targetKind: "installation",
+        targetKey: activeInstallation.installationKey,
+        outcome: "succeeded",
+        metadata: { capletId: bundle.id },
+        createdAt: bundle.now,
+      });
+    }
+    const sequence = record.headGeneration + 1;
+    bundle.recordKey = record.recordKey;
+    await transaction.insert(postgres.capletRevisions).values(revisionValues(bundle, sequence));
+    if (bundle.tags.length > 0) {
+      await transaction.insert(postgres.capletRevisionTags).values(tagValues(bundle));
+    }
+    if (bundle.backends.length > 0) {
+      await transaction.insert(postgres.capletRevisionBackends).values(backendValues(bundle));
+    }
+    for (const entry of bundle.entries) {
+      await ensurePostgresBlob(transaction, bundle, entry);
+      await transaction.insert(postgres.capletBundleEntries).values(entryValues(bundle, entry));
+    }
+    await transaction
+      .update(postgres.capletRecords)
+      .set({
+        currentRevisionKey: bundle.revisionKey,
+        headGeneration: sequence,
+        updatedAt: bundle.now,
+      })
+      .where(eq(postgres.capletRecords.recordKey, record.recordKey));
+    const retained = Math.max(1, record.historyLimit ?? 1);
+    const revisions = await transaction
+      .select({ revisionKey: postgres.capletRevisions.revisionKey })
+      .from(postgres.capletRevisions)
+      .where(eq(postgres.capletRevisions.recordKey, record.recordKey))
+      .orderBy(desc(postgres.capletRevisions.sequence));
+    const expired = revisions.slice(retained).map((revision) => revision.revisionKey);
+    if (expired.length > 0) {
+      await transaction
+        .delete(postgres.capletRevisions)
+        .where(inArray(postgres.capletRevisions.revisionKey, expired));
+    }
+    await insertPostgresInstallation(transaction, bundle);
+    await transaction
+      .insert(postgres.operatorActivity)
+      .values(recordActivityValues(bundle, "caplet.update"));
+    await advancePostgresConfigGeneration(transaction, bundle.contentHash, bundle.actor);
+  });
+}
+
+function updateFromSourceSqlite(
+  db: SqliteHostDatabase,
+  bundle: PreparedBundle,
+  input: UpdateCapletFromSourceInput,
+): void {
+  db.transaction((transaction) => {
+    const record = transaction
+      .select()
+      .from(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.capletId, bundle.id))
+      .get();
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${bundle.id} was not found.`);
+    if (record.headGeneration !== input.expectedGeneration) {
+      throw staleGeneration(bundle.id, input.expectedGeneration, record.headGeneration);
+    }
+    const installation = transaction
+      .select()
+      .from(sqlite.capletInstallations)
+      .where(
+        and(
+          eq(sqlite.capletInstallations.recordKey, record.recordKey),
+          eq(sqlite.capletInstallations.status, "active"),
+        ),
+      )
+      .get();
+    if (!installation) throw sourceInstallationRequired(bundle.id);
+    if (installation.generation !== input.expectedInstallationGeneration) {
+      throw staleInstallationGeneration(bundle.id);
+    }
+    if (!record.currentRevisionKey) throw missingCurrentRevision(bundle.id);
+    const currentRevision = transaction
+      .select({ contentHash: sqlite.capletRevisions.contentHash })
+      .from(sqlite.capletRevisions)
+      .where(eq(sqlite.capletRevisions.revisionKey, record.currentRevisionKey))
+      .get();
+    if (!currentRevision) throw missingCurrentRevision(bundle.id);
+
+    const contentChanged = currentRevision.contentHash !== bundle.contentHash;
+    const retainProvenanceRevision = !contentChanged && record.historyLimit !== 0;
+    const createRevision = contentChanged || retainProvenanceRevision;
+    const sequence = record.headGeneration + (createRevision ? 1 : 0);
+    bundle.recordKey = record.recordKey;
+    if (createRevision) {
+      transaction.insert(sqlite.capletRevisions).values(revisionValues(bundle, sequence)).run();
+      if (bundle.tags.length > 0) {
+        transaction.insert(sqlite.capletRevisionTags).values(tagValues(bundle)).run();
+      }
+      if (bundle.backends.length > 0) {
+        transaction.insert(sqlite.capletRevisionBackends).values(backendValues(bundle)).run();
+      }
+      for (const entry of bundle.entries) {
+        ensureSqliteBlob(transaction, bundle, entry);
+        transaction.insert(sqlite.capletBundleEntries).values(entryValues(bundle, entry)).run();
+      }
+      const updatedRecord = transaction
+        .update(sqlite.capletRecords)
+        .set({
+          currentRevisionKey: contentChanged ? bundle.revisionKey : record.currentRevisionKey,
+          headGeneration: sequence,
+          updatedAt: bundle.now,
+        })
+        .where(
+          and(
+            eq(sqlite.capletRecords.recordKey, record.recordKey),
+            eq(sqlite.capletRecords.headGeneration, input.expectedGeneration),
+          ),
+        )
+        .run();
+      if (updatedRecord.changes !== 1) {
+        throw staleGeneration(bundle.id, input.expectedGeneration, record.headGeneration);
+      }
+      pruneSourceRevisionsSqlite(
+        transaction,
+        record.recordKey,
+        contentChanged ? bundle.revisionKey : record.currentRevisionKey,
+        Math.max(1, record.historyLimit ?? 1),
+      );
+    }
+
+    const latestObservation = transaction
+      .select({ observedAt: sqlite.capletInstallationObservations.observedAt })
+      .from(sqlite.capletInstallationObservations)
+      .where(
+        eq(sqlite.capletInstallationObservations.installationKey, installation.installationKey),
+      )
+      .orderBy(desc(sqlite.capletInstallationObservations.observedAt))
+      .limit(1)
+      .get();
+    const observedAt = sourceObservationTime(bundle.now, latestObservation?.observedAt);
+    const updatedInstallation = transaction
+      .update(sqlite.capletInstallations)
+      .set({ generation: installation.generation + 1, updatedAt: observedAt })
+      .where(
+        and(
+          eq(sqlite.capletInstallations.installationKey, installation.installationKey),
+          eq(sqlite.capletInstallations.generation, input.expectedInstallationGeneration),
+          eq(sqlite.capletInstallations.status, "active"),
+        ),
+      )
+      .run();
+    if (updatedInstallation.changes !== 1) throw staleInstallationGeneration(bundle.id);
+    transaction
+      .insert(sqlite.capletInstallationObservations)
+      .values(sourceObservationValues(installation.installationKey, input, observedAt))
+      .run();
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values(
+        sourceUpdateActivity(
+          bundle,
+          installation.installationKey,
+          input,
+          contentChanged,
+          createRevision,
+          observedAt,
+        ),
+      )
+      .run();
+    if (contentChanged)
+      advanceSqliteConfigGeneration(transaction, bundle.contentHash, bundle.actor);
+  });
+}
+
+async function updateFromSourcePostgres(
+  db: PostgresHostDatabase,
+  bundle: PreparedBundle,
+  input: UpdateCapletFromSourceInput,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const [record] = await transaction
+      .select()
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.capletId, bundle.id))
+      .for("update")
+      .limit(1);
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${bundle.id} was not found.`);
+    if (record.headGeneration !== input.expectedGeneration) {
+      throw staleGeneration(bundle.id, input.expectedGeneration, record.headGeneration);
+    }
+    const [installation] = await transaction
+      .select()
+      .from(postgres.capletInstallations)
+      .where(
+        and(
+          eq(postgres.capletInstallations.recordKey, record.recordKey),
+          eq(postgres.capletInstallations.status, "active"),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!installation) throw sourceInstallationRequired(bundle.id);
+    if (installation.generation !== input.expectedInstallationGeneration) {
+      throw staleInstallationGeneration(bundle.id);
+    }
+    if (!record.currentRevisionKey) throw missingCurrentRevision(bundle.id);
+    const [currentRevision] = await transaction
+      .select({ contentHash: postgres.capletRevisions.contentHash })
+      .from(postgres.capletRevisions)
+      .where(eq(postgres.capletRevisions.revisionKey, record.currentRevisionKey))
+      .limit(1);
+    if (!currentRevision) throw missingCurrentRevision(bundle.id);
+
+    const contentChanged = currentRevision.contentHash !== bundle.contentHash;
+    const retainProvenanceRevision = !contentChanged && record.historyLimit !== 0;
+    const createRevision = contentChanged || retainProvenanceRevision;
+    const sequence = record.headGeneration + (createRevision ? 1 : 0);
+    bundle.recordKey = record.recordKey;
+    if (createRevision) {
+      await transaction.insert(postgres.capletRevisions).values(revisionValues(bundle, sequence));
+      if (bundle.tags.length > 0) {
+        await transaction.insert(postgres.capletRevisionTags).values(tagValues(bundle));
+      }
+      if (bundle.backends.length > 0) {
+        await transaction.insert(postgres.capletRevisionBackends).values(backendValues(bundle));
+      }
+      for (const entry of bundle.entries) {
+        await ensurePostgresBlob(transaction, bundle, entry);
+        await transaction.insert(postgres.capletBundleEntries).values(entryValues(bundle, entry));
+      }
+      const [updatedRecord] = await transaction
+        .update(postgres.capletRecords)
+        .set({
+          currentRevisionKey: contentChanged ? bundle.revisionKey : record.currentRevisionKey,
+          headGeneration: sequence,
+          updatedAt: bundle.now,
+        })
+        .where(
+          and(
+            eq(postgres.capletRecords.recordKey, record.recordKey),
+            eq(postgres.capletRecords.headGeneration, input.expectedGeneration),
+          ),
+        )
+        .returning({ recordKey: postgres.capletRecords.recordKey });
+      if (!updatedRecord) {
+        throw staleGeneration(bundle.id, input.expectedGeneration, record.headGeneration);
+      }
+      await pruneSourceRevisionsPostgres(
+        transaction,
+        record.recordKey,
+        contentChanged ? bundle.revisionKey : record.currentRevisionKey,
+        Math.max(1, record.historyLimit ?? 1),
+      );
+    }
+
+    const [latestObservation] = await transaction
+      .select({ observedAt: postgres.capletInstallationObservations.observedAt })
+      .from(postgres.capletInstallationObservations)
+      .where(
+        eq(postgres.capletInstallationObservations.installationKey, installation.installationKey),
+      )
+      .orderBy(desc(postgres.capletInstallationObservations.observedAt))
+      .limit(1);
+    const observedAt = sourceObservationTime(bundle.now, latestObservation?.observedAt);
+    const [updatedInstallation] = await transaction
+      .update(postgres.capletInstallations)
+      .set({ generation: installation.generation + 1, updatedAt: observedAt })
+      .where(
+        and(
+          eq(postgres.capletInstallations.installationKey, installation.installationKey),
+          eq(postgres.capletInstallations.generation, input.expectedInstallationGeneration),
+          eq(postgres.capletInstallations.status, "active"),
+        ),
+      )
+      .returning({ installationKey: postgres.capletInstallations.installationKey });
+    if (!updatedInstallation) throw staleInstallationGeneration(bundle.id);
+    await transaction
+      .insert(postgres.capletInstallationObservations)
+      .values(sourceObservationValues(installation.installationKey, input, observedAt));
+    await transaction
+      .insert(postgres.operatorActivity)
+      .values(
+        sourceUpdateActivity(
+          bundle,
+          installation.installationKey,
+          input,
+          contentChanged,
+          createRevision,
+          observedAt,
+        ),
+      );
+    if (contentChanged) {
+      await advancePostgresConfigGeneration(transaction, bundle.contentHash, bundle.actor);
+    }
+  });
+}
+function deleteRevisionSqlite(db: SqliteHostDatabase, input: DeleteCapletRevisionInput): void {
+  db.transaction((transaction) => {
+    const record = transaction
+      .select()
+      .from(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.capletId, input.id))
+      .get();
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${input.id} was not found.`);
+    if (record.headGeneration !== input.expectedGeneration) {
+      throw staleGeneration(input.id, input.expectedGeneration, record.headGeneration);
+    }
+    const revision = transaction
+      .select()
+      .from(sqlite.capletRevisions)
+      .where(eq(sqlite.capletRevisions.revisionKey, input.revisionKey))
+      .get();
+    if (!revision || revision.recordKey !== record.recordKey) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        `Caplet Revision ${input.revisionKey} was not found.`,
+      );
+    }
+    transaction
+      .delete(sqlite.capletRevisions)
+      .where(eq(sqlite.capletRevisions.revisionKey, input.revisionKey))
+      .run();
+    const activityAt = new Date().toISOString();
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values({
+        activityKey: randomUUID(),
+        operatorClientId: requireOperator(input.operator),
+        action: "caplet.revision_delete",
+        targetKind: "caplet_record",
+        targetKey: record.recordKey,
+        outcome: "succeeded",
+        metadata: { capletId: input.id, revisionKey: input.revisionKey },
+        createdAt: activityAt,
+      })
+      .run();
+    advanceSqliteConfigGeneration(transaction, input.revisionKey, requireOperator(input.operator));
+    const remaining = transaction
+      .select({ revisionKey: sqlite.capletRevisions.revisionKey })
+      .from(sqlite.capletRevisions)
+      .where(eq(sqlite.capletRevisions.recordKey, record.recordKey))
+      .orderBy(desc(sqlite.capletRevisions.sequence))
+      .all();
+    if (remaining.length === 0) {
+      transaction
+        .delete(sqlite.capletRecords)
+        .where(eq(sqlite.capletRecords.recordKey, record.recordKey))
+        .run();
+      return;
+    }
+    transaction
+      .update(sqlite.capletRecords)
+      .set({
+        currentRevisionKey:
+          record.currentRevisionKey === input.revisionKey
+            ? remaining[0]!.revisionKey
+            : record.currentRevisionKey,
+        headGeneration: record.headGeneration + 1,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(sqlite.capletRecords.recordKey, record.recordKey))
+      .run();
+  });
+}
+
+async function deleteRevisionPostgres(
+  db: PostgresHostDatabase,
+  input: DeleteCapletRevisionInput,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const [record] = await transaction
+      .select()
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.capletId, input.id))
+      .for("update")
+      .limit(1);
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${input.id} was not found.`);
+    if (record.headGeneration !== input.expectedGeneration) {
+      throw staleGeneration(input.id, input.expectedGeneration, record.headGeneration);
+    }
+    const [revision] = await transaction
+      .select()
+      .from(postgres.capletRevisions)
+      .where(eq(postgres.capletRevisions.revisionKey, input.revisionKey))
+      .limit(1);
+    if (!revision || revision.recordKey !== record.recordKey) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        `Caplet Revision ${input.revisionKey} was not found.`,
+      );
+    }
+    await transaction
+      .delete(postgres.capletRevisions)
+      .where(eq(postgres.capletRevisions.revisionKey, input.revisionKey));
+    const activityAt = new Date().toISOString();
+    await transaction.insert(postgres.operatorActivity).values({
+      activityKey: randomUUID(),
+      operatorClientId: requireOperator(input.operator),
+      action: "caplet.revision_delete",
+      targetKind: "caplet_record",
+      targetKey: record.recordKey,
+      outcome: "succeeded",
+      metadata: { capletId: input.id, revisionKey: input.revisionKey },
+      createdAt: activityAt,
+    });
+    await advancePostgresConfigGeneration(
+      transaction,
+      input.revisionKey,
+      requireOperator(input.operator),
+    );
+    const remaining = await transaction
+      .select({ revisionKey: postgres.capletRevisions.revisionKey })
+      .from(postgres.capletRevisions)
+      .where(eq(postgres.capletRevisions.recordKey, record.recordKey))
+      .orderBy(desc(postgres.capletRevisions.sequence));
+    if (remaining.length === 0) {
+      await transaction
+        .delete(postgres.capletRecords)
+        .where(eq(postgres.capletRecords.recordKey, record.recordKey));
+      return;
+    }
+    await transaction
+      .update(postgres.capletRecords)
+      .set({
+        currentRevisionKey:
+          record.currentRevisionKey === input.revisionKey
+            ? remaining[0]!.revisionKey
+            : record.currentRevisionKey,
+        headGeneration: record.headGeneration + 1,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(postgres.capletRecords.recordKey, record.recordKey));
+  });
+}
+
+function restoreRevisionSqlite(db: SqliteHostDatabase, input: RestoreCapletRevisionInput): void {
+  db.transaction((transaction) => {
+    const record = transaction
+      .select()
+      .from(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.capletId, input.id))
+      .get();
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${input.id} was not found.`);
+    if (record.headGeneration !== input.expectedGeneration) {
+      throw staleGeneration(input.id, input.expectedGeneration, record.headGeneration);
+    }
+    const source = transaction
+      .select()
+      .from(sqlite.capletRevisions)
+      .where(
+        and(
+          eq(sqlite.capletRevisions.revisionKey, input.revisionKey),
+          eq(sqlite.capletRevisions.recordKey, record.recordKey),
+        ),
+      )
+      .get();
+    if (!source) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        `Caplet Revision ${input.revisionKey} was not found.`,
+      );
+    }
+    const revisionKey = randomUUID();
+    const sequence = record.headGeneration + 1;
+    const now = new Date().toISOString();
+    transaction
+      .insert(sqlite.capletRevisions)
+      .values({ ...source, revisionKey, sequence, createdAt: now, actor: input.operator.clientId })
+      .run();
+    const tags = transaction
+      .select()
+      .from(sqlite.capletRevisionTags)
+      .where(eq(sqlite.capletRevisionTags.revisionKey, source.revisionKey))
+      .all();
+    if (tags.length > 0) {
+      transaction
+        .insert(sqlite.capletRevisionTags)
+        .values(tags.map((tag) => ({ ...tag, revisionKey })))
+        .run();
+    }
+    const backends = transaction
+      .select()
+      .from(sqlite.capletRevisionBackends)
+      .where(eq(sqlite.capletRevisionBackends.revisionKey, source.revisionKey))
+      .all();
+    if (backends.length > 0) {
+      transaction
+        .insert(sqlite.capletRevisionBackends)
+        .values(backends.map((backend) => ({ ...backend, revisionKey })))
+        .run();
+    }
+    const entries = transaction
+      .select()
+      .from(sqlite.capletBundleEntries)
+      .where(eq(sqlite.capletBundleEntries.revisionKey, source.revisionKey))
+      .all();
+    if (entries.length > 0) {
+      transaction
+        .insert(sqlite.capletBundleEntries)
+        .values(entries.map((entry) => ({ ...entry, revisionKey })))
+        .run();
+    }
+    transaction
+      .update(sqlite.capletRecords)
+      .set({ currentRevisionKey: revisionKey, headGeneration: sequence, updatedAt: now })
+      .where(eq(sqlite.capletRecords.recordKey, record.recordKey))
+      .run();
+    pruneSqliteRevisions(transaction, record.recordKey, Math.max(1, record.historyLimit ?? 1));
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values({
+        activityKey: randomUUID(),
+        operatorClientId: input.operator.clientId,
+        action: "caplet.revision_restore",
+        targetKind: "caplet_record",
+        targetKey: record.recordKey,
+        outcome: "succeeded",
+        metadata: { capletId: input.id, sourceRevisionKey: source.revisionKey, revisionKey },
+        createdAt: now,
+      })
+      .run();
+    advanceSqliteConfigGeneration(transaction, source.contentHash, input.operator.clientId);
+  });
+}
+
+async function restoreRevisionPostgres(
+  db: PostgresHostDatabase,
+  input: RestoreCapletRevisionInput,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const [record] = await transaction
+      .select()
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.capletId, input.id))
+      .for("update")
+      .limit(1);
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${input.id} was not found.`);
+    if (record.headGeneration !== input.expectedGeneration) {
+      throw staleGeneration(input.id, input.expectedGeneration, record.headGeneration);
+    }
+    const [source] = await transaction
+      .select()
+      .from(postgres.capletRevisions)
+      .where(
+        and(
+          eq(postgres.capletRevisions.revisionKey, input.revisionKey),
+          eq(postgres.capletRevisions.recordKey, record.recordKey),
+        ),
+      )
+      .limit(1);
+    if (!source) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        `Caplet Revision ${input.revisionKey} was not found.`,
+      );
+    }
+    const revisionKey = randomUUID();
+    const sequence = record.headGeneration + 1;
+    const now = new Date().toISOString();
+    await transaction
+      .insert(postgres.capletRevisions)
+      .values({ ...source, revisionKey, sequence, createdAt: now, actor: input.operator.clientId });
+    const [tags, backends, entries] = await Promise.all([
+      transaction
+        .select()
+        .from(postgres.capletRevisionTags)
+        .where(eq(postgres.capletRevisionTags.revisionKey, source.revisionKey)),
+      transaction
+        .select()
+        .from(postgres.capletRevisionBackends)
+        .where(eq(postgres.capletRevisionBackends.revisionKey, source.revisionKey)),
+      transaction
+        .select()
+        .from(postgres.capletBundleEntries)
+        .where(eq(postgres.capletBundleEntries.revisionKey, source.revisionKey)),
+    ]);
+    if (tags.length > 0) {
+      await transaction
+        .insert(postgres.capletRevisionTags)
+        .values(tags.map((tag) => ({ ...tag, revisionKey })));
+    }
+    if (backends.length > 0) {
+      await transaction
+        .insert(postgres.capletRevisionBackends)
+        .values(backends.map((backend) => ({ ...backend, revisionKey })));
+    }
+    if (entries.length > 0) {
+      await transaction
+        .insert(postgres.capletBundleEntries)
+        .values(entries.map((entry) => ({ ...entry, revisionKey })));
+    }
+    await transaction
+      .update(postgres.capletRecords)
+      .set({ currentRevisionKey: revisionKey, headGeneration: sequence, updatedAt: now })
+      .where(eq(postgres.capletRecords.recordKey, record.recordKey));
+    await prunePostgresRevisions(
+      transaction,
+      record.recordKey,
+      Math.max(1, record.historyLimit ?? 1),
+    );
+    await transaction.insert(postgres.operatorActivity).values({
+      activityKey: randomUUID(),
+      operatorClientId: input.operator.clientId,
+      action: "caplet.revision_restore",
+      targetKind: "caplet_record",
+      targetKey: record.recordKey,
+      outcome: "succeeded",
+      metadata: { capletId: input.id, sourceRevisionKey: source.revisionKey, revisionKey },
+      createdAt: now,
+    });
+    await advancePostgresConfigGeneration(transaction, source.contentHash, input.operator.clientId);
+  });
+}
+
+function renameSqlite(db: SqliteHostDatabase, input: RenameCapletRecordInput): void {
+  db.transaction((transaction) => {
+    const record = transaction
+      .select()
+      .from(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.capletId, input.id))
+      .get();
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${input.id} was not found.`);
+    if (record.headGeneration !== input.expectedGeneration) {
+      throw staleGeneration(input.id, input.expectedGeneration, record.headGeneration);
+    }
+    const collision = transaction
+      .select({ recordKey: sqlite.capletRecords.recordKey })
+      .from(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.capletId, input.newId))
+      .get();
+    if (collision)
+      throw new CapletsError("CONFIG_EXISTS", `Caplet Record ${input.newId} already exists.`);
+    const now = new Date().toISOString();
+    transaction
+      .update(sqlite.capletRecords)
+      .set({ capletId: input.newId, headGeneration: record.headGeneration + 1, updatedAt: now })
+      .where(eq(sqlite.capletRecords.recordKey, record.recordKey))
+      .run();
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values({
+        activityKey: randomUUID(),
+        operatorClientId: input.operator.clientId,
+        action: "caplet.rename",
+        targetKind: "caplet_record",
+        targetKey: record.recordKey,
+        outcome: "succeeded",
+        metadata: { previousCapletId: input.id, capletId: input.newId },
+        createdAt: now,
+      })
+      .run();
+    advanceSqliteConfigGeneration(
+      transaction,
+      `rename:${record.recordKey}:${input.newId}`,
+      input.operator.clientId,
+    );
+  });
+}
+
+async function renamePostgres(
+  db: PostgresHostDatabase,
+  input: RenameCapletRecordInput,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const [record] = await transaction
+      .select()
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.capletId, input.id))
+      .for("update")
+      .limit(1);
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${input.id} was not found.`);
+    if (record.headGeneration !== input.expectedGeneration) {
+      throw staleGeneration(input.id, input.expectedGeneration, record.headGeneration);
+    }
+    const [collision] = await transaction
+      .select({ recordKey: postgres.capletRecords.recordKey })
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.capletId, input.newId))
+      .limit(1);
+    if (collision)
+      throw new CapletsError("CONFIG_EXISTS", `Caplet Record ${input.newId} already exists.`);
+    const now = new Date().toISOString();
+    await transaction
+      .update(postgres.capletRecords)
+      .set({ capletId: input.newId, headGeneration: record.headGeneration + 1, updatedAt: now })
+      .where(eq(postgres.capletRecords.recordKey, record.recordKey));
+    await transaction.insert(postgres.operatorActivity).values({
+      activityKey: randomUUID(),
+      operatorClientId: input.operator.clientId,
+      action: "caplet.rename",
+      targetKind: "caplet_record",
+      targetKey: record.recordKey,
+      outcome: "succeeded",
+      metadata: { previousCapletId: input.id, capletId: input.newId },
+      createdAt: now,
+    });
+    await advancePostgresConfigGeneration(
+      transaction,
+      `rename:${record.recordKey}:${input.newId}`,
+      input.operator.clientId,
+    );
+  });
+}
+
+function setRetentionSqlite(db: SqliteHostDatabase, input: SetCapletRetentionInput): void {
+  db.transaction((transaction) => {
+    const record = transaction
+      .select()
+      .from(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.capletId, input.id))
+      .get();
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${input.id} was not found.`);
+    if (record.headGeneration !== input.expectedGeneration) {
+      throw staleGeneration(input.id, input.expectedGeneration, record.headGeneration);
+    }
+    const now = new Date().toISOString();
+    transaction
+      .update(sqlite.capletRecords)
+      .set({
+        historyLimit: input.historyLimit,
+        headGeneration: record.headGeneration + 1,
+        updatedAt: now,
+      })
+      .where(eq(sqlite.capletRecords.recordKey, record.recordKey))
+      .run();
+    pruneSqliteRevisions(transaction, record.recordKey, Math.max(1, input.historyLimit ?? 1));
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values({
+        activityKey: randomUUID(),
+        operatorClientId: input.operator.clientId,
+        action: "caplet.retention_set",
+        targetKind: "caplet_record",
+        targetKey: record.recordKey,
+        outcome: "succeeded",
+        metadata: { capletId: input.id, historyLimit: input.historyLimit },
+        createdAt: now,
+      })
+      .run();
+  });
+}
+
+async function setRetentionPostgres(
+  db: PostgresHostDatabase,
+  input: SetCapletRetentionInput,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const [record] = await transaction
+      .select()
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.capletId, input.id))
+      .for("update")
+      .limit(1);
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${input.id} was not found.`);
+    if (record.headGeneration !== input.expectedGeneration) {
+      throw staleGeneration(input.id, input.expectedGeneration, record.headGeneration);
+    }
+    const now = new Date().toISOString();
+    await transaction
+      .update(postgres.capletRecords)
+      .set({
+        historyLimit: input.historyLimit,
+        headGeneration: record.headGeneration + 1,
+        updatedAt: now,
+      })
+      .where(eq(postgres.capletRecords.recordKey, record.recordKey));
+    await prunePostgresRevisions(
+      transaction,
+      record.recordKey,
+      Math.max(1, input.historyLimit ?? 1),
+    );
+    await transaction.insert(postgres.operatorActivity).values({
+      activityKey: randomUUID(),
+      operatorClientId: input.operator.clientId,
+      action: "caplet.retention_set",
+      targetKind: "caplet_record",
+      targetKey: record.recordKey,
+      outcome: "succeeded",
+      metadata: { capletId: input.id, historyLimit: input.historyLimit },
+      createdAt: now,
+    });
+  });
+}
+
+function hardDeleteSqlite(db: SqliteHostDatabase, input: HardDeleteCapletRecordInput): void {
+  db.transaction((transaction) => {
+    const record = transaction
+      .select()
+      .from(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.capletId, input.id))
+      .get();
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${input.id} was not found.`);
+    if (record.headGeneration !== input.expectedGeneration) {
+      throw staleGeneration(input.id, input.expectedGeneration, record.headGeneration);
+    }
+    transaction
+      .delete(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.recordKey, record.recordKey))
+      .run();
+    const now = new Date().toISOString();
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values({
+        activityKey: randomUUID(),
+        operatorClientId: input.operator.clientId,
+        action: "caplet.hard_delete",
+        targetKind: "caplet_record",
+        targetKey: record.recordKey,
+        outcome: "succeeded",
+        metadata: { capletId: input.id },
+        createdAt: now,
+      })
+      .run();
+    advanceSqliteConfigGeneration(
+      transaction,
+      `delete:${record.recordKey}`,
+      input.operator.clientId,
+    );
+  });
+}
+
+async function hardDeletePostgres(
+  db: PostgresHostDatabase,
+  input: HardDeleteCapletRecordInput,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const [record] = await transaction
+      .select()
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.capletId, input.id))
+      .for("update")
+      .limit(1);
+    if (!record)
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${input.id} was not found.`);
+    if (record.headGeneration !== input.expectedGeneration) {
+      throw staleGeneration(input.id, input.expectedGeneration, record.headGeneration);
+    }
+    await transaction
+      .delete(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.recordKey, record.recordKey));
+    const now = new Date().toISOString();
+    await transaction.insert(postgres.operatorActivity).values({
+      activityKey: randomUUID(),
+      operatorClientId: input.operator.clientId,
+      action: "caplet.hard_delete",
+      targetKind: "caplet_record",
+      targetKey: record.recordKey,
+      outcome: "succeeded",
+      metadata: { capletId: input.id },
+      createdAt: now,
+    });
+    await advancePostgresConfigGeneration(
+      transaction,
+      `delete:${record.recordKey}`,
+      input.operator.clientId,
+    );
+  });
+}
+
+function pruneSqliteRevisions(
+  transaction: Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0],
+  recordKey: string,
+  retained: number,
+): void {
+  const revisions = transaction
+    .select({ revisionKey: sqlite.capletRevisions.revisionKey })
+    .from(sqlite.capletRevisions)
+    .where(eq(sqlite.capletRevisions.recordKey, recordKey))
+    .orderBy(desc(sqlite.capletRevisions.sequence))
+    .all();
+  const expired = revisions.slice(retained).map((revision) => revision.revisionKey);
+  if (expired.length > 0) {
+    transaction
+      .delete(sqlite.capletRevisions)
+      .where(inArray(sqlite.capletRevisions.revisionKey, expired))
+      .run();
+  }
+}
+
+async function prunePostgresRevisions(
+  transaction: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  recordKey: string,
+  retained: number,
+): Promise<void> {
+  const revisions = await transaction
+    .select({ revisionKey: postgres.capletRevisions.revisionKey })
+    .from(postgres.capletRevisions)
+    .where(eq(postgres.capletRevisions.recordKey, recordKey))
+    .orderBy(desc(postgres.capletRevisions.sequence));
+  const expired = revisions.slice(retained).map((revision) => revision.revisionKey);
+  if (expired.length > 0) {
+    await transaction
+      .delete(postgres.capletRevisions)
+      .where(inArray(postgres.capletRevisions.revisionKey, expired));
+  }
+}
+
+function pruneSourceRevisionsSqlite(
+  transaction: Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0],
+  recordKey: string,
+  currentRevisionKey: string,
+  retained: number,
+): void {
+  const revisions = transaction
+    .select({ revisionKey: sqlite.capletRevisions.revisionKey })
+    .from(sqlite.capletRevisions)
+    .where(eq(sqlite.capletRevisions.recordKey, recordKey))
+    .orderBy(desc(sqlite.capletRevisions.sequence))
+    .all();
+  const retainedKeys = new Set<string>([currentRevisionKey]);
+  for (const revision of revisions) {
+    if (retainedKeys.size >= retained) break;
+    retainedKeys.add(revision.revisionKey);
+  }
+  const expired = revisions
+    .filter((revision) => !retainedKeys.has(revision.revisionKey))
+    .map((revision) => revision.revisionKey);
+  if (expired.length > 0) {
+    transaction
+      .delete(sqlite.capletRevisions)
+      .where(inArray(sqlite.capletRevisions.revisionKey, expired))
+      .run();
+  }
+}
+
+async function pruneSourceRevisionsPostgres(
+  transaction: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  recordKey: string,
+  currentRevisionKey: string,
+  retained: number,
+): Promise<void> {
+  const revisions = await transaction
+    .select({ revisionKey: postgres.capletRevisions.revisionKey })
+    .from(postgres.capletRevisions)
+    .where(eq(postgres.capletRevisions.recordKey, recordKey))
+    .orderBy(desc(postgres.capletRevisions.sequence));
+  const retainedKeys = new Set<string>([currentRevisionKey]);
+  for (const revision of revisions) {
+    if (retainedKeys.size >= retained) break;
+    retainedKeys.add(revision.revisionKey);
+  }
+  const expired = revisions
+    .filter((revision) => !retainedKeys.has(revision.revisionKey))
+    .map((revision) => revision.revisionKey);
+  if (expired.length > 0) {
+    await transaction
+      .delete(postgres.capletRevisions)
+      .where(inArray(postgres.capletRevisions.revisionKey, expired));
+  }
+}
+
+function validateCapletRecordId(id: string): void {
+  if (!/^[A-Za-z0-9_-]+$/u.test(id)) {
+    throw new CapletsError("CONFIG_INVALID", `Invalid Caplet ID ${id}.`);
+  }
+}
+
+function validateHistoryLimit(historyLimit: number | null): void {
+  if (historyLimit !== null && (!Number.isInteger(historyLimit) || historyLimit < 0)) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "Caplet history limit must be a non-negative integer or null.",
+    );
+  }
+}
+
+async function getRevisionByKey(
+  database: HostDatabase,
+  recordKey: string,
+  revisionKey: string,
+): Promise<CapletRevisionView | undefined> {
+  if (database.dialect === "sqlite") {
+    const record = database.db
+      .select()
+      .from(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.recordKey, recordKey))
+      .get();
+    const revision = database.db
+      .select()
+      .from(sqlite.capletRevisions)
+      .where(
+        and(
+          eq(sqlite.capletRevisions.recordKey, recordKey),
+          eq(sqlite.capletRevisions.revisionKey, revisionKey),
+        ),
+      )
+      .get();
+    if (!record || !revision) return undefined;
+    const tags = database.db
+      .select()
+      .from(sqlite.capletRevisionTags)
+      .where(eq(sqlite.capletRevisionTags.revisionKey, revisionKey))
+      .orderBy(asc(sqlite.capletRevisionTags.position))
+      .all();
+    const backends = database.db
+      .select()
+      .from(sqlite.capletRevisionBackends)
+      .where(eq(sqlite.capletRevisionBackends.revisionKey, revisionKey))
+      .orderBy(asc(sqlite.capletRevisionBackends.position))
+      .all();
+    const entries = database.db
+      .select()
+      .from(sqlite.capletBundleEntries)
+      .where(eq(sqlite.capletBundleEntries.revisionKey, revisionKey))
+      .orderBy(asc(sqlite.capletBundleEntries.path))
+      .all();
+    return recordView(record, revision, tags, backends, entries).currentRevision;
+  }
+  const [[record], [revision], tags, backends, entries] = await Promise.all([
+    database.db
+      .select()
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.recordKey, recordKey))
+      .limit(1),
+    database.db
+      .select()
+      .from(postgres.capletRevisions)
+      .where(
+        and(
+          eq(postgres.capletRevisions.recordKey, recordKey),
+          eq(postgres.capletRevisions.revisionKey, revisionKey),
+        ),
+      )
+      .limit(1),
+    database.db
+      .select()
+      .from(postgres.capletRevisionTags)
+      .where(eq(postgres.capletRevisionTags.revisionKey, revisionKey))
+      .orderBy(asc(postgres.capletRevisionTags.position)),
+    database.db
+      .select()
+      .from(postgres.capletRevisionBackends)
+      .where(eq(postgres.capletRevisionBackends.revisionKey, revisionKey))
+      .orderBy(asc(postgres.capletRevisionBackends.position)),
+    database.db
+      .select()
+      .from(postgres.capletBundleEntries)
+      .where(eq(postgres.capletBundleEntries.revisionKey, revisionKey))
+      .orderBy(asc(postgres.capletBundleEntries.path)),
+  ]);
+  if (!record || !revision) return undefined;
+  return recordView(record, revision, tags, backends, entries).currentRevision;
+}
+
+async function appendOperatorActivity(
+  database: HostDatabase,
+  activity: {
+    operatorClientId: string;
+    action: string;
+    targetKind: string;
+    targetKey: string;
+    metadata: Record<string, unknown>;
+  },
+): Promise<void> {
+  const values = {
+    activityKey: randomUUID(),
+    ...activity,
+    outcome: "succeeded",
+    createdAt: new Date().toISOString(),
+  };
+  if (database.dialect === "sqlite") {
+    database.db.insert(sqlite.operatorActivity).values(values).run();
+  } else {
+    await database.db.insert(postgres.operatorActivity).values(values);
+  }
+}
+
+function recordValues(bundle: PreparedBundle) {
+  return {
+    recordKey: bundle.recordKey,
+    capletId: bundle.id,
+    currentRevisionKey: null,
+    headGeneration: 1,
+    historyLimit: bundle.historyLimit,
+    createdAt: bundle.now,
+    updatedAt: bundle.now,
+  };
+}
+
+function revisionValues(bundle: PreparedBundle, sequence = 1) {
+  return {
+    revisionKey: bundle.revisionKey,
+    recordKey: bundle.recordKey,
+    sequence,
+    name: bundle.name,
+    description: bundle.description,
+    body: bundle.body,
+    schemaUrl: bundle.schemaUrl,
+    content: bundle.content,
+    contentHash: bundle.contentHash,
+    sourceRevision: bundle.sourceRevision,
+    sourceContentHash: bundle.sourceContentHash,
+    createdAt: bundle.now,
+    actor: bundle.actor,
+  };
+}
+
+function tagValues(bundle: PreparedBundle) {
+  return bundle.tags.map((value, position) => ({
+    revisionKey: bundle.revisionKey,
+    position,
+    value,
+  }));
+}
+
+function backendValues(bundle: PreparedBundle) {
+  return bundle.backends.map((backend, position) => ({
+    revisionKey: bundle.revisionKey,
+    position,
+    family: backend.family,
+    childId: backend.childId,
+    config: backend.config,
+  }));
+}
+
+function blobValues(bundle: PreparedBundle, entry: PreparedBundle["entries"][number]) {
+  return {
+    hash: entry.hash,
+    size: entry.size,
+    payload: entry.sqlPayload,
+    objectKey: entry.objectKey,
+    verificationStatus: "verified",
+    createdAt: bundle.now,
+  };
+}
+
+function entryValues(bundle: PreparedBundle, entry: PreparedBundle["entries"][number]) {
+  return {
+    revisionKey: bundle.revisionKey,
+    path: entry.path,
+    blobHash: entry.hash,
+    mediaType: entry.mediaType,
+    size: entry.size,
+    executable: entry.executable,
+  };
+}
+
+function getSqlite(db: SqliteHostDatabase, id: string): CapletRecordView | undefined {
+  const row = db
+    .select()
+    .from(sqlite.capletRecords)
+    .where(eq(sqlite.capletRecords.capletId, id))
+    .get();
+  if (!row?.currentRevisionKey) return undefined;
+  const revision = db
+    .select()
+    .from(sqlite.capletRevisions)
+    .where(eq(sqlite.capletRevisions.revisionKey, row.currentRevisionKey))
+    .get();
+  if (!revision) throw missingCurrentRevision(id);
+  const tags = db
+    .select()
+    .from(sqlite.capletRevisionTags)
+    .where(eq(sqlite.capletRevisionTags.revisionKey, revision.revisionKey))
+    .orderBy(asc(sqlite.capletRevisionTags.position))
+    .all();
+  const backends = db
+    .select()
+    .from(sqlite.capletRevisionBackends)
+    .where(eq(sqlite.capletRevisionBackends.revisionKey, revision.revisionKey))
+    .orderBy(asc(sqlite.capletRevisionBackends.position))
+    .all();
+  const entries = db
+    .select()
+    .from(sqlite.capletBundleEntries)
+    .where(eq(sqlite.capletBundleEntries.revisionKey, revision.revisionKey))
+    .orderBy(asc(sqlite.capletBundleEntries.path))
+    .all();
+  return recordView(row, revision, tags, backends, entries);
+}
+
+async function getPostgres(
+  db: PostgresHostDatabase,
+  id: string,
+): Promise<CapletRecordView | undefined> {
+  const [row] = await db
+    .select()
+    .from(postgres.capletRecords)
+    .where(eq(postgres.capletRecords.capletId, id))
+    .limit(1);
+  if (!row?.currentRevisionKey) return undefined;
+  const [revision] = await db
+    .select()
+    .from(postgres.capletRevisions)
+    .where(eq(postgres.capletRevisions.revisionKey, row.currentRevisionKey))
+    .limit(1);
+  if (!revision) throw missingCurrentRevision(id);
+  const [tags, backends, entries] = await Promise.all([
+    db
+      .select()
+      .from(postgres.capletRevisionTags)
+      .where(eq(postgres.capletRevisionTags.revisionKey, revision.revisionKey))
+      .orderBy(asc(postgres.capletRevisionTags.position)),
+    db
+      .select()
+      .from(postgres.capletRevisionBackends)
+      .where(eq(postgres.capletRevisionBackends.revisionKey, revision.revisionKey))
+      .orderBy(asc(postgres.capletRevisionBackends.position)),
+    db
+      .select()
+      .from(postgres.capletBundleEntries)
+      .where(eq(postgres.capletBundleEntries.revisionKey, revision.revisionKey))
+      .orderBy(asc(postgres.capletBundleEntries.path)),
+  ]);
+  return recordView(row, revision, tags, backends, entries);
+}
+
+function recordView(
+  record: typeof sqlite.capletRecords.$inferSelect,
+  revision: typeof sqlite.capletRevisions.$inferSelect,
+  tags: Array<typeof sqlite.capletRevisionTags.$inferSelect>,
+  backends: Array<typeof sqlite.capletRevisionBackends.$inferSelect>,
+  entries: Array<typeof sqlite.capletBundleEntries.$inferSelect>,
+): CapletRecordView {
+  return {
+    recordKey: record.recordKey,
+    id: record.capletId,
+    headGeneration: record.headGeneration,
+    historyLimit: record.historyLimit,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    currentRevision: {
+      revisionKey: revision.revisionKey,
+      sequence: revision.sequence,
+      name: revision.name,
+      description: revision.description,
+      body: revision.body,
+      schemaUrl: revision.schemaUrl,
+      content: revision.content,
+      contentHash: revision.contentHash,
+      sourceRevision: revision.sourceRevision,
+      sourceContentHash: revision.sourceContentHash,
+      createdAt: revision.createdAt,
+      actor: revision.actor,
+      tags: tags.map((tag) => tag.value),
+      backends: backends.map((backend) => ({
+        family: backend.family,
+        childId: backend.childId,
+        config: backend.config,
+      })),
+      bundle: entries.map((entry) => ({
+        path: entry.path,
+        hash: entry.blobHash,
+        mediaType: entry.mediaType,
+        size: entry.size,
+        executable: Boolean(entry.executable),
+      })),
+    },
+  };
+}
+
+function renderCapletDocument(revision: CapletRevisionView): string {
+  const frontmatter: Record<string, unknown> = {};
+  if (revision.schemaUrl) frontmatter.$schema = revision.schemaUrl;
+  frontmatter.name = revision.name;
+  frontmatter.description = revision.description;
+  if (revision.tags.length > 0) frontmatter.tags = revision.tags;
+  Object.assign(frontmatter, revision.content);
+  for (const backend of revision.backends) {
+    if (backend.childId === null) {
+      frontmatter[backend.family] = backend.config;
+      continue;
+    }
+    const children = (frontmatter[backend.family] ?? {}) as Record<string, unknown>;
+    children[backend.childId] = backend.config;
+    frontmatter[backend.family] = children;
+  }
+  return `---\n${stringifyYaml(frontmatter, { lineWidth: 0 }).trimEnd()}\n---\n${revision.body}`;
+}
+
+function mediaTypeForPath(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case ".json":
+      return "application/json";
+    case ".md":
+      return "text/markdown";
+    case ".sh":
+      return "text/x-shellscript";
+    case ".txt":
+    case ".yaml":
+    case ".yml":
+      return "text/plain";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function missingCurrentRevision(id: string): CapletsError {
+  return new CapletsError("INTERNAL_ERROR", `Caplet Record ${id} has a missing current revision.`);
+}
+
+function staleGeneration(
+  id: string,
+  expectedGeneration: number,
+  currentGeneration: number,
+): CapletsError {
+  return new CapletsError(
+    "REQUEST_INVALID",
+    `Caplet Record ${id} changed after it was read; reload and retry.`,
+    { kind: "stale_generation", expectedGeneration, currentGeneration },
+  );
+}
+
+function deleteUnreferencedSqliteBlob(
+  db: SqliteHostDatabase,
+  hash: string,
+): string | null | undefined {
+  return db.transaction((transaction) => {
+    const blob = transaction
+      .select({ objectKey: sqlite.capletAssetBlobs.objectKey })
+      .from(sqlite.capletAssetBlobs)
+      .where(eq(sqlite.capletAssetBlobs.hash, hash))
+      .get();
+    if (!blob) return undefined;
+    const reference = transaction
+      .select({ path: sqlite.capletBundleEntries.path })
+      .from(sqlite.capletBundleEntries)
+      .where(eq(sqlite.capletBundleEntries.blobHash, hash))
+      .limit(1)
+      .get();
+    if (reference) return undefined;
+    transaction.delete(sqlite.capletAssetBlobs).where(eq(sqlite.capletAssetBlobs.hash, hash)).run();
+    return blob.objectKey;
+  });
+}
+
+async function deleteUnreferencedPostgresBlob(
+  db: PostgresHostDatabase,
+  hash: string,
+): Promise<string | null | undefined> {
+  return await db.transaction(async (transaction) => {
+    const [blob] = await transaction
+      .select({ objectKey: postgres.capletAssetBlobs.objectKey })
+      .from(postgres.capletAssetBlobs)
+      .where(eq(postgres.capletAssetBlobs.hash, hash))
+      .for("update")
+      .limit(1);
+    if (!blob) return undefined;
+    const [reference] = await transaction
+      .select({ path: postgres.capletBundleEntries.path })
+      .from(postgres.capletBundleEntries)
+      .where(eq(postgres.capletBundleEntries.blobHash, hash))
+      .limit(1);
+    if (reference) return undefined;
+    await transaction
+      .delete(postgres.capletAssetBlobs)
+      .where(eq(postgres.capletAssetBlobs.hash, hash));
+    return blob.objectKey;
+  });
+}
+
+function ensureSqliteBlob(
+  transaction: Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0],
+  bundle: PreparedBundle,
+  entry: PreparedBundle["entries"][number],
+): void {
+  if (entry.assetWasExisting) {
+    const row = transaction
+      .select({ hash: sqlite.capletAssetBlobs.hash })
+      .from(sqlite.capletAssetBlobs)
+      .where(eq(sqlite.capletAssetBlobs.hash, entry.hash))
+      .get();
+    if (!row) {
+      throw new CapletsError(
+        "SERVER_UNAVAILABLE",
+        `Caplet asset ${entry.hash} changed during import; retry the operation.`,
+      );
+    }
+    return;
+  }
+  transaction
+    .insert(sqlite.capletAssetBlobs)
+    .values(blobValues(bundle, entry))
+    .onConflictDoNothing()
+    .run();
+}
+
+async function ensurePostgresBlob(
+  transaction: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  bundle: PreparedBundle,
+  entry: PreparedBundle["entries"][number],
+): Promise<void> {
+  if (entry.assetWasExisting) {
+    const [row] = await transaction
+      .select({ hash: postgres.capletAssetBlobs.hash })
+      .from(postgres.capletAssetBlobs)
+      .where(eq(postgres.capletAssetBlobs.hash, entry.hash))
+      .limit(1);
+    if (!row) {
+      throw new CapletsError(
+        "SERVER_UNAVAILABLE",
+        `Caplet asset ${entry.hash} changed during import; retry the operation.`,
+      );
+    }
+    return;
+  }
+  await transaction
+    .insert(postgres.capletAssetBlobs)
+    .values(blobValues(bundle, entry))
+    .onConflictDoNothing();
+}
+
+function trackedInstallation(id: string): CapletsError {
+  return new CapletsError(
+    "REQUEST_INVALID",
+    `Caplet ${id} has a tracked installation; detach it before overwriting the record.`,
+    { kind: "tracked_installation" },
+  );
+}
+
+function sourceInstallationRequired(id: string): CapletsError {
+  return new CapletsError(
+    "REQUEST_INVALID",
+    `Caplet ${id} does not have an active source installation.`,
+    { kind: "tracked_installation_required" },
+  );
+}
+
+function staleInstallationGeneration(id: string): CapletsError {
+  return new CapletsError(
+    "REQUEST_INVALID",
+    `Caplet installation ${id} changed after it was read; reload and retry.`,
+    { kind: "stale_generation" },
+  );
+}
+
+function sourceObservationTime(candidate: string, previous: string | undefined): string {
+  const candidateTime = Date.parse(candidate);
+  const previousTime = previous === undefined ? Number.NEGATIVE_INFINITY : Date.parse(previous);
+  if (
+    !Number.isFinite(candidateTime) ||
+    (previous !== undefined && !Number.isFinite(previousTime))
+  ) {
+    throw new CapletsError(
+      "INTERNAL_ERROR",
+      "Caplet source provenance contains an invalid timestamp.",
+    );
+  }
+  return new Date(Math.max(candidateTime, previousTime + 1)).toISOString();
+}
+
+function sourceObservationValues(
+  installationKey: string,
+  input: UpdateCapletFromSourceInput,
+  observedAt: string,
+) {
+  return {
+    observationKey: randomUUID(),
+    installationKey,
+    resolvedRevision: input.sourceRevision,
+    contentHash: input.sourceContentHash,
+    risk: input.risk ?? null,
+    status: input.observationStatus,
+    observedAt,
+  };
+}
+
+function sourceUpdateActivity(
+  bundle: PreparedBundle,
+  installationKey: string,
+  input: UpdateCapletFromSourceInput,
+  contentChanged: boolean,
+  revisionCreated: boolean,
+  createdAt: string,
+) {
+  return {
+    activityKey: randomUUID(),
+    operatorClientId: bundle.actor,
+    action: "caplet.source_update",
+    targetKind: "caplet_record",
+    targetKey: bundle.recordKey,
+    outcome: "succeeded",
+    metadata: {
+      capletId: bundle.id,
+      installationKey,
+      observationStatus: input.observationStatus,
+      contentChanged,
+      revisionCreated,
+      ...(revisionCreated ? { revisionKey: bundle.revisionKey } : {}),
+    },
+    createdAt,
+  };
+}
+
+function recordActivityValues(bundle: PreparedBundle, action: string) {
+  return {
+    activityKey: randomUUID(),
+    operatorClientId: bundle.actor,
+    action,
+    targetKind: "caplet_record",
+    targetKey: bundle.recordKey,
+    outcome: "succeeded",
+    metadata: { capletId: bundle.id, revisionKey: bundle.revisionKey },
+    createdAt: bundle.now,
+  };
+}
+
+function insertSqliteInstallation(
+  transaction: Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0],
+  bundle: PreparedBundle,
+): void {
+  if (!bundle.installation) return;
+  transaction
+    .insert(sqlite.capletInstallations)
+    .values({
+      installationKey: bundle.installation.installationKey,
+      recordKey: bundle.recordKey,
+      generation: 1,
+      status: "active",
+      sourceKind: bundle.installation.sourceKind,
+      sourceIdentity: bundle.installation.sourceIdentity,
+      channel: bundle.installation.channel,
+      createdAt: bundle.now,
+      updatedAt: bundle.now,
+    })
+    .run();
+  transaction
+    .insert(sqlite.capletInstallationObservations)
+    .values({
+      observationKey: randomUUID(),
+      installationKey: bundle.installation.installationKey,
+      resolvedRevision: bundle.sourceRevision,
+      contentHash: bundle.sourceContentHash ?? bundle.contentHash,
+      risk: bundle.installation.risk,
+      status: "current",
+      observedAt: bundle.now,
+    })
+    .run();
+}
+
+async function insertPostgresInstallation(
+  transaction: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  bundle: PreparedBundle,
+): Promise<void> {
+  if (!bundle.installation) return;
+  await transaction.insert(postgres.capletInstallations).values({
+    installationKey: bundle.installation.installationKey,
+    recordKey: bundle.recordKey,
+    generation: 1,
+    status: "active",
+    sourceKind: bundle.installation.sourceKind,
+    sourceIdentity: bundle.installation.sourceIdentity,
+    channel: bundle.installation.channel,
+    createdAt: bundle.now,
+    updatedAt: bundle.now,
+  });
+  await transaction.insert(postgres.capletInstallationObservations).values({
+    observationKey: randomUUID(),
+    installationKey: bundle.installation.installationKey,
+    resolvedRevision: bundle.sourceRevision,
+    contentHash: bundle.sourceContentHash ?? bundle.contentHash,
+    risk: bundle.installation.risk,
+    status: "current",
+    observedAt: bundle.now,
+  });
+}

--- a/packages/core/src/storage/caplet-records.ts
+++ b/packages/core/src/storage/caplet-records.ts
@@ -14,7 +14,14 @@ import {
 } from "./installations";
 import * as postgres from "./schema/postgres";
 import * as sqlite from "./schema/sqlite";
-import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+import type {
+  HostDatabase,
+  HostDatabaseTransaction,
+  PostgresHostDatabase,
+  PostgresHostTransaction,
+  SqliteHostDatabase,
+  SqliteHostTransaction,
+} from "./types";
 
 export type CapletBundleInputFile = {
   path: string;
@@ -243,6 +250,31 @@ export class CapletRecordStore {
       return record;
     });
   }
+  async prepareBundleAssetsForImport(inputs: ImportCapletBundleInput[]): Promise<void> {
+    for (const input of inputs) requireOperator(input.operator);
+    await this.prepareAssetStorage(inputs.map((input) => prepareBundle(input, this.limits)));
+  }
+
+  importBundlesInTransaction(
+    inputs: ImportCapletBundleInput[],
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    for (const input of inputs) requireOperator(input.operator);
+    const bundles = inputs.map((input) => prepareBundle(input, this.limits));
+    if (bundles.length === 0) return;
+    return transaction.dialect === "sqlite"
+      ? importManySqliteTransaction(transaction.db, bundles)
+      : importManyPostgresTransaction(transaction.db, bundles);
+  }
+
+  getInTransaction(
+    id: string,
+    transaction: HostDatabaseTransaction,
+  ): CapletRecordView | undefined | Promise<CapletRecordView | undefined> {
+    return transaction.dialect === "sqlite"
+      ? getSqlite(transaction.db, id)
+      : getPostgres(transaction.db, id);
+  }
 
   async get(id: string): Promise<CapletRecordView | undefined> {
     return this.database.dialect === "sqlite"
@@ -330,6 +362,96 @@ export class CapletRecordStore {
       this.database.db.select({ count: count() }).from(postgres.capletBundleEntries),
     ]);
     return { blobs: blobs?.count ?? 0, entries: entries?.count ?? 0 };
+  }
+
+  async currentAssetHealth(): Promise<{ ready: boolean; affectedRecordIds: string[] }> {
+    if (!this.objectStore) return { ready: true, affectedRecordIds: [] };
+    const references =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select({
+              recordId: sqlite.capletRecords.capletId,
+              entryHash: sqlite.capletBundleEntries.blobHash,
+              entrySize: sqlite.capletBundleEntries.size,
+              blobHash: sqlite.capletAssetBlobs.hash,
+              blobSize: sqlite.capletAssetBlobs.size,
+              payload: sqlite.capletAssetBlobs.payload,
+              objectKey: sqlite.capletAssetBlobs.objectKey,
+              verificationStatus: sqlite.capletAssetBlobs.verificationStatus,
+            })
+            .from(sqlite.capletRecords)
+            .innerJoin(
+              sqlite.capletBundleEntries,
+              eq(sqlite.capletBundleEntries.revisionKey, sqlite.capletRecords.currentRevisionKey),
+            )
+            .leftJoin(
+              sqlite.capletAssetBlobs,
+              eq(sqlite.capletAssetBlobs.hash, sqlite.capletBundleEntries.blobHash),
+            )
+            .all()
+        : await this.database.db
+            .select({
+              recordId: postgres.capletRecords.capletId,
+              entryHash: postgres.capletBundleEntries.blobHash,
+              entrySize: postgres.capletBundleEntries.size,
+              blobHash: postgres.capletAssetBlobs.hash,
+              blobSize: postgres.capletAssetBlobs.size,
+              payload: postgres.capletAssetBlobs.payload,
+              objectKey: postgres.capletAssetBlobs.objectKey,
+              verificationStatus: postgres.capletAssetBlobs.verificationStatus,
+            })
+            .from(postgres.capletRecords)
+            .innerJoin(
+              postgres.capletBundleEntries,
+              eq(
+                postgres.capletBundleEntries.revisionKey,
+                postgres.capletRecords.currentRevisionKey,
+              ),
+            )
+            .leftJoin(
+              postgres.capletAssetBlobs,
+              eq(postgres.capletAssetBlobs.hash, postgres.capletBundleEntries.blobHash),
+            );
+    const checks = new Map<string, Promise<boolean>>();
+    const affectedRecordIds = new Set<string>();
+    await Promise.all(
+      references.map(async (reference) => {
+        if (
+          reference.blobHash !== reference.entryHash ||
+          reference.blobSize !== reference.entrySize ||
+          reference.verificationStatus !== "verified"
+        ) {
+          affectedRecordIds.add(reference.recordId);
+          return;
+        }
+        let check = checks.get(reference.entryHash);
+        if (!check) {
+          check = (async () => {
+            try {
+              if (reference.payload) {
+                const payload = Buffer.from(reference.payload);
+                return (
+                  payload.byteLength === reference.entrySize &&
+                  createHash("sha256").update(payload).digest("hex") === reference.entryHash
+                );
+              }
+              if (!reference.objectKey) return false;
+              await this.objectStore!.getVerified(reference.objectKey, {
+                hash: reference.entryHash,
+                size: reference.entrySize,
+              });
+              return true;
+            } catch {
+              return false;
+            }
+          })();
+          checks.set(reference.entryHash, check);
+        }
+        if (!(await check)) affectedRecordIds.add(reference.recordId);
+      }),
+    );
+    const ids = [...affectedRecordIds].sort();
+    return { ready: ids.length === 0, affectedRecordIds: ids };
   }
 
   async updateBundle(input: UpdateCapletBundleInput): Promise<CapletRecordView> {
@@ -668,6 +790,7 @@ export class CapletRecordStore {
 
   private async bundlePayloads(revision: CapletRevisionView): Promise<Map<string, Buffer>> {
     const hashes = [...new Set(revision.bundle.map((entry) => entry.hash))];
+    const expectedSizes = new Map(revision.bundle.map((entry) => [entry.hash, entry.size]));
     if (hashes.length === 0) return new Map();
     const rows =
       this.database.dialect === "sqlite"
@@ -682,20 +805,30 @@ export class CapletRecordStore {
             .where(inArray(postgres.capletAssetBlobs.hash, hashes));
     const payloads = new Map<string, Buffer>();
     for (const row of rows) {
-      const payload = row.payload
-        ? Buffer.from(row.payload)
-        : row.objectKey && this.objectStore
-          ? await this.objectStore.get(row.objectKey)
-          : undefined;
-      if (!payload) {
-        throw new CapletsError("SERVER_UNAVAILABLE", `Caplet asset ${row.hash} is unavailable.`);
-      }
-      const actualHash = createHash("sha256").update(payload).digest("hex");
-      if (actualHash !== row.hash || payload.byteLength !== row.size) {
+      if (row.verificationStatus !== "verified" || expectedSizes.get(row.hash) !== row.size) {
         throw new CapletsError(
           "INTERNAL_ERROR",
-          `Caplet asset ${row.hash} failed integrity verification.`,
+          `Caplet asset ${row.hash} has invalid stored metadata.`,
         );
+      }
+      let payload: Buffer | undefined;
+      if (row.payload) {
+        payload = Buffer.from(row.payload);
+        const actualHash = createHash("sha256").update(payload).digest("hex");
+        if (actualHash !== row.hash || payload.byteLength !== row.size) {
+          throw new CapletsError(
+            "INTERNAL_ERROR",
+            `Caplet asset ${row.hash} failed integrity verification.`,
+          );
+        }
+      } else if (row.objectKey && this.objectStore) {
+        payload = await this.objectStore.getVerified(row.objectKey, {
+          hash: row.hash,
+          size: row.size,
+        });
+      }
+      if (!payload) {
+        throw new CapletsError("SERVER_UNAVAILABLE", `Caplet asset ${row.hash} is unavailable.`);
       }
       payloads.set(row.hash, payload);
     }
@@ -953,45 +1086,50 @@ function importSqlite(db: SqliteHostDatabase, bundle: PreparedBundle): void {
 }
 
 function importManySqlite(db: SqliteHostDatabase, bundles: PreparedBundle[]): void {
-  db.transaction((transaction) => {
-    for (const bundle of bundles) {
-      if (
-        transaction
-          .select()
-          .from(sqlite.capletRecords)
-          .where(eq(sqlite.capletRecords.capletId, bundle.id))
-          .get()
-      ) {
-        throw new CapletsError("CONFIG_INVALID", `Caplet Record ${bundle.id} already exists.`);
-      }
-      transaction.insert(sqlite.capletRecords).values(recordValues(bundle)).run();
-      transaction.insert(sqlite.capletRevisions).values(revisionValues(bundle)).run();
-      if (bundle.tags.length > 0) {
-        transaction.insert(sqlite.capletRevisionTags).values(tagValues(bundle)).run();
-      }
-      if (bundle.backends.length > 0) {
-        transaction.insert(sqlite.capletRevisionBackends).values(backendValues(bundle)).run();
-      }
-      for (const entry of bundle.entries) {
-        ensureSqliteBlob(transaction, bundle, entry);
-        transaction.insert(sqlite.capletBundleEntries).values(entryValues(bundle, entry)).run();
-      }
+  db.transaction((transaction) => importManySqliteTransaction(transaction, bundles));
+}
+
+function importManySqliteTransaction(
+  transaction: SqliteHostTransaction,
+  bundles: PreparedBundle[],
+): void {
+  for (const bundle of bundles) {
+    if (
       transaction
-        .update(sqlite.capletRecords)
-        .set({ currentRevisionKey: bundle.revisionKey })
-        .where(eq(sqlite.capletRecords.recordKey, bundle.recordKey))
-        .run();
-      insertSqliteInstallation(transaction, bundle);
-      transaction
-        .insert(sqlite.operatorActivity)
-        .values(recordActivityValues(bundle, "caplet.import"))
-        .run();
+        .select()
+        .from(sqlite.capletRecords)
+        .where(eq(sqlite.capletRecords.capletId, bundle.id))
+        .get()
+    ) {
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${bundle.id} already exists.`);
     }
-    const generationHash = createHash("sha256")
-      .update(bundles.map((bundle) => bundle.contentHash).join("\0"))
-      .digest("hex");
-    advanceSqliteConfigGeneration(transaction, generationHash, bundles[0]!.actor);
-  });
+    transaction.insert(sqlite.capletRecords).values(recordValues(bundle)).run();
+    transaction.insert(sqlite.capletRevisions).values(revisionValues(bundle)).run();
+    if (bundle.tags.length > 0) {
+      transaction.insert(sqlite.capletRevisionTags).values(tagValues(bundle)).run();
+    }
+    if (bundle.backends.length > 0) {
+      transaction.insert(sqlite.capletRevisionBackends).values(backendValues(bundle)).run();
+    }
+    for (const entry of bundle.entries) {
+      ensureSqliteBlob(transaction, bundle, entry);
+      transaction.insert(sqlite.capletBundleEntries).values(entryValues(bundle, entry)).run();
+    }
+    transaction
+      .update(sqlite.capletRecords)
+      .set({ currentRevisionKey: bundle.revisionKey })
+      .where(eq(sqlite.capletRecords.recordKey, bundle.recordKey))
+      .run();
+    insertSqliteInstallation(transaction, bundle);
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values(recordActivityValues(bundle, "caplet.import"))
+      .run();
+  }
+  const generationHash = createHash("sha256")
+    .update(bundles.map((bundle) => bundle.contentHash).join("\0"))
+    .digest("hex");
+  advanceSqliteConfigGeneration(transaction, generationHash, bundles[0]!.actor);
 }
 
 async function importPostgres(db: PostgresHostDatabase, bundle: PreparedBundle): Promise<void> {
@@ -1002,42 +1140,49 @@ async function importManyPostgres(
   db: PostgresHostDatabase,
   bundles: PreparedBundle[],
 ): Promise<void> {
-  await db.transaction(async (transaction) => {
-    for (const bundle of bundles) {
-      const [existing] = await transaction
-        .select()
-        .from(postgres.capletRecords)
-        .where(eq(postgres.capletRecords.capletId, bundle.id))
-        .limit(1);
-      if (existing) {
-        throw new CapletsError("CONFIG_INVALID", `Caplet Record ${bundle.id} already exists.`);
-      }
-      await transaction.insert(postgres.capletRecords).values(recordValues(bundle));
-      await transaction.insert(postgres.capletRevisions).values(revisionValues(bundle));
-      if (bundle.tags.length > 0) {
-        await transaction.insert(postgres.capletRevisionTags).values(tagValues(bundle));
-      }
-      if (bundle.backends.length > 0) {
-        await transaction.insert(postgres.capletRevisionBackends).values(backendValues(bundle));
-      }
-      for (const entry of bundle.entries) {
-        await ensurePostgresBlob(transaction, bundle, entry);
-        await transaction.insert(postgres.capletBundleEntries).values(entryValues(bundle, entry));
-      }
-      await transaction
-        .update(postgres.capletRecords)
-        .set({ currentRevisionKey: bundle.revisionKey })
-        .where(eq(postgres.capletRecords.recordKey, bundle.recordKey));
-      await insertPostgresInstallation(transaction, bundle);
-      await transaction
-        .insert(postgres.operatorActivity)
-        .values(recordActivityValues(bundle, "caplet.import"));
+  await db.transaction(
+    async (transaction) => await importManyPostgresTransaction(transaction, bundles),
+  );
+}
+
+async function importManyPostgresTransaction(
+  transaction: PostgresHostTransaction,
+  bundles: PreparedBundle[],
+): Promise<void> {
+  for (const bundle of bundles) {
+    const [existing] = await transaction
+      .select()
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.capletId, bundle.id))
+      .limit(1);
+    if (existing) {
+      throw new CapletsError("CONFIG_INVALID", `Caplet Record ${bundle.id} already exists.`);
     }
-    const generationHash = createHash("sha256")
-      .update(bundles.map((bundle) => bundle.contentHash).join("\0"))
-      .digest("hex");
-    await advancePostgresConfigGeneration(transaction, generationHash, bundles[0]!.actor);
-  });
+    await transaction.insert(postgres.capletRecords).values(recordValues(bundle));
+    await transaction.insert(postgres.capletRevisions).values(revisionValues(bundle));
+    if (bundle.tags.length > 0) {
+      await transaction.insert(postgres.capletRevisionTags).values(tagValues(bundle));
+    }
+    if (bundle.backends.length > 0) {
+      await transaction.insert(postgres.capletRevisionBackends).values(backendValues(bundle));
+    }
+    for (const entry of bundle.entries) {
+      await ensurePostgresBlob(transaction, bundle, entry);
+      await transaction.insert(postgres.capletBundleEntries).values(entryValues(bundle, entry));
+    }
+    await transaction
+      .update(postgres.capletRecords)
+      .set({ currentRevisionKey: bundle.revisionKey })
+      .where(eq(postgres.capletRecords.recordKey, bundle.recordKey));
+    await insertPostgresInstallation(transaction, bundle);
+    await transaction
+      .insert(postgres.operatorActivity)
+      .values(recordActivityValues(bundle, "caplet.import"));
+  }
+  const generationHash = createHash("sha256")
+    .update(bundles.map((bundle) => bundle.contentHash).join("\0"))
+    .digest("hex");
+  await advancePostgresConfigGeneration(transaction, generationHash, bundles[0]!.actor);
 }
 
 function updateSqlite(
@@ -2331,7 +2476,10 @@ function entryValues(bundle: PreparedBundle, entry: PreparedBundle["entries"][nu
   };
 }
 
-function getSqlite(db: SqliteHostDatabase, id: string): CapletRecordView | undefined {
+function getSqlite(
+  db: SqliteHostDatabase | SqliteHostTransaction,
+  id: string,
+): CapletRecordView | undefined {
   const row = db
     .select()
     .from(sqlite.capletRecords)
@@ -2366,7 +2514,7 @@ function getSqlite(db: SqliteHostDatabase, id: string): CapletRecordView | undef
 }
 
 async function getPostgres(
-  db: PostgresHostDatabase,
+  db: PostgresHostDatabase | PostgresHostTransaction,
   id: string,
 ): Promise<CapletRecordView | undefined> {
   const [row] = await db

--- a/packages/core/src/storage/caplet-records.ts
+++ b/packages/core/src/storage/caplet-records.ts
@@ -283,19 +283,9 @@ export class CapletRecordStore {
   }
 
   async list(): Promise<CapletRecordView[]> {
-    const ids =
-      this.database.dialect === "sqlite"
-        ? this.database.db
-            .select({ id: sqlite.capletRecords.capletId })
-            .from(sqlite.capletRecords)
-            .orderBy(asc(sqlite.capletRecords.capletId))
-            .all()
-        : await this.database.db
-            .select({ id: postgres.capletRecords.capletId })
-            .from(postgres.capletRecords)
-            .orderBy(asc(postgres.capletRecords.capletId));
-    const records = await Promise.all(ids.map(async ({ id }) => await this.get(id)));
-    return records.filter((record): record is CapletRecordView => record !== undefined);
+    return this.database.dialect === "sqlite"
+      ? listSqlite(this.database.db)
+      : await listPostgres(this.database.db);
   }
 
   async collectAssetGarbage(input: {
@@ -2474,6 +2464,112 @@ function entryValues(bundle: PreparedBundle, entry: PreparedBundle["entries"][nu
     size: entry.size,
     executable: entry.executable,
   };
+}
+
+function listSqlite(db: SqliteHostDatabase): CapletRecordView[] {
+  const records = db
+    .select()
+    .from(sqlite.capletRecords)
+    .orderBy(asc(sqlite.capletRecords.capletId))
+    .all();
+  const revisionKeys = records.flatMap(({ currentRevisionKey }) =>
+    currentRevisionKey === null ? [] : [currentRevisionKey],
+  );
+  if (revisionKeys.length === 0) return [];
+  const revisions = db
+    .select()
+    .from(sqlite.capletRevisions)
+    .where(inArray(sqlite.capletRevisions.revisionKey, revisionKeys))
+    .all();
+  const tags = db
+    .select()
+    .from(sqlite.capletRevisionTags)
+    .where(inArray(sqlite.capletRevisionTags.revisionKey, revisionKeys))
+    .orderBy(asc(sqlite.capletRevisionTags.position))
+    .all();
+  const backends = db
+    .select()
+    .from(sqlite.capletRevisionBackends)
+    .where(inArray(sqlite.capletRevisionBackends.revisionKey, revisionKeys))
+    .orderBy(asc(sqlite.capletRevisionBackends.position))
+    .all();
+  const entries = db
+    .select()
+    .from(sqlite.capletBundleEntries)
+    .where(inArray(sqlite.capletBundleEntries.revisionKey, revisionKeys))
+    .orderBy(asc(sqlite.capletBundleEntries.path))
+    .all();
+  return recordViews(records, revisions, tags, backends, entries);
+}
+
+async function listPostgres(db: PostgresHostDatabase): Promise<CapletRecordView[]> {
+  const records = await db
+    .select()
+    .from(postgres.capletRecords)
+    .orderBy(asc(postgres.capletRecords.capletId));
+  const revisionKeys = records.flatMap(({ currentRevisionKey }) =>
+    currentRevisionKey === null ? [] : [currentRevisionKey],
+  );
+  if (revisionKeys.length === 0) return [];
+  const revisions = await db
+    .select()
+    .from(postgres.capletRevisions)
+    .where(inArray(postgres.capletRevisions.revisionKey, revisionKeys));
+  const [tags, backends, entries] = await Promise.all([
+    db
+      .select()
+      .from(postgres.capletRevisionTags)
+      .where(inArray(postgres.capletRevisionTags.revisionKey, revisionKeys))
+      .orderBy(asc(postgres.capletRevisionTags.position)),
+    db
+      .select()
+      .from(postgres.capletRevisionBackends)
+      .where(inArray(postgres.capletRevisionBackends.revisionKey, revisionKeys))
+      .orderBy(asc(postgres.capletRevisionBackends.position)),
+    db
+      .select()
+      .from(postgres.capletBundleEntries)
+      .where(inArray(postgres.capletBundleEntries.revisionKey, revisionKeys))
+      .orderBy(asc(postgres.capletBundleEntries.path)),
+  ]);
+  return recordViews(records, revisions, tags, backends, entries);
+}
+
+function recordViews(
+  records: Array<typeof sqlite.capletRecords.$inferSelect>,
+  revisions: Array<typeof sqlite.capletRevisions.$inferSelect>,
+  tags: Array<typeof sqlite.capletRevisionTags.$inferSelect>,
+  backends: Array<typeof sqlite.capletRevisionBackends.$inferSelect>,
+  entries: Array<typeof sqlite.capletBundleEntries.$inferSelect>,
+): CapletRecordView[] {
+  const revisionsByKey = new Map(revisions.map((revision) => [revision.revisionKey, revision]));
+  const tagsByRevision = groupByRevisionKey(tags);
+  const backendsByRevision = groupByRevisionKey(backends);
+  const entriesByRevision = groupByRevisionKey(entries);
+  return records.flatMap((record) => {
+    if (record.currentRevisionKey === null) return [];
+    const revision = revisionsByKey.get(record.currentRevisionKey);
+    if (!revision) throw missingCurrentRevision(record.capletId);
+    return [
+      recordView(
+        record,
+        revision,
+        tagsByRevision.get(revision.revisionKey) ?? [],
+        backendsByRevision.get(revision.revisionKey) ?? [],
+        entriesByRevision.get(revision.revisionKey) ?? [],
+      ),
+    ];
+  });
+}
+
+function groupByRevisionKey<T extends { revisionKey: string }>(rows: T[]): Map<string, T[]> {
+  const grouped = new Map<string, T[]>();
+  for (const row of rows) {
+    const group = grouped.get(row.revisionKey);
+    if (group) group.push(row);
+    else grouped.set(row.revisionKey, [row]);
+  }
+  return grouped;
 }
 
 function getSqlite(

--- a/packages/core/src/storage/catalog-lifecycle.ts
+++ b/packages/core/src/storage/catalog-lifecycle.ts
@@ -1,0 +1,569 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import {
+  capletRiskIncreases,
+  indexInstalledCapletsFromLockfile,
+  installCaplets,
+  type InstallableCaplet,
+} from "../install";
+import {
+  readCapletsLockfile,
+  type CapletsLockEntry,
+  type CapletsLockRiskSummary,
+} from "../lockfile";
+import { CapletsError } from "../errors";
+import type { HostStorage } from "./database";
+import type { CapletBundleInputFile, CapletRecordView } from "./caplet-records";
+import type { CapletInstallationView, OperatorPrincipal } from "./installations";
+
+export type SqlCatalogInstallInput = {
+  storage: HostStorage;
+  operator: OperatorPrincipal;
+  source: string;
+  capletIds?: string[] | undefined;
+  force?: boolean | undefined;
+  disableCatalogIndexing?: boolean | undefined;
+};
+
+export type SqlCatalogUpdateInput = {
+  storage: HostStorage;
+  operator: OperatorPrincipal;
+  capletIds?: string[] | undefined;
+  force?: boolean | undefined;
+  allowRiskIncrease?: boolean | undefined;
+  disableCatalogIndexing?: boolean | undefined;
+};
+
+export async function installSqlCatalogCaplets(
+  input: SqlCatalogInstallInput,
+): Promise<{ installed: InstallableCaplet[] }> {
+  return await withStagedCatalog(
+    input.source,
+    input.capletIds,
+    input.disableCatalogIndexing,
+    async (stage) => {
+      const existing = await Promise.all(
+        stage.entries.map(async (entry) => await input.storage.caplets.get(entry.id)),
+      );
+      const existingCount = existing.filter((record) => record !== undefined).length;
+      if (existingCount > 0 && !input.force) {
+        const ids = stage.entries
+          .filter((_entry, index) => existing[index] !== undefined)
+          .map((entry) => entry.id);
+        throw new CapletsError(
+          "CONFIG_EXISTS",
+          `Caplet Record ${ids.join(", ")} already exists; use caplets update --global for tracked installations.`,
+        );
+      }
+      if (existingCount > 0 && existingCount !== stage.entries.length) {
+        throw new CapletsError(
+          "REQUEST_INVALID",
+          "A forced SQL catalog install cannot mix new and existing Caplet Records.",
+        );
+      }
+
+      let records: CapletRecordView[];
+      let statuses: InstallableCaplet["status"][];
+      if (existingCount === 0) {
+        records = await input.storage.caplets.importBundles(
+          stage.entries.map((entry) => {
+            const provenance = catalogProvenance(entry, input.source);
+            return {
+              id: entry.id,
+              files: readCapletBundleFiles(stage.installedById.get(entry.id)!.destination).files,
+              operator: input.operator,
+              sourceRevision: provenance.sourceRevision,
+              sourceContentHash: entry.installedHash,
+              installation: {
+                sourceKind: provenance.sourceKind,
+                sourceIdentity: provenance.sourceIdentity,
+                ...(provenance.channel ? { channel: provenance.channel } : {}),
+                risk: entry.risk,
+              },
+            };
+          }),
+        );
+        statuses = records.map(() => "installed");
+      } else {
+        const updated = await applyStagedUpdates({
+          storage: input.storage,
+          operator: input.operator,
+          entries: stage.entries,
+          installedById: stage.installedById,
+          existing: existing.map((record) => {
+            if (!record)
+              throw new CapletsError("INTERNAL_ERROR", "Existing Caplet Record disappeared.");
+            return record;
+          }),
+          active: await activeInstallations(
+            input.storage,
+            stage.entries.map((entry) => entry.id),
+          ),
+          allowRiskIncrease: true,
+        });
+        records = updated.records;
+        statuses = updated.statuses;
+      }
+      const catalogIndexing = await catalogIndexingForStage(
+        stage.installed,
+        stage.disableCatalogIndexing,
+      );
+      return {
+        installed: stage.entries.map((entry, index) =>
+          installedView(
+            entry,
+            records[index]!,
+            statuses[index],
+            catalogIndexing.get(entry.id),
+            catalogProvenance(entry, input.source).sourceIdentity,
+          ),
+        ),
+      };
+    },
+  );
+}
+
+export async function updateSqlCatalogCaplets(
+  input: SqlCatalogUpdateInput,
+): Promise<{ installed: InstallableCaplet[] }> {
+  const records = await input.storage.caplets.list();
+  const explicitlySelected = Boolean(input.capletIds && input.capletIds.length > 0);
+  const selectedIds = [
+    ...new Set(explicitlySelected ? input.capletIds! : records.map((record) => record.id)),
+  ];
+  const active = await activeInstallations(input.storage, selectedIds, explicitlySelected);
+  if (active.length === 0) {
+    throw new CapletsError("CONFIG_NOT_FOUND", "No active SQL catalog installations were found.");
+  }
+  const activeIds = new Set(active.map((installation) => installation.capletId));
+  const updateIds = selectedIds.filter((id) => activeIds.has(id));
+  const sourceGroups = new Map<string, { source: string; ids: string[] }>();
+  for (const installation of active) {
+    const key = `${installation.sourceKind}\0${installation.sourceIdentity}`;
+    const group = sourceGroups.get(key);
+    if (group) group.ids.push(installation.capletId);
+    else
+      sourceGroups.set(key, { source: installation.sourceIdentity, ids: [installation.capletId] });
+  }
+
+  const stagingRoot = mkdtempSync(join(tmpdir(), "caplets-sql-catalog-update-"));
+  try {
+    const destinationRoot = join(stagingRoot, "caplets");
+    const lockfilePath = join(stagingRoot, "caplets-lock.json");
+    const stagedInstalled: InstallableCaplet[] = [];
+    for (const group of sourceGroups.values()) {
+      try {
+        stagedInstalled.push(
+          ...installCaplets(group.source, {
+            capletIds: group.ids,
+            destinationRoot,
+            lockfilePath,
+          }).installed,
+        );
+      } catch (error) {
+        if (error instanceof CapletsError && error.code === "CONFIG_NOT_FOUND") {
+          await markSourceUnavailable(input, active, group.ids);
+        }
+        throw error;
+      }
+    }
+    const lockfile = readCapletsLockfile(lockfilePath);
+    const entries = updateIds.map((id) => {
+      const entry = lockfile.entries.find((candidate) => candidate.id === id);
+      if (!entry)
+        throw new CapletsError("CONFIG_NOT_FOUND", `Updated source did not contain ${id}.`);
+      return entry;
+    });
+    const installedById = new Map(stagedInstalled.map((entry) => [entry.id, entry]));
+    const recordsById = new Map(records.map((record) => [record.id, record]));
+    const existing = entries.map((entry) => {
+      const record = recordsById.get(entry.id);
+      if (!record)
+        throw new CapletsError("CONFIG_NOT_FOUND", `Caplet Record ${entry.id} was not found.`);
+      return record;
+    });
+    const updated = await applyStagedUpdates({
+      storage: input.storage,
+      operator: input.operator,
+      entries,
+      installedById,
+      existing,
+      active,
+      allowRiskIncrease: input.allowRiskIncrease ?? input.force ?? false,
+    });
+    const catalogIndexing = await catalogIndexingForStage(
+      stagedInstalled,
+      input.disableCatalogIndexing,
+    );
+    return {
+      installed: entries.map((entry, index) =>
+        installedView(
+          entry,
+          updated.records[index]!,
+          updated.statuses[index],
+          catalogIndexing.get(entry.id),
+          active.find((installation) => installation.capletId === entry.id)!.sourceIdentity,
+        ),
+      ),
+    };
+  } finally {
+    rmSync(stagingRoot, { recursive: true, force: true });
+  }
+}
+
+type StagedCatalog = {
+  entries: CapletsLockEntry[];
+  installed: InstallableCaplet[];
+  installedById: Map<string, InstallableCaplet>;
+  disableCatalogIndexing: boolean | undefined;
+};
+
+async function withStagedCatalog<T>(
+  source: string,
+  capletIds: string[] | undefined,
+  disableCatalogIndexing: boolean | undefined,
+  run: (stage: StagedCatalog) => Promise<T>,
+): Promise<T> {
+  const root = mkdtempSync(join(tmpdir(), "caplets-sql-catalog-install-"));
+  try {
+    const lockfilePath = join(root, "caplets-lock.json");
+    const staged = installCaplets(source, {
+      ...(capletIds ? { capletIds } : {}),
+      destinationRoot: join(root, "caplets"),
+      lockfilePath,
+    }).installed;
+    const lockfile = readCapletsLockfile(lockfilePath);
+    return await run({
+      entries: lockfile.entries,
+      installed: staged,
+      installedById: new Map(staged.map((entry) => [entry.id, entry])),
+      disableCatalogIndexing,
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function catalogIndexingForStage(
+  installed: InstallableCaplet[],
+  disabled: boolean | undefined,
+): Promise<Map<string, InstallableCaplet["catalogIndexing"]>> {
+  try {
+    return await indexInstalledCapletsFromLockfile(installed, {
+      disableCatalogIndexing: disabled ?? false,
+    });
+  } catch {
+    return new Map(
+      installed.map((entry) => [
+        entry.id,
+        { status: "unavailable" as const, reason: "indexer_unavailable" as const },
+      ]),
+    );
+  }
+}
+
+async function markSourceUnavailable(
+  input: SqlCatalogUpdateInput,
+  active: CapletInstallationView[],
+  capletIds: string[],
+): Promise<void> {
+  const selected = new Set(capletIds);
+  await Promise.all(
+    active
+      .filter((installation) => selected.has(installation.capletId))
+      .map(async (installation) => {
+        await input.storage.installations.appendObservation({
+          capletId: installation.capletId,
+          expectedGeneration: installation.generation,
+          status: "source-unavailable",
+          operator: input.operator,
+        });
+      }),
+  );
+}
+
+async function activeInstallations(
+  storage: HostStorage,
+  capletIds: string[],
+  requireAll = true,
+): Promise<CapletInstallationView[]> {
+  const active = await Promise.all(
+    capletIds.map(async (id) => ({ id, installation: await storage.installations.getActive(id) })),
+  );
+  const missing = active.filter(({ installation }) => !installation).map(({ id }) => id);
+  if (requireAll && missing.length > 0) {
+    throw new CapletsError(
+      "CONFIG_NOT_FOUND",
+      `Active SQL installation provenance was not found for ${missing.join(", ")}.`,
+    );
+  }
+  return active
+    .map(({ installation }) => installation)
+    .filter((installation): installation is CapletInstallationView => installation !== undefined);
+}
+
+async function applyStagedUpdates(input: {
+  storage: HostStorage;
+  operator: OperatorPrincipal;
+  entries: CapletsLockEntry[];
+  installedById: Map<string, InstallableCaplet>;
+  existing: CapletRecordView[];
+  active: CapletInstallationView[];
+  allowRiskIncrease: boolean;
+}): Promise<{ records: CapletRecordView[]; statuses: InstallableCaplet["status"][] }> {
+  const activeById = new Map(
+    input.active.map((installation) => [installation.capletId, installation]),
+  );
+  const prepared = await Promise.all(
+    input.entries.map(async (entry, index) => {
+      const record = input.existing[index]!;
+      const installation = activeById.get(entry.id);
+      if (!installation) {
+        throw new CapletsError(
+          "CONFIG_NOT_FOUND",
+          `Active SQL installation for ${entry.id} was not found.`,
+        );
+      }
+      const staged = input.installedById.get(entry.id);
+      if (!staged)
+        throw new CapletsError("INTERNAL_ERROR", `Staged Caplet ${entry.id} was not found.`);
+      const provenance = catalogProvenance(entry, installation.sourceIdentity);
+      if (
+        provenance.sourceKind !== installation.sourceKind ||
+        provenance.sourceIdentity !== installation.sourceIdentity
+      ) {
+        throw new CapletsError(
+          "REQUEST_INVALID",
+          `Caplet ${entry.id} source identity changed; detach and replace its installation explicitly.`,
+        );
+      }
+      const latestObservation = await input.storage.installations.getLatestObservation(entry.id);
+      const currentRisk = persistedRisk(latestObservation?.risk, entry.id);
+      if (!input.allowRiskIncrease && capletRiskIncreases(currentRisk, entry.risk)) {
+        throw new CapletsError(
+          "REQUEST_INVALID",
+          `Caplet ${entry.id} update changes its risk profile; pass --force to update it.`,
+        );
+      }
+      return {
+        entry,
+        record,
+        installation,
+        files: readCapletBundleFiles(staged.destination).files,
+        sourceRevision: provenance.sourceRevision,
+      };
+    }),
+  );
+
+  const records: CapletRecordView[] = [];
+  const statuses: InstallableCaplet["status"][] = [];
+  for (const candidate of prepared) {
+    const unchanged =
+      candidate.record.currentRevision.sourceContentHash === candidate.entry.installedHash;
+    records.push(
+      await input.storage.caplets.updateFromSource({
+        id: candidate.entry.id,
+        files: candidate.files,
+        expectedGeneration: candidate.record.headGeneration,
+        expectedInstallationGeneration: candidate.installation.generation,
+        sourceRevision: candidate.sourceRevision,
+        sourceContentHash: candidate.entry.installedHash,
+        observationStatus: "current",
+        risk: candidate.entry.risk,
+        operator: input.operator,
+      }),
+    );
+    statuses.push(unchanged ? "noop" : "updated");
+  }
+  return { records, statuses };
+}
+
+function catalogProvenance(
+  entry: CapletsLockEntry,
+  localSource: string,
+): {
+  sourceKind: "git" | "local";
+  sourceIdentity: string;
+  channel?: string;
+  sourceRevision: string;
+} {
+  if (entry.source.type === "git") {
+    return {
+      sourceKind: "git",
+      sourceIdentity: entry.source.repository,
+      ...(entry.source.trackedRef ? { channel: entry.source.trackedRef } : {}),
+      sourceRevision: entry.source.resolvedRevision ?? entry.installedHash,
+    };
+  }
+  return {
+    sourceKind: "local",
+    sourceIdentity: resolve(localSource),
+    sourceRevision: entry.source.gitRevision ?? entry.installedHash,
+  };
+}
+
+function installedView(
+  entry: CapletsLockEntry,
+  record: CapletRecordView,
+  status: InstallableCaplet["status"],
+  catalogIndexing: InstallableCaplet["catalogIndexing"],
+  sourceIdentity: string,
+): InstallableCaplet {
+  const source = sourceIdentity;
+  return {
+    id: entry.id,
+    source,
+    destination: `sql://caplet-records/${encodeURIComponent(record.id)}`,
+    kind: entry.kind,
+    hash: entry.installedHash,
+    status,
+    ...(catalogIndexing ? { catalogIndexing } : {}),
+  };
+}
+
+function persistedRisk(value: unknown, id: string): CapletsLockRiskSummary {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    !("backendFamilies" in value) ||
+    !Array.isArray(value.backendFamilies) ||
+    !value.backendFamilies.every((family) => typeof family === "string") ||
+    !("safety" in value) ||
+    (value.safety !== "standard" &&
+      value.safety !== "mutating_saas" &&
+      value.safety !== "local_control" &&
+      value.safety !== "unknown") ||
+    !("projectBindingRequired" in value) ||
+    typeof value.projectBindingRequired !== "boolean" ||
+    !("mutating" in value) ||
+    typeof value.mutating !== "boolean" ||
+    !("destructive" in value) ||
+    typeof value.destructive !== "boolean" ||
+    ("authScopes" in value &&
+      value.authScopes !== undefined &&
+      (!Array.isArray(value.authScopes) ||
+        !value.authScopes.every((scope) => typeof scope === "string"))) ||
+    ("runtimeFeatures" in value &&
+      value.runtimeFeatures !== undefined &&
+      (!Array.isArray(value.runtimeFeatures) ||
+        !value.runtimeFeatures.every((feature) => typeof feature === "string"))) ||
+    ("bodyHash" in value && value.bodyHash !== undefined && typeof value.bodyHash !== "string") ||
+    ("referenceHash" in value &&
+      value.referenceHash !== undefined &&
+      typeof value.referenceHash !== "string")
+  ) {
+    throw new CapletsError("CONFIG_INVALID", `Persisted risk provenance for ${id} is invalid.`);
+  }
+  return value as CapletsLockRiskSummary;
+}
+
+export function readCapletBundleFiles(bundlePath: string): {
+  id: string;
+  files: CapletBundleInputFile[];
+} {
+  const inputPath = resolve(bundlePath);
+  if (!existsSync(inputPath)) {
+    throw new CapletsError("CONFIG_NOT_FOUND", `Caplet bundle ${bundlePath} was not found.`);
+  }
+  const inputStats = lstatSync(inputPath);
+  if (inputStats.isFile()) {
+    const filename = basename(inputPath);
+    if (filename !== "CAPLET.md" && extname(filename) !== ".md") {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        `Caplet bundle file ${bundlePath} must be Markdown.`,
+      );
+    }
+    return {
+      id: filename === "CAPLET.md" ? basename(dirname(inputPath)) : basename(filename, ".md"),
+      files: [
+        {
+          path: "CAPLET.md",
+          content: readFileSync(inputPath),
+          executable: (inputStats.mode & 0o111) !== 0,
+        },
+      ],
+    };
+  }
+  if (!inputStats.isDirectory()) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Caplet bundle ${bundlePath} must be a directory or regular file.`,
+    );
+  }
+  const root = realpathSync(inputPath);
+  const files: CapletBundleInputFile[] = [];
+  collectBundleFiles(root, root, "", files, new Set<string>());
+  if (!files.some((file) => file.path === "CAPLET.md")) {
+    throw new CapletsError("CONFIG_INVALID", `Caplet bundle ${bundlePath} is missing CAPLET.md.`);
+  }
+  return { id: basename(root), files };
+}
+
+function collectBundleFiles(
+  root: string,
+  sourcePath: string,
+  bundlePath: string,
+  files: CapletBundleInputFile[],
+  ancestors: Set<string>,
+): void {
+  const sourceStats = lstatSync(sourcePath);
+  const resolvedPath = sourceStats.isSymbolicLink() ? realpathSync(sourcePath) : sourcePath;
+  const resolvedRelative = relative(root, resolvedPath);
+  if (
+    resolvedRelative === ".." ||
+    resolvedRelative.startsWith(`..${sep}`) ||
+    isAbsolute(resolvedRelative)
+  ) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Caplet bundle symbolic link ${bundlePath || "."} escapes the bundle root.`,
+    );
+  }
+  const stats = sourceStats.isSymbolicLink() ? statSync(resolvedPath) : sourceStats;
+  if (stats.isDirectory()) {
+    const canonicalPath = realpathSync(resolvedPath);
+    if (ancestors.has(canonicalPath)) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        `Caplet bundle symbolic link cycle at ${bundlePath || "."}.`,
+      );
+    }
+    const childAncestors = new Set(ancestors);
+    childAncestors.add(canonicalPath);
+    for (const entry of readdirSync(resolvedPath).sort((left, right) =>
+      left.localeCompare(right),
+    )) {
+      collectBundleFiles(
+        root,
+        join(resolvedPath, entry),
+        bundlePath ? `${bundlePath}/${entry}` : entry,
+        files,
+        childAncestors,
+      );
+    }
+    return;
+  }
+  if (!stats.isFile()) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Caplet bundle entry ${bundlePath || "."} is not a regular file.`,
+    );
+  }
+  files.push({
+    path: bundlePath,
+    content: readFileSync(resolvedPath),
+    executable: (stats.mode & 0o111) !== 0,
+  });
+}

--- a/packages/core/src/storage/coordination.ts
+++ b/packages/core/src/storage/coordination.ts
@@ -523,25 +523,37 @@ async function acquireLeasePostgres(
   input: AcquireLeaseInput,
 ): Promise<MaintenanceLease | undefined> {
   return await db.transaction(async (transaction) => {
-    const now = input.now ?? new Date();
+    await transaction.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify([
+        "maintenance-lease",
+        input.leaseName,
+      ])}, 0))`,
+    );
     const [existing] = await transaction
       .select()
       .from(postgres.maintenanceLeases)
       .where(eq(postgres.maintenanceLeases.leaseName, input.leaseName))
       .for("update")
       .limit(1);
+    const clockResult = await transaction.execute<{ acquiredAt: string; expiresAt: string }>(
+      sql`select
+        to_char(clock_timestamp() at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as "acquiredAt",
+        to_char((clock_timestamp() + (${input.ttlMs} * interval '1 millisecond')) at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as "expiresAt"`,
+    );
+    const clock = clockResult.rows[0];
+    if (!clock) throw new CapletsError("INTERNAL_ERROR", "Lease clock query failed.");
     if (
       existing &&
       existing.ownerNodeId !== input.ownerNodeId &&
-      existing.expiresAt > now.toISOString()
+      existing.expiresAt > clock.acquiredAt
     )
       return undefined;
     const lease = {
       leaseName: input.leaseName,
       ownerNodeId: input.ownerNodeId,
       fencingToken: (existing?.fencingToken ?? 0) + 1,
-      expiresAt: new Date(now.getTime() + input.ttlMs).toISOString(),
-      updatedAt: now.toISOString(),
+      expiresAt: clock.expiresAt,
+      updatedAt: clock.acquiredAt,
     };
     await transaction
       .insert(postgres.maintenanceLeases)
@@ -600,14 +612,22 @@ async function checkpointPostgres(
       .where(eq(postgres.maintenanceLeases.leaseName, input.leaseName))
       .for("update")
       .limit(1);
-    assertLease(lease, input);
-    const now = (input.now ?? new Date()).toISOString();
+    const clockResult = await transaction.execute<{ authorityNow: string }>(
+      sql`select to_char(clock_timestamp() at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as "authorityNow"`,
+    );
+    const clock = clockResult.rows[0];
+    if (!clock) throw new CapletsError("INTERNAL_ERROR", "Lease clock query failed.");
+    assertLease(lease, { ...input, now: new Date(clock.authorityNow) });
     await transaction
       .insert(postgres.maintenanceCursors)
-      .values({ jobName: input.leaseName, cursor: input.cursor, updatedAt: now })
+      .values({
+        jobName: input.leaseName,
+        cursor: input.cursor,
+        updatedAt: clock.authorityNow,
+      })
       .onConflictDoUpdate({
         target: postgres.maintenanceCursors.jobName,
-        set: { cursor: input.cursor, updatedAt: now },
+        set: { cursor: input.cursor, updatedAt: clock.authorityNow },
       });
   });
 }

--- a/packages/core/src/storage/coordination.ts
+++ b/packages/core/src/storage/coordination.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, desc, eq, gt, ne, sql } from "drizzle-orm";
+import { and, count, desc, eq, gt, ne, sql } from "drizzle-orm";
 import { CapletsError } from "../errors";
 import * as postgres from "./schema/postgres";
 import * as sqlite from "./schema/sqlite";
@@ -109,17 +109,26 @@ export class HostCoordinationStore {
   }
 
   async activeNodeCount(maxHeartbeatAgeMs = 5_000): Promise<number> {
-    const rows =
-      this.database.dialect === "sqlite"
-        ? this.database.db
-            .select({ heartbeatAt: sqlite.hostNodes.heartbeatAt })
-            .from(sqlite.hostNodes)
-            .all()
-        : await this.database.db
-            .select({ heartbeatAt: postgres.hostNodes.heartbeatAt })
-            .from(postgres.hostNodes);
-    const cutoff = Date.now() - maxHeartbeatAgeMs;
-    return rows.filter((row) => Date.parse(row.heartbeatAt) >= cutoff).length;
+    if (this.database.dialect === "sqlite") {
+      const row = this.database.db
+        .select({ count: count() })
+        .from(sqlite.hostNodes)
+        .where(
+          gt(sqlite.hostNodes.heartbeatAt, new Date(Date.now() - maxHeartbeatAgeMs).toISOString()),
+        )
+        .get();
+      return row?.count ?? 0;
+    }
+    const [row] = await this.database.db
+      .select({ count: count() })
+      .from(postgres.hostNodes)
+      .where(
+        sql`${postgres.hostNodes.heartbeatAt} >= to_char(
+          clock_timestamp() - (${maxHeartbeatAgeMs} * interval '1 millisecond'),
+          'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+        )`,
+      );
+    return row?.count ?? 0;
   }
 
   async publishConfigGeneration(contentHash: string, createdBy: string): Promise<number> {
@@ -427,9 +436,11 @@ async function registerPostgres(
   input: RegisterNodeInput,
 ): Promise<HostNodeRegistration> {
   return await db.transaction(async (transaction) => {
-    const now = input.now ?? new Date();
-    const nowText = now.toISOString();
-    const cutoff = new Date(now.getTime() - (input.heartbeatTtlMs ?? 15_000)).toISOString();
+    const clockResult = await transaction.execute<{ now: string }>(
+      sql`select to_char(clock_timestamp() at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as "now"`,
+    );
+    const nowText = clockResult.rows[0]?.now;
+    if (!nowText) throw new CapletsError("INTERNAL_ERROR", "Host-node clock query failed.");
     await transaction
       .insert(postgres.hostIdentity)
       .values({ singleton: 1, hostId: randomUUID(), createdAt: nowText })
@@ -446,7 +457,10 @@ async function registerPostgres(
       .where(
         and(
           ne(postgres.hostNodes.nodeId, input.nodeId),
-          gt(postgres.hostNodes.heartbeatAt, cutoff),
+          sql`${postgres.hostNodes.heartbeatAt} >= to_char(
+            clock_timestamp() - (${input.heartbeatTtlMs ?? 15_000} * interval '1 millisecond'),
+            'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+          )`,
         ),
       )
       .for("update");
@@ -489,33 +503,36 @@ function acquireLeaseSqlite(
   db: SqliteHostDatabase,
   input: AcquireLeaseInput,
 ): MaintenanceLease | undefined {
-  return db.transaction((transaction) => {
-    const now = input.now ?? new Date();
-    const existing = transaction
-      .select()
-      .from(sqlite.maintenanceLeases)
-      .where(eq(sqlite.maintenanceLeases.leaseName, input.leaseName))
-      .get();
-    if (
-      existing &&
-      existing.ownerNodeId !== input.ownerNodeId &&
-      existing.expiresAt > now.toISOString()
-    )
-      return undefined;
-    const lease = {
-      leaseName: input.leaseName,
-      ownerNodeId: input.ownerNodeId,
-      fencingToken: (existing?.fencingToken ?? 0) + 1,
-      expiresAt: new Date(now.getTime() + input.ttlMs).toISOString(),
-      updatedAt: now.toISOString(),
-    };
-    transaction
-      .insert(sqlite.maintenanceLeases)
-      .values(lease)
-      .onConflictDoUpdate({ target: sqlite.maintenanceLeases.leaseName, set: lease })
-      .run();
-    return lease;
-  });
+  return db.transaction(
+    (transaction) => {
+      const now = input.now ?? new Date();
+      const existing = transaction
+        .select()
+        .from(sqlite.maintenanceLeases)
+        .where(eq(sqlite.maintenanceLeases.leaseName, input.leaseName))
+        .get();
+      if (
+        existing &&
+        existing.ownerNodeId !== input.ownerNodeId &&
+        existing.expiresAt > now.toISOString()
+      )
+        return undefined;
+      const lease = {
+        leaseName: input.leaseName,
+        ownerNodeId: input.ownerNodeId,
+        fencingToken: (existing?.fencingToken ?? 0) + 1,
+        expiresAt: new Date(now.getTime() + input.ttlMs).toISOString(),
+        updatedAt: now.toISOString(),
+      };
+      transaction
+        .insert(sqlite.maintenanceLeases)
+        .values(lease)
+        .onConflictDoUpdate({ target: sqlite.maintenanceLeases.leaseName, set: lease })
+        .run();
+      return lease;
+    },
+    { behavior: "exclusive" },
+  );
 }
 
 async function acquireLeasePostgres(

--- a/packages/core/src/storage/coordination.ts
+++ b/packages/core/src/storage/coordination.ts
@@ -1,0 +1,637 @@
+import { randomUUID } from "node:crypto";
+import { and, desc, eq, gt, ne, sql } from "drizzle-orm";
+import { CapletsError } from "../errors";
+import * as postgres from "./schema/postgres";
+import * as sqlite from "./schema/sqlite";
+import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+
+export const CONFIG_GENERATION_CHANNEL = "caplets_config_generation";
+const CONFIG_GENERATION_POLL_INTERVAL_MS = 5_000;
+
+type PostgresNotification = {
+  channel: string;
+};
+
+type PostgresListenerClient = {
+  query(queryText: string): Promise<unknown>;
+  on(event: "notification", listener: (notification: PostgresNotification) => void): unknown;
+  removeListener(
+    event: "notification",
+    listener: (notification: PostgresNotification) => void,
+  ): unknown;
+  release(): void;
+};
+
+type PostgresListenerPool = {
+  connect(): Promise<PostgresListenerClient>;
+};
+
+export type WaitForConfigGenerationOptions = {
+  pollIntervalMs?: number | undefined;
+  signal?: AbortSignal | undefined;
+};
+
+export type HostNodeRegistration = {
+  hostId: string;
+  nodeId: string;
+  ready: boolean;
+  conflict: "global_file_manifest" | "runtime_fingerprint" | null;
+};
+
+export type MaintenanceLease = {
+  leaseName: string;
+  ownerNodeId: string;
+  fencingToken: number;
+  expiresAt: string;
+};
+
+type RegisterNodeInput = {
+  nodeId: string;
+  globalFileManifest: string;
+  runtimeFingerprint: string;
+  heartbeatTtlMs?: number | undefined;
+  now?: Date | undefined;
+};
+
+type AcquireLeaseInput = {
+  leaseName: string;
+  ownerNodeId: string;
+  ttlMs: number;
+  now?: Date | undefined;
+};
+
+export class HostCoordinationStore {
+  private readonly activeWaits = new Map<AbortController, Promise<number>>();
+  private closed = false;
+
+  constructor(
+    private readonly database: HostDatabase,
+    private readonly postgresListenerPool?: PostgresListenerPool | undefined,
+  ) {}
+
+  async registerNode(input: RegisterNodeInput): Promise<HostNodeRegistration> {
+    validateNodeInput(input);
+    return this.database.dialect === "sqlite"
+      ? registerSqlite(this.database.db, input)
+      : await registerPostgres(this.database.db, input);
+  }
+
+  async heartbeat(input: RegisterNodeInput): Promise<HostNodeRegistration> {
+    return await this.registerNode(input);
+  }
+
+  async unregisterNode(nodeId: string): Promise<void> {
+    if (this.database.dialect === "sqlite") {
+      this.database.db.delete(sqlite.hostNodes).where(eq(sqlite.hostNodes.nodeId, nodeId)).run();
+    } else {
+      await this.database.db
+        .delete(postgres.hostNodes)
+        .where(eq(postgres.hostNodes.nodeId, nodeId));
+    }
+  }
+
+  async nodeReady(nodeId: string): Promise<boolean> {
+    const row =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select({ ready: sqlite.hostNodes.ready })
+            .from(sqlite.hostNodes)
+            .where(eq(sqlite.hostNodes.nodeId, nodeId))
+            .get()
+        : (
+            await this.database.db
+              .select({ ready: postgres.hostNodes.ready })
+              .from(postgres.hostNodes)
+              .where(eq(postgres.hostNodes.nodeId, nodeId))
+              .limit(1)
+          )[0];
+    return row?.ready === true;
+  }
+
+  async activeNodeCount(maxHeartbeatAgeMs = 5_000): Promise<number> {
+    const rows =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select({ heartbeatAt: sqlite.hostNodes.heartbeatAt })
+            .from(sqlite.hostNodes)
+            .all()
+        : await this.database.db
+            .select({ heartbeatAt: postgres.hostNodes.heartbeatAt })
+            .from(postgres.hostNodes);
+    const cutoff = Date.now() - maxHeartbeatAgeMs;
+    return rows.filter((row) => Date.parse(row.heartbeatAt) >= cutoff).length;
+  }
+
+  async publishConfigGeneration(contentHash: string, createdBy: string): Promise<number> {
+    return this.database.dialect === "sqlite"
+      ? this.database.db.transaction((transaction) =>
+          advanceSqliteConfigGeneration(transaction, contentHash, createdBy, true),
+        )
+      : await this.database.db.transaction(
+          async (transaction) =>
+            await advancePostgresConfigGeneration(transaction, contentHash, createdBy, true),
+        );
+  }
+
+  async currentConfigGeneration(): Promise<number> {
+    const row =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select({ generation: sqlite.hostConfigGenerations.generation })
+            .from(sqlite.hostConfigGenerations)
+            .orderBy(desc(sqlite.hostConfigGenerations.generation))
+            .get()
+        : (
+            await this.database.db
+              .select({ generation: postgres.hostConfigGenerations.generation })
+              .from(postgres.hostConfigGenerations)
+              .orderBy(desc(postgres.hostConfigGenerations.generation))
+              .limit(1)
+          )[0];
+    return row?.generation ?? 0;
+  }
+
+  async waitForConfigGeneration(
+    afterGeneration: number,
+    options: WaitForConfigGenerationOptions = {},
+  ): Promise<number> {
+    if (this.closed) throw configGenerationWaitAborted();
+    const controller = new AbortController();
+    const forwardAbort = () => controller.abort();
+    options.signal?.addEventListener("abort", forwardAbort, { once: true });
+    if (options.signal?.aborted) controller.abort();
+    const pollIntervalMs = options.pollIntervalMs ?? CONFIG_GENERATION_POLL_INTERVAL_MS;
+    if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+      options.signal?.removeEventListener("abort", forwardAbort);
+      throw new CapletsError(
+        "REQUEST_INVALID",
+        "Config generation poll interval must be positive.",
+      );
+    }
+    const wait =
+      this.database.dialect === "sqlite"
+        ? this.waitForSqliteConfigGeneration(afterGeneration, pollIntervalMs, controller.signal)
+        : this.waitForPostgresConfigGeneration(afterGeneration, pollIntervalMs, controller.signal);
+    this.activeWaits.set(controller, wait);
+    try {
+      return await wait;
+    } finally {
+      this.activeWaits.delete(controller);
+      options.signal?.removeEventListener("abort", forwardAbort);
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    const waits = [...this.activeWaits.entries()];
+    for (const [controller] of waits) controller.abort();
+    await Promise.allSettled(waits.map(([, wait]) => wait));
+  }
+
+  private async waitForSqliteConfigGeneration(
+    afterGeneration: number,
+    pollIntervalMs: number,
+    signal: AbortSignal,
+  ): Promise<number> {
+    const latest = await this.currentConfigGeneration();
+    if (latest > afterGeneration) return latest;
+    await waitForNotificationOrPoll(undefined, pollIntervalMs, signal);
+    return await this.currentConfigGeneration();
+  }
+
+  private async waitForPostgresConfigGeneration(
+    afterGeneration: number,
+    pollIntervalMs: number,
+    signal: AbortSignal,
+  ): Promise<number> {
+    if (!this.postgresListenerPool) {
+      throw new CapletsError(
+        "INTERNAL_ERROR",
+        "PostgreSQL config generation listener is unavailable.",
+      );
+    }
+    const client = await connectPostgresListener(this.postgresListenerPool, signal);
+    let listening = false;
+    let notify: (() => void) | undefined;
+    const notified = new Promise<void>((resolve) => {
+      notify = resolve;
+    });
+    const onNotification = (notification: PostgresNotification) => {
+      if (notification.channel === CONFIG_GENERATION_CHANNEL) notify?.();
+    };
+    client.on("notification", onNotification);
+    try {
+      await client.query(`LISTEN ${CONFIG_GENERATION_CHANNEL}`);
+      listening = true;
+      const latest = await this.currentConfigGeneration();
+      if (latest > afterGeneration) return latest;
+      await waitForNotificationOrPoll(notified, pollIntervalMs, signal);
+      return await this.currentConfigGeneration();
+    } finally {
+      client.removeListener("notification", onNotification);
+      if (listening) {
+        await client.query(`UNLISTEN ${CONFIG_GENERATION_CHANNEL}`).catch(() => undefined);
+      }
+      client.release();
+    }
+  }
+
+  async acquireLease(input: AcquireLeaseInput): Promise<MaintenanceLease | undefined> {
+    if (!Number.isFinite(input.ttlMs) || input.ttlMs <= 0)
+      throw new CapletsError("REQUEST_INVALID", "Lease TTL must be positive.");
+    return this.database.dialect === "sqlite"
+      ? acquireLeaseSqlite(this.database.db, input)
+      : await acquireLeasePostgres(this.database.db, input);
+  }
+
+  async checkpointLease(input: {
+    leaseName: string;
+    ownerNodeId: string;
+    fencingToken: number;
+    cursor: string | null;
+    now?: Date | undefined;
+  }): Promise<void> {
+    if (this.database.dialect === "sqlite") checkpointSqlite(this.database.db, input);
+    else await checkpointPostgres(this.database.db, input);
+  }
+}
+
+async function connectPostgresListener(
+  pool: PostgresListenerPool,
+  signal: AbortSignal,
+): Promise<PostgresListenerClient> {
+  const connection = pool.connect();
+  if (signal.aborted) {
+    void connection.then(
+      (client) => client.release(),
+      () => undefined,
+    );
+    throw configGenerationWaitAborted();
+  }
+  let abort: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    abort = () => reject(configGenerationWaitAborted());
+    signal.addEventListener("abort", abort, { once: true });
+  });
+  try {
+    return await Promise.race([connection, aborted]);
+  } catch (error) {
+    if (signal.aborted) {
+      void connection.then(
+        (client) => client.release(),
+        () => undefined,
+      );
+    }
+    throw error;
+  } finally {
+    if (abort) signal.removeEventListener("abort", abort);
+  }
+}
+
+export function advanceSqliteConfigGeneration(
+  transaction: Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0],
+  contentHash: string,
+  createdBy: string,
+  deduplicate = false,
+): number {
+  const latest = transaction
+    .select({
+      generation: sqlite.hostConfigGenerations.generation,
+      contentHash: sqlite.hostConfigGenerations.contentHash,
+    })
+    .from(sqlite.hostConfigGenerations)
+    .orderBy(desc(sqlite.hostConfigGenerations.generation))
+    .get();
+  if (deduplicate && latest?.contentHash === contentHash) return latest.generation;
+  const generation = (latest?.generation ?? 0) + 1;
+  transaction
+    .insert(sqlite.hostConfigGenerations)
+    .values({
+      generation,
+      contentHash,
+      createdAt: new Date().toISOString(),
+      createdBy,
+    })
+    .run();
+  return generation;
+}
+
+export async function advancePostgresConfigGeneration(
+  transaction: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  contentHash: string,
+  createdBy: string,
+  deduplicate = false,
+): Promise<number> {
+  await transaction.execute(sql`select pg_advisory_xact_lock(1128352845)`);
+  const [latest] = await transaction
+    .select({
+      generation: postgres.hostConfigGenerations.generation,
+      contentHash: postgres.hostConfigGenerations.contentHash,
+    })
+    .from(postgres.hostConfigGenerations)
+    .orderBy(desc(postgres.hostConfigGenerations.generation))
+    .limit(1);
+  if (deduplicate && latest?.contentHash === contentHash) return latest.generation;
+  const generation = (latest?.generation ?? 0) + 1;
+  await transaction.insert(postgres.hostConfigGenerations).values({
+    generation,
+    contentHash,
+    createdAt: new Date().toISOString(),
+    createdBy,
+  });
+  await transaction.execute(
+    sql`select pg_notify(${CONFIG_GENERATION_CHANNEL}, ${String(generation)})`,
+  );
+  return generation;
+}
+
+function waitForNotificationOrPoll(
+  notification: Promise<void> | undefined,
+  pollIntervalMs: number,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) return Promise.reject(configGenerationWaitAborted());
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      if (error) reject(error);
+      else resolve();
+    };
+    const onAbort = () => finish(configGenerationWaitAborted());
+    const timer = setTimeout(() => finish(), pollIntervalMs);
+    timer.unref();
+    signal.addEventListener("abort", onAbort, { once: true });
+    void notification?.then(() => finish());
+  });
+}
+
+function configGenerationWaitAborted(): Error {
+  const error = new Error("Config generation wait was aborted.");
+  error.name = "AbortError";
+  return error;
+}
+
+function registerSqlite(db: SqliteHostDatabase, input: RegisterNodeInput): HostNodeRegistration {
+  return db.transaction((transaction) => {
+    const now = input.now ?? new Date();
+    const nowText = now.toISOString();
+    const cutoff = new Date(now.getTime() - (input.heartbeatTtlMs ?? 15_000)).toISOString();
+    let identity = transaction
+      .select()
+      .from(sqlite.hostIdentity)
+      .where(eq(sqlite.hostIdentity.singleton, 1))
+      .get();
+    if (!identity) {
+      identity = { singleton: 1, hostId: randomUUID(), createdAt: nowText };
+      transaction.insert(sqlite.hostIdentity).values(identity).run();
+    }
+    const peers = transaction
+      .select()
+      .from(sqlite.hostNodes)
+      .where(
+        and(ne(sqlite.hostNodes.nodeId, input.nodeId), gt(sqlite.hostNodes.heartbeatAt, cutoff)),
+      )
+      .all();
+    const conflict = parityConflict(peers, input);
+    transaction
+      .insert(sqlite.hostNodes)
+      .values({
+        nodeId: input.nodeId,
+        startedAt: nowText,
+        heartbeatAt: nowText,
+        globalFileManifest: input.globalFileManifest,
+        runtimeFingerprint: input.runtimeFingerprint,
+        ready: conflict === null,
+      })
+      .onConflictDoUpdate({
+        target: sqlite.hostNodes.nodeId,
+        set: {
+          heartbeatAt: nowText,
+          globalFileManifest: input.globalFileManifest,
+          runtimeFingerprint: input.runtimeFingerprint,
+          ready: conflict === null,
+        },
+      })
+      .run();
+    return { hostId: identity.hostId, nodeId: input.nodeId, ready: conflict === null, conflict };
+  });
+}
+
+async function registerPostgres(
+  db: PostgresHostDatabase,
+  input: RegisterNodeInput,
+): Promise<HostNodeRegistration> {
+  return await db.transaction(async (transaction) => {
+    const now = input.now ?? new Date();
+    const nowText = now.toISOString();
+    const cutoff = new Date(now.getTime() - (input.heartbeatTtlMs ?? 15_000)).toISOString();
+    await transaction
+      .insert(postgres.hostIdentity)
+      .values({ singleton: 1, hostId: randomUUID(), createdAt: nowText })
+      .onConflictDoNothing();
+    const [identity] = await transaction
+      .select()
+      .from(postgres.hostIdentity)
+      .where(eq(postgres.hostIdentity.singleton, 1))
+      .limit(1);
+    if (!identity) throw new CapletsError("INTERNAL_ERROR", "Host identity registration failed.");
+    const peers = await transaction
+      .select()
+      .from(postgres.hostNodes)
+      .where(
+        and(
+          ne(postgres.hostNodes.nodeId, input.nodeId),
+          gt(postgres.hostNodes.heartbeatAt, cutoff),
+        ),
+      )
+      .for("update");
+    const conflict = parityConflict(peers, input);
+    await transaction
+      .insert(postgres.hostNodes)
+      .values({
+        nodeId: input.nodeId,
+        startedAt: nowText,
+        heartbeatAt: nowText,
+        globalFileManifest: input.globalFileManifest,
+        runtimeFingerprint: input.runtimeFingerprint,
+        ready: conflict === null,
+      })
+      .onConflictDoUpdate({
+        target: postgres.hostNodes.nodeId,
+        set: {
+          heartbeatAt: nowText,
+          globalFileManifest: input.globalFileManifest,
+          runtimeFingerprint: input.runtimeFingerprint,
+          ready: conflict === null,
+        },
+      });
+    return { hostId: identity.hostId, nodeId: input.nodeId, ready: conflict === null, conflict };
+  });
+}
+
+function parityConflict(
+  peers: Array<{ globalFileManifest: string; runtimeFingerprint: string }>,
+  input: RegisterNodeInput,
+): HostNodeRegistration["conflict"] {
+  if (peers.some((peer) => peer.globalFileManifest !== input.globalFileManifest))
+    return "global_file_manifest";
+  if (peers.some((peer) => peer.runtimeFingerprint !== input.runtimeFingerprint))
+    return "runtime_fingerprint";
+  return null;
+}
+
+function acquireLeaseSqlite(
+  db: SqliteHostDatabase,
+  input: AcquireLeaseInput,
+): MaintenanceLease | undefined {
+  return db.transaction((transaction) => {
+    const now = input.now ?? new Date();
+    const existing = transaction
+      .select()
+      .from(sqlite.maintenanceLeases)
+      .where(eq(sqlite.maintenanceLeases.leaseName, input.leaseName))
+      .get();
+    if (
+      existing &&
+      existing.ownerNodeId !== input.ownerNodeId &&
+      existing.expiresAt > now.toISOString()
+    )
+      return undefined;
+    const lease = {
+      leaseName: input.leaseName,
+      ownerNodeId: input.ownerNodeId,
+      fencingToken: (existing?.fencingToken ?? 0) + 1,
+      expiresAt: new Date(now.getTime() + input.ttlMs).toISOString(),
+      updatedAt: now.toISOString(),
+    };
+    transaction
+      .insert(sqlite.maintenanceLeases)
+      .values(lease)
+      .onConflictDoUpdate({ target: sqlite.maintenanceLeases.leaseName, set: lease })
+      .run();
+    return lease;
+  });
+}
+
+async function acquireLeasePostgres(
+  db: PostgresHostDatabase,
+  input: AcquireLeaseInput,
+): Promise<MaintenanceLease | undefined> {
+  return await db.transaction(async (transaction) => {
+    const now = input.now ?? new Date();
+    const [existing] = await transaction
+      .select()
+      .from(postgres.maintenanceLeases)
+      .where(eq(postgres.maintenanceLeases.leaseName, input.leaseName))
+      .for("update")
+      .limit(1);
+    if (
+      existing &&
+      existing.ownerNodeId !== input.ownerNodeId &&
+      existing.expiresAt > now.toISOString()
+    )
+      return undefined;
+    const lease = {
+      leaseName: input.leaseName,
+      ownerNodeId: input.ownerNodeId,
+      fencingToken: (existing?.fencingToken ?? 0) + 1,
+      expiresAt: new Date(now.getTime() + input.ttlMs).toISOString(),
+      updatedAt: now.toISOString(),
+    };
+    await transaction
+      .insert(postgres.maintenanceLeases)
+      .values(lease)
+      .onConflictDoUpdate({ target: postgres.maintenanceLeases.leaseName, set: lease });
+    return lease;
+  });
+}
+
+function checkpointSqlite(
+  db: SqliteHostDatabase,
+  input: {
+    leaseName: string;
+    ownerNodeId: string;
+    fencingToken: number;
+    cursor: string | null;
+    now?: Date | undefined;
+  },
+): void {
+  db.transaction((transaction) => {
+    const lease = transaction
+      .select()
+      .from(sqlite.maintenanceLeases)
+      .where(eq(sqlite.maintenanceLeases.leaseName, input.leaseName))
+      .get();
+    assertLease(lease, input);
+    transaction
+      .insert(sqlite.maintenanceCursors)
+      .values({
+        jobName: input.leaseName,
+        cursor: input.cursor,
+        updatedAt: (input.now ?? new Date()).toISOString(),
+      })
+      .onConflictDoUpdate({
+        target: sqlite.maintenanceCursors.jobName,
+        set: { cursor: input.cursor, updatedAt: (input.now ?? new Date()).toISOString() },
+      })
+      .run();
+  });
+}
+
+async function checkpointPostgres(
+  db: PostgresHostDatabase,
+  input: {
+    leaseName: string;
+    ownerNodeId: string;
+    fencingToken: number;
+    cursor: string | null;
+    now?: Date | undefined;
+  },
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const [lease] = await transaction
+      .select()
+      .from(postgres.maintenanceLeases)
+      .where(eq(postgres.maintenanceLeases.leaseName, input.leaseName))
+      .for("update")
+      .limit(1);
+    assertLease(lease, input);
+    const now = (input.now ?? new Date()).toISOString();
+    await transaction
+      .insert(postgres.maintenanceCursors)
+      .values({ jobName: input.leaseName, cursor: input.cursor, updatedAt: now })
+      .onConflictDoUpdate({
+        target: postgres.maintenanceCursors.jobName,
+        set: { cursor: input.cursor, updatedAt: now },
+      });
+  });
+}
+
+function assertLease(
+  lease: MaintenanceLease | undefined,
+  input: { ownerNodeId: string; fencingToken: number; now?: Date | undefined },
+): void {
+  if (
+    !lease ||
+    lease.ownerNodeId !== input.ownerNodeId ||
+    lease.fencingToken !== input.fencingToken ||
+    lease.expiresAt <= (input.now ?? new Date()).toISOString()
+  ) {
+    throw new CapletsError("REQUEST_INVALID", "Maintenance lease is stale or no longer owned.", {
+      kind: "stale_lease",
+    });
+  }
+}
+
+function validateNodeInput(input: RegisterNodeInput): void {
+  if (!input.nodeId || !input.globalFileManifest || !input.runtimeFingerprint)
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "Node registration requires identity and parity fingerprints.",
+    );
+}

--- a/packages/core/src/storage/coordination.ts
+++ b/packages/core/src/storage/coordination.ts
@@ -449,6 +449,7 @@ async function registerPostgres(
       .select()
       .from(postgres.hostIdentity)
       .where(eq(postgres.hostIdentity.singleton, 1))
+      .for("update")
       .limit(1);
     if (!identity) throw new CapletsError("INTERNAL_ERROR", "Host identity registration failed.");
     const peers = await transaction
@@ -462,8 +463,7 @@ async function registerPostgres(
             'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
           )`,
         ),
-      )
-      .for("update");
+      );
     const conflict = parityConflict(peers, input);
     await transaction
       .insert(postgres.hostNodes)

--- a/packages/core/src/storage/dashboard-sessions.ts
+++ b/packages/core/src/storage/dashboard-sessions.ts
@@ -1,0 +1,333 @@
+import { randomUUID } from "node:crypto";
+import { eq, lt, lte, ne, or } from "drizzle-orm";
+import { DASHBOARD_SESSION_IDLE_TIMEOUT_MS, type DashboardSessionRecord } from "../dashboard/types";
+import { CapletsError } from "../errors";
+import * as postgres from "./schema/postgres";
+import * as sqlite from "./schema/sqlite";
+import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+
+type DeleteOptions = {
+  expectedSecretHash?: string | undefined;
+  operatorInitiated?: boolean | undefined;
+};
+
+export class DashboardSessionRepository {
+  constructor(private readonly database: HostDatabase) {}
+
+  async create(session: DashboardSessionRecord): Promise<boolean> {
+    const persisted = parseDashboardSessionRecord(session);
+    if (!persisted) {
+      throw new CapletsError("REQUEST_INVALID", "Dashboard session record is invalid.");
+    }
+    return this.database.dialect === "sqlite"
+      ? createSqlite(this.database.db, persisted)
+      : await createPostgres(this.database.db, persisted);
+  }
+
+  async get(sessionId: string): Promise<DashboardSessionRecord | undefined> {
+    const row =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select()
+            .from(sqlite.dashboardSessions)
+            .where(eq(sqlite.dashboardSessions.sessionId, sessionId))
+            .get()
+        : (
+            await this.database.db
+              .select()
+              .from(postgres.dashboardSessions)
+              .where(eq(postgres.dashboardSessions.sessionId, sessionId))
+              .limit(1)
+          )[0];
+    return parseDashboardSessionRecord(row);
+  }
+
+  async touch(
+    sessionId: string,
+    expectedSecretHash: string,
+    now: Date,
+  ): Promise<DashboardSessionRecord | undefined> {
+    return this.database.dialect === "sqlite"
+      ? touchSqlite(this.database.db, sessionId, expectedSecretHash, now)
+      : await touchPostgres(this.database.db, sessionId, expectedSecretHash, now);
+  }
+
+  async delete(sessionId: string, options: DeleteOptions = {}): Promise<boolean> {
+    return this.database.dialect === "sqlite"
+      ? deleteSqlite(this.database.db, sessionId, options)
+      : await deletePostgres(this.database.db, sessionId, options);
+  }
+
+  async cleanupExpired(now: Date): Promise<number> {
+    const nowText = now.toISOString();
+    const idleCutoff = new Date(now.getTime() - DASHBOARD_SESSION_IDLE_TIMEOUT_MS).toISOString();
+    return this.database.dialect === "sqlite"
+      ? this.database.db
+          .delete(sqlite.dashboardSessions)
+          .where(
+            or(
+              lte(sqlite.dashboardSessions.expiresAt, nowText),
+              lt(sqlite.dashboardSessions.lastUsedAt, idleCutoff),
+              ne(sqlite.dashboardSessions.role, "operator"),
+            ),
+          )
+          .run().changes
+      : (
+          await this.database.db
+            .delete(postgres.dashboardSessions)
+            .where(
+              or(
+                lte(postgres.dashboardSessions.expiresAt, nowText),
+                lt(postgres.dashboardSessions.lastUsedAt, idleCutoff),
+                ne(postgres.dashboardSessions.role, "operator"),
+              ),
+            )
+            .returning({ sessionId: postgres.dashboardSessions.sessionId })
+        ).length;
+  }
+}
+
+function createSqlite(db: SqliteHostDatabase, session: DashboardSessionRecord): boolean {
+  return db.transaction((transaction) => {
+    const created =
+      transaction.insert(sqlite.dashboardSessions).values(session).onConflictDoNothing().run()
+        .changes > 0;
+    if (created) {
+      transaction
+        .insert(sqlite.operatorActivity)
+        .values(
+          activityValues(session.operatorClientId, "dashboard.session.create", session.sessionId),
+        )
+        .run();
+    }
+    return created;
+  });
+}
+
+async function createPostgres(
+  db: PostgresHostDatabase,
+  session: DashboardSessionRecord,
+): Promise<boolean> {
+  return await db.transaction(async (transaction) => {
+    const created = await transaction
+      .insert(postgres.dashboardSessions)
+      .values(session)
+      .onConflictDoNothing()
+      .returning({ sessionId: postgres.dashboardSessions.sessionId });
+    if (created.length > 0) {
+      await transaction
+        .insert(postgres.operatorActivity)
+        .values(
+          activityValues(session.operatorClientId, "dashboard.session.create", session.sessionId),
+        );
+    }
+    return created.length > 0;
+  });
+}
+
+function touchSqlite(
+  db: SqliteHostDatabase,
+  sessionId: string,
+  expectedSecretHash: string,
+  now: Date,
+): DashboardSessionRecord | undefined {
+  return db.transaction((transaction) => {
+    const row = transaction
+      .select()
+      .from(sqlite.dashboardSessions)
+      .where(eq(sqlite.dashboardSessions.sessionId, sessionId))
+      .get();
+    const session = parseDashboardSessionRecord(row);
+    if (!session) {
+      if (row) {
+        transaction
+          .delete(sqlite.dashboardSessions)
+          .where(eq(sqlite.dashboardSessions.sessionId, sessionId))
+          .run();
+      }
+      return undefined;
+    }
+    if (session.secretHash !== expectedSecretHash) return undefined;
+    if (sessionExpired(session, now)) {
+      transaction
+        .delete(sqlite.dashboardSessions)
+        .where(eq(sqlite.dashboardSessions.sessionId, sessionId))
+        .run();
+      return undefined;
+    }
+    const lastUsedAt = now.toISOString();
+    transaction
+      .update(sqlite.dashboardSessions)
+      .set({ lastUsedAt })
+      .where(eq(sqlite.dashboardSessions.sessionId, sessionId))
+      .run();
+    return { ...session, lastUsedAt };
+  });
+}
+
+async function touchPostgres(
+  db: PostgresHostDatabase,
+  sessionId: string,
+  expectedSecretHash: string,
+  now: Date,
+): Promise<DashboardSessionRecord | undefined> {
+  return await db.transaction(async (transaction) => {
+    const [row] = await transaction
+      .select()
+      .from(postgres.dashboardSessions)
+      .where(eq(postgres.dashboardSessions.sessionId, sessionId))
+      .for("update")
+      .limit(1);
+    const session = parseDashboardSessionRecord(row);
+    if (!session) {
+      if (row) {
+        await transaction
+          .delete(postgres.dashboardSessions)
+          .where(eq(postgres.dashboardSessions.sessionId, sessionId));
+      }
+      return undefined;
+    }
+    if (session.secretHash !== expectedSecretHash) return undefined;
+    if (sessionExpired(session, now)) {
+      await transaction
+        .delete(postgres.dashboardSessions)
+        .where(eq(postgres.dashboardSessions.sessionId, sessionId));
+      return undefined;
+    }
+    const lastUsedAt = now.toISOString();
+    await transaction
+      .update(postgres.dashboardSessions)
+      .set({ lastUsedAt })
+      .where(eq(postgres.dashboardSessions.sessionId, sessionId));
+    return { ...session, lastUsedAt };
+  });
+}
+
+function deleteSqlite(db: SqliteHostDatabase, sessionId: string, options: DeleteOptions): boolean {
+  return db.transaction((transaction) => {
+    const row = transaction
+      .select()
+      .from(sqlite.dashboardSessions)
+      .where(eq(sqlite.dashboardSessions.sessionId, sessionId))
+      .get();
+    if (!row) return false;
+    const session = parseDashboardSessionRecord(row);
+    if (
+      options.expectedSecretHash !== undefined &&
+      session?.secretHash !== options.expectedSecretHash
+    ) {
+      return false;
+    }
+    transaction
+      .delete(sqlite.dashboardSessions)
+      .where(eq(sqlite.dashboardSessions.sessionId, sessionId))
+      .run();
+    if (options.operatorInitiated && session) {
+      transaction
+        .insert(sqlite.operatorActivity)
+        .values(activityValues(session.operatorClientId, "dashboard.session.delete", sessionId))
+        .run();
+    }
+    return true;
+  });
+}
+
+async function deletePostgres(
+  db: PostgresHostDatabase,
+  sessionId: string,
+  options: DeleteOptions,
+): Promise<boolean> {
+  return await db.transaction(async (transaction) => {
+    const [row] = await transaction
+      .select()
+      .from(postgres.dashboardSessions)
+      .where(eq(postgres.dashboardSessions.sessionId, sessionId))
+      .for("update")
+      .limit(1);
+    if (!row) return false;
+    const session = parseDashboardSessionRecord(row);
+    if (
+      options.expectedSecretHash !== undefined &&
+      session?.secretHash !== options.expectedSecretHash
+    ) {
+      return false;
+    }
+    await transaction
+      .delete(postgres.dashboardSessions)
+      .where(eq(postgres.dashboardSessions.sessionId, sessionId));
+    if (options.operatorInitiated && session) {
+      await transaction
+        .insert(postgres.operatorActivity)
+        .values(activityValues(session.operatorClientId, "dashboard.session.delete", sessionId));
+    }
+    return true;
+  });
+}
+
+function parseDashboardSessionRecord(value: unknown): DashboardSessionRecord | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.sessionId !== "string" ||
+    record.sessionId.length === 0 ||
+    typeof record.secretHash !== "string" ||
+    record.secretHash.length === 0 ||
+    typeof record.operatorClientId !== "string" ||
+    record.operatorClientId.length === 0 ||
+    record.role !== "operator" ||
+    typeof record.csrfToken !== "string" ||
+    record.csrfToken.length === 0 ||
+    !isCanonicalTimestamp(record.createdAt) ||
+    !isCanonicalTimestamp(record.expiresAt) ||
+    !isCanonicalTimestamp(record.lastUsedAt)
+  ) {
+    return undefined;
+  }
+  return {
+    sessionId: record.sessionId,
+    secretHash: record.secretHash,
+    operatorClientId: record.operatorClientId,
+    role: "operator",
+    csrfToken: record.csrfToken,
+    createdAt: record.createdAt,
+    expiresAt: record.expiresAt,
+    lastUsedAt: record.lastUsedAt,
+  };
+}
+
+function sessionExpired(session: DashboardSessionRecord, now: Date): boolean {
+  if (Date.parse(session.expiresAt) <= now.getTime()) return true;
+  return now.getTime() - Date.parse(session.lastUsedAt) > 60 * 60_000;
+}
+
+function isCanonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const milliseconds = Date.parse(value);
+  return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString() === value;
+}
+
+function activityValues(
+  operatorClientId: string,
+  action: string,
+  sessionId: string,
+): {
+  activityKey: string;
+  operatorClientId: string;
+  action: string;
+  targetKind: string;
+  targetKey: string;
+  outcome: string;
+  metadata: Record<string, never>;
+  createdAt: string;
+} {
+  return {
+    activityKey: randomUUID(),
+    operatorClientId,
+    action,
+    targetKind: "dashboard_session",
+    targetKey: sessionId,
+    outcome: "succeeded",
+    metadata: {},
+    createdAt: new Date().toISOString(),
+  };
+}

--- a/packages/core/src/storage/database.ts
+++ b/packages/core/src/storage/database.ts
@@ -1,0 +1,276 @@
+import { randomUUID } from "node:crypto";
+import { chmodSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import BetterSqlite3 from "better-sqlite3";
+import { drizzle as drizzleSqlite } from "drizzle-orm/better-sqlite3";
+import { drizzle as drizzlePostgres } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { defaultStateBaseDir } from "../config/paths";
+import { CapletsError } from "../errors";
+import { createAssetObjectStore, type AssetObjectStore } from "./asset-store";
+import { CapletRecordStore, type AssetGarbageCollectionResult } from "./caplet-records";
+import { CapletInstallationStore } from "./installations";
+import { HostCoordinationStore } from "./coordination";
+import { VaultGrantStore } from "./vault-grants";
+import { BackendAuthStateStore } from "./backend-auth";
+import { DashboardSessionRepository } from "./dashboard-sessions";
+import { ProjectBindingStore } from "./project-bindings";
+import { RemoteSecurityStore } from "./remote-security";
+import { SetupStateStore } from "./setup-state";
+import { OperatorActivityStore } from "./operator-activity";
+import { VaultValueStore } from "./vault-values";
+import { inspectHostDatabase, migrateHostDatabase } from "./migrations";
+import { postgresSchema } from "./schema/postgres";
+import { sqliteSchema } from "./schema/sqlite";
+import type {
+  HostDatabase,
+  HostStorageConfig,
+  HostStorageHealth,
+  PostgresHostStorageConfig,
+  SqliteHostStorageConfig,
+} from "./types";
+
+const POSTGRES_SCHEMA_PATTERN = /^[a-z_][a-z0-9_]{0,62}$/u;
+
+export type HostStorageOptions = {
+  vaultRoot?: string | undefined;
+};
+
+export class HostStorage {
+  readonly backend: HostStorageConfig["type"];
+  readonly caplets: CapletRecordStore;
+  readonly installations: CapletInstallationStore;
+  readonly coordination: HostCoordinationStore;
+  readonly vaultGrants: VaultGrantStore;
+  readonly backendAuth: BackendAuthStateStore;
+  readonly dashboardSessions: DashboardSessionRepository;
+  readonly projectBindings: ProjectBindingStore;
+  readonly remoteSecurity: RemoteSecurityStore;
+  readonly setupState: SetupStateStore;
+  readonly operatorActivity: OperatorActivityStore;
+  readonly vaultValues: VaultValueStore;
+  private readonly assetObjectStore: AssetObjectStore | undefined;
+  private closed = false;
+
+  constructor(
+    readonly database: HostDatabase,
+    private readonly closeDatabase: () => Promise<void>,
+    config: HostStorageConfig,
+    options: HostStorageOptions = {},
+    postgresListenerPool?: Pick<Pool, "connect"> | undefined,
+  ) {
+    this.backend = database.dialect;
+    this.assetObjectStore = createAssetObjectStore(config.assets);
+    this.caplets = new CapletRecordStore(database, {
+      objectStore: this.assetObjectStore,
+      limits: config.bundleLimits,
+    });
+    this.installations = new CapletInstallationStore(database);
+    this.vaultGrants = new VaultGrantStore(database);
+    this.coordination = new HostCoordinationStore(database, postgresListenerPool);
+    this.backendAuth = new BackendAuthStateStore(database);
+    this.dashboardSessions = new DashboardSessionRepository(database);
+    this.projectBindings = new ProjectBindingStore(database);
+    this.remoteSecurity = new RemoteSecurityStore(database);
+    this.setupState = new SetupStateStore(database);
+    this.operatorActivity = new OperatorActivityStore(database);
+    this.vaultValues = new VaultValueStore(
+      database,
+      options.vaultRoot === undefined ? {} : { root: options.vaultRoot },
+    );
+  }
+
+  async health(): Promise<HostStorageHealth> {
+    const assetBackend = this.assetObjectStore ? "s3" : "sql";
+    if (this.closed) {
+      return {
+        backend: this.backend,
+        ready: false,
+        reason: "database_unavailable",
+        assets: { backend: assetBackend, ready: false },
+      };
+    }
+    const databaseHealth = await inspectHostDatabase(this.database);
+    if (!databaseHealth.ready) {
+      return {
+        ...databaseHealth,
+        assets: { backend: assetBackend, ready: false },
+      };
+    }
+    const assetsReady = this.assetObjectStore ? await this.assetObjectStore.health() : true;
+    return {
+      ...databaseHealth,
+      ready: assetsReady,
+      ...(assetsReady ? {} : { reason: "object_store_unavailable" as const }),
+      assets: { backend: assetBackend, ready: assetsReady },
+    };
+  }
+
+  async maintainAssets(input: {
+    ownerNodeId: string;
+    graceMs: number;
+    leaseTtlMs?: number | undefined;
+    now?: Date | undefined;
+  }): Promise<(AssetGarbageCollectionResult & { fencingToken: number }) | undefined> {
+    const lease = await this.coordination.acquireLease({
+      leaseName: "caplet-asset-cleanup",
+      ownerNodeId: input.ownerNodeId,
+      ttlMs: input.leaseTtlMs ?? 30_000,
+      now: input.now,
+    });
+    if (!lease) return undefined;
+    const result = await this.caplets.collectAssetGarbage({
+      graceMs: input.graceMs,
+      now: input.now,
+    });
+    await this.coordination.checkpointLease({
+      leaseName: lease.leaseName,
+      ownerNodeId: lease.ownerNodeId,
+      fencingToken: lease.fencingToken,
+      cursor: JSON.stringify(result),
+      now: input.now,
+    });
+    return { ...result, fencingToken: lease.fencingToken };
+  }
+
+  async invalidateConfig(createdBy: string): Promise<number> {
+    return await this.coordination.publishConfigGeneration(`mutation:${randomUUID()}`, createdBy);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      await this.coordination.close();
+    } finally {
+      try {
+        await this.closeDatabase();
+      } finally {
+        this.assetObjectStore?.close();
+      }
+    }
+  }
+}
+
+export async function createHostStorage(
+  config: HostStorageConfig = { type: "sqlite" },
+  options: HostStorageOptions = {},
+): Promise<HostStorage> {
+  const storage = openHostStorage(config, options);
+  try {
+    if (config.type === "sqlite") {
+      await migrateHostDatabase(storage.database);
+    } else {
+      const health = await storage.health();
+      if (!health.ready) throw schemaHealthError(health);
+    }
+    return storage;
+  } catch (error) {
+    await storage.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function migrateHostStorage(config: HostStorageConfig): Promise<void> {
+  if (config.type === "postgres") {
+    const schema = validatedPostgresSchema(config);
+    const migrator = new Pool({ connectionString: config.connectionString });
+    try {
+      await migrator.query(`create schema if not exists "${schema}"`);
+    } finally {
+      await migrator.end();
+    }
+  }
+
+  const storage = openHostStorage(config);
+  try {
+    await migrateHostDatabase(storage.database);
+  } finally {
+    await storage.close();
+  }
+}
+
+export function defaultSqliteStoragePath(
+  env: NodeJS.ProcessEnv = process.env,
+  home?: string,
+  platform?: NodeJS.Platform,
+): string {
+  return join(defaultStateBaseDir(env, home, platform), "caplets.sqlite3");
+}
+
+function openHostStorage(config: HostStorageConfig, options: HostStorageOptions = {}): HostStorage {
+  if (config.type === "sqlite") return openSqliteStorage(config, options);
+  return openPostgresStorage(config, options);
+}
+
+function openSqliteStorage(
+  config: SqliteHostStorageConfig,
+  options: HostStorageOptions,
+): HostStorage {
+  const path = config.path ?? defaultSqliteStoragePath();
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const client = new BetterSqlite3(path);
+  client.pragma("busy_timeout = 5000");
+  client.pragma("foreign_keys = ON");
+  client.pragma("journal_mode = WAL");
+  client.pragma("synchronous = FULL");
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // Best effort on platforms without POSIX permissions.
+  }
+  const db = drizzleSqlite(client, { schema: sqliteSchema });
+  return new HostStorage(
+    { dialect: "sqlite", db },
+    async () => {
+      client.close();
+    },
+    config,
+    options,
+  );
+}
+
+function openPostgresStorage(
+  config: PostgresHostStorageConfig,
+  options: HostStorageOptions,
+): HostStorage {
+  const schema = validatedPostgresSchema(config);
+  const client = new Pool({
+    connectionString: config.connectionString,
+    options: `-c search_path=${schema}`,
+  });
+  const db = drizzlePostgres(client, { schema: postgresSchema });
+  return new HostStorage(
+    { dialect: "postgres", db, schema },
+    async () => await client.end(),
+    config,
+    options,
+    client,
+  );
+}
+
+function validatedPostgresSchema(config: PostgresHostStorageConfig): string {
+  const schema = config.schema ?? "caplets";
+  if (!POSTGRES_SCHEMA_PATTERN.test(schema)) {
+    throw new CapletsError("CONFIG_INVALID", `Invalid PostgreSQL schema name ${schema}.`);
+  }
+  if (!config.connectionString.trim()) {
+    throw new CapletsError("CONFIG_INVALID", "PostgreSQL storage requires a connection string.");
+  }
+  return schema;
+}
+
+function schemaHealthError(health: HostStorageHealth): CapletsError {
+  const detail =
+    health.schemaVersion === undefined ? "" : ` Current version: ${health.schemaVersion}.`;
+  if (health.reason === "database_unavailable") {
+    return new CapletsError(
+      "SERVER_UNAVAILABLE",
+      "Authoritative PostgreSQL storage is unavailable.",
+    );
+  }
+  return new CapletsError(
+    "CONFIG_INVALID",
+    `Authoritative PostgreSQL storage is not ready (${health.reason ?? "unknown"}).${detail}`,
+  );
+}

--- a/packages/core/src/storage/database.ts
+++ b/packages/core/src/storage/database.ts
@@ -97,12 +97,48 @@ export class HostStorage {
         assets: { backend: assetBackend, ready: false },
       };
     }
-    const assetsReady = this.assetObjectStore ? await this.assetObjectStore.health() : true;
+    if (!this.assetObjectStore) {
+      return {
+        ...databaseHealth,
+        ready: true,
+        assets: { backend: "sql", ready: true },
+      };
+    }
+    if (!(await this.assetObjectStore.health())) {
+      return {
+        ...databaseHealth,
+        ready: false,
+        reason: "object_store_unavailable",
+        assets: { backend: "s3", ready: false },
+      };
+    }
+    let currentAssets;
+    try {
+      currentAssets = await this.caplets.currentAssetHealth();
+    } catch {
+      return {
+        ...databaseHealth,
+        ready: false,
+        reason: "database_unavailable",
+        assets: { backend: "s3", ready: false },
+      };
+    }
+    if (!currentAssets.ready) {
+      return {
+        ...databaseHealth,
+        ready: false,
+        reason: "current_record_assets_unavailable",
+        assets: {
+          backend: "s3",
+          ready: false,
+          affectedRecordIds: currentAssets.affectedRecordIds,
+        },
+      };
+    }
     return {
       ...databaseHealth,
-      ready: assetsReady,
-      ...(assetsReady ? {} : { reason: "object_store_unavailable" as const }),
-      assets: { backend: assetBackend, ready: assetsReady },
+      ready: true,
+      assets: { backend: "s3", ready: true },
     };
   }
 

--- a/packages/core/src/storage/drizzle/postgres/0000_ancient_firedrake.sql
+++ b/packages/core/src/storage/drizzle/postgres/0000_ancient_firedrake.sql
@@ -1,0 +1,74 @@
+CREATE TABLE "caplet_asset_blobs" (
+	"hash" text PRIMARY KEY NOT NULL,
+	"size" integer NOT NULL,
+	"payload" "bytea",
+	"object_key" text,
+	"verification_status" text NOT NULL,
+	"created_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "caplet_bundle_entries" (
+	"revision_key" text NOT NULL,
+	"path" text NOT NULL,
+	"blob_hash" text NOT NULL,
+	"media_type" text NOT NULL,
+	"size" integer NOT NULL,
+	"executable" boolean NOT NULL,
+	CONSTRAINT "caplet_bundle_entries_revision_key_path_pk" PRIMARY KEY("revision_key","path")
+);
+--> statement-breakpoint
+CREATE TABLE "caplet_records" (
+	"record_key" text PRIMARY KEY NOT NULL,
+	"caplet_id" text NOT NULL,
+	"current_revision_key" text,
+	"head_generation" integer NOT NULL,
+	"history_limit" integer,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "caplet_revision_backends" (
+	"revision_key" text NOT NULL,
+	"position" integer NOT NULL,
+	"family" text NOT NULL,
+	"child_id" text,
+	"config" jsonb NOT NULL,
+	CONSTRAINT "caplet_revision_backends_revision_key_position_pk" PRIMARY KEY("revision_key","position")
+);
+--> statement-breakpoint
+CREATE TABLE "caplet_revision_tags" (
+	"revision_key" text NOT NULL,
+	"position" integer NOT NULL,
+	"value" text NOT NULL,
+	CONSTRAINT "caplet_revision_tags_revision_key_position_pk" PRIMARY KEY("revision_key","position")
+);
+--> statement-breakpoint
+CREATE TABLE "caplet_revisions" (
+	"revision_key" text PRIMARY KEY NOT NULL,
+	"record_key" text NOT NULL,
+	"sequence" integer NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"body" text NOT NULL,
+	"schema_url" text,
+	"content" jsonb NOT NULL,
+	"content_hash" text NOT NULL,
+	"source_revision" text,
+	"source_content_hash" text,
+	"created_at" text NOT NULL,
+	"actor" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "caplets_schema" (
+	"singleton" integer PRIMARY KEY NOT NULL,
+	"version" integer NOT NULL,
+	"applied_at" text NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "caplet_bundle_entries" ADD CONSTRAINT "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk" FOREIGN KEY ("revision_key") REFERENCES "caplet_revisions"("revision_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "caplet_bundle_entries" ADD CONSTRAINT "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk" FOREIGN KEY ("blob_hash") REFERENCES "caplet_asset_blobs"("hash") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "caplet_revision_backends" ADD CONSTRAINT "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk" FOREIGN KEY ("revision_key") REFERENCES "caplet_revisions"("revision_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "caplet_revision_tags" ADD CONSTRAINT "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk" FOREIGN KEY ("revision_key") REFERENCES "caplet_revisions"("revision_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "caplet_revisions" ADD CONSTRAINT "caplet_revisions_record_key_caplet_records_record_key_fk" FOREIGN KEY ("record_key") REFERENCES "caplet_records"("record_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "caplet_records_caplet_id_unique" ON "caplet_records" USING btree ("caplet_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "caplet_revisions_record_sequence_unique" ON "caplet_revisions" USING btree ("record_key","sequence");

--- a/packages/core/src/storage/drizzle/postgres/0001_lean_hellcat.sql
+++ b/packages/core/src/storage/drizzle/postgres/0001_lean_hellcat.sql
@@ -1,0 +1,89 @@
+CREATE TABLE "caplet_installation_observations" (
+	"observation_key" text PRIMARY KEY NOT NULL,
+	"installation_key" text NOT NULL,
+	"resolved_revision" text,
+	"content_hash" text,
+	"risk" jsonb,
+	"status" text NOT NULL,
+	"observed_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "caplet_installations" (
+	"installation_key" text PRIMARY KEY NOT NULL,
+	"record_key" text NOT NULL,
+	"generation" integer NOT NULL,
+	"status" text NOT NULL,
+	"source_kind" text NOT NULL,
+	"source_identity" text NOT NULL,
+	"channel" text,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	"detached_at" text,
+	"detached_by" text
+);
+--> statement-breakpoint
+CREATE TABLE "host_config_generations" (
+	"generation" integer PRIMARY KEY NOT NULL,
+	"content_hash" text NOT NULL,
+	"created_at" text NOT NULL,
+	"created_by" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "host_identity" (
+	"singleton" integer PRIMARY KEY NOT NULL,
+	"host_id" text NOT NULL,
+	"created_at" text NOT NULL,
+	CONSTRAINT "host_identity_host_id_unique" UNIQUE("host_id")
+);
+--> statement-breakpoint
+CREATE TABLE "host_nodes" (
+	"node_id" text PRIMARY KEY NOT NULL,
+	"started_at" text NOT NULL,
+	"heartbeat_at" text NOT NULL,
+	"global_file_manifest" text NOT NULL,
+	"runtime_fingerprint" text NOT NULL,
+	"ready" boolean NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "maintenance_cursors" (
+	"job_name" text PRIMARY KEY NOT NULL,
+	"cursor" text,
+	"updated_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "maintenance_leases" (
+	"lease_name" text PRIMARY KEY NOT NULL,
+	"owner_node_id" text NOT NULL,
+	"fencing_token" integer NOT NULL,
+	"expires_at" text NOT NULL,
+	"updated_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "operator_activity" (
+	"activity_key" text PRIMARY KEY NOT NULL,
+	"operator_client_id" text NOT NULL,
+	"action" text NOT NULL,
+	"target_kind" text NOT NULL,
+	"target_key" text NOT NULL,
+	"outcome" text NOT NULL,
+	"metadata" jsonb NOT NULL,
+	"created_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "vault_access_grants" (
+	"record_key" text NOT NULL,
+	"vault_key" text NOT NULL,
+	"origin_kind" text NOT NULL,
+	"origin_path" text,
+	"created_at" text NOT NULL,
+	"created_by" text NOT NULL,
+	CONSTRAINT "vault_access_grants_record_key_vault_key_pk" PRIMARY KEY("record_key","vault_key")
+);
+--> statement-breakpoint
+ALTER TABLE "caplet_installation_observations" ADD CONSTRAINT "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk" FOREIGN KEY ("installation_key") REFERENCES "caplet_installations"("installation_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "caplet_installations" ADD CONSTRAINT "caplet_installations_record_key_caplet_records_record_key_fk" FOREIGN KEY ("record_key") REFERENCES "caplet_records"("record_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vault_access_grants" ADD CONSTRAINT "vault_access_grants_record_key_caplet_records_record_key_fk" FOREIGN KEY ("record_key") REFERENCES "caplet_records"("record_key") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "caplet_installation_observations_installation_idx" ON "caplet_installation_observations" USING btree ("installation_key","observed_at");--> statement-breakpoint
+CREATE INDEX "caplet_installations_record_status_idx" ON "caplet_installations" USING btree ("record_key","status");--> statement-breakpoint
+CREATE UNIQUE INDEX "caplet_installations_key_generation_unique" ON "caplet_installations" USING btree ("installation_key","generation");--> statement-breakpoint
+CREATE INDEX "operator_activity_created_idx" ON "operator_activity" USING btree ("created_at");

--- a/packages/core/src/storage/drizzle/postgres/0002_motionless_magneto.sql
+++ b/packages/core/src/storage/drizzle/postgres/0002_motionless_magneto.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "host_state_records" (
+	"namespace" text NOT NULL,
+	"state_key" text NOT NULL,
+	"generation" integer NOT NULL,
+	"payload" jsonb NOT NULL,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	CONSTRAINT "host_state_records_namespace_state_key_pk" PRIMARY KEY("namespace","state_key")
+);

--- a/packages/core/src/storage/drizzle/postgres/0003_nice_colonel_america.sql
+++ b/packages/core/src/storage/drizzle/postgres/0003_nice_colonel_america.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "vault_access_grants" ADD COLUMN "reference_name" text;--> statement-breakpoint
+UPDATE "vault_access_grants" SET "reference_name" = "vault_key";--> statement-breakpoint
+ALTER TABLE "vault_access_grants" ALTER COLUMN "reference_name" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "vault_access_grants" DROP CONSTRAINT "vault_access_grants_record_key_vault_key_pk";--> statement-breakpoint
+ALTER TABLE "vault_access_grants" ADD CONSTRAINT "vault_access_grants_record_key_reference_name_pk" PRIMARY KEY("record_key","reference_name");

--- a/packages/core/src/storage/drizzle/postgres/0004_big_rawhide_kid.sql
+++ b/packages/core/src/storage/drizzle/postgres/0004_big_rawhide_kid.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "vault_access_grants" ADD COLUMN "subject_kind" text;--> statement-breakpoint
+ALTER TABLE "vault_access_grants" ADD COLUMN "subject_key" text;--> statement-breakpoint
+ALTER TABLE "vault_access_grants" ADD COLUMN "caplet_id" text;--> statement-breakpoint
+UPDATE "vault_access_grants" SET "subject_kind" = 'record', "subject_key" = "record_key";--> statement-breakpoint
+ALTER TABLE "vault_access_grants" ALTER COLUMN "subject_kind" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "vault_access_grants" ALTER COLUMN "subject_key" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "vault_access_grants" DROP CONSTRAINT "vault_access_grants_record_key_reference_name_pk";--> statement-breakpoint
+ALTER TABLE "vault_access_grants" ALTER COLUMN "record_key" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "vault_access_grants" ADD CONSTRAINT "vault_access_grants_subject_kind_subject_key_reference_name_pk" PRIMARY KEY("subject_kind","subject_key","reference_name");

--- a/packages/core/src/storage/drizzle/postgres/0005_steady_george_stacy.sql
+++ b/packages/core/src/storage/drizzle/postgres/0005_steady_george_stacy.sql
@@ -1,0 +1,82 @@
+CREATE TABLE "remote_client_superseded_refresh_tokens" (
+	"family_id" text NOT NULL,
+	"token_hash" text NOT NULL,
+	"superseded_at" text NOT NULL,
+	CONSTRAINT "remote_client_superseded_refresh_tokens_family_id_token_hash_pk" PRIMARY KEY("family_id","token_hash")
+);
+--> statement-breakpoint
+CREATE TABLE "remote_client_token_families" (
+	"family_id" text PRIMARY KEY NOT NULL,
+	"client_id" text NOT NULL,
+	"refresh_token_hash" text NOT NULL,
+	"created_at" text NOT NULL,
+	"revoked_at" text
+);
+--> statement-breakpoint
+CREATE TABLE "remote_clients" (
+	"client_id" text PRIMARY KEY NOT NULL,
+	"client_label" text NOT NULL,
+	"role" text NOT NULL,
+	"host_url" text NOT NULL,
+	"access_token_hash" text NOT NULL,
+	"access_expires_at" text NOT NULL,
+	"created_at" text NOT NULL,
+	"last_used_at" text,
+	"revoked_at" text
+);
+--> statement-breakpoint
+CREATE TABLE "remote_pairing_codes" (
+	"code_id" text PRIMARY KEY NOT NULL,
+	"host_url" text NOT NULL,
+	"secret_hash" text NOT NULL,
+	"client_label" text,
+	"created_at" text NOT NULL,
+	"expires_at" text NOT NULL,
+	"attempts" integer NOT NULL,
+	"max_attempts" integer NOT NULL,
+	"used_at" text
+);
+--> statement-breakpoint
+CREATE TABLE "remote_pending_logins" (
+	"flow_id" text PRIMARY KEY NOT NULL,
+	"host_url" text NOT NULL,
+	"host_identity" text,
+	"operator_code_hash" text NOT NULL,
+	"pending_refresh_hash" text NOT NULL,
+	"pending_refresh_replay" jsonb,
+	"pending_completion_hash" text NOT NULL,
+	"completion_replay" jsonb,
+	"client_label" text NOT NULL,
+	"requested_role" text NOT NULL,
+	"granted_role" text,
+	"client_fingerprint" text,
+	"source_hint" text,
+	"created_at" text NOT NULL,
+	"code_expires_at" text NOT NULL,
+	"flow_expires_at" text NOT NULL,
+	"status" text NOT NULL,
+	"operator_code_fingerprint" text,
+	"approved_at" text,
+	"denied_at" text,
+	"cancelled_at" text,
+	"exchanged_at" text
+);
+--> statement-breakpoint
+CREATE TABLE "remote_pending_superseded_refresh_tokens" (
+	"flow_id" text NOT NULL,
+	"token_hash" text NOT NULL,
+	"superseded_at" text NOT NULL,
+	CONSTRAINT "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk" PRIMARY KEY("flow_id","token_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "remote_client_superseded_refresh_tokens" ADD CONSTRAINT "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk" FOREIGN KEY ("family_id") REFERENCES "remote_client_token_families"("family_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "remote_client_token_families" ADD CONSTRAINT "remote_client_token_families_client_id_remote_clients_client_id_fk" FOREIGN KEY ("client_id") REFERENCES "remote_clients"("client_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "remote_pending_superseded_refresh_tokens" ADD CONSTRAINT "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk" FOREIGN KEY ("flow_id") REFERENCES "remote_pending_logins"("flow_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "remote_client_superseded_refresh_hash_unique" ON "remote_client_superseded_refresh_tokens" USING btree ("token_hash");--> statement-breakpoint
+CREATE UNIQUE INDEX "remote_client_token_families_client_unique" ON "remote_client_token_families" USING btree ("client_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "remote_client_token_families_refresh_hash_unique" ON "remote_client_token_families" USING btree ("refresh_token_hash");--> statement-breakpoint
+CREATE UNIQUE INDEX "remote_clients_access_token_hash_unique" ON "remote_clients" USING btree ("access_token_hash");--> statement-breakpoint
+CREATE UNIQUE INDEX "remote_pending_logins_operator_code_hash_unique" ON "remote_pending_logins" USING btree ("operator_code_hash");--> statement-breakpoint
+CREATE UNIQUE INDEX "remote_pending_logins_refresh_hash_unique" ON "remote_pending_logins" USING btree ("pending_refresh_hash");--> statement-breakpoint
+CREATE UNIQUE INDEX "remote_pending_logins_completion_hash_unique" ON "remote_pending_logins" USING btree ("pending_completion_hash");--> statement-breakpoint
+CREATE UNIQUE INDEX "remote_pending_superseded_refresh_hash_unique" ON "remote_pending_superseded_refresh_tokens" USING btree ("token_hash");

--- a/packages/core/src/storage/drizzle/postgres/0006_gray_deathstrike.sql
+++ b/packages/core/src/storage/drizzle/postgres/0006_gray_deathstrike.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "dashboard_sessions" (
+	"session_id" text PRIMARY KEY NOT NULL,
+	"secret_hash" text NOT NULL,
+	"operator_client_id" text NOT NULL,
+	"role" text NOT NULL,
+	"csrf_token" text NOT NULL,
+	"created_at" text NOT NULL,
+	"expires_at" text NOT NULL,
+	"last_used_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "dashboard_sessions_expires_at_idx" ON "dashboard_sessions" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "dashboard_sessions_last_used_at_idx" ON "dashboard_sessions" USING btree ("last_used_at");

--- a/packages/core/src/storage/drizzle/postgres/0007_heavy_kingpin.sql
+++ b/packages/core/src/storage/drizzle/postgres/0007_heavy_kingpin.sql
@@ -1,0 +1,47 @@
+CREATE TABLE "project_bindings" (
+	"binding_id" text PRIMARY KEY NOT NULL,
+	"session_id" text NOT NULL,
+	"project_fingerprint" text NOT NULL,
+	"project_root" text NOT NULL,
+	"server_project_root" text NOT NULL,
+	"owner_node_id" text NOT NULL,
+	"generation" integer NOT NULL,
+	"revision" integer NOT NULL,
+	"state" text NOT NULL,
+	"sync_state" text NOT NULL,
+	"readiness" text NOT NULL,
+	"active" boolean NOT NULL,
+	"last_heartbeat_at" text NOT NULL,
+	"expires_at" text NOT NULL,
+	"quarantined_at" text,
+	"quarantine_reason" text,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "setup_approvals" (
+	"project_fingerprint" text NOT NULL,
+	"caplet_id" text NOT NULL,
+	"content_hash" text NOT NULL,
+	"target_kind" text NOT NULL,
+	"generation" integer NOT NULL,
+	"payload" jsonb NOT NULL,
+	"approved_at" text NOT NULL,
+	"actor" text NOT NULL,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	CONSTRAINT "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk" PRIMARY KEY("project_fingerprint","caplet_id","content_hash","target_kind")
+);
+--> statement-breakpoint
+CREATE TABLE "setup_attempt_sets" (
+	"project_fingerprint" text NOT NULL,
+	"caplet_id" text NOT NULL,
+	"generation" integer NOT NULL,
+	"payload" jsonb NOT NULL,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	CONSTRAINT "setup_attempt_sets_project_fingerprint_caplet_id_pk" PRIMARY KEY("project_fingerprint","caplet_id")
+);
+--> statement-breakpoint
+CREATE INDEX "project_bindings_owner_expiry_idx" ON "project_bindings" USING btree ("owner_node_id","expires_at");--> statement-breakpoint
+CREATE INDEX "project_bindings_active_expiry_idx" ON "project_bindings" USING btree ("active","expires_at");

--- a/packages/core/src/storage/drizzle/postgres/0008_old_gladiator.sql
+++ b/packages/core/src/storage/drizzle/postgres/0008_old_gladiator.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "backend_auth_states" (
+	"server" text PRIMARY KEY NOT NULL,
+	"generation" integer NOT NULL,
+	"token_bundle" jsonb NOT NULL,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO "backend_auth_states" ("server", "generation", "token_bundle", "created_at", "updated_at")
+SELECT "state_key", "generation", "payload", "created_at", "updated_at"
+FROM "host_state_records"
+WHERE "namespace" = 'backend-auth';
+--> statement-breakpoint
+DELETE FROM "host_state_records" WHERE "namespace" = 'backend-auth';

--- a/packages/core/src/storage/drizzle/postgres/0009_massive_union_jack.sql
+++ b/packages/core/src/storage/drizzle/postgres/0009_massive_union_jack.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "vault_values" (
+	"vault_key" text PRIMARY KEY NOT NULL,
+	"generation" integer NOT NULL,
+	"version" integer NOT NULL,
+	"algorithm" text NOT NULL,
+	"nonce" text NOT NULL,
+	"ciphertext" text NOT NULL,
+	"auth_tag" text NOT NULL,
+	"value_bytes" integer NOT NULL,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO "vault_values" ("vault_key", "generation", "version", "algorithm", "nonce", "ciphertext", "auth_tag", "value_bytes", "created_at", "updated_at")
+SELECT "state_key", "generation", ("payload" ->> 'version')::integer, "payload" ->> 'algorithm', "payload" ->> 'nonce', "payload" ->> 'ciphertext', "payload" ->> 'authTag', ("payload" ->> 'valueBytes')::integer, "payload" ->> 'createdAt', "payload" ->> 'updatedAt'
+FROM "host_state_records"
+WHERE "namespace" = 'vault-values';--> statement-breakpoint
+DELETE FROM "host_state_records" WHERE "namespace" = 'vault-values';

--- a/packages/core/src/storage/drizzle/postgres/0010_melted_captain_flint.sql
+++ b/packages/core/src/storage/drizzle/postgres/0010_melted_captain_flint.sql
@@ -1,0 +1,1 @@
+DROP TABLE "host_state_records" CASCADE;

--- a/packages/core/src/storage/drizzle/postgres/meta/0000_snapshot.json
+++ b/packages/core/src/storage/drizzle/postgres/meta/0000_snapshot.json
@@ -1,0 +1,470 @@
+{
+  "id": "8da26bec-3e55-4b68-a3c0-ff5a1c94d530",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable": {
+          "name": "executable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "name": "caplet_bundle_entries_revision_key_path_pk",
+          "columns": ["revision_key", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_records": {
+      "name": "caplet_records",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": [
+            {
+              "expression": "caplet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "name": "caplet_revision_backends_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "name": "caplet_revision_tags_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revisions": {
+      "name": "caplet_revisions",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplets_schema": {
+      "name": "caplets_schema",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/postgres/meta/0001_snapshot.json
+++ b/packages/core/src/storage/drizzle/postgres/meta/0001_snapshot.json
@@ -1,0 +1,1027 @@
+{
+  "id": "92889f37-3595-4683-a057-508fd324b3a6",
+  "prevId": "8da26bec-3e55-4b68-a3c0-ff5a1c94d530",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable": {
+          "name": "executable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "name": "caplet_bundle_entries_revision_key_path_pk",
+          "columns": ["revision_key", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "schema": "",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installations": {
+      "name": "caplet_installations",
+      "schema": "",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_records": {
+      "name": "caplet_records",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": [
+            {
+              "expression": "caplet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "name": "caplet_revision_backends_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "name": "caplet_revision_tags_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revisions": {
+      "name": "caplet_revisions",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplets_schema": {
+      "name": "caplets_schema",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_config_generations": {
+      "name": "host_config_generations",
+      "schema": "",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_identity": {
+      "name": "host_identity",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["host_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_nodes": {
+      "name": "host_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "schema": "",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_leases": {
+      "name": "maintenance_leases",
+      "schema": "",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_activity": {
+      "name": "operator_activity",
+      "schema": "",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_access_grants": {
+      "name": "vault_access_grants",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_record_key_vault_key_pk": {
+          "name": "vault_access_grants_record_key_vault_key_pk",
+          "columns": ["record_key", "vault_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/postgres/meta/0002_snapshot.json
+++ b/packages/core/src/storage/drizzle/postgres/meta/0002_snapshot.json
@@ -1,0 +1,1081 @@
+{
+  "id": "9938943b-423f-48e1-888e-2a872e328a3d",
+  "prevId": "92889f37-3595-4683-a057-508fd324b3a6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable": {
+          "name": "executable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "name": "caplet_bundle_entries_revision_key_path_pk",
+          "columns": ["revision_key", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "schema": "",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installations": {
+      "name": "caplet_installations",
+      "schema": "",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_records": {
+      "name": "caplet_records",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": [
+            {
+              "expression": "caplet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "name": "caplet_revision_backends_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "name": "caplet_revision_tags_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revisions": {
+      "name": "caplet_revisions",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplets_schema": {
+      "name": "caplets_schema",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_config_generations": {
+      "name": "host_config_generations",
+      "schema": "",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_identity": {
+      "name": "host_identity",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["host_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_nodes": {
+      "name": "host_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_state_records": {
+      "name": "host_state_records",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "name": "host_state_records_namespace_state_key_pk",
+          "columns": ["namespace", "state_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "schema": "",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_leases": {
+      "name": "maintenance_leases",
+      "schema": "",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_activity": {
+      "name": "operator_activity",
+      "schema": "",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_access_grants": {
+      "name": "vault_access_grants",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_record_key_vault_key_pk": {
+          "name": "vault_access_grants_record_key_vault_key_pk",
+          "columns": ["record_key", "vault_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/postgres/meta/0003_snapshot.json
+++ b/packages/core/src/storage/drizzle/postgres/meta/0003_snapshot.json
@@ -1,0 +1,1087 @@
+{
+  "id": "38752c0b-a8bb-451f-a24e-15e4a868cf25",
+  "prevId": "9938943b-423f-48e1-888e-2a872e328a3d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable": {
+          "name": "executable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "name": "caplet_bundle_entries_revision_key_path_pk",
+          "columns": ["revision_key", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "schema": "",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installations": {
+      "name": "caplet_installations",
+      "schema": "",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_records": {
+      "name": "caplet_records",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": [
+            {
+              "expression": "caplet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "name": "caplet_revision_backends_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "name": "caplet_revision_tags_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revisions": {
+      "name": "caplet_revisions",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplets_schema": {
+      "name": "caplets_schema",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_config_generations": {
+      "name": "host_config_generations",
+      "schema": "",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_identity": {
+      "name": "host_identity",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["host_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_nodes": {
+      "name": "host_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_state_records": {
+      "name": "host_state_records",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "name": "host_state_records_namespace_state_key_pk",
+          "columns": ["namespace", "state_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "schema": "",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_leases": {
+      "name": "maintenance_leases",
+      "schema": "",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_activity": {
+      "name": "operator_activity",
+      "schema": "",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_access_grants": {
+      "name": "vault_access_grants",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_record_key_reference_name_pk": {
+          "name": "vault_access_grants_record_key_reference_name_pk",
+          "columns": ["record_key", "reference_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/postgres/meta/0004_snapshot.json
+++ b/packages/core/src/storage/drizzle/postgres/meta/0004_snapshot.json
@@ -1,0 +1,1105 @@
+{
+  "id": "bc7a1a84-6abc-427c-9f34-4f74ff6995ec",
+  "prevId": "38752c0b-a8bb-451f-a24e-15e4a868cf25",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable": {
+          "name": "executable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "name": "caplet_bundle_entries_revision_key_path_pk",
+          "columns": ["revision_key", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "schema": "",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installations": {
+      "name": "caplet_installations",
+      "schema": "",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_records": {
+      "name": "caplet_records",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": [
+            {
+              "expression": "caplet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "name": "caplet_revision_backends_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "name": "caplet_revision_tags_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revisions": {
+      "name": "caplet_revisions",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplets_schema": {
+      "name": "caplets_schema",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_config_generations": {
+      "name": "host_config_generations",
+      "schema": "",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_identity": {
+      "name": "host_identity",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["host_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_nodes": {
+      "name": "host_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_state_records": {
+      "name": "host_state_records",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "name": "host_state_records_namespace_state_key_pk",
+          "columns": ["namespace", "state_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "schema": "",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_leases": {
+      "name": "maintenance_leases",
+      "schema": "",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_activity": {
+      "name": "operator_activity",
+      "schema": "",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_access_grants": {
+      "name": "vault_access_grants",
+      "schema": "",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk",
+          "columns": ["subject_kind", "subject_key", "reference_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/postgres/meta/0005_snapshot.json
+++ b/packages/core/src/storage/drizzle/postgres/meta/0005_snapshot.json
@@ -1,0 +1,1654 @@
+{
+  "id": "fca6edb8-c438-4fae-b44e-7469188ea22e",
+  "prevId": "bc7a1a84-6abc-427c-9f34-4f74ff6995ec",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable": {
+          "name": "executable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "name": "caplet_bundle_entries_revision_key_path_pk",
+          "columns": ["revision_key", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "schema": "",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installations": {
+      "name": "caplet_installations",
+      "schema": "",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_records": {
+      "name": "caplet_records",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": [
+            {
+              "expression": "caplet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "name": "caplet_revision_backends_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "name": "caplet_revision_tags_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revisions": {
+      "name": "caplet_revisions",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplets_schema": {
+      "name": "caplets_schema",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_config_generations": {
+      "name": "host_config_generations",
+      "schema": "",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_identity": {
+      "name": "host_identity",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["host_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_nodes": {
+      "name": "host_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_state_records": {
+      "name": "host_state_records",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "name": "host_state_records_namespace_state_key_pk",
+          "columns": ["namespace", "state_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "schema": "",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_leases": {
+      "name": "maintenance_leases",
+      "schema": "",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_activity": {
+      "name": "operator_activity",
+      "schema": "",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_client_superseded_refresh_tokens": {
+      "name": "remote_client_superseded_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remote_client_superseded_refresh_hash_unique": {
+          "name": "remote_client_superseded_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk",
+          "tableFrom": "remote_client_superseded_refresh_tokens",
+          "tableTo": "remote_client_token_families",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["family_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_token_hash_pk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_token_hash_pk",
+          "columns": ["family_id", "token_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_client_token_families": {
+      "name": "remote_client_token_families",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_client_token_families_client_unique": {
+          "name": "remote_client_token_families_client_unique",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_client_token_families_refresh_hash_unique": {
+          "name": "remote_client_token_families_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_client_token_families_client_id_remote_clients_client_id_fk": {
+          "name": "remote_client_token_families_client_id_remote_clients_client_id_fk",
+          "tableFrom": "remote_client_token_families",
+          "tableTo": "remote_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_clients": {
+      "name": "remote_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_clients_access_token_hash_unique": {
+          "name": "remote_clients_access_token_hash_unique",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pairing_codes": {
+      "name": "remote_pairing_codes",
+      "schema": "",
+      "columns": {
+        "code_id": {
+          "name": "code_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pending_logins": {
+      "name": "remote_pending_logins",
+      "schema": "",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_identity": {
+          "name": "host_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_code_hash": {
+          "name": "operator_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_refresh_hash": {
+          "name": "pending_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_refresh_replay": {
+          "name": "pending_refresh_replay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_completion_hash": {
+          "name": "pending_completion_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_replay": {
+          "name": "completion_replay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_role": {
+          "name": "granted_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_fingerprint": {
+          "name": "client_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hint": {
+          "name": "source_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_expires_at": {
+          "name": "flow_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_code_fingerprint": {
+          "name": "operator_code_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_pending_logins_operator_code_hash_unique": {
+          "name": "remote_pending_logins_operator_code_hash_unique",
+          "columns": [
+            {
+              "expression": "operator_code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_pending_logins_refresh_hash_unique": {
+          "name": "remote_pending_logins_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "pending_refresh_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_pending_logins_completion_hash_unique": {
+          "name": "remote_pending_logins_completion_hash_unique",
+          "columns": [
+            {
+              "expression": "pending_completion_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pending_superseded_refresh_tokens": {
+      "name": "remote_pending_superseded_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remote_pending_superseded_refresh_hash_unique": {
+          "name": "remote_pending_superseded_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk",
+          "tableFrom": "remote_pending_superseded_refresh_tokens",
+          "tableTo": "remote_pending_logins",
+          "columnsFrom": ["flow_id"],
+          "columnsTo": ["flow_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk",
+          "columns": ["flow_id", "token_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_access_grants": {
+      "name": "vault_access_grants",
+      "schema": "",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk",
+          "columns": ["subject_kind", "subject_key", "reference_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/postgres/meta/0006_snapshot.json
+++ b/packages/core/src/storage/drizzle/postgres/meta/0006_snapshot.json
@@ -1,0 +1,1746 @@
+{
+  "id": "be96b7f7-8173-43d7-bfe5-8e6ff165572c",
+  "prevId": "fca6edb8-c438-4fae-b44e-7469188ea22e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable": {
+          "name": "executable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "name": "caplet_bundle_entries_revision_key_path_pk",
+          "columns": ["revision_key", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "schema": "",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installations": {
+      "name": "caplet_installations",
+      "schema": "",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_records": {
+      "name": "caplet_records",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": [
+            {
+              "expression": "caplet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "name": "caplet_revision_backends_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "name": "caplet_revision_tags_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revisions": {
+      "name": "caplet_revisions",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplets_schema": {
+      "name": "caplets_schema",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_sessions": {
+      "name": "dashboard_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "csrf_token": {
+          "name": "csrf_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dashboard_sessions_expires_at_idx": {
+          "name": "dashboard_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_sessions_last_used_at_idx": {
+          "name": "dashboard_sessions_last_used_at_idx",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_config_generations": {
+      "name": "host_config_generations",
+      "schema": "",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_identity": {
+      "name": "host_identity",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["host_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_nodes": {
+      "name": "host_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_state_records": {
+      "name": "host_state_records",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "name": "host_state_records_namespace_state_key_pk",
+          "columns": ["namespace", "state_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "schema": "",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_leases": {
+      "name": "maintenance_leases",
+      "schema": "",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_activity": {
+      "name": "operator_activity",
+      "schema": "",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_client_superseded_refresh_tokens": {
+      "name": "remote_client_superseded_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remote_client_superseded_refresh_hash_unique": {
+          "name": "remote_client_superseded_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk",
+          "tableFrom": "remote_client_superseded_refresh_tokens",
+          "tableTo": "remote_client_token_families",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["family_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_token_hash_pk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_token_hash_pk",
+          "columns": ["family_id", "token_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_client_token_families": {
+      "name": "remote_client_token_families",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_client_token_families_client_unique": {
+          "name": "remote_client_token_families_client_unique",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_client_token_families_refresh_hash_unique": {
+          "name": "remote_client_token_families_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_client_token_families_client_id_remote_clients_client_id_fk": {
+          "name": "remote_client_token_families_client_id_remote_clients_client_id_fk",
+          "tableFrom": "remote_client_token_families",
+          "tableTo": "remote_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_clients": {
+      "name": "remote_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_clients_access_token_hash_unique": {
+          "name": "remote_clients_access_token_hash_unique",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pairing_codes": {
+      "name": "remote_pairing_codes",
+      "schema": "",
+      "columns": {
+        "code_id": {
+          "name": "code_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pending_logins": {
+      "name": "remote_pending_logins",
+      "schema": "",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_identity": {
+          "name": "host_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_code_hash": {
+          "name": "operator_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_refresh_hash": {
+          "name": "pending_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_refresh_replay": {
+          "name": "pending_refresh_replay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_completion_hash": {
+          "name": "pending_completion_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_replay": {
+          "name": "completion_replay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_role": {
+          "name": "granted_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_fingerprint": {
+          "name": "client_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hint": {
+          "name": "source_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_expires_at": {
+          "name": "flow_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_code_fingerprint": {
+          "name": "operator_code_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_pending_logins_operator_code_hash_unique": {
+          "name": "remote_pending_logins_operator_code_hash_unique",
+          "columns": [
+            {
+              "expression": "operator_code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_pending_logins_refresh_hash_unique": {
+          "name": "remote_pending_logins_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "pending_refresh_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_pending_logins_completion_hash_unique": {
+          "name": "remote_pending_logins_completion_hash_unique",
+          "columns": [
+            {
+              "expression": "pending_completion_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pending_superseded_refresh_tokens": {
+      "name": "remote_pending_superseded_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remote_pending_superseded_refresh_hash_unique": {
+          "name": "remote_pending_superseded_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk",
+          "tableFrom": "remote_pending_superseded_refresh_tokens",
+          "tableTo": "remote_pending_logins",
+          "columnsFrom": ["flow_id"],
+          "columnsTo": ["flow_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk",
+          "columns": ["flow_id", "token_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_access_grants": {
+      "name": "vault_access_grants",
+      "schema": "",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk",
+          "columns": ["subject_kind", "subject_key", "reference_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/postgres/meta/0007_snapshot.json
+++ b/packages/core/src/storage/drizzle/postgres/meta/0007_snapshot.json
@@ -1,0 +1,2042 @@
+{
+  "id": "c8f2f015-8f39-46d0-a49b-6bdc9ddd1cac",
+  "prevId": "be96b7f7-8173-43d7-bfe5-8e6ff165572c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable": {
+          "name": "executable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "name": "caplet_bundle_entries_revision_key_path_pk",
+          "columns": ["revision_key", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "schema": "",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installations": {
+      "name": "caplet_installations",
+      "schema": "",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_records": {
+      "name": "caplet_records",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": [
+            {
+              "expression": "caplet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "name": "caplet_revision_backends_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "name": "caplet_revision_tags_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revisions": {
+      "name": "caplet_revisions",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplets_schema": {
+      "name": "caplets_schema",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_sessions": {
+      "name": "dashboard_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "csrf_token": {
+          "name": "csrf_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dashboard_sessions_expires_at_idx": {
+          "name": "dashboard_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_sessions_last_used_at_idx": {
+          "name": "dashboard_sessions_last_used_at_idx",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_config_generations": {
+      "name": "host_config_generations",
+      "schema": "",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_identity": {
+      "name": "host_identity",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["host_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_nodes": {
+      "name": "host_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_state_records": {
+      "name": "host_state_records",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "name": "host_state_records_namespace_state_key_pk",
+          "columns": ["namespace", "state_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "schema": "",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_leases": {
+      "name": "maintenance_leases",
+      "schema": "",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_activity": {
+      "name": "operator_activity",
+      "schema": "",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_bindings": {
+      "name": "project_bindings",
+      "schema": "",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_root": {
+          "name": "project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_project_root": {
+          "name": "server_project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "readiness": {
+          "name": "readiness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarantined_at": {
+          "name": "quarantined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quarantine_reason": {
+          "name": "quarantine_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_bindings_owner_expiry_idx": {
+          "name": "project_bindings_owner_expiry_idx",
+          "columns": [
+            {
+              "expression": "owner_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_bindings_active_expiry_idx": {
+          "name": "project_bindings_active_expiry_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_client_superseded_refresh_tokens": {
+      "name": "remote_client_superseded_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remote_client_superseded_refresh_hash_unique": {
+          "name": "remote_client_superseded_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk",
+          "tableFrom": "remote_client_superseded_refresh_tokens",
+          "tableTo": "remote_client_token_families",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["family_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_token_hash_pk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_token_hash_pk",
+          "columns": ["family_id", "token_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_client_token_families": {
+      "name": "remote_client_token_families",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_client_token_families_client_unique": {
+          "name": "remote_client_token_families_client_unique",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_client_token_families_refresh_hash_unique": {
+          "name": "remote_client_token_families_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_client_token_families_client_id_remote_clients_client_id_fk": {
+          "name": "remote_client_token_families_client_id_remote_clients_client_id_fk",
+          "tableFrom": "remote_client_token_families",
+          "tableTo": "remote_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_clients": {
+      "name": "remote_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_clients_access_token_hash_unique": {
+          "name": "remote_clients_access_token_hash_unique",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pairing_codes": {
+      "name": "remote_pairing_codes",
+      "schema": "",
+      "columns": {
+        "code_id": {
+          "name": "code_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pending_logins": {
+      "name": "remote_pending_logins",
+      "schema": "",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_identity": {
+          "name": "host_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_code_hash": {
+          "name": "operator_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_refresh_hash": {
+          "name": "pending_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_refresh_replay": {
+          "name": "pending_refresh_replay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_completion_hash": {
+          "name": "pending_completion_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_replay": {
+          "name": "completion_replay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_role": {
+          "name": "granted_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_fingerprint": {
+          "name": "client_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hint": {
+          "name": "source_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_expires_at": {
+          "name": "flow_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_code_fingerprint": {
+          "name": "operator_code_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_pending_logins_operator_code_hash_unique": {
+          "name": "remote_pending_logins_operator_code_hash_unique",
+          "columns": [
+            {
+              "expression": "operator_code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_pending_logins_refresh_hash_unique": {
+          "name": "remote_pending_logins_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "pending_refresh_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_pending_logins_completion_hash_unique": {
+          "name": "remote_pending_logins_completion_hash_unique",
+          "columns": [
+            {
+              "expression": "pending_completion_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pending_superseded_refresh_tokens": {
+      "name": "remote_pending_superseded_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remote_pending_superseded_refresh_hash_unique": {
+          "name": "remote_pending_superseded_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk",
+          "tableFrom": "remote_pending_superseded_refresh_tokens",
+          "tableTo": "remote_pending_logins",
+          "columnsFrom": ["flow_id"],
+          "columnsTo": ["flow_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk",
+          "columns": ["flow_id", "token_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_approvals": {
+      "name": "setup_approvals",
+      "schema": "",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk": {
+          "name": "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk",
+          "columns": ["project_fingerprint", "caplet_id", "content_hash", "target_kind"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_attempt_sets": {
+      "name": "setup_attempt_sets",
+      "schema": "",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_attempt_sets_project_fingerprint_caplet_id_pk": {
+          "name": "setup_attempt_sets_project_fingerprint_caplet_id_pk",
+          "columns": ["project_fingerprint", "caplet_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_access_grants": {
+      "name": "vault_access_grants",
+      "schema": "",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk",
+          "columns": ["subject_kind", "subject_key", "reference_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/postgres/meta/0008_snapshot.json
+++ b/packages/core/src/storage/drizzle/postgres/meta/0008_snapshot.json
@@ -1,0 +1,2085 @@
+{
+  "id": "08c6cfe3-b166-4c3a-a4e2-c673ade3e79d",
+  "prevId": "c8f2f015-8f39-46d0-a49b-6bdc9ddd1cac",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.backend_auth_states": {
+      "name": "backend_auth_states",
+      "schema": "",
+      "columns": {
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_bundle": {
+          "name": "token_bundle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable": {
+          "name": "executable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "name": "caplet_bundle_entries_revision_key_path_pk",
+          "columns": ["revision_key", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "schema": "",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installations": {
+      "name": "caplet_installations",
+      "schema": "",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_records": {
+      "name": "caplet_records",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": [
+            {
+              "expression": "caplet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "name": "caplet_revision_backends_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "name": "caplet_revision_tags_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revisions": {
+      "name": "caplet_revisions",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplets_schema": {
+      "name": "caplets_schema",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_sessions": {
+      "name": "dashboard_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "csrf_token": {
+          "name": "csrf_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dashboard_sessions_expires_at_idx": {
+          "name": "dashboard_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_sessions_last_used_at_idx": {
+          "name": "dashboard_sessions_last_used_at_idx",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_config_generations": {
+      "name": "host_config_generations",
+      "schema": "",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_identity": {
+      "name": "host_identity",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["host_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_nodes": {
+      "name": "host_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_state_records": {
+      "name": "host_state_records",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "name": "host_state_records_namespace_state_key_pk",
+          "columns": ["namespace", "state_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "schema": "",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_leases": {
+      "name": "maintenance_leases",
+      "schema": "",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_activity": {
+      "name": "operator_activity",
+      "schema": "",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_bindings": {
+      "name": "project_bindings",
+      "schema": "",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_root": {
+          "name": "project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_project_root": {
+          "name": "server_project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "readiness": {
+          "name": "readiness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarantined_at": {
+          "name": "quarantined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quarantine_reason": {
+          "name": "quarantine_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_bindings_owner_expiry_idx": {
+          "name": "project_bindings_owner_expiry_idx",
+          "columns": [
+            {
+              "expression": "owner_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_bindings_active_expiry_idx": {
+          "name": "project_bindings_active_expiry_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_client_superseded_refresh_tokens": {
+      "name": "remote_client_superseded_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remote_client_superseded_refresh_hash_unique": {
+          "name": "remote_client_superseded_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk",
+          "tableFrom": "remote_client_superseded_refresh_tokens",
+          "tableTo": "remote_client_token_families",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["family_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_token_hash_pk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_token_hash_pk",
+          "columns": ["family_id", "token_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_client_token_families": {
+      "name": "remote_client_token_families",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_client_token_families_client_unique": {
+          "name": "remote_client_token_families_client_unique",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_client_token_families_refresh_hash_unique": {
+          "name": "remote_client_token_families_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_client_token_families_client_id_remote_clients_client_id_fk": {
+          "name": "remote_client_token_families_client_id_remote_clients_client_id_fk",
+          "tableFrom": "remote_client_token_families",
+          "tableTo": "remote_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_clients": {
+      "name": "remote_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_clients_access_token_hash_unique": {
+          "name": "remote_clients_access_token_hash_unique",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pairing_codes": {
+      "name": "remote_pairing_codes",
+      "schema": "",
+      "columns": {
+        "code_id": {
+          "name": "code_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pending_logins": {
+      "name": "remote_pending_logins",
+      "schema": "",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_identity": {
+          "name": "host_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_code_hash": {
+          "name": "operator_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_refresh_hash": {
+          "name": "pending_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_refresh_replay": {
+          "name": "pending_refresh_replay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_completion_hash": {
+          "name": "pending_completion_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_replay": {
+          "name": "completion_replay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_role": {
+          "name": "granted_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_fingerprint": {
+          "name": "client_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hint": {
+          "name": "source_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_expires_at": {
+          "name": "flow_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_code_fingerprint": {
+          "name": "operator_code_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_pending_logins_operator_code_hash_unique": {
+          "name": "remote_pending_logins_operator_code_hash_unique",
+          "columns": [
+            {
+              "expression": "operator_code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_pending_logins_refresh_hash_unique": {
+          "name": "remote_pending_logins_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "pending_refresh_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_pending_logins_completion_hash_unique": {
+          "name": "remote_pending_logins_completion_hash_unique",
+          "columns": [
+            {
+              "expression": "pending_completion_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pending_superseded_refresh_tokens": {
+      "name": "remote_pending_superseded_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remote_pending_superseded_refresh_hash_unique": {
+          "name": "remote_pending_superseded_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk",
+          "tableFrom": "remote_pending_superseded_refresh_tokens",
+          "tableTo": "remote_pending_logins",
+          "columnsFrom": ["flow_id"],
+          "columnsTo": ["flow_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk",
+          "columns": ["flow_id", "token_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_approvals": {
+      "name": "setup_approvals",
+      "schema": "",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk": {
+          "name": "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk",
+          "columns": ["project_fingerprint", "caplet_id", "content_hash", "target_kind"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_attempt_sets": {
+      "name": "setup_attempt_sets",
+      "schema": "",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_attempt_sets_project_fingerprint_caplet_id_pk": {
+          "name": "setup_attempt_sets_project_fingerprint_caplet_id_pk",
+          "columns": ["project_fingerprint", "caplet_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_access_grants": {
+      "name": "vault_access_grants",
+      "schema": "",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk",
+          "columns": ["subject_kind", "subject_key", "reference_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/postgres/meta/0009_snapshot.json
+++ b/packages/core/src/storage/drizzle/postgres/meta/0009_snapshot.json
@@ -1,0 +1,2158 @@
+{
+  "id": "02d71210-ea5c-4dd6-9e3e-410be20c96c5",
+  "prevId": "08c6cfe3-b166-4c3a-a4e2-c673ade3e79d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.backend_auth_states": {
+      "name": "backend_auth_states",
+      "schema": "",
+      "columns": {
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_bundle": {
+          "name": "token_bundle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable": {
+          "name": "executable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "name": "caplet_bundle_entries_revision_key_path_pk",
+          "columns": ["revision_key", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "schema": "",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installations": {
+      "name": "caplet_installations",
+      "schema": "",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_records": {
+      "name": "caplet_records",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": [
+            {
+              "expression": "caplet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "name": "caplet_revision_backends_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "name": "caplet_revision_tags_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revisions": {
+      "name": "caplet_revisions",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplets_schema": {
+      "name": "caplets_schema",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_sessions": {
+      "name": "dashboard_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "csrf_token": {
+          "name": "csrf_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dashboard_sessions_expires_at_idx": {
+          "name": "dashboard_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_sessions_last_used_at_idx": {
+          "name": "dashboard_sessions_last_used_at_idx",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_config_generations": {
+      "name": "host_config_generations",
+      "schema": "",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_identity": {
+      "name": "host_identity",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["host_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_nodes": {
+      "name": "host_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_state_records": {
+      "name": "host_state_records",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "name": "host_state_records_namespace_state_key_pk",
+          "columns": ["namespace", "state_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "schema": "",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_leases": {
+      "name": "maintenance_leases",
+      "schema": "",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_activity": {
+      "name": "operator_activity",
+      "schema": "",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_bindings": {
+      "name": "project_bindings",
+      "schema": "",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_root": {
+          "name": "project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_project_root": {
+          "name": "server_project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "readiness": {
+          "name": "readiness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarantined_at": {
+          "name": "quarantined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quarantine_reason": {
+          "name": "quarantine_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_bindings_owner_expiry_idx": {
+          "name": "project_bindings_owner_expiry_idx",
+          "columns": [
+            {
+              "expression": "owner_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_bindings_active_expiry_idx": {
+          "name": "project_bindings_active_expiry_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_client_superseded_refresh_tokens": {
+      "name": "remote_client_superseded_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remote_client_superseded_refresh_hash_unique": {
+          "name": "remote_client_superseded_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk",
+          "tableFrom": "remote_client_superseded_refresh_tokens",
+          "tableTo": "remote_client_token_families",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["family_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_token_hash_pk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_token_hash_pk",
+          "columns": ["family_id", "token_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_client_token_families": {
+      "name": "remote_client_token_families",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_client_token_families_client_unique": {
+          "name": "remote_client_token_families_client_unique",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_client_token_families_refresh_hash_unique": {
+          "name": "remote_client_token_families_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_client_token_families_client_id_remote_clients_client_id_fk": {
+          "name": "remote_client_token_families_client_id_remote_clients_client_id_fk",
+          "tableFrom": "remote_client_token_families",
+          "tableTo": "remote_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_clients": {
+      "name": "remote_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_clients_access_token_hash_unique": {
+          "name": "remote_clients_access_token_hash_unique",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pairing_codes": {
+      "name": "remote_pairing_codes",
+      "schema": "",
+      "columns": {
+        "code_id": {
+          "name": "code_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pending_logins": {
+      "name": "remote_pending_logins",
+      "schema": "",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_identity": {
+          "name": "host_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_code_hash": {
+          "name": "operator_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_refresh_hash": {
+          "name": "pending_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_refresh_replay": {
+          "name": "pending_refresh_replay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_completion_hash": {
+          "name": "pending_completion_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_replay": {
+          "name": "completion_replay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_role": {
+          "name": "granted_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_fingerprint": {
+          "name": "client_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hint": {
+          "name": "source_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_expires_at": {
+          "name": "flow_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_code_fingerprint": {
+          "name": "operator_code_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_pending_logins_operator_code_hash_unique": {
+          "name": "remote_pending_logins_operator_code_hash_unique",
+          "columns": [
+            {
+              "expression": "operator_code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_pending_logins_refresh_hash_unique": {
+          "name": "remote_pending_logins_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "pending_refresh_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_pending_logins_completion_hash_unique": {
+          "name": "remote_pending_logins_completion_hash_unique",
+          "columns": [
+            {
+              "expression": "pending_completion_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pending_superseded_refresh_tokens": {
+      "name": "remote_pending_superseded_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remote_pending_superseded_refresh_hash_unique": {
+          "name": "remote_pending_superseded_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk",
+          "tableFrom": "remote_pending_superseded_refresh_tokens",
+          "tableTo": "remote_pending_logins",
+          "columnsFrom": ["flow_id"],
+          "columnsTo": ["flow_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk",
+          "columns": ["flow_id", "token_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_approvals": {
+      "name": "setup_approvals",
+      "schema": "",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk": {
+          "name": "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk",
+          "columns": ["project_fingerprint", "caplet_id", "content_hash", "target_kind"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_attempt_sets": {
+      "name": "setup_attempt_sets",
+      "schema": "",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_attempt_sets_project_fingerprint_caplet_id_pk": {
+          "name": "setup_attempt_sets_project_fingerprint_caplet_id_pk",
+          "columns": ["project_fingerprint", "caplet_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_access_grants": {
+      "name": "vault_access_grants",
+      "schema": "",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk",
+          "columns": ["subject_kind", "subject_key", "reference_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_values": {
+      "name": "vault_values",
+      "schema": "",
+      "columns": {
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_bytes": {
+          "name": "value_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/postgres/meta/0010_snapshot.json
+++ b/packages/core/src/storage/drizzle/postgres/meta/0010_snapshot.json
@@ -1,0 +1,2104 @@
+{
+  "id": "afe1f519-b3a9-4c3b-ab90-5bd00736ccd6",
+  "prevId": "02d71210-ea5c-4dd6-9e3e-410be20c96c5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.backend_auth_states": {
+      "name": "backend_auth_states",
+      "schema": "",
+      "columns": {
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_bundle": {
+          "name": "token_bundle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executable": {
+          "name": "executable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "name": "caplet_bundle_entries_revision_key_path_pk",
+          "columns": ["revision_key", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "schema": "",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_installations": {
+      "name": "caplet_installations",
+      "schema": "",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": [
+            {
+              "expression": "installation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_records": {
+      "name": "caplet_records",
+      "schema": "",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": [
+            {
+              "expression": "caplet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "name": "caplet_revision_backends_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "name": "caplet_revision_tags_revision_key_position_pk",
+          "columns": ["revision_key", "position"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplet_revisions": {
+      "name": "caplet_revisions",
+      "schema": "",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": [
+            {
+              "expression": "record_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caplets_schema": {
+      "name": "caplets_schema",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_sessions": {
+      "name": "dashboard_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "csrf_token": {
+          "name": "csrf_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dashboard_sessions_expires_at_idx": {
+          "name": "dashboard_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_sessions_last_used_at_idx": {
+          "name": "dashboard_sessions_last_used_at_idx",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_config_generations": {
+      "name": "host_config_generations",
+      "schema": "",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_identity": {
+      "name": "host_identity",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["host_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_nodes": {
+      "name": "host_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready": {
+          "name": "ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "schema": "",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_leases": {
+      "name": "maintenance_leases",
+      "schema": "",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_activity": {
+      "name": "operator_activity",
+      "schema": "",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_bindings": {
+      "name": "project_bindings",
+      "schema": "",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_root": {
+          "name": "project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_project_root": {
+          "name": "server_project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "readiness": {
+          "name": "readiness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quarantined_at": {
+          "name": "quarantined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quarantine_reason": {
+          "name": "quarantine_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_bindings_owner_expiry_idx": {
+          "name": "project_bindings_owner_expiry_idx",
+          "columns": [
+            {
+              "expression": "owner_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_bindings_active_expiry_idx": {
+          "name": "project_bindings_active_expiry_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_client_superseded_refresh_tokens": {
+      "name": "remote_client_superseded_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remote_client_superseded_refresh_hash_unique": {
+          "name": "remote_client_superseded_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk",
+          "tableFrom": "remote_client_superseded_refresh_tokens",
+          "tableTo": "remote_client_token_families",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["family_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_token_hash_pk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_token_hash_pk",
+          "columns": ["family_id", "token_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_client_token_families": {
+      "name": "remote_client_token_families",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_client_token_families_client_unique": {
+          "name": "remote_client_token_families_client_unique",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_client_token_families_refresh_hash_unique": {
+          "name": "remote_client_token_families_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_client_token_families_client_id_remote_clients_client_id_fk": {
+          "name": "remote_client_token_families_client_id_remote_clients_client_id_fk",
+          "tableFrom": "remote_client_token_families",
+          "tableTo": "remote_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_clients": {
+      "name": "remote_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_clients_access_token_hash_unique": {
+          "name": "remote_clients_access_token_hash_unique",
+          "columns": [
+            {
+              "expression": "access_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pairing_codes": {
+      "name": "remote_pairing_codes",
+      "schema": "",
+      "columns": {
+        "code_id": {
+          "name": "code_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pending_logins": {
+      "name": "remote_pending_logins",
+      "schema": "",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_identity": {
+          "name": "host_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_code_hash": {
+          "name": "operator_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_refresh_hash": {
+          "name": "pending_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_refresh_replay": {
+          "name": "pending_refresh_replay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_completion_hash": {
+          "name": "pending_completion_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_replay": {
+          "name": "completion_replay",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_role": {
+          "name": "granted_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_fingerprint": {
+          "name": "client_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hint": {
+          "name": "source_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flow_expires_at": {
+          "name": "flow_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_code_fingerprint": {
+          "name": "operator_code_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "remote_pending_logins_operator_code_hash_unique": {
+          "name": "remote_pending_logins_operator_code_hash_unique",
+          "columns": [
+            {
+              "expression": "operator_code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_pending_logins_refresh_hash_unique": {
+          "name": "remote_pending_logins_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "pending_refresh_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "remote_pending_logins_completion_hash_unique": {
+          "name": "remote_pending_logins_completion_hash_unique",
+          "columns": [
+            {
+              "expression": "pending_completion_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remote_pending_superseded_refresh_tokens": {
+      "name": "remote_pending_superseded_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "remote_pending_superseded_refresh_hash_unique": {
+          "name": "remote_pending_superseded_refresh_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk",
+          "tableFrom": "remote_pending_superseded_refresh_tokens",
+          "tableTo": "remote_pending_logins",
+          "columnsFrom": ["flow_id"],
+          "columnsTo": ["flow_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk",
+          "columns": ["flow_id", "token_hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_approvals": {
+      "name": "setup_approvals",
+      "schema": "",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk": {
+          "name": "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk",
+          "columns": ["project_fingerprint", "caplet_id", "content_hash", "target_kind"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_attempt_sets": {
+      "name": "setup_attempt_sets",
+      "schema": "",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_attempt_sets_project_fingerprint_caplet_id_pk": {
+          "name": "setup_attempt_sets_project_fingerprint_caplet_id_pk",
+          "columns": ["project_fingerprint", "caplet_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_access_grants": {
+      "name": "vault_access_grants",
+      "schema": "",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk",
+          "columns": ["subject_kind", "subject_key", "reference_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_values": {
+      "name": "vault_values",
+      "schema": "",
+      "columns": {
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_bytes": {
+          "name": "value_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/postgres/meta/_journal.json
+++ b/packages/core/src/storage/drizzle/postgres/meta/_journal.json
@@ -1,0 +1,83 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1784383684175,
+      "tag": "0000_ancient_firedrake",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1784385915631,
+      "tag": "0001_lean_hellcat",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784389407812,
+      "tag": "0002_motionless_magneto",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1784391891785,
+      "tag": "0003_nice_colonel_america",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1784394444202,
+      "tag": "0004_big_rawhide_kid",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1784394618892,
+      "tag": "0005_steady_george_stacy",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1784394690531,
+      "tag": "0006_gray_deathstrike",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1784394748031,
+      "tag": "0007_heavy_kingpin",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1784394792483,
+      "tag": "0008_old_gladiator",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1784394897273,
+      "tag": "0009_massive_union_jack",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1784395208651,
+      "tag": "0010_melted_captain_flint",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/core/src/storage/drizzle/sqlite/0000_charming_kulan_gath.sql
+++ b/packages/core/src/storage/drizzle/sqlite/0000_charming_kulan_gath.sql
@@ -1,0 +1,73 @@
+CREATE TABLE `caplet_asset_blobs` (
+	`hash` text PRIMARY KEY NOT NULL,
+	`size` integer NOT NULL,
+	`payload` blob,
+	`object_key` text,
+	`verification_status` text NOT NULL,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `caplet_bundle_entries` (
+	`revision_key` text NOT NULL,
+	`path` text NOT NULL,
+	`blob_hash` text NOT NULL,
+	`media_type` text NOT NULL,
+	`size` integer NOT NULL,
+	`executable` integer NOT NULL,
+	PRIMARY KEY(`revision_key`, `path`),
+	FOREIGN KEY (`revision_key`) REFERENCES `caplet_revisions`(`revision_key`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`blob_hash`) REFERENCES `caplet_asset_blobs`(`hash`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `caplet_records` (
+	`record_key` text PRIMARY KEY NOT NULL,
+	`caplet_id` text NOT NULL,
+	`current_revision_key` text,
+	`head_generation` integer NOT NULL,
+	`history_limit` integer,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `caplet_records_caplet_id_unique` ON `caplet_records` (`caplet_id`);--> statement-breakpoint
+CREATE TABLE `caplet_revision_backends` (
+	`revision_key` text NOT NULL,
+	`position` integer NOT NULL,
+	`family` text NOT NULL,
+	`child_id` text,
+	`config` text NOT NULL,
+	PRIMARY KEY(`revision_key`, `position`),
+	FOREIGN KEY (`revision_key`) REFERENCES `caplet_revisions`(`revision_key`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `caplet_revision_tags` (
+	`revision_key` text NOT NULL,
+	`position` integer NOT NULL,
+	`value` text NOT NULL,
+	PRIMARY KEY(`revision_key`, `position`),
+	FOREIGN KEY (`revision_key`) REFERENCES `caplet_revisions`(`revision_key`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `caplet_revisions` (
+	`revision_key` text PRIMARY KEY NOT NULL,
+	`record_key` text NOT NULL,
+	`sequence` integer NOT NULL,
+	`name` text NOT NULL,
+	`description` text NOT NULL,
+	`body` text NOT NULL,
+	`schema_url` text,
+	`content` text NOT NULL,
+	`content_hash` text NOT NULL,
+	`source_revision` text,
+	`source_content_hash` text,
+	`created_at` text NOT NULL,
+	`actor` text NOT NULL,
+	FOREIGN KEY (`record_key`) REFERENCES `caplet_records`(`record_key`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `caplet_revisions_record_sequence_unique` ON `caplet_revisions` (`record_key`,`sequence`);--> statement-breakpoint
+CREATE TABLE `caplets_schema` (
+	`singleton` integer PRIMARY KEY NOT NULL,
+	`version` integer NOT NULL,
+	`applied_at` text NOT NULL
+);

--- a/packages/core/src/storage/drizzle/sqlite/0001_plain_puma.sql
+++ b/packages/core/src/storage/drizzle/sqlite/0001_plain_puma.sql
@@ -1,0 +1,88 @@
+CREATE TABLE `caplet_installation_observations` (
+	`observation_key` text PRIMARY KEY NOT NULL,
+	`installation_key` text NOT NULL,
+	`resolved_revision` text,
+	`content_hash` text,
+	`risk` text,
+	`status` text NOT NULL,
+	`observed_at` text NOT NULL,
+	FOREIGN KEY (`installation_key`) REFERENCES `caplet_installations`(`installation_key`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `caplet_installation_observations_installation_idx` ON `caplet_installation_observations` (`installation_key`,`observed_at`);--> statement-breakpoint
+CREATE TABLE `caplet_installations` (
+	`installation_key` text PRIMARY KEY NOT NULL,
+	`record_key` text NOT NULL,
+	`generation` integer NOT NULL,
+	`status` text NOT NULL,
+	`source_kind` text NOT NULL,
+	`source_identity` text NOT NULL,
+	`channel` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	`detached_at` text,
+	`detached_by` text,
+	FOREIGN KEY (`record_key`) REFERENCES `caplet_records`(`record_key`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `caplet_installations_record_status_idx` ON `caplet_installations` (`record_key`,`status`);--> statement-breakpoint
+CREATE UNIQUE INDEX `caplet_installations_key_generation_unique` ON `caplet_installations` (`installation_key`,`generation`);--> statement-breakpoint
+CREATE TABLE `host_config_generations` (
+	`generation` integer PRIMARY KEY NOT NULL,
+	`content_hash` text NOT NULL,
+	`created_at` text NOT NULL,
+	`created_by` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `host_identity` (
+	`singleton` integer PRIMARY KEY NOT NULL,
+	`host_id` text NOT NULL,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `host_identity_host_id_unique` ON `host_identity` (`host_id`);--> statement-breakpoint
+CREATE TABLE `host_nodes` (
+	`node_id` text PRIMARY KEY NOT NULL,
+	`started_at` text NOT NULL,
+	`heartbeat_at` text NOT NULL,
+	`global_file_manifest` text NOT NULL,
+	`runtime_fingerprint` text NOT NULL,
+	`ready` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `maintenance_cursors` (
+	`job_name` text PRIMARY KEY NOT NULL,
+	`cursor` text,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `maintenance_leases` (
+	`lease_name` text PRIMARY KEY NOT NULL,
+	`owner_node_id` text NOT NULL,
+	`fencing_token` integer NOT NULL,
+	`expires_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `operator_activity` (
+	`activity_key` text PRIMARY KEY NOT NULL,
+	`operator_client_id` text NOT NULL,
+	`action` text NOT NULL,
+	`target_kind` text NOT NULL,
+	`target_key` text NOT NULL,
+	`outcome` text NOT NULL,
+	`metadata` text NOT NULL,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `operator_activity_created_idx` ON `operator_activity` (`created_at`);--> statement-breakpoint
+CREATE TABLE `vault_access_grants` (
+	`record_key` text NOT NULL,
+	`vault_key` text NOT NULL,
+	`origin_kind` text NOT NULL,
+	`origin_path` text,
+	`created_at` text NOT NULL,
+	`created_by` text NOT NULL,
+	PRIMARY KEY(`record_key`, `vault_key`),
+	FOREIGN KEY (`record_key`) REFERENCES `caplet_records`(`record_key`) ON UPDATE no action ON DELETE cascade
+);

--- a/packages/core/src/storage/drizzle/sqlite/0002_mature_wolfpack.sql
+++ b/packages/core/src/storage/drizzle/sqlite/0002_mature_wolfpack.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `host_state_records` (
+	`namespace` text NOT NULL,
+	`state_key` text NOT NULL,
+	`generation` integer NOT NULL,
+	`payload` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	PRIMARY KEY(`namespace`, `state_key`)
+);

--- a/packages/core/src/storage/drizzle/sqlite/0003_next_eddie_brock.sql
+++ b/packages/core/src/storage/drizzle/sqlite/0003_next_eddie_brock.sql
@@ -1,0 +1,17 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_vault_access_grants` (
+	`record_key` text NOT NULL,
+	`vault_key` text NOT NULL,
+	`reference_name` text NOT NULL,
+	`origin_kind` text NOT NULL,
+	`origin_path` text,
+	`created_at` text NOT NULL,
+	`created_by` text NOT NULL,
+	PRIMARY KEY(`record_key`, `reference_name`),
+	FOREIGN KEY (`record_key`) REFERENCES `caplet_records`(`record_key`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_vault_access_grants`("record_key", "vault_key", "reference_name", "origin_kind", "origin_path", "created_at", "created_by") SELECT "record_key", "vault_key", "vault_key", "origin_kind", "origin_path", "created_at", "created_by" FROM `vault_access_grants`;--> statement-breakpoint
+DROP TABLE `vault_access_grants`;--> statement-breakpoint
+ALTER TABLE `__new_vault_access_grants` RENAME TO `vault_access_grants`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/packages/core/src/storage/drizzle/sqlite/0004_nasty_praxagora.sql
+++ b/packages/core/src/storage/drizzle/sqlite/0004_nasty_praxagora.sql
@@ -1,0 +1,20 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_vault_access_grants` (
+	`subject_kind` text NOT NULL,
+	`subject_key` text NOT NULL,
+	`record_key` text,
+	`caplet_id` text,
+	`vault_key` text NOT NULL,
+	`reference_name` text NOT NULL,
+	`origin_kind` text NOT NULL,
+	`origin_path` text,
+	`created_at` text NOT NULL,
+	`created_by` text NOT NULL,
+	PRIMARY KEY(`subject_kind`, `subject_key`, `reference_name`),
+	FOREIGN KEY (`record_key`) REFERENCES `caplet_records`(`record_key`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_vault_access_grants`("subject_kind", "subject_key", "record_key", "caplet_id", "vault_key", "reference_name", "origin_kind", "origin_path", "created_at", "created_by") SELECT 'record', "record_key", "record_key", NULL, "vault_key", "reference_name", "origin_kind", "origin_path", "created_at", "created_by" FROM `vault_access_grants`;--> statement-breakpoint
+DROP TABLE `vault_access_grants`;--> statement-breakpoint
+ALTER TABLE `__new_vault_access_grants` RENAME TO `vault_access_grants`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/packages/core/src/storage/drizzle/sqlite/0005_strange_franklin_richards.sql
+++ b/packages/core/src/storage/drizzle/sqlite/0005_strange_franklin_richards.sql
@@ -1,0 +1,82 @@
+CREATE TABLE `remote_client_superseded_refresh_tokens` (
+	`family_id` text NOT NULL,
+	`token_hash` text NOT NULL,
+	`superseded_at` text NOT NULL,
+	PRIMARY KEY(`family_id`, `token_hash`),
+	FOREIGN KEY (`family_id`) REFERENCES `remote_client_token_families`(`family_id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_client_superseded_refresh_hash_unique` ON `remote_client_superseded_refresh_tokens` (`token_hash`);--> statement-breakpoint
+CREATE TABLE `remote_client_token_families` (
+	`family_id` text PRIMARY KEY NOT NULL,
+	`client_id` text NOT NULL,
+	`refresh_token_hash` text NOT NULL,
+	`created_at` text NOT NULL,
+	`revoked_at` text,
+	FOREIGN KEY (`client_id`) REFERENCES `remote_clients`(`client_id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_client_token_families_client_unique` ON `remote_client_token_families` (`client_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_client_token_families_refresh_hash_unique` ON `remote_client_token_families` (`refresh_token_hash`);--> statement-breakpoint
+CREATE TABLE `remote_clients` (
+	`client_id` text PRIMARY KEY NOT NULL,
+	`client_label` text NOT NULL,
+	`role` text NOT NULL,
+	`host_url` text NOT NULL,
+	`access_token_hash` text NOT NULL,
+	`access_expires_at` text NOT NULL,
+	`created_at` text NOT NULL,
+	`last_used_at` text,
+	`revoked_at` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_clients_access_token_hash_unique` ON `remote_clients` (`access_token_hash`);--> statement-breakpoint
+CREATE TABLE `remote_pairing_codes` (
+	`code_id` text PRIMARY KEY NOT NULL,
+	`host_url` text NOT NULL,
+	`secret_hash` text NOT NULL,
+	`client_label` text,
+	`created_at` text NOT NULL,
+	`expires_at` text NOT NULL,
+	`attempts` integer NOT NULL,
+	`max_attempts` integer NOT NULL,
+	`used_at` text
+);
+--> statement-breakpoint
+CREATE TABLE `remote_pending_logins` (
+	`flow_id` text PRIMARY KEY NOT NULL,
+	`host_url` text NOT NULL,
+	`host_identity` text,
+	`operator_code_hash` text NOT NULL,
+	`pending_refresh_hash` text NOT NULL,
+	`pending_refresh_replay` text,
+	`pending_completion_hash` text NOT NULL,
+	`completion_replay` text,
+	`client_label` text NOT NULL,
+	`requested_role` text NOT NULL,
+	`granted_role` text,
+	`client_fingerprint` text,
+	`source_hint` text,
+	`created_at` text NOT NULL,
+	`code_expires_at` text NOT NULL,
+	`flow_expires_at` text NOT NULL,
+	`status` text NOT NULL,
+	`operator_code_fingerprint` text,
+	`approved_at` text,
+	`denied_at` text,
+	`cancelled_at` text,
+	`exchanged_at` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_pending_logins_operator_code_hash_unique` ON `remote_pending_logins` (`operator_code_hash`);--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_pending_logins_refresh_hash_unique` ON `remote_pending_logins` (`pending_refresh_hash`);--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_pending_logins_completion_hash_unique` ON `remote_pending_logins` (`pending_completion_hash`);--> statement-breakpoint
+CREATE TABLE `remote_pending_superseded_refresh_tokens` (
+	`flow_id` text NOT NULL,
+	`token_hash` text NOT NULL,
+	`superseded_at` text NOT NULL,
+	PRIMARY KEY(`flow_id`, `token_hash`),
+	FOREIGN KEY (`flow_id`) REFERENCES `remote_pending_logins`(`flow_id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_pending_superseded_refresh_hash_unique` ON `remote_pending_superseded_refresh_tokens` (`token_hash`);

--- a/packages/core/src/storage/drizzle/sqlite/0006_illegal_harry_osborn.sql
+++ b/packages/core/src/storage/drizzle/sqlite/0006_illegal_harry_osborn.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `dashboard_sessions` (
+	`session_id` text PRIMARY KEY NOT NULL,
+	`secret_hash` text NOT NULL,
+	`operator_client_id` text NOT NULL,
+	`role` text NOT NULL,
+	`csrf_token` text NOT NULL,
+	`created_at` text NOT NULL,
+	`expires_at` text NOT NULL,
+	`last_used_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `dashboard_sessions_expires_at_idx` ON `dashboard_sessions` (`expires_at`);--> statement-breakpoint
+CREATE INDEX `dashboard_sessions_last_used_at_idx` ON `dashboard_sessions` (`last_used_at`);

--- a/packages/core/src/storage/drizzle/sqlite/0007_polite_ser_duncan.sql
+++ b/packages/core/src/storage/drizzle/sqlite/0007_polite_ser_duncan.sql
@@ -1,0 +1,46 @@
+CREATE TABLE `project_bindings` (
+	`binding_id` text PRIMARY KEY NOT NULL,
+	`session_id` text NOT NULL,
+	`project_fingerprint` text NOT NULL,
+	`project_root` text NOT NULL,
+	`server_project_root` text NOT NULL,
+	`owner_node_id` text NOT NULL,
+	`generation` integer NOT NULL,
+	`revision` integer NOT NULL,
+	`state` text NOT NULL,
+	`sync_state` text NOT NULL,
+	`readiness` text NOT NULL,
+	`active` integer NOT NULL,
+	`last_heartbeat_at` text NOT NULL,
+	`expires_at` text NOT NULL,
+	`quarantined_at` text,
+	`quarantine_reason` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `project_bindings_owner_expiry_idx` ON `project_bindings` (`owner_node_id`,`expires_at`);--> statement-breakpoint
+CREATE INDEX `project_bindings_active_expiry_idx` ON `project_bindings` (`active`,`expires_at`);--> statement-breakpoint
+CREATE TABLE `setup_approvals` (
+	`project_fingerprint` text NOT NULL,
+	`caplet_id` text NOT NULL,
+	`content_hash` text NOT NULL,
+	`target_kind` text NOT NULL,
+	`generation` integer NOT NULL,
+	`payload` text NOT NULL,
+	`approved_at` text NOT NULL,
+	`actor` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	PRIMARY KEY(`project_fingerprint`, `caplet_id`, `content_hash`, `target_kind`)
+);
+--> statement-breakpoint
+CREATE TABLE `setup_attempt_sets` (
+	`project_fingerprint` text NOT NULL,
+	`caplet_id` text NOT NULL,
+	`generation` integer NOT NULL,
+	`payload` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	PRIMARY KEY(`project_fingerprint`, `caplet_id`)
+);

--- a/packages/core/src/storage/drizzle/sqlite/0008_dry_supreme_intelligence.sql
+++ b/packages/core/src/storage/drizzle/sqlite/0008_dry_supreme_intelligence.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `backend_auth_states` (
+	`server` text PRIMARY KEY NOT NULL,
+	`generation` integer NOT NULL,
+	`token_bundle` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `backend_auth_states` (`server`, `generation`, `token_bundle`, `created_at`, `updated_at`)
+SELECT `state_key`, `generation`, `payload`, `created_at`, `updated_at`
+FROM `host_state_records`
+WHERE `namespace` = 'backend-auth';
+--> statement-breakpoint
+DELETE FROM `host_state_records` WHERE `namespace` = 'backend-auth';

--- a/packages/core/src/storage/drizzle/sqlite/0009_gray_sister_grimm.sql
+++ b/packages/core/src/storage/drizzle/sqlite/0009_gray_sister_grimm.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `vault_values` (
+	`vault_key` text PRIMARY KEY NOT NULL,
+	`generation` integer NOT NULL,
+	`version` integer NOT NULL,
+	`algorithm` text NOT NULL,
+	`nonce` text NOT NULL,
+	`ciphertext` text NOT NULL,
+	`auth_tag` text NOT NULL,
+	`value_bytes` integer NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `vault_values` (`vault_key`, `generation`, `version`, `algorithm`, `nonce`, `ciphertext`, `auth_tag`, `value_bytes`, `created_at`, `updated_at`)
+SELECT `state_key`, `generation`, json_extract(`payload`, '$.version'), json_extract(`payload`, '$.algorithm'), json_extract(`payload`, '$.nonce'), json_extract(`payload`, '$.ciphertext'), json_extract(`payload`, '$.authTag'), json_extract(`payload`, '$.valueBytes'), json_extract(`payload`, '$.createdAt'), json_extract(`payload`, '$.updatedAt')
+FROM `host_state_records`
+WHERE `namespace` = 'vault-values';--> statement-breakpoint
+DELETE FROM `host_state_records` WHERE `namespace` = 'vault-values';

--- a/packages/core/src/storage/drizzle/sqlite/0010_friendly_stone_men.sql
+++ b/packages/core/src/storage/drizzle/sqlite/0010_friendly_stone_men.sql
@@ -1,0 +1,1 @@
+DROP TABLE `host_state_records`;

--- a/packages/core/src/storage/drizzle/sqlite/meta/0000_snapshot.json
+++ b/packages/core/src/storage/drizzle/sqlite/meta/0000_snapshot.json
@@ -1,0 +1,465 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a0317c2b-42ea-4a8f-afca-12289082167d",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "columns": ["revision_key", "path"],
+          "name": "caplet_bundle_entries_revision_key_path_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_records": {
+      "name": "caplet_records",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": ["caplet_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_backends_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_tags_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revisions": {
+      "name": "caplet_revisions",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": ["record_key", "sequence"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplets_schema": {
+      "name": "caplets_schema",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/sqlite/meta/0001_snapshot.json
+++ b/packages/core/src/storage/drizzle/sqlite/meta/0001_snapshot.json
@@ -1,0 +1,990 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "eaa37edc-4458-495c-9f1e-17857e1bd31e",
+  "prevId": "a0317c2b-42ea-4a8f-afca-12289082167d",
+  "tables": {
+    "caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "columns": ["revision_key", "path"],
+          "name": "caplet_bundle_entries_revision_key_path_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": ["installation_key", "observed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installations": {
+      "name": "caplet_installations",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": ["record_key", "status"],
+          "isUnique": false
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": ["installation_key", "generation"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_records": {
+      "name": "caplet_records",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": ["caplet_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_backends_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_tags_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revisions": {
+      "name": "caplet_revisions",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": ["record_key", "sequence"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplets_schema": {
+      "name": "caplets_schema",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_config_generations": {
+      "name": "host_config_generations",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_identity": {
+      "name": "host_identity",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "columns": ["host_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_nodes": {
+      "name": "host_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_leases": {
+      "name": "maintenance_leases",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "operator_activity": {
+      "name": "operator_activity",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_access_grants": {
+      "name": "vault_access_grants",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_record_key_vault_key_pk": {
+          "columns": ["record_key", "vault_key"],
+          "name": "vault_access_grants_record_key_vault_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/sqlite/meta/0002_snapshot.json
+++ b/packages/core/src/storage/drizzle/sqlite/meta/0002_snapshot.json
@@ -1,0 +1,1047 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6041d33b-6cb6-4fd4-bb7e-dab7f60fcdca",
+  "prevId": "eaa37edc-4458-495c-9f1e-17857e1bd31e",
+  "tables": {
+    "caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "columns": ["revision_key", "path"],
+          "name": "caplet_bundle_entries_revision_key_path_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": ["installation_key", "observed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installations": {
+      "name": "caplet_installations",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": ["record_key", "status"],
+          "isUnique": false
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": ["installation_key", "generation"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_records": {
+      "name": "caplet_records",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": ["caplet_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_backends_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_tags_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revisions": {
+      "name": "caplet_revisions",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": ["record_key", "sequence"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplets_schema": {
+      "name": "caplets_schema",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_config_generations": {
+      "name": "host_config_generations",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_identity": {
+      "name": "host_identity",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "columns": ["host_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_nodes": {
+      "name": "host_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_state_records": {
+      "name": "host_state_records",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "columns": ["namespace", "state_key"],
+          "name": "host_state_records_namespace_state_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_leases": {
+      "name": "maintenance_leases",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "operator_activity": {
+      "name": "operator_activity",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_access_grants": {
+      "name": "vault_access_grants",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_record_key_vault_key_pk": {
+          "columns": ["record_key", "vault_key"],
+          "name": "vault_access_grants_record_key_vault_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/sqlite/meta/0003_snapshot.json
+++ b/packages/core/src/storage/drizzle/sqlite/meta/0003_snapshot.json
@@ -1,0 +1,1054 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a7e3091e-7338-4a15-921c-f221917315d4",
+  "prevId": "6041d33b-6cb6-4fd4-bb7e-dab7f60fcdca",
+  "tables": {
+    "caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "columns": ["revision_key", "path"],
+          "name": "caplet_bundle_entries_revision_key_path_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": ["installation_key", "observed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installations": {
+      "name": "caplet_installations",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": ["record_key", "status"],
+          "isUnique": false
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": ["installation_key", "generation"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_records": {
+      "name": "caplet_records",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": ["caplet_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_backends_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_tags_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revisions": {
+      "name": "caplet_revisions",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": ["record_key", "sequence"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplets_schema": {
+      "name": "caplets_schema",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_config_generations": {
+      "name": "host_config_generations",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_identity": {
+      "name": "host_identity",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "columns": ["host_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_nodes": {
+      "name": "host_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_state_records": {
+      "name": "host_state_records",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "columns": ["namespace", "state_key"],
+          "name": "host_state_records_namespace_state_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_leases": {
+      "name": "maintenance_leases",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "operator_activity": {
+      "name": "operator_activity",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_access_grants": {
+      "name": "vault_access_grants",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_record_key_reference_name_pk": {
+          "columns": ["record_key", "reference_name"],
+          "name": "vault_access_grants_record_key_reference_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/sqlite/meta/0004_snapshot.json
+++ b/packages/core/src/storage/drizzle/sqlite/meta/0004_snapshot.json
@@ -1,0 +1,1075 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7b1c207d-3a1e-4294-ae61-89b4ed35bfa0",
+  "prevId": "a7e3091e-7338-4a15-921c-f221917315d4",
+  "tables": {
+    "caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "columns": ["revision_key", "path"],
+          "name": "caplet_bundle_entries_revision_key_path_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": ["installation_key", "observed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installations": {
+      "name": "caplet_installations",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": ["record_key", "status"],
+          "isUnique": false
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": ["installation_key", "generation"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_records": {
+      "name": "caplet_records",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": ["caplet_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_backends_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_tags_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revisions": {
+      "name": "caplet_revisions",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": ["record_key", "sequence"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplets_schema": {
+      "name": "caplets_schema",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_config_generations": {
+      "name": "host_config_generations",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_identity": {
+      "name": "host_identity",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "columns": ["host_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_nodes": {
+      "name": "host_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_state_records": {
+      "name": "host_state_records",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "columns": ["namespace", "state_key"],
+          "name": "host_state_records_namespace_state_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_leases": {
+      "name": "maintenance_leases",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "operator_activity": {
+      "name": "operator_activity",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_access_grants": {
+      "name": "vault_access_grants",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "columns": ["subject_kind", "subject_key", "reference_name"],
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/sqlite/meta/0005_snapshot.json
+++ b/packages/core/src/storage/drizzle/sqlite/meta/0005_snapshot.json
@@ -1,0 +1,1577 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "764606bc-3ad9-4fef-ab1b-738566befef1",
+  "prevId": "7b1c207d-3a1e-4294-ae61-89b4ed35bfa0",
+  "tables": {
+    "caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "columns": ["revision_key", "path"],
+          "name": "caplet_bundle_entries_revision_key_path_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": ["installation_key", "observed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installations": {
+      "name": "caplet_installations",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": ["record_key", "status"],
+          "isUnique": false
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": ["installation_key", "generation"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_records": {
+      "name": "caplet_records",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": ["caplet_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_backends_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_tags_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revisions": {
+      "name": "caplet_revisions",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": ["record_key", "sequence"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplets_schema": {
+      "name": "caplets_schema",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_config_generations": {
+      "name": "host_config_generations",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_identity": {
+      "name": "host_identity",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "columns": ["host_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_nodes": {
+      "name": "host_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_state_records": {
+      "name": "host_state_records",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "columns": ["namespace", "state_key"],
+          "name": "host_state_records_namespace_state_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_leases": {
+      "name": "maintenance_leases",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "operator_activity": {
+      "name": "operator_activity",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_client_superseded_refresh_tokens": {
+      "name": "remote_client_superseded_refresh_tokens",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_client_superseded_refresh_hash_unique": {
+          "name": "remote_client_superseded_refresh_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk",
+          "tableFrom": "remote_client_superseded_refresh_tokens",
+          "tableTo": "remote_client_token_families",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["family_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_token_hash_pk": {
+          "columns": ["family_id", "token_hash"],
+          "name": "remote_client_superseded_refresh_tokens_family_id_token_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_client_token_families": {
+      "name": "remote_client_token_families",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_client_token_families_client_unique": {
+          "name": "remote_client_token_families_client_unique",
+          "columns": ["client_id"],
+          "isUnique": true
+        },
+        "remote_client_token_families_refresh_hash_unique": {
+          "name": "remote_client_token_families_refresh_hash_unique",
+          "columns": ["refresh_token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_client_token_families_client_id_remote_clients_client_id_fk": {
+          "name": "remote_client_token_families_client_id_remote_clients_client_id_fk",
+          "tableFrom": "remote_client_token_families",
+          "tableTo": "remote_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_clients": {
+      "name": "remote_clients",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_clients_access_token_hash_unique": {
+          "name": "remote_clients_access_token_hash_unique",
+          "columns": ["access_token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pairing_codes": {
+      "name": "remote_pairing_codes",
+      "columns": {
+        "code_id": {
+          "name": "code_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pending_logins": {
+      "name": "remote_pending_logins",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_identity": {
+          "name": "host_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operator_code_hash": {
+          "name": "operator_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_refresh_hash": {
+          "name": "pending_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_refresh_replay": {
+          "name": "pending_refresh_replay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_completion_hash": {
+          "name": "pending_completion_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_replay": {
+          "name": "completion_replay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "granted_role": {
+          "name": "granted_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_fingerprint": {
+          "name": "client_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_hint": {
+          "name": "source_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flow_expires_at": {
+          "name": "flow_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_code_fingerprint": {
+          "name": "operator_code_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_pending_logins_operator_code_hash_unique": {
+          "name": "remote_pending_logins_operator_code_hash_unique",
+          "columns": ["operator_code_hash"],
+          "isUnique": true
+        },
+        "remote_pending_logins_refresh_hash_unique": {
+          "name": "remote_pending_logins_refresh_hash_unique",
+          "columns": ["pending_refresh_hash"],
+          "isUnique": true
+        },
+        "remote_pending_logins_completion_hash_unique": {
+          "name": "remote_pending_logins_completion_hash_unique",
+          "columns": ["pending_completion_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pending_superseded_refresh_tokens": {
+      "name": "remote_pending_superseded_refresh_tokens",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_pending_superseded_refresh_hash_unique": {
+          "name": "remote_pending_superseded_refresh_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk",
+          "tableFrom": "remote_pending_superseded_refresh_tokens",
+          "tableTo": "remote_pending_logins",
+          "columnsFrom": ["flow_id"],
+          "columnsTo": ["flow_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk": {
+          "columns": ["flow_id", "token_hash"],
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_access_grants": {
+      "name": "vault_access_grants",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "columns": ["subject_kind", "subject_key", "reference_name"],
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/sqlite/meta/0006_snapshot.json
+++ b/packages/core/src/storage/drizzle/sqlite/meta/0006_snapshot.json
@@ -1,0 +1,1654 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7be6a2ec-a875-43b7-bc44-1f22d20c6ef3",
+  "prevId": "764606bc-3ad9-4fef-ab1b-738566befef1",
+  "tables": {
+    "caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "columns": ["revision_key", "path"],
+          "name": "caplet_bundle_entries_revision_key_path_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": ["installation_key", "observed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installations": {
+      "name": "caplet_installations",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": ["record_key", "status"],
+          "isUnique": false
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": ["installation_key", "generation"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_records": {
+      "name": "caplet_records",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": ["caplet_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_backends_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_tags_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revisions": {
+      "name": "caplet_revisions",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": ["record_key", "sequence"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplets_schema": {
+      "name": "caplets_schema",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dashboard_sessions": {
+      "name": "dashboard_sessions",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "csrf_token": {
+          "name": "csrf_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dashboard_sessions_expires_at_idx": {
+          "name": "dashboard_sessions_expires_at_idx",
+          "columns": ["expires_at"],
+          "isUnique": false
+        },
+        "dashboard_sessions_last_used_at_idx": {
+          "name": "dashboard_sessions_last_used_at_idx",
+          "columns": ["last_used_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_config_generations": {
+      "name": "host_config_generations",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_identity": {
+      "name": "host_identity",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "columns": ["host_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_nodes": {
+      "name": "host_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_state_records": {
+      "name": "host_state_records",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "columns": ["namespace", "state_key"],
+          "name": "host_state_records_namespace_state_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_leases": {
+      "name": "maintenance_leases",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "operator_activity": {
+      "name": "operator_activity",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_client_superseded_refresh_tokens": {
+      "name": "remote_client_superseded_refresh_tokens",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_client_superseded_refresh_hash_unique": {
+          "name": "remote_client_superseded_refresh_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk",
+          "tableFrom": "remote_client_superseded_refresh_tokens",
+          "tableTo": "remote_client_token_families",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["family_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_token_hash_pk": {
+          "columns": ["family_id", "token_hash"],
+          "name": "remote_client_superseded_refresh_tokens_family_id_token_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_client_token_families": {
+      "name": "remote_client_token_families",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_client_token_families_client_unique": {
+          "name": "remote_client_token_families_client_unique",
+          "columns": ["client_id"],
+          "isUnique": true
+        },
+        "remote_client_token_families_refresh_hash_unique": {
+          "name": "remote_client_token_families_refresh_hash_unique",
+          "columns": ["refresh_token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_client_token_families_client_id_remote_clients_client_id_fk": {
+          "name": "remote_client_token_families_client_id_remote_clients_client_id_fk",
+          "tableFrom": "remote_client_token_families",
+          "tableTo": "remote_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_clients": {
+      "name": "remote_clients",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_clients_access_token_hash_unique": {
+          "name": "remote_clients_access_token_hash_unique",
+          "columns": ["access_token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pairing_codes": {
+      "name": "remote_pairing_codes",
+      "columns": {
+        "code_id": {
+          "name": "code_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pending_logins": {
+      "name": "remote_pending_logins",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_identity": {
+          "name": "host_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operator_code_hash": {
+          "name": "operator_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_refresh_hash": {
+          "name": "pending_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_refresh_replay": {
+          "name": "pending_refresh_replay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_completion_hash": {
+          "name": "pending_completion_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_replay": {
+          "name": "completion_replay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "granted_role": {
+          "name": "granted_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_fingerprint": {
+          "name": "client_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_hint": {
+          "name": "source_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flow_expires_at": {
+          "name": "flow_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_code_fingerprint": {
+          "name": "operator_code_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_pending_logins_operator_code_hash_unique": {
+          "name": "remote_pending_logins_operator_code_hash_unique",
+          "columns": ["operator_code_hash"],
+          "isUnique": true
+        },
+        "remote_pending_logins_refresh_hash_unique": {
+          "name": "remote_pending_logins_refresh_hash_unique",
+          "columns": ["pending_refresh_hash"],
+          "isUnique": true
+        },
+        "remote_pending_logins_completion_hash_unique": {
+          "name": "remote_pending_logins_completion_hash_unique",
+          "columns": ["pending_completion_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pending_superseded_refresh_tokens": {
+      "name": "remote_pending_superseded_refresh_tokens",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_pending_superseded_refresh_hash_unique": {
+          "name": "remote_pending_superseded_refresh_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk",
+          "tableFrom": "remote_pending_superseded_refresh_tokens",
+          "tableTo": "remote_pending_logins",
+          "columnsFrom": ["flow_id"],
+          "columnsTo": ["flow_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk": {
+          "columns": ["flow_id", "token_hash"],
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_access_grants": {
+      "name": "vault_access_grants",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "columns": ["subject_kind", "subject_key", "reference_name"],
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/sqlite/meta/0007_snapshot.json
+++ b/packages/core/src/storage/drizzle/sqlite/meta/0007_snapshot.json
@@ -1,0 +1,1943 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4e57f45e-a1c8-4c0f-91eb-109990f28619",
+  "prevId": "7be6a2ec-a875-43b7-bc44-1f22d20c6ef3",
+  "tables": {
+    "caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "columns": ["revision_key", "path"],
+          "name": "caplet_bundle_entries_revision_key_path_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": ["installation_key", "observed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installations": {
+      "name": "caplet_installations",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": ["record_key", "status"],
+          "isUnique": false
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": ["installation_key", "generation"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_records": {
+      "name": "caplet_records",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": ["caplet_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_backends_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_tags_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revisions": {
+      "name": "caplet_revisions",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": ["record_key", "sequence"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplets_schema": {
+      "name": "caplets_schema",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dashboard_sessions": {
+      "name": "dashboard_sessions",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "csrf_token": {
+          "name": "csrf_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dashboard_sessions_expires_at_idx": {
+          "name": "dashboard_sessions_expires_at_idx",
+          "columns": ["expires_at"],
+          "isUnique": false
+        },
+        "dashboard_sessions_last_used_at_idx": {
+          "name": "dashboard_sessions_last_used_at_idx",
+          "columns": ["last_used_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_config_generations": {
+      "name": "host_config_generations",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_identity": {
+      "name": "host_identity",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "columns": ["host_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_nodes": {
+      "name": "host_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_state_records": {
+      "name": "host_state_records",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "columns": ["namespace", "state_key"],
+          "name": "host_state_records_namespace_state_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_leases": {
+      "name": "maintenance_leases",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "operator_activity": {
+      "name": "operator_activity",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_bindings": {
+      "name": "project_bindings",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_root": {
+          "name": "project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_project_root": {
+          "name": "server_project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "readiness": {
+          "name": "readiness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quarantined_at": {
+          "name": "quarantined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quarantine_reason": {
+          "name": "quarantine_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_bindings_owner_expiry_idx": {
+          "name": "project_bindings_owner_expiry_idx",
+          "columns": ["owner_node_id", "expires_at"],
+          "isUnique": false
+        },
+        "project_bindings_active_expiry_idx": {
+          "name": "project_bindings_active_expiry_idx",
+          "columns": ["active", "expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_client_superseded_refresh_tokens": {
+      "name": "remote_client_superseded_refresh_tokens",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_client_superseded_refresh_hash_unique": {
+          "name": "remote_client_superseded_refresh_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk",
+          "tableFrom": "remote_client_superseded_refresh_tokens",
+          "tableTo": "remote_client_token_families",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["family_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_token_hash_pk": {
+          "columns": ["family_id", "token_hash"],
+          "name": "remote_client_superseded_refresh_tokens_family_id_token_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_client_token_families": {
+      "name": "remote_client_token_families",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_client_token_families_client_unique": {
+          "name": "remote_client_token_families_client_unique",
+          "columns": ["client_id"],
+          "isUnique": true
+        },
+        "remote_client_token_families_refresh_hash_unique": {
+          "name": "remote_client_token_families_refresh_hash_unique",
+          "columns": ["refresh_token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_client_token_families_client_id_remote_clients_client_id_fk": {
+          "name": "remote_client_token_families_client_id_remote_clients_client_id_fk",
+          "tableFrom": "remote_client_token_families",
+          "tableTo": "remote_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_clients": {
+      "name": "remote_clients",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_clients_access_token_hash_unique": {
+          "name": "remote_clients_access_token_hash_unique",
+          "columns": ["access_token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pairing_codes": {
+      "name": "remote_pairing_codes",
+      "columns": {
+        "code_id": {
+          "name": "code_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pending_logins": {
+      "name": "remote_pending_logins",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_identity": {
+          "name": "host_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operator_code_hash": {
+          "name": "operator_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_refresh_hash": {
+          "name": "pending_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_refresh_replay": {
+          "name": "pending_refresh_replay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_completion_hash": {
+          "name": "pending_completion_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_replay": {
+          "name": "completion_replay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "granted_role": {
+          "name": "granted_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_fingerprint": {
+          "name": "client_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_hint": {
+          "name": "source_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flow_expires_at": {
+          "name": "flow_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_code_fingerprint": {
+          "name": "operator_code_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_pending_logins_operator_code_hash_unique": {
+          "name": "remote_pending_logins_operator_code_hash_unique",
+          "columns": ["operator_code_hash"],
+          "isUnique": true
+        },
+        "remote_pending_logins_refresh_hash_unique": {
+          "name": "remote_pending_logins_refresh_hash_unique",
+          "columns": ["pending_refresh_hash"],
+          "isUnique": true
+        },
+        "remote_pending_logins_completion_hash_unique": {
+          "name": "remote_pending_logins_completion_hash_unique",
+          "columns": ["pending_completion_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pending_superseded_refresh_tokens": {
+      "name": "remote_pending_superseded_refresh_tokens",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_pending_superseded_refresh_hash_unique": {
+          "name": "remote_pending_superseded_refresh_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk",
+          "tableFrom": "remote_pending_superseded_refresh_tokens",
+          "tableTo": "remote_pending_logins",
+          "columnsFrom": ["flow_id"],
+          "columnsTo": ["flow_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk": {
+          "columns": ["flow_id", "token_hash"],
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_approvals": {
+      "name": "setup_approvals",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk": {
+          "columns": ["project_fingerprint", "caplet_id", "content_hash", "target_kind"],
+          "name": "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_attempt_sets": {
+      "name": "setup_attempt_sets",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_attempt_sets_project_fingerprint_caplet_id_pk": {
+          "columns": ["project_fingerprint", "caplet_id"],
+          "name": "setup_attempt_sets_project_fingerprint_caplet_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_access_grants": {
+      "name": "vault_access_grants",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "columns": ["subject_kind", "subject_key", "reference_name"],
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/sqlite/meta/0008_snapshot.json
+++ b/packages/core/src/storage/drizzle/sqlite/meta/0008_snapshot.json
@@ -1,0 +1,1988 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d706d828-e535-4c62-b096-0e5358ec4197",
+  "prevId": "4e57f45e-a1c8-4c0f-91eb-109990f28619",
+  "tables": {
+    "backend_auth_states": {
+      "name": "backend_auth_states",
+      "columns": {
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_bundle": {
+          "name": "token_bundle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "columns": ["revision_key", "path"],
+          "name": "caplet_bundle_entries_revision_key_path_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": ["installation_key", "observed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installations": {
+      "name": "caplet_installations",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": ["record_key", "status"],
+          "isUnique": false
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": ["installation_key", "generation"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_records": {
+      "name": "caplet_records",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": ["caplet_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_backends_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_tags_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revisions": {
+      "name": "caplet_revisions",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": ["record_key", "sequence"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplets_schema": {
+      "name": "caplets_schema",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dashboard_sessions": {
+      "name": "dashboard_sessions",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "csrf_token": {
+          "name": "csrf_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dashboard_sessions_expires_at_idx": {
+          "name": "dashboard_sessions_expires_at_idx",
+          "columns": ["expires_at"],
+          "isUnique": false
+        },
+        "dashboard_sessions_last_used_at_idx": {
+          "name": "dashboard_sessions_last_used_at_idx",
+          "columns": ["last_used_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_config_generations": {
+      "name": "host_config_generations",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_identity": {
+      "name": "host_identity",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "columns": ["host_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_nodes": {
+      "name": "host_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_state_records": {
+      "name": "host_state_records",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "columns": ["namespace", "state_key"],
+          "name": "host_state_records_namespace_state_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_leases": {
+      "name": "maintenance_leases",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "operator_activity": {
+      "name": "operator_activity",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_bindings": {
+      "name": "project_bindings",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_root": {
+          "name": "project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_project_root": {
+          "name": "server_project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "readiness": {
+          "name": "readiness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quarantined_at": {
+          "name": "quarantined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quarantine_reason": {
+          "name": "quarantine_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_bindings_owner_expiry_idx": {
+          "name": "project_bindings_owner_expiry_idx",
+          "columns": ["owner_node_id", "expires_at"],
+          "isUnique": false
+        },
+        "project_bindings_active_expiry_idx": {
+          "name": "project_bindings_active_expiry_idx",
+          "columns": ["active", "expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_client_superseded_refresh_tokens": {
+      "name": "remote_client_superseded_refresh_tokens",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_client_superseded_refresh_hash_unique": {
+          "name": "remote_client_superseded_refresh_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk",
+          "tableFrom": "remote_client_superseded_refresh_tokens",
+          "tableTo": "remote_client_token_families",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["family_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_token_hash_pk": {
+          "columns": ["family_id", "token_hash"],
+          "name": "remote_client_superseded_refresh_tokens_family_id_token_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_client_token_families": {
+      "name": "remote_client_token_families",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_client_token_families_client_unique": {
+          "name": "remote_client_token_families_client_unique",
+          "columns": ["client_id"],
+          "isUnique": true
+        },
+        "remote_client_token_families_refresh_hash_unique": {
+          "name": "remote_client_token_families_refresh_hash_unique",
+          "columns": ["refresh_token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_client_token_families_client_id_remote_clients_client_id_fk": {
+          "name": "remote_client_token_families_client_id_remote_clients_client_id_fk",
+          "tableFrom": "remote_client_token_families",
+          "tableTo": "remote_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_clients": {
+      "name": "remote_clients",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_clients_access_token_hash_unique": {
+          "name": "remote_clients_access_token_hash_unique",
+          "columns": ["access_token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pairing_codes": {
+      "name": "remote_pairing_codes",
+      "columns": {
+        "code_id": {
+          "name": "code_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pending_logins": {
+      "name": "remote_pending_logins",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_identity": {
+          "name": "host_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operator_code_hash": {
+          "name": "operator_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_refresh_hash": {
+          "name": "pending_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_refresh_replay": {
+          "name": "pending_refresh_replay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_completion_hash": {
+          "name": "pending_completion_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_replay": {
+          "name": "completion_replay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "granted_role": {
+          "name": "granted_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_fingerprint": {
+          "name": "client_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_hint": {
+          "name": "source_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flow_expires_at": {
+          "name": "flow_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_code_fingerprint": {
+          "name": "operator_code_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_pending_logins_operator_code_hash_unique": {
+          "name": "remote_pending_logins_operator_code_hash_unique",
+          "columns": ["operator_code_hash"],
+          "isUnique": true
+        },
+        "remote_pending_logins_refresh_hash_unique": {
+          "name": "remote_pending_logins_refresh_hash_unique",
+          "columns": ["pending_refresh_hash"],
+          "isUnique": true
+        },
+        "remote_pending_logins_completion_hash_unique": {
+          "name": "remote_pending_logins_completion_hash_unique",
+          "columns": ["pending_completion_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pending_superseded_refresh_tokens": {
+      "name": "remote_pending_superseded_refresh_tokens",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_pending_superseded_refresh_hash_unique": {
+          "name": "remote_pending_superseded_refresh_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk",
+          "tableFrom": "remote_pending_superseded_refresh_tokens",
+          "tableTo": "remote_pending_logins",
+          "columnsFrom": ["flow_id"],
+          "columnsTo": ["flow_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk": {
+          "columns": ["flow_id", "token_hash"],
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_approvals": {
+      "name": "setup_approvals",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk": {
+          "columns": ["project_fingerprint", "caplet_id", "content_hash", "target_kind"],
+          "name": "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_attempt_sets": {
+      "name": "setup_attempt_sets",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_attempt_sets_project_fingerprint_caplet_id_pk": {
+          "columns": ["project_fingerprint", "caplet_id"],
+          "name": "setup_attempt_sets_project_fingerprint_caplet_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_access_grants": {
+      "name": "vault_access_grants",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "columns": ["subject_kind", "subject_key", "reference_name"],
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/sqlite/meta/0009_snapshot.json
+++ b/packages/core/src/storage/drizzle/sqlite/meta/0009_snapshot.json
@@ -1,0 +1,2068 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "615bed52-1eb1-4a95-8c6b-14807302b9a7",
+  "prevId": "d706d828-e535-4c62-b096-0e5358ec4197",
+  "tables": {
+    "backend_auth_states": {
+      "name": "backend_auth_states",
+      "columns": {
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_bundle": {
+          "name": "token_bundle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "columns": ["revision_key", "path"],
+          "name": "caplet_bundle_entries_revision_key_path_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": ["installation_key", "observed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installations": {
+      "name": "caplet_installations",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": ["record_key", "status"],
+          "isUnique": false
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": ["installation_key", "generation"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_records": {
+      "name": "caplet_records",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": ["caplet_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_backends_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_tags_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revisions": {
+      "name": "caplet_revisions",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": ["record_key", "sequence"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplets_schema": {
+      "name": "caplets_schema",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dashboard_sessions": {
+      "name": "dashboard_sessions",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "csrf_token": {
+          "name": "csrf_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dashboard_sessions_expires_at_idx": {
+          "name": "dashboard_sessions_expires_at_idx",
+          "columns": ["expires_at"],
+          "isUnique": false
+        },
+        "dashboard_sessions_last_used_at_idx": {
+          "name": "dashboard_sessions_last_used_at_idx",
+          "columns": ["last_used_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_config_generations": {
+      "name": "host_config_generations",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_identity": {
+      "name": "host_identity",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "columns": ["host_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_nodes": {
+      "name": "host_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_state_records": {
+      "name": "host_state_records",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state_key": {
+          "name": "state_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "host_state_records_namespace_state_key_pk": {
+          "columns": ["namespace", "state_key"],
+          "name": "host_state_records_namespace_state_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_leases": {
+      "name": "maintenance_leases",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "operator_activity": {
+      "name": "operator_activity",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_bindings": {
+      "name": "project_bindings",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_root": {
+          "name": "project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_project_root": {
+          "name": "server_project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "readiness": {
+          "name": "readiness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quarantined_at": {
+          "name": "quarantined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quarantine_reason": {
+          "name": "quarantine_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_bindings_owner_expiry_idx": {
+          "name": "project_bindings_owner_expiry_idx",
+          "columns": ["owner_node_id", "expires_at"],
+          "isUnique": false
+        },
+        "project_bindings_active_expiry_idx": {
+          "name": "project_bindings_active_expiry_idx",
+          "columns": ["active", "expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_client_superseded_refresh_tokens": {
+      "name": "remote_client_superseded_refresh_tokens",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_client_superseded_refresh_hash_unique": {
+          "name": "remote_client_superseded_refresh_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk",
+          "tableFrom": "remote_client_superseded_refresh_tokens",
+          "tableTo": "remote_client_token_families",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["family_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_token_hash_pk": {
+          "columns": ["family_id", "token_hash"],
+          "name": "remote_client_superseded_refresh_tokens_family_id_token_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_client_token_families": {
+      "name": "remote_client_token_families",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_client_token_families_client_unique": {
+          "name": "remote_client_token_families_client_unique",
+          "columns": ["client_id"],
+          "isUnique": true
+        },
+        "remote_client_token_families_refresh_hash_unique": {
+          "name": "remote_client_token_families_refresh_hash_unique",
+          "columns": ["refresh_token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_client_token_families_client_id_remote_clients_client_id_fk": {
+          "name": "remote_client_token_families_client_id_remote_clients_client_id_fk",
+          "tableFrom": "remote_client_token_families",
+          "tableTo": "remote_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_clients": {
+      "name": "remote_clients",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_clients_access_token_hash_unique": {
+          "name": "remote_clients_access_token_hash_unique",
+          "columns": ["access_token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pairing_codes": {
+      "name": "remote_pairing_codes",
+      "columns": {
+        "code_id": {
+          "name": "code_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pending_logins": {
+      "name": "remote_pending_logins",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_identity": {
+          "name": "host_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operator_code_hash": {
+          "name": "operator_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_refresh_hash": {
+          "name": "pending_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_refresh_replay": {
+          "name": "pending_refresh_replay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_completion_hash": {
+          "name": "pending_completion_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_replay": {
+          "name": "completion_replay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "granted_role": {
+          "name": "granted_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_fingerprint": {
+          "name": "client_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_hint": {
+          "name": "source_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flow_expires_at": {
+          "name": "flow_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_code_fingerprint": {
+          "name": "operator_code_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_pending_logins_operator_code_hash_unique": {
+          "name": "remote_pending_logins_operator_code_hash_unique",
+          "columns": ["operator_code_hash"],
+          "isUnique": true
+        },
+        "remote_pending_logins_refresh_hash_unique": {
+          "name": "remote_pending_logins_refresh_hash_unique",
+          "columns": ["pending_refresh_hash"],
+          "isUnique": true
+        },
+        "remote_pending_logins_completion_hash_unique": {
+          "name": "remote_pending_logins_completion_hash_unique",
+          "columns": ["pending_completion_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pending_superseded_refresh_tokens": {
+      "name": "remote_pending_superseded_refresh_tokens",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_pending_superseded_refresh_hash_unique": {
+          "name": "remote_pending_superseded_refresh_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk",
+          "tableFrom": "remote_pending_superseded_refresh_tokens",
+          "tableTo": "remote_pending_logins",
+          "columnsFrom": ["flow_id"],
+          "columnsTo": ["flow_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk": {
+          "columns": ["flow_id", "token_hash"],
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_approvals": {
+      "name": "setup_approvals",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk": {
+          "columns": ["project_fingerprint", "caplet_id", "content_hash", "target_kind"],
+          "name": "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_attempt_sets": {
+      "name": "setup_attempt_sets",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_attempt_sets_project_fingerprint_caplet_id_pk": {
+          "columns": ["project_fingerprint", "caplet_id"],
+          "name": "setup_attempt_sets_project_fingerprint_caplet_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_access_grants": {
+      "name": "vault_access_grants",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "columns": ["subject_kind", "subject_key", "reference_name"],
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_values": {
+      "name": "vault_values",
+      "columns": {
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_bytes": {
+          "name": "value_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/sqlite/meta/0010_snapshot.json
+++ b/packages/core/src/storage/drizzle/sqlite/meta/0010_snapshot.json
@@ -1,0 +1,2011 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f7271714-1358-4087-9dfb-2524d5898c6e",
+  "prevId": "615bed52-1eb1-4a95-8c6b-14807302b9a7",
+  "tables": {
+    "backend_auth_states": {
+      "name": "backend_auth_states",
+      "columns": {
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_bundle": {
+          "name": "token_bundle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_asset_blobs": {
+      "name": "caplet_asset_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_bundle_entries": {
+      "name": "caplet_bundle_entries",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executable": {
+          "name": "executable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_bundle_entries_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk": {
+          "name": "caplet_bundle_entries_blob_hash_caplet_asset_blobs_hash_fk",
+          "tableFrom": "caplet_bundle_entries",
+          "tableTo": "caplet_asset_blobs",
+          "columnsFrom": ["blob_hash"],
+          "columnsTo": ["hash"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_bundle_entries_revision_key_path_pk": {
+          "columns": ["revision_key", "path"],
+          "name": "caplet_bundle_entries_revision_key_path_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installation_observations": {
+      "name": "caplet_installation_observations",
+      "columns": {
+        "observation_key": {
+          "name": "observation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_revision": {
+          "name": "resolved_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installation_observations_installation_idx": {
+          "name": "caplet_installation_observations_installation_idx",
+          "columns": ["installation_key", "observed_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk": {
+          "name": "caplet_installation_observations_installation_key_caplet_installations_installation_key_fk",
+          "tableFrom": "caplet_installation_observations",
+          "tableTo": "caplet_installations",
+          "columnsFrom": ["installation_key"],
+          "columnsTo": ["installation_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_installations": {
+      "name": "caplet_installations",
+      "columns": {
+        "installation_key": {
+          "name": "installation_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_identity": {
+          "name": "source_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detached_by": {
+          "name": "detached_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_installations_record_status_idx": {
+          "name": "caplet_installations_record_status_idx",
+          "columns": ["record_key", "status"],
+          "isUnique": false
+        },
+        "caplet_installations_key_generation_unique": {
+          "name": "caplet_installations_key_generation_unique",
+          "columns": ["installation_key", "generation"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_installations_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_installations_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_installations",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_records": {
+      "name": "caplet_records",
+      "columns": {
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_revision_key": {
+          "name": "current_revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "head_generation": {
+          "name": "head_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "history_limit": {
+          "name": "history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_records_caplet_id_unique": {
+          "name": "caplet_records_caplet_id_unique",
+          "columns": ["caplet_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_backends": {
+      "name": "caplet_revision_backends",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_backends_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_backends",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_backends_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_backends_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revision_tags": {
+      "name": "caplet_revision_tags",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk": {
+          "name": "caplet_revision_tags_revision_key_caplet_revisions_revision_key_fk",
+          "tableFrom": "caplet_revision_tags",
+          "tableTo": "caplet_revisions",
+          "columnsFrom": ["revision_key"],
+          "columnsTo": ["revision_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caplet_revision_tags_revision_key_position_pk": {
+          "columns": ["revision_key", "position"],
+          "name": "caplet_revision_tags_revision_key_position_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplet_revisions": {
+      "name": "caplet_revisions",
+      "columns": {
+        "revision_key": {
+          "name": "revision_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_url": {
+          "name": "schema_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "caplet_revisions_record_sequence_unique": {
+          "name": "caplet_revisions_record_sequence_unique",
+          "columns": ["record_key", "sequence"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "caplet_revisions_record_key_caplet_records_record_key_fk": {
+          "name": "caplet_revisions_record_key_caplet_records_record_key_fk",
+          "tableFrom": "caplet_revisions",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caplets_schema": {
+      "name": "caplets_schema",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dashboard_sessions": {
+      "name": "dashboard_sessions",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "csrf_token": {
+          "name": "csrf_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "dashboard_sessions_expires_at_idx": {
+          "name": "dashboard_sessions_expires_at_idx",
+          "columns": ["expires_at"],
+          "isUnique": false
+        },
+        "dashboard_sessions_last_used_at_idx": {
+          "name": "dashboard_sessions_last_used_at_idx",
+          "columns": ["last_used_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_config_generations": {
+      "name": "host_config_generations",
+      "columns": {
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_identity": {
+      "name": "host_identity",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_identity_host_id_unique": {
+          "name": "host_identity_host_id_unique",
+          "columns": ["host_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_nodes": {
+      "name": "host_nodes",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_file_manifest": {
+          "name": "global_file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_fingerprint": {
+          "name": "runtime_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ready": {
+          "name": "ready",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_cursors": {
+      "name": "maintenance_cursors",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_leases": {
+      "name": "maintenance_leases",
+      "columns": {
+        "lease_name": {
+          "name": "lease_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fencing_token": {
+          "name": "fencing_token",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "operator_activity": {
+      "name": "operator_activity",
+      "columns": {
+        "activity_key": {
+          "name": "activity_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_client_id": {
+          "name": "operator_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "operator_activity_created_idx": {
+          "name": "operator_activity_created_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_bindings": {
+      "name": "project_bindings",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_root": {
+          "name": "project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_project_root": {
+          "name": "server_project_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_node_id": {
+          "name": "owner_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "readiness": {
+          "name": "readiness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quarantined_at": {
+          "name": "quarantined_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quarantine_reason": {
+          "name": "quarantine_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_bindings_owner_expiry_idx": {
+          "name": "project_bindings_owner_expiry_idx",
+          "columns": ["owner_node_id", "expires_at"],
+          "isUnique": false
+        },
+        "project_bindings_active_expiry_idx": {
+          "name": "project_bindings_active_expiry_idx",
+          "columns": ["active", "expires_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_client_superseded_refresh_tokens": {
+      "name": "remote_client_superseded_refresh_tokens",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_client_superseded_refresh_hash_unique": {
+          "name": "remote_client_superseded_refresh_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk": {
+          "name": "remote_client_superseded_refresh_tokens_family_id_remote_client_token_families_family_id_fk",
+          "tableFrom": "remote_client_superseded_refresh_tokens",
+          "tableTo": "remote_client_token_families",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["family_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_client_superseded_refresh_tokens_family_id_token_hash_pk": {
+          "columns": ["family_id", "token_hash"],
+          "name": "remote_client_superseded_refresh_tokens_family_id_token_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_client_token_families": {
+      "name": "remote_client_token_families",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_client_token_families_client_unique": {
+          "name": "remote_client_token_families_client_unique",
+          "columns": ["client_id"],
+          "isUnique": true
+        },
+        "remote_client_token_families_refresh_hash_unique": {
+          "name": "remote_client_token_families_refresh_hash_unique",
+          "columns": ["refresh_token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_client_token_families_client_id_remote_clients_client_id_fk": {
+          "name": "remote_client_token_families_client_id_remote_clients_client_id_fk",
+          "tableFrom": "remote_client_token_families",
+          "tableTo": "remote_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_clients": {
+      "name": "remote_clients",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_expires_at": {
+          "name": "access_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_clients_access_token_hash_unique": {
+          "name": "remote_clients_access_token_hash_unique",
+          "columns": ["access_token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pairing_codes": {
+      "name": "remote_pairing_codes",
+      "columns": {
+        "code_id": {
+          "name": "code_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pending_logins": {
+      "name": "remote_pending_logins",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_url": {
+          "name": "host_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_identity": {
+          "name": "host_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operator_code_hash": {
+          "name": "operator_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_refresh_hash": {
+          "name": "pending_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_refresh_replay": {
+          "name": "pending_refresh_replay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_completion_hash": {
+          "name": "pending_completion_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_replay": {
+          "name": "completion_replay",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_label": {
+          "name": "client_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "granted_role": {
+          "name": "granted_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_fingerprint": {
+          "name": "client_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_hint": {
+          "name": "source_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_expires_at": {
+          "name": "code_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flow_expires_at": {
+          "name": "flow_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operator_code_fingerprint": {
+          "name": "operator_code_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_pending_logins_operator_code_hash_unique": {
+          "name": "remote_pending_logins_operator_code_hash_unique",
+          "columns": ["operator_code_hash"],
+          "isUnique": true
+        },
+        "remote_pending_logins_refresh_hash_unique": {
+          "name": "remote_pending_logins_refresh_hash_unique",
+          "columns": ["pending_refresh_hash"],
+          "isUnique": true
+        },
+        "remote_pending_logins_completion_hash_unique": {
+          "name": "remote_pending_logins_completion_hash_unique",
+          "columns": ["pending_completion_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_pending_superseded_refresh_tokens": {
+      "name": "remote_pending_superseded_refresh_tokens",
+      "columns": {
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_pending_superseded_refresh_hash_unique": {
+          "name": "remote_pending_superseded_refresh_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk": {
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_remote_pending_logins_flow_id_fk",
+          "tableFrom": "remote_pending_superseded_refresh_tokens",
+          "tableTo": "remote_pending_logins",
+          "columnsFrom": ["flow_id"],
+          "columnsTo": ["flow_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk": {
+          "columns": ["flow_id", "token_hash"],
+          "name": "remote_pending_superseded_refresh_tokens_flow_id_token_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_approvals": {
+      "name": "setup_approvals",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk": {
+          "columns": ["project_fingerprint", "caplet_id", "content_hash", "target_kind"],
+          "name": "setup_approvals_project_fingerprint_caplet_id_content_hash_target_kind_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_attempt_sets": {
+      "name": "setup_attempt_sets",
+      "columns": {
+        "project_fingerprint": {
+          "name": "project_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "setup_attempt_sets_project_fingerprint_caplet_id_pk": {
+          "columns": ["project_fingerprint", "caplet_id"],
+          "name": "setup_attempt_sets_project_fingerprint_caplet_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_access_grants": {
+      "name": "vault_access_grants",
+      "columns": {
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_key": {
+          "name": "record_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caplet_id": {
+          "name": "caplet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_path": {
+          "name": "origin_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vault_access_grants_record_key_caplet_records_record_key_fk": {
+          "name": "vault_access_grants_record_key_caplet_records_record_key_fk",
+          "tableFrom": "vault_access_grants",
+          "tableTo": "caplet_records",
+          "columnsFrom": ["record_key"],
+          "columnsTo": ["record_key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vault_access_grants_subject_kind_subject_key_reference_name_pk": {
+          "columns": ["subject_kind", "subject_key", "reference_name"],
+          "name": "vault_access_grants_subject_kind_subject_key_reference_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_values": {
+      "name": "vault_values",
+      "columns": {
+        "vault_key": {
+          "name": "vault_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_bytes": {
+          "name": "value_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/src/storage/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/src/storage/drizzle/sqlite/meta/_journal.json
@@ -1,0 +1,83 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1784383682333,
+      "tag": "0000_charming_kulan_gath",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1784385913762,
+      "tag": "0001_plain_puma",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1784389406835,
+      "tag": "0002_mature_wolfpack",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1784391890963,
+      "tag": "0003_next_eddie_brock",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1784394443293,
+      "tag": "0004_nasty_praxagora",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1784394618018,
+      "tag": "0005_strange_franklin_richards",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1784394689671,
+      "tag": "0006_illegal_harry_osborn",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1784394747130,
+      "tag": "0007_polite_ser_duncan",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1784394791566,
+      "tag": "0008_dry_supreme_intelligence",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1784394896171,
+      "tag": "0009_gray_sister_grimm",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1784395207778,
+      "tag": "0010_friendly_stone_men",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -1,0 +1,85 @@
+export {
+  HostStorage,
+  createHostStorage,
+  defaultSqliteStoragePath,
+  migrateHostStorage,
+  type HostStorageOptions,
+} from "./database";
+export {
+  CapletInstallationStore,
+  type CapletInstallationView,
+  type OperatorActivityView,
+  type OperatorPrincipal,
+} from "./installations";
+export {
+  VaultGrantStore,
+  type StoredVaultGrant,
+  type VaultGrantInput,
+  type VaultGrantRevokeInput,
+} from "./vault-grants";
+export {
+  HostCoordinationStore,
+  type HostNodeRegistration,
+  type MaintenanceLease,
+} from "./coordination";
+export {
+  migrateLegacyHostState,
+  type LegacyMigrationOptions,
+  type LegacyMigrationReport,
+} from "./legacy-migration";
+export {
+  CapletRecordStore,
+  type CapletBundleInputFile,
+  type CapletRecordView,
+  type ReadCapletBundleResult,
+} from "./caplet-records";
+export { BackendAuthStateStore, type BackendAuthMutationOptions } from "./backend-auth";
+export { DashboardSessionRepository } from "./dashboard-sessions";
+export {
+  ProjectBindingStore,
+  PROJECT_BINDINGS_NAMESPACE,
+  type CreateProjectBindingInput,
+  type EndProjectBindingInput,
+  type HeartbeatProjectBindingInput,
+  type QuarantineProjectBindingOwnerLossInput,
+  type RebindProjectBindingInput,
+} from "./project-bindings";
+export {
+  RemoteSecurityStore,
+  type ChangeRemoteClientRoleInput,
+  type OperatorPendingLoginFlowInput,
+  type OperatorPendingLoginInput,
+  type RevokeRemoteClientInput,
+} from "./remote-security";
+export {
+  SetupStateStore,
+  SETUP_APPROVALS_NAMESPACE,
+  SETUP_ATTEMPTS_NAMESPACE,
+  type SetupStateMutationOptions,
+  type SetupStateStoreOptions,
+} from "./setup-state";
+export {
+  OperatorActivityStore,
+  type AppendOperatorActivityInput,
+  type ListOperatorActivityInput,
+  type OperatorActivityEntry,
+  type OperatorActivityPage,
+} from "./operator-activity";
+export {
+  VaultValueStore,
+  VAULT_VALUES_NAMESPACE,
+  type VaultValueDeleteOptions,
+  type VaultValueDeleteResult,
+  type VaultValueRecordStatus,
+  type VaultValueRepository,
+  type VaultValueSetOptions,
+  type VaultValueStoreOptions,
+} from "./vault-values";
+export { createHostStorageVaultResolver } from "./vault-resolver";
+export {
+  HOST_STORAGE_SCHEMA_VERSION,
+  type HostStorageConfig,
+  type HostStorageHealth,
+  type PostgresHostStorageConfig,
+  type SqliteHostStorageConfig,
+} from "./types";

--- a/packages/core/src/storage/installations.ts
+++ b/packages/core/src/storage/installations.ts
@@ -4,7 +4,14 @@ import { CapletsError } from "../errors";
 import { advancePostgresConfigGeneration, advanceSqliteConfigGeneration } from "./coordination";
 import * as postgres from "./schema/postgres";
 import * as sqlite from "./schema/sqlite";
-import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+import type {
+  HostDatabase,
+  HostDatabaseTransaction,
+  PostgresHostDatabase,
+  PostgresHostTransaction,
+  SqliteHostDatabase,
+  SqliteHostTransaction,
+} from "./types";
 
 export type OperatorPrincipal = {
   clientId: string;
@@ -130,6 +137,14 @@ export class CapletInstallationStore {
     return this.database.dialect === "sqlite"
       ? getSqlite(this.database.db, capletId, true)
       : await getPostgres(this.database.db, capletId, true);
+  }
+  getActiveInTransaction(
+    capletId: string,
+    transaction: HostDatabaseTransaction,
+  ): CapletInstallationView | undefined | Promise<CapletInstallationView | undefined> {
+    return transaction.dialect === "sqlite"
+      ? getSqlite(transaction.db, capletId, true)
+      : getPostgres(transaction.db, capletId, true);
   }
 
   async getLatest(capletId: string): Promise<CapletInstallationView | undefined> {
@@ -616,7 +631,7 @@ async function detachPostgres(
 }
 
 function getSqlite(
-  db: SqliteHostDatabase,
+  db: SqliteHostDatabase | SqliteHostTransaction,
   capletId: string,
   activeOnly: boolean,
 ): CapletInstallationView | undefined {
@@ -645,7 +660,7 @@ function getSqlite(
 }
 
 async function getPostgres(
-  db: PostgresHostDatabase,
+  db: PostgresHostDatabase | PostgresHostTransaction,
   capletId: string,
   activeOnly: boolean,
 ): Promise<CapletInstallationView | undefined> {

--- a/packages/core/src/storage/installations.ts
+++ b/packages/core/src/storage/installations.ts
@@ -1,0 +1,996 @@
+import { randomUUID } from "node:crypto";
+import { and, desc, eq } from "drizzle-orm";
+import { CapletsError } from "../errors";
+import { advancePostgresConfigGeneration, advanceSqliteConfigGeneration } from "./coordination";
+import * as postgres from "./schema/postgres";
+import * as sqlite from "./schema/sqlite";
+import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+
+export type OperatorPrincipal = {
+  clientId: string;
+  role: "operator" | "access";
+};
+
+export type CapletInstallationView = {
+  installationKey: string;
+  capletId: string;
+  recordKey: string;
+  generation: number;
+  status: "active" | "detached";
+  sourceKind: string;
+  sourceIdentity: string;
+  channel: string | null;
+  createdAt: string;
+  updatedAt: string;
+  detachedAt: string | null;
+  detachedBy: string | null;
+};
+
+export type CapletInstallationObservationStatus =
+  | "current"
+  | "metadata-only"
+  | "source-unavailable";
+
+export type CapletInstallationObservationView = {
+  observationKey: string;
+  installationKey: string;
+  resolvedRevision: string | null;
+  contentHash: string | null;
+  risk: Record<string, unknown> | null;
+  status: CapletInstallationObservationStatus;
+  observedAt: string;
+};
+
+export type OperatorActivityView = {
+  activityKey: string;
+  operatorClientId: string;
+  action: string;
+  targetKind: string;
+  targetKey: string;
+  outcome: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+};
+
+type InstallationSourceInput = {
+  capletId: string;
+  sourceKind: string;
+  sourceIdentity: string;
+  channel?: string | undefined;
+  operator: OperatorPrincipal;
+};
+
+type InstallInput = InstallationSourceInput;
+
+type DetachInput = {
+  capletId: string;
+  expectedGeneration: number;
+  operator: OperatorPrincipal;
+};
+
+export type ReplaceDetachedInstallationInput = InstallationSourceInput & {
+  expectedGeneration: number;
+  detachedInstallationKey?: string | undefined;
+};
+
+export type AppendInstallationObservationInput = {
+  capletId: string;
+  expectedGeneration: number;
+  status: CapletInstallationObservationStatus;
+  resolvedRevision?: string | null | undefined;
+  contentHash?: string | null | undefined;
+  risk?: Record<string, unknown> | null | undefined;
+  operator: OperatorPrincipal;
+};
+
+export class CapletInstallationStore {
+  constructor(private readonly database: HostDatabase) {}
+
+  async install(input: InstallInput): Promise<CapletInstallationView> {
+    const operatorId = requireOperator(input.operator);
+    if (this.database.dialect === "sqlite") installSqlite(this.database.db, input, operatorId);
+    else await installPostgres(this.database.db, input, operatorId);
+    const installed = await this.getActive(input.capletId);
+    if (!installed)
+      throw new CapletsError("INTERNAL_ERROR", `Installed Caplet ${input.capletId} was not found.`);
+    return installed;
+  }
+
+  async replaceDetached(input: ReplaceDetachedInstallationInput): Promise<CapletInstallationView> {
+    const operatorId = requireOperator(input.operator);
+    if (this.database.dialect === "sqlite")
+      replaceDetachedSqlite(this.database.db, input, operatorId);
+    else await replaceDetachedPostgres(this.database.db, input, operatorId);
+    const installed = await this.getActive(input.capletId);
+    if (!installed)
+      throw new CapletsError(
+        "INTERNAL_ERROR",
+        `Replacement installation for ${input.capletId} was not found.`,
+      );
+    return installed;
+  }
+
+  async appendObservation(
+    input: AppendInstallationObservationInput,
+  ): Promise<CapletInstallationObservationView> {
+    const operatorId = requireOperator(input.operator);
+    return this.database.dialect === "sqlite"
+      ? appendObservationSqlite(this.database.db, input, operatorId)
+      : await appendObservationPostgres(this.database.db, input, operatorId);
+  }
+
+  async detach(input: DetachInput): Promise<CapletInstallationView | undefined> {
+    const operatorId = requireOperator(input.operator);
+    if (this.database.dialect === "sqlite") detachSqlite(this.database.db, input, operatorId);
+    else await detachPostgres(this.database.db, input, operatorId);
+    return await this.getLatest(input.capletId);
+  }
+
+  async getActive(capletId: string): Promise<CapletInstallationView | undefined> {
+    return this.database.dialect === "sqlite"
+      ? getSqlite(this.database.db, capletId, true)
+      : await getPostgres(this.database.db, capletId, true);
+  }
+
+  async getLatest(capletId: string): Promise<CapletInstallationView | undefined> {
+    return this.database.dialect === "sqlite"
+      ? getSqlite(this.database.db, capletId, false)
+      : await getPostgres(this.database.db, capletId, false);
+  }
+
+  async list(capletId: string): Promise<CapletInstallationView[]> {
+    return this.database.dialect === "sqlite"
+      ? listSqlite(this.database.db, capletId)
+      : await listPostgres(this.database.db, capletId);
+  }
+
+  async getLatestObservation(
+    capletId: string,
+  ): Promise<CapletInstallationObservationView | undefined> {
+    const installation = await this.getLatest(capletId);
+    if (!installation) return undefined;
+    return this.database.dialect === "sqlite"
+      ? latestObservationSqlite(this.database.db, installation.installationKey)
+      : await latestObservationPostgres(this.database.db, installation.installationKey);
+  }
+
+  async listObservations(capletId: string): Promise<CapletInstallationObservationView[]> {
+    const installation = await this.getLatest(capletId);
+    if (!installation) return [];
+    const rows =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select()
+            .from(sqlite.capletInstallationObservations)
+            .where(
+              eq(
+                sqlite.capletInstallationObservations.installationKey,
+                installation.installationKey,
+              ),
+            )
+            .orderBy(
+              desc(sqlite.capletInstallationObservations.observedAt),
+              desc(sqlite.capletInstallationObservations.observationKey),
+            )
+            .all()
+        : await this.database.db
+            .select()
+            .from(postgres.capletInstallationObservations)
+            .where(
+              eq(
+                postgres.capletInstallationObservations.installationKey,
+                installation.installationKey,
+              ),
+            )
+            .orderBy(
+              desc(postgres.capletInstallationObservations.observedAt),
+              desc(postgres.capletInstallationObservations.observationKey),
+            );
+    return rows.map(observationView);
+  }
+
+  async listActivity(limit = 100): Promise<OperatorActivityView[]> {
+    const bounded = Math.max(1, Math.min(limit, 500));
+    const rows =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select()
+            .from(sqlite.operatorActivity)
+            .orderBy(desc(sqlite.operatorActivity.createdAt))
+            .limit(bounded)
+            .all()
+        : await this.database.db
+            .select()
+            .from(postgres.operatorActivity)
+            .orderBy(desc(postgres.operatorActivity.createdAt))
+            .limit(bounded);
+    return rows as OperatorActivityView[];
+  }
+}
+
+export function requireOperator(principal: OperatorPrincipal): string {
+  if (principal.role !== "operator" || !principal.clientId.trim()) {
+    throw new CapletsError("AUTH_REQUIRED", "An Operator Client is required for this operation.");
+  }
+  return principal.clientId;
+}
+
+function installSqlite(db: SqliteHostDatabase, input: InstallInput, operatorId: string): void {
+  db.transaction((transaction) => {
+    const record = transaction
+      .select()
+      .from(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.capletId, input.capletId))
+      .get();
+    if (!record)
+      throw new CapletsError("REQUEST_INVALID", `Caplet Record ${input.capletId} was not found.`);
+    const latest = transaction
+      .select()
+      .from(sqlite.capletInstallations)
+      .where(eq(sqlite.capletInstallations.recordKey, record.recordKey))
+      .orderBy(
+        desc(sqlite.capletInstallations.updatedAt),
+        desc(sqlite.capletInstallations.installationKey),
+      )
+      .limit(1)
+      .get();
+    assertFreshInstall(input.capletId, latest?.status);
+    const now = new Date().toISOString();
+    const installationKey = randomUUID();
+    transaction
+      .insert(sqlite.capletInstallations)
+      .values({
+        installationKey,
+        recordKey: record.recordKey,
+        generation: 1,
+        status: "active",
+        sourceKind: input.sourceKind,
+        sourceIdentity: input.sourceIdentity,
+        channel: input.channel ?? null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values(
+        activity(operatorId, "caplet.install", "installation", installationKey, now, {
+          capletId: input.capletId,
+        }),
+      )
+      .run();
+    advanceSqliteConfigGeneration(
+      transaction,
+      `install:${record.recordKey}:${installationKey}`,
+      operatorId,
+    );
+  });
+}
+
+async function installPostgres(
+  db: PostgresHostDatabase,
+  input: InstallInput,
+  operatorId: string,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const [record] = await transaction
+      .select()
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.capletId, input.capletId))
+      .for("update")
+      .limit(1);
+    if (!record)
+      throw new CapletsError("REQUEST_INVALID", `Caplet Record ${input.capletId} was not found.`);
+    const [latest] = await transaction
+      .select()
+      .from(postgres.capletInstallations)
+      .where(eq(postgres.capletInstallations.recordKey, record.recordKey))
+      .orderBy(
+        desc(postgres.capletInstallations.updatedAt),
+        desc(postgres.capletInstallations.installationKey),
+      )
+      .limit(1);
+    assertFreshInstall(input.capletId, latest?.status);
+    const now = new Date().toISOString();
+    const installationKey = randomUUID();
+    await transaction.insert(postgres.capletInstallations).values({
+      installationKey,
+      recordKey: record.recordKey,
+      generation: 1,
+      status: "active",
+      sourceKind: input.sourceKind,
+      sourceIdentity: input.sourceIdentity,
+      channel: input.channel ?? null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await transaction.insert(postgres.operatorActivity).values(
+      activity(operatorId, "caplet.install", "installation", installationKey, now, {
+        capletId: input.capletId,
+      }),
+    );
+    await advancePostgresConfigGeneration(
+      transaction,
+      `install:${record.recordKey}:${installationKey}`,
+      operatorId,
+    );
+  });
+}
+
+function replaceDetachedSqlite(
+  db: SqliteHostDatabase,
+  input: ReplaceDetachedInstallationInput,
+  operatorId: string,
+): void {
+  db.transaction((transaction) => {
+    const record = transaction
+      .select()
+      .from(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.capletId, input.capletId))
+      .get();
+    if (!record)
+      throw new CapletsError("REQUEST_INVALID", `Caplet Record ${input.capletId} was not found.`);
+    const latest = transaction
+      .select()
+      .from(sqlite.capletInstallations)
+      .where(eq(sqlite.capletInstallations.recordKey, record.recordKey))
+      .orderBy(
+        desc(sqlite.capletInstallations.updatedAt),
+        desc(sqlite.capletInstallations.installationKey),
+      )
+      .limit(1)
+      .get();
+    assertDetachedReplacement(input, latest);
+    const now = nextTimestamp(latest!.updatedAt);
+    const installationKey = randomUUID();
+    transaction
+      .insert(sqlite.capletInstallations)
+      .values({
+        installationKey,
+        recordKey: record.recordKey,
+        generation: 1,
+        status: "active",
+        sourceKind: input.sourceKind,
+        sourceIdentity: input.sourceIdentity,
+        channel: input.channel ?? null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values(
+        activity(operatorId, "caplet.replace_installation", "installation", installationKey, now, {
+          capletId: input.capletId,
+          detachedInstallationKey: latest!.installationKey,
+        }),
+      )
+      .run();
+    advanceSqliteConfigGeneration(
+      transaction,
+      `install:${record.recordKey}:${installationKey}`,
+      operatorId,
+    );
+  });
+}
+
+async function replaceDetachedPostgres(
+  db: PostgresHostDatabase,
+  input: ReplaceDetachedInstallationInput,
+  operatorId: string,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const [record] = await transaction
+      .select()
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.capletId, input.capletId))
+      .for("update")
+      .limit(1);
+    if (!record)
+      throw new CapletsError("REQUEST_INVALID", `Caplet Record ${input.capletId} was not found.`);
+    const [latest] = await transaction
+      .select()
+      .from(postgres.capletInstallations)
+      .where(eq(postgres.capletInstallations.recordKey, record.recordKey))
+      .orderBy(
+        desc(postgres.capletInstallations.updatedAt),
+        desc(postgres.capletInstallations.installationKey),
+      )
+      .for("update")
+      .limit(1);
+    assertDetachedReplacement(input, latest);
+    const now = nextTimestamp(latest!.updatedAt);
+    const installationKey = randomUUID();
+    await transaction.insert(postgres.capletInstallations).values({
+      installationKey,
+      recordKey: record.recordKey,
+      generation: 1,
+      status: "active",
+      sourceKind: input.sourceKind,
+      sourceIdentity: input.sourceIdentity,
+      channel: input.channel ?? null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await transaction.insert(postgres.operatorActivity).values(
+      activity(operatorId, "caplet.replace_installation", "installation", installationKey, now, {
+        capletId: input.capletId,
+        detachedInstallationKey: latest!.installationKey,
+      }),
+    );
+    await advancePostgresConfigGeneration(
+      transaction,
+      `install:${record.recordKey}:${installationKey}`,
+      operatorId,
+    );
+  });
+}
+
+function appendObservationSqlite(
+  db: SqliteHostDatabase,
+  input: AppendInstallationObservationInput,
+  operatorId: string,
+): CapletInstallationObservationView {
+  return db.transaction((transaction) => {
+    const current = activeSqlite(transaction, input.capletId);
+    if (!current) throw missingActiveInstallation(input.capletId);
+    if (current.generation !== input.expectedGeneration) throw staleInstallation(input.capletId);
+    const latest = transaction
+      .select()
+      .from(sqlite.capletInstallationObservations)
+      .where(eq(sqlite.capletInstallationObservations.installationKey, current.installationKey))
+      .orderBy(
+        desc(sqlite.capletInstallationObservations.observedAt),
+        desc(sqlite.capletInstallationObservations.observationKey),
+      )
+      .limit(1)
+      .get();
+    const now = nextTimestamp(latest?.observedAt);
+    const observation = observationValues(current.installationKey, input, now);
+    const updated = transaction
+      .update(sqlite.capletInstallations)
+      .set({ generation: current.generation + 1, updatedAt: now })
+      .where(
+        and(
+          eq(sqlite.capletInstallations.installationKey, current.installationKey),
+          eq(sqlite.capletInstallations.generation, input.expectedGeneration),
+          eq(sqlite.capletInstallations.status, "active"),
+        ),
+      )
+      .run();
+    if (updated.changes !== 1) throw staleInstallation(input.capletId);
+    transaction.insert(sqlite.capletInstallationObservations).values(observation).run();
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values(
+        activity(
+          operatorId,
+          "caplet.observe_source",
+          "installation",
+          current.installationKey,
+          now,
+          { capletId: input.capletId, status: input.status },
+        ),
+      )
+      .run();
+    return observationView(observation);
+  });
+}
+
+async function appendObservationPostgres(
+  db: PostgresHostDatabase,
+  input: AppendInstallationObservationInput,
+  operatorId: string,
+): Promise<CapletInstallationObservationView> {
+  return await db.transaction(async (transaction) => {
+    const current = await activePostgres(transaction, input.capletId, true);
+    if (!current) throw missingActiveInstallation(input.capletId);
+    if (current.generation !== input.expectedGeneration) throw staleInstallation(input.capletId);
+    const [latest] = await transaction
+      .select()
+      .from(postgres.capletInstallationObservations)
+      .where(eq(postgres.capletInstallationObservations.installationKey, current.installationKey))
+      .orderBy(
+        desc(postgres.capletInstallationObservations.observedAt),
+        desc(postgres.capletInstallationObservations.observationKey),
+      )
+      .limit(1);
+    const now = nextTimestamp(latest?.observedAt);
+    const observation = observationValues(current.installationKey, input, now);
+    const [updated] = await transaction
+      .update(postgres.capletInstallations)
+      .set({ generation: current.generation + 1, updatedAt: now })
+      .where(
+        and(
+          eq(postgres.capletInstallations.installationKey, current.installationKey),
+          eq(postgres.capletInstallations.generation, input.expectedGeneration),
+          eq(postgres.capletInstallations.status, "active"),
+        ),
+      )
+      .returning({ installationKey: postgres.capletInstallations.installationKey });
+    if (!updated) throw staleInstallation(input.capletId);
+    await transaction.insert(postgres.capletInstallationObservations).values(observation);
+    await transaction
+      .insert(postgres.operatorActivity)
+      .values(
+        activity(
+          operatorId,
+          "caplet.observe_source",
+          "installation",
+          current.installationKey,
+          now,
+          { capletId: input.capletId, status: input.status },
+        ),
+      );
+    return observationView(observation);
+  });
+}
+
+function detachSqlite(db: SqliteHostDatabase, input: DetachInput, operatorId: string): void {
+  db.transaction((transaction) => {
+    const current = activeSqlite(transaction, input.capletId);
+    if (!current) {
+      assertNoStaleDetachedSqlite(transaction, input);
+      return;
+    }
+    if (current.generation !== input.expectedGeneration) throw staleInstallation(input.capletId);
+    const now = new Date().toISOString();
+    const updated = transaction
+      .update(sqlite.capletInstallations)
+      .set({
+        status: "detached",
+        generation: current.generation + 1,
+        detachedAt: now,
+        detachedBy: operatorId,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(sqlite.capletInstallations.installationKey, current.installationKey),
+          eq(sqlite.capletInstallations.generation, input.expectedGeneration),
+          eq(sqlite.capletInstallations.status, "active"),
+        ),
+      )
+      .run();
+    if (updated.changes !== 1) throw staleInstallation(input.capletId);
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values(
+        activity(operatorId, "caplet.detach", "installation", current.installationKey, now, {
+          capletId: input.capletId,
+        }),
+      )
+      .run();
+    advanceSqliteConfigGeneration(
+      transaction,
+      `detach:${current.installationKey}:${current.generation + 1}`,
+      operatorId,
+    );
+  });
+}
+
+async function detachPostgres(
+  db: PostgresHostDatabase,
+  input: DetachInput,
+  operatorId: string,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const current = await activePostgres(transaction, input.capletId, true);
+    if (!current) {
+      const latest = await latestPostgresInTransaction(transaction, input.capletId, true);
+      if (latest && latest.generation !== input.expectedGeneration)
+        throw staleInstallation(input.capletId);
+      return;
+    }
+    if (current.generation !== input.expectedGeneration) throw staleInstallation(input.capletId);
+    const now = new Date().toISOString();
+    const [updated] = await transaction
+      .update(postgres.capletInstallations)
+      .set({
+        status: "detached",
+        generation: current.generation + 1,
+        detachedAt: now,
+        detachedBy: operatorId,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(postgres.capletInstallations.installationKey, current.installationKey),
+          eq(postgres.capletInstallations.generation, input.expectedGeneration),
+          eq(postgres.capletInstallations.status, "active"),
+        ),
+      )
+      .returning({ installationKey: postgres.capletInstallations.installationKey });
+    if (!updated) throw staleInstallation(input.capletId);
+    await transaction.insert(postgres.operatorActivity).values(
+      activity(operatorId, "caplet.detach", "installation", current.installationKey, now, {
+        capletId: input.capletId,
+      }),
+    );
+    await advancePostgresConfigGeneration(
+      transaction,
+      `detach:${current.installationKey}:${current.generation + 1}`,
+      operatorId,
+    );
+  });
+}
+
+function getSqlite(
+  db: SqliteHostDatabase,
+  capletId: string,
+  activeOnly: boolean,
+): CapletInstallationView | undefined {
+  const row = db
+    .select({ installation: sqlite.capletInstallations, capletId: sqlite.capletRecords.capletId })
+    .from(sqlite.capletInstallations)
+    .innerJoin(
+      sqlite.capletRecords,
+      eq(sqlite.capletRecords.recordKey, sqlite.capletInstallations.recordKey),
+    )
+    .where(
+      activeOnly
+        ? and(
+            eq(sqlite.capletRecords.capletId, capletId),
+            eq(sqlite.capletInstallations.status, "active"),
+          )
+        : eq(sqlite.capletRecords.capletId, capletId),
+    )
+    .orderBy(
+      desc(sqlite.capletInstallations.updatedAt),
+      desc(sqlite.capletInstallations.installationKey),
+    )
+    .limit(1)
+    .get();
+  return row ? installationView(row.capletId, row.installation) : undefined;
+}
+
+async function getPostgres(
+  db: PostgresHostDatabase,
+  capletId: string,
+  activeOnly: boolean,
+): Promise<CapletInstallationView | undefined> {
+  const [row] = await db
+    .select({
+      installation: postgres.capletInstallations,
+      capletId: postgres.capletRecords.capletId,
+    })
+    .from(postgres.capletInstallations)
+    .innerJoin(
+      postgres.capletRecords,
+      eq(postgres.capletRecords.recordKey, postgres.capletInstallations.recordKey),
+    )
+    .where(
+      activeOnly
+        ? and(
+            eq(postgres.capletRecords.capletId, capletId),
+            eq(postgres.capletInstallations.status, "active"),
+          )
+        : eq(postgres.capletRecords.capletId, capletId),
+    )
+    .orderBy(
+      desc(postgres.capletInstallations.updatedAt),
+      desc(postgres.capletInstallations.installationKey),
+    )
+    .limit(1);
+  return row ? installationView(row.capletId, row.installation) : undefined;
+}
+
+function listSqlite(db: SqliteHostDatabase, capletId: string): CapletInstallationView[] {
+  return db
+    .select({ installation: sqlite.capletInstallations, capletId: sqlite.capletRecords.capletId })
+    .from(sqlite.capletInstallations)
+    .innerJoin(
+      sqlite.capletRecords,
+      eq(sqlite.capletRecords.recordKey, sqlite.capletInstallations.recordKey),
+    )
+    .where(eq(sqlite.capletRecords.capletId, capletId))
+    .orderBy(
+      desc(sqlite.capletInstallations.updatedAt),
+      desc(sqlite.capletInstallations.installationKey),
+    )
+    .all()
+    .map((row) => installationView(row.capletId, row.installation));
+}
+
+async function listPostgres(
+  db: PostgresHostDatabase,
+  capletId: string,
+): Promise<CapletInstallationView[]> {
+  const rows = await db
+    .select({
+      installation: postgres.capletInstallations,
+      capletId: postgres.capletRecords.capletId,
+    })
+    .from(postgres.capletInstallations)
+    .innerJoin(
+      postgres.capletRecords,
+      eq(postgres.capletRecords.recordKey, postgres.capletInstallations.recordKey),
+    )
+    .where(eq(postgres.capletRecords.capletId, capletId))
+    .orderBy(
+      desc(postgres.capletInstallations.updatedAt),
+      desc(postgres.capletInstallations.installationKey),
+    );
+  return rows.map((row) => installationView(row.capletId, row.installation));
+}
+
+function activeSqlite(
+  db: Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0],
+  capletId: string,
+) {
+  return db
+    .select({
+      installationKey: sqlite.capletInstallations.installationKey,
+      generation: sqlite.capletInstallations.generation,
+    })
+    .from(sqlite.capletInstallations)
+    .innerJoin(
+      sqlite.capletRecords,
+      eq(sqlite.capletRecords.recordKey, sqlite.capletInstallations.recordKey),
+    )
+    .where(
+      and(
+        eq(sqlite.capletRecords.capletId, capletId),
+        eq(sqlite.capletInstallations.status, "active"),
+      ),
+    )
+    .get();
+}
+
+async function activePostgres(
+  db: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  capletId: string,
+  lock = false,
+) {
+  const query = db
+    .select({
+      installationKey: postgres.capletInstallations.installationKey,
+      generation: postgres.capletInstallations.generation,
+    })
+    .from(postgres.capletInstallations)
+    .innerJoin(
+      postgres.capletRecords,
+      eq(postgres.capletRecords.recordKey, postgres.capletInstallations.recordKey),
+    )
+    .where(
+      and(
+        eq(postgres.capletRecords.capletId, capletId),
+        eq(postgres.capletInstallations.status, "active"),
+      ),
+    )
+    .limit(1);
+  const [row] = lock ? await query.for("update") : await query;
+  return row;
+}
+
+function latestObservationSqlite(
+  db: SqliteHostDatabase,
+  installationKey: string,
+): CapletInstallationObservationView | undefined {
+  const row = db
+    .select()
+    .from(sqlite.capletInstallationObservations)
+    .where(eq(sqlite.capletInstallationObservations.installationKey, installationKey))
+    .orderBy(
+      desc(sqlite.capletInstallationObservations.observedAt),
+      desc(sqlite.capletInstallationObservations.observationKey),
+    )
+    .limit(1)
+    .get();
+  return row ? observationView(row) : undefined;
+}
+
+async function latestObservationPostgres(
+  db: PostgresHostDatabase,
+  installationKey: string,
+): Promise<CapletInstallationObservationView | undefined> {
+  const [row] = await db
+    .select()
+    .from(postgres.capletInstallationObservations)
+    .where(eq(postgres.capletInstallationObservations.installationKey, installationKey))
+    .orderBy(
+      desc(postgres.capletInstallationObservations.observedAt),
+      desc(postgres.capletInstallationObservations.observationKey),
+    )
+    .limit(1);
+  return row ? observationView(row) : undefined;
+}
+
+function assertNoStaleDetachedSqlite(
+  db: Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0],
+  input: DetachInput,
+): void {
+  const latest = db
+    .select({ generation: sqlite.capletInstallations.generation })
+    .from(sqlite.capletInstallations)
+    .innerJoin(
+      sqlite.capletRecords,
+      eq(sqlite.capletRecords.recordKey, sqlite.capletInstallations.recordKey),
+    )
+    .where(eq(sqlite.capletRecords.capletId, input.capletId))
+    .orderBy(
+      desc(sqlite.capletInstallations.updatedAt),
+      desc(sqlite.capletInstallations.installationKey),
+    )
+    .limit(1)
+    .get();
+  if (latest && latest.generation !== input.expectedGeneration)
+    throw staleInstallation(input.capletId);
+}
+
+async function latestPostgresInTransaction(
+  db: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  capletId: string,
+  lock: boolean,
+) {
+  const query = db
+    .select({ generation: postgres.capletInstallations.generation })
+    .from(postgres.capletInstallations)
+    .innerJoin(
+      postgres.capletRecords,
+      eq(postgres.capletRecords.recordKey, postgres.capletInstallations.recordKey),
+    )
+    .where(eq(postgres.capletRecords.capletId, capletId))
+    .orderBy(
+      desc(postgres.capletInstallations.updatedAt),
+      desc(postgres.capletInstallations.installationKey),
+    )
+    .limit(1);
+  const [row] = lock ? await query.for("update") : await query;
+  return row;
+}
+
+function observationValues(
+  installationKey: string,
+  input: AppendInstallationObservationInput,
+  observedAt: string,
+) {
+  return {
+    observationKey: randomUUID(),
+    installationKey,
+    resolvedRevision: input.resolvedRevision ?? null,
+    contentHash: input.contentHash ?? null,
+    risk: input.risk ?? null,
+    status: input.status,
+    observedAt,
+  };
+}
+
+function activity(
+  operatorClientId: string,
+  action: string,
+  targetKind: string,
+  targetKey: string,
+  createdAt: string,
+  metadata: Record<string, unknown>,
+) {
+  return {
+    activityKey: randomUUID(),
+    operatorClientId,
+    action,
+    targetKind,
+    targetKey,
+    outcome: "succeeded",
+    metadata,
+    createdAt,
+  };
+}
+
+function installationView(
+  capletId: string,
+  row: Omit<CapletInstallationView, "capletId" | "status"> & { status: string },
+): CapletInstallationView {
+  if (row.status !== "active" && row.status !== "detached") {
+    throw new CapletsError(
+      "INTERNAL_ERROR",
+      `Caplet installation has invalid status ${row.status}.`,
+    );
+  }
+  return { capletId, ...row, status: row.status };
+}
+
+function observationView(row: {
+  observationKey: string;
+  installationKey: string;
+  resolvedRevision: string | null;
+  contentHash: string | null;
+  risk: unknown;
+  status: string;
+  observedAt: string;
+}): CapletInstallationObservationView {
+  if (
+    row.status !== "current" &&
+    row.status !== "metadata-only" &&
+    row.status !== "source-unavailable"
+  ) {
+    throw new CapletsError(
+      "INTERNAL_ERROR",
+      `Caplet installation observation has invalid status ${row.status}.`,
+    );
+  }
+  if (row.risk !== null && !isRecord(row.risk)) {
+    throw new CapletsError(
+      "INTERNAL_ERROR",
+      "Caplet installation observation has an invalid risk payload.",
+    );
+  }
+  assertTimestamp(row.observedAt);
+  return { ...row, status: row.status, risk: row.risk };
+}
+
+function assertFreshInstall(capletId: string, status: string | undefined): void {
+  if (status === "active")
+    throw new CapletsError(
+      "CONFIG_EXISTS",
+      `Caplet ${capletId} already has an active installation.`,
+    );
+  if (status === "detached") {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      `Caplet ${capletId} has a detached installation; use explicit replacement.`,
+      { kind: "detached_installation_replacement_required" },
+    );
+  }
+  if (status !== undefined)
+    throw new CapletsError("INTERNAL_ERROR", `Caplet installation has invalid status ${status}.`);
+}
+
+function assertDetachedReplacement(
+  input: ReplaceDetachedInstallationInput,
+  latest:
+    | { installationKey: string; generation: number; status: string; updatedAt: string }
+    | undefined,
+): void {
+  if (!latest)
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      `Caplet ${input.capletId} has no detached installation to replace.`,
+      { kind: "detached_installation_required" },
+    );
+  if (latest.status === "active")
+    throw new CapletsError(
+      "CONFIG_EXISTS",
+      `Caplet ${input.capletId} already has an active installation.`,
+    );
+  if (latest.status !== "detached")
+    throw new CapletsError(
+      "INTERNAL_ERROR",
+      `Caplet installation has invalid status ${latest.status}.`,
+    );
+  if (
+    (input.detachedInstallationKey !== undefined &&
+      input.detachedInstallationKey !== latest.installationKey) ||
+    input.expectedGeneration !== latest.generation
+  ) {
+    throw staleInstallation(input.capletId);
+  }
+}
+
+function nextTimestamp(previous: string | undefined): string {
+  if (previous === undefined) return new Date().toISOString();
+  assertTimestamp(previous);
+  return new Date(Math.max(Date.now(), Date.parse(previous) + 1)).toISOString();
+}
+
+function assertTimestamp(value: string): void {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed) || new Date(parsed).toISOString() !== value) {
+    throw new CapletsError("INTERNAL_ERROR", "Caplet installation contains an invalid timestamp.");
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function missingActiveInstallation(capletId: string): CapletsError {
+  return new CapletsError("REQUEST_INVALID", `Caplet ${capletId} has no active installation.`);
+}
+
+function staleInstallation(capletId: string): CapletsError {
+  return new CapletsError(
+    "REQUEST_INVALID",
+    `Caplet installation ${capletId} changed after it was read; reload and retry.`,
+    { kind: "stale_generation" },
+  );
+}

--- a/packages/core/src/storage/legacy-migration.ts
+++ b/packages/core/src/storage/legacy-migration.ts
@@ -1,0 +1,642 @@
+import { createHash, type Hash } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import {
+  readLegacyOAuthTokenBundleSnapshot,
+  type LegacyOAuthTokenBundleSnapshot,
+} from "../auth/store";
+import { readCapletsLockfile, validateLockfileDestination } from "../lockfile";
+import { DashboardActivityLog, type DashboardActivityEntry } from "../dashboard/activity-log";
+import { CapletsError } from "../errors";
+import {
+  RemoteServerCredentialStore,
+  type RemoteServerCredentialState,
+} from "../remote/server-credential-store";
+import { LocalSetupStore, type LegacySetupMigrationSnapshot } from "../setup/local-store";
+import { FileVaultStore, type LegacyVaultMigrationSnapshot } from "../vault";
+import { createHostStorage, type HostStorage } from "./database";
+import type { LegacyRecordVaultGrantImport } from "./vault-grants";
+import type { HostStorageConfig } from "./types";
+
+export type LegacyMigrationOptions = {
+  storage: HostStorageConfig;
+  capletsRoot: string;
+  lockfilePath: string;
+  operatorClientId: string;
+  backupRoot?: string | undefined;
+  dryRun?: boolean | undefined;
+  backendAuthDir?: string | undefined;
+  legacyVaultRoot?: string | undefined;
+  legacyVaultEnv?: Record<string, string | undefined> | undefined;
+  targetVaultRoot?: string | undefined;
+  remoteSecurityDir?: string | undefined;
+  setupStateDir?: string | undefined;
+  operatorActivityDir?: string | undefined;
+};
+
+export type LegacyMigrationDomainReport = {
+  backendAuthTokenBundles: number;
+  vaultValues: number;
+  vaultGrants: number;
+  remotePairingCodes: number;
+  remoteClients: number;
+  remotePendingLogins: number;
+  setupApprovals: number;
+  setupAttempts: number;
+  operatorActivityEntries: number;
+  dashboardSessions: "not_applicable_no_legacy_format";
+  projectBindings: "not_applicable_no_legacy_format";
+};
+
+export type LegacyMigrationReport = {
+  status: "verified" | "migrated";
+  records: number;
+  installations: number;
+  backupPath: string | null;
+  domains?: LegacyMigrationDomainReport | undefined;
+};
+
+type PlannedArtifact = {
+  id: string;
+  destination: string;
+  installedHash: string;
+  sourceKind: string;
+  sourceIdentity: string;
+  files: Array<{ path: string; content: Buffer; executable: boolean }>;
+};
+
+type BackupMove = {
+  source: string;
+  target: string;
+};
+
+type PlannedLegacyState = {
+  artifacts: PlannedArtifact[];
+  backendAuth: LegacyOAuthTokenBundleSnapshot;
+  vault: LegacyVaultMigrationSnapshot;
+  vaultGrants: LegacyRecordVaultGrantImport[];
+  remoteSecurity: RemoteServerCredentialState;
+  setup: LegacySetupMigrationSnapshot;
+  operatorActivity: DashboardActivityEntry[];
+  backupMoves: BackupMove[];
+  includeDomainReport: boolean;
+};
+
+const EMPTY_BACKEND_AUTH: LegacyOAuthTokenBundleSnapshot = { bundles: [], sourcePaths: [] };
+const EMPTY_VAULT: LegacyVaultMigrationSnapshot = { values: [], grants: [], sourcePaths: [] };
+const EMPTY_REMOTE_SECURITY: RemoteServerCredentialState = {
+  version: 1,
+  pairingCodes: [],
+  pendingLogins: [],
+  clients: [],
+};
+const EMPTY_SETUP: LegacySetupMigrationSnapshot = {
+  approvals: [],
+  attempts: [],
+  sourcePaths: [],
+};
+
+export async function migrateLegacyHostState(
+  options: LegacyMigrationOptions,
+): Promise<LegacyMigrationReport> {
+  const lockPath = `${options.lockfilePath}.migration.lock`;
+  mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
+  let lock: number;
+  try {
+    lock = openSync(lockPath, "wx", 0o600);
+  } catch {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      `Legacy migration is already active or left a stale lock at ${lockPath}.`,
+    );
+  }
+
+  let storage: HostStorage | undefined;
+  try {
+    const backupPath =
+      options.backupRoot ??
+      join(dirname(options.lockfilePath), "migration-backups", timestampForPath(new Date()));
+    const plan = planLegacyState(options, backupPath);
+    storage = await createHostStorage(
+      options.storage,
+      options.targetVaultRoot === undefined ? {} : { vaultRoot: options.targetVaultRoot },
+    );
+    if (
+      options.legacyVaultRoot !== undefined &&
+      resolve(storage.vaultValues.root) === resolve(options.legacyVaultRoot)
+    ) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        "Legacy and SQL Vault key roots must be different during migration.",
+      );
+    }
+    if ((await storage.coordination.activeNodeCount()) > 0) {
+      throw new CapletsError(
+        "SERVER_UNAVAILABLE",
+        "Stop every Host Node before migrating legacy filesystem state.",
+      );
+    }
+
+    const pending: PlannedArtifact[] = [];
+    for (const artifact of plan.artifacts) {
+      const existing = await storage.caplets.get(artifact.id);
+      if (!existing) {
+        pending.push(artifact);
+        continue;
+      }
+      if (existing.currentRevision.sourceContentHash !== artifact.installedHash) {
+        throw new CapletsError(
+          "CONFIG_EXISTS",
+          `Caplet Record ${artifact.id} conflicts with the tracked filesystem artifact.`,
+        );
+      }
+      const installation = await storage.installations.getActive(artifact.id);
+      if (!installation || installation.sourceIdentity !== artifact.sourceIdentity) {
+        throw new CapletsError(
+          "CONFIG_EXISTS",
+          `Caplet installation ${artifact.id} conflicts with the tracked filesystem artifact.`,
+        );
+      }
+    }
+
+    const operator = { clientId: options.operatorClientId, role: "operator" as const };
+    await storage.backendAuth.assertLegacyBundlesImportable(plan.backendAuth.bundles);
+    await storage.vaultValues.assertLegacyValuesImportable(plan.vault.values);
+    await storage.remoteSecurity.assertLegacySnapshotImportable(plan.remoteSecurity);
+    await storage.setupState.assertLegacySnapshotImportable(plan.setup);
+    await storage.operatorActivity.assertLegacyEntriesImportable(plan.operatorActivity);
+    const existingVaultGrants = await assertRequiredVaultRecords(
+      storage,
+      plan.vaultGrants,
+      plan.artifacts,
+    );
+    await storage.vaultGrants.assertLegacyRecordGrantsImportable(existingVaultGrants, operator);
+
+    if (options.dryRun) {
+      return reportForPlan("verified", null, plan);
+    }
+
+    if (pending.length > 0) {
+      await storage.caplets.importBundles(
+        pending.map((artifact) => ({
+          id: artifact.id,
+          operator: { clientId: options.operatorClientId, role: "operator" as const },
+          files: artifact.files,
+          sourceContentHash: artifact.installedHash,
+          installation: {
+            sourceKind: artifact.sourceKind,
+            sourceIdentity: artifact.sourceIdentity,
+          },
+        })),
+      );
+    }
+
+    await storage.vaultGrants.assertLegacyRecordGrantsImportable(plan.vaultGrants, operator);
+    await storage.backendAuth.importLegacyBundles(plan.backendAuth.bundles);
+    await storage.vaultValues.importLegacyValues(plan.vault.values);
+    await storage.vaultGrants.importLegacyRecordGrants(plan.vaultGrants, operator);
+    await storage.remoteSecurity.importLegacySnapshot(plan.remoteSecurity);
+    await storage.setupState.importLegacySnapshot(plan.setup);
+    await storage.operatorActivity.importLegacyEntries(plan.operatorActivity);
+
+    await verifyImportedArtifacts(storage, plan.artifacts);
+    await storage.backendAuth.verifyLegacyBundles(plan.backendAuth.bundles);
+    await storage.vaultValues.verifyLegacyValues(plan.vault.values);
+    await storage.vaultGrants.verifyLegacyRecordGrants(plan.vaultGrants, operator);
+    await storage.remoteSecurity.verifyLegacySnapshot(plan.remoteSecurity);
+    await storage.setupState.verifyLegacySnapshot(plan.setup);
+    await storage.operatorActivity.verifyLegacyEntries(plan.operatorActivity);
+
+    moveLegacyArtifactsToBackup(plan.backupMoves);
+    return reportForPlan("migrated", backupPath, plan);
+  } finally {
+    await storage?.close();
+    closeSync(lock);
+    rmSync(lockPath, { force: true });
+  }
+}
+
+function planLegacyState(options: LegacyMigrationOptions, backupPath: string): PlannedLegacyState {
+  const backupMoves: BackupMove[] = [];
+  const capletsBackupRoot = join(backupPath, "caplets");
+  const capletsBackupLockfile = join(backupPath, "caplets.lock.json");
+  const capletsFromBackup = !existsSync(options.lockfilePath) && existsSync(capletsBackupLockfile);
+  const artifacts = planArtifacts(
+    capletsFromBackup ? capletsBackupRoot : options.capletsRoot,
+    capletsFromBackup ? capletsBackupLockfile : options.lockfilePath,
+  );
+  if (!capletsFromBackup) {
+    for (const artifact of artifacts) {
+      backupMoves.push({
+        source: artifact.destination,
+        target: join(
+          capletsBackupRoot,
+          portableRelative(resolve(options.capletsRoot), artifact.destination),
+        ),
+      });
+    }
+    backupMoves.push({ source: options.lockfilePath, target: capletsBackupLockfile });
+  }
+
+  const backendAuth = options.backendAuthDir
+    ? snapshotWithBackupFallback(
+        () => readLegacyOAuthTokenBundleSnapshot(options.backendAuthDir as string),
+        () => readLegacyOAuthTokenBundleSnapshot(join(backupPath, "backend-auth")),
+        (snapshot) => snapshot.sourcePaths.length === 0,
+      )
+    : { snapshot: EMPTY_BACKEND_AUTH, fromBackup: false };
+  if (!backendAuth.fromBackup && options.backendAuthDir) {
+    appendFileBackupMoves(
+      backupMoves,
+      backendAuth.snapshot.sourcePaths,
+      options.backendAuthDir,
+      join(backupPath, "backend-auth"),
+    );
+  }
+
+  const vault = options.legacyVaultRoot
+    ? snapshotWithBackupFallback(
+        () =>
+          new FileVaultStore({
+            root: options.legacyVaultRoot,
+            env: options.legacyVaultEnv,
+          }).exportForMigration(),
+        () =>
+          new FileVaultStore({
+            root: join(backupPath, "vault"),
+            env: options.legacyVaultEnv,
+          }).exportForMigration(),
+        (snapshot) => snapshot.sourcePaths.length === 0,
+      )
+    : { snapshot: EMPTY_VAULT, fromBackup: false };
+  if (!vault.fromBackup && options.legacyVaultRoot) {
+    appendFileBackupMoves(
+      backupMoves,
+      vault.snapshot.sourcePaths,
+      options.legacyVaultRoot,
+      join(backupPath, "vault"),
+    );
+  }
+  const vaultGrants = plannedVaultGrants(vault.snapshot);
+
+  const remoteSecurity = options.remoteSecurityDir
+    ? snapshotWithBackupFallback(
+        () =>
+          new RemoteServerCredentialStore({
+            dir: options.remoteSecurityDir as string,
+          }).exportForMigration(),
+        () =>
+          new RemoteServerCredentialStore({
+            dir: join(backupPath, "remote-security"),
+          }).exportForMigration(),
+        (snapshot) => snapshot.sourcePaths.length === 0,
+      )
+    : { snapshot: { state: EMPTY_REMOTE_SECURITY, sourcePaths: [] }, fromBackup: false };
+  if (!remoteSecurity.fromBackup && options.remoteSecurityDir) {
+    appendFileBackupMoves(
+      backupMoves,
+      remoteSecurity.snapshot.sourcePaths,
+      options.remoteSecurityDir,
+      join(backupPath, "remote-security"),
+    );
+  }
+
+  const setup = options.setupStateDir
+    ? snapshotWithBackupFallback(
+        () =>
+          new LocalSetupStore({ baseDir: options.setupStateDir as string }).exportForMigration(),
+        () =>
+          new LocalSetupStore({ baseDir: join(backupPath, "setup-state") }).exportForMigration(),
+        (snapshot) => snapshot.sourcePaths.length === 0,
+      )
+    : { snapshot: EMPTY_SETUP, fromBackup: false };
+  if (!setup.fromBackup && options.setupStateDir) {
+    appendFileBackupMoves(
+      backupMoves,
+      setup.snapshot.sourcePaths,
+      options.setupStateDir,
+      join(backupPath, "setup-state"),
+    );
+  }
+
+  const operatorActivity = options.operatorActivityDir
+    ? snapshotWithBackupFallback(
+        () =>
+          new DashboardActivityLog({
+            dir: options.operatorActivityDir as string,
+          }).exportForMigration(),
+        () =>
+          new DashboardActivityLog({
+            dir: join(backupPath, "operator-activity"),
+          }).exportForMigration(),
+        (snapshot) => snapshot.sourcePaths.length === 0,
+      )
+    : { snapshot: { entries: [], sourcePaths: [] }, fromBackup: false };
+  if (!operatorActivity.fromBackup && options.operatorActivityDir) {
+    appendFileBackupMoves(
+      backupMoves,
+      operatorActivity.snapshot.sourcePaths,
+      options.operatorActivityDir,
+      join(backupPath, "operator-activity"),
+    );
+  }
+
+  return {
+    artifacts,
+    backendAuth: backendAuth.snapshot,
+    vault: vault.snapshot,
+    vaultGrants,
+    remoteSecurity: remoteSecurity.snapshot.state,
+    setup: setup.snapshot,
+    operatorActivity: operatorActivity.snapshot.entries,
+    backupMoves,
+    includeDomainReport: Boolean(
+      options.backendAuthDir ||
+      options.legacyVaultRoot ||
+      options.remoteSecurityDir ||
+      options.setupStateDir ||
+      options.operatorActivityDir,
+    ),
+  };
+}
+
+function snapshotWithBackupFallback<T>(
+  source: () => T,
+  backup: () => T,
+  empty: (snapshot: T) => boolean,
+): { snapshot: T; fromBackup: boolean } {
+  const sourceSnapshot = source();
+  if (!empty(sourceSnapshot)) return { snapshot: sourceSnapshot, fromBackup: false };
+  const backupSnapshot = backup();
+  return empty(backupSnapshot)
+    ? { snapshot: sourceSnapshot, fromBackup: false }
+    : { snapshot: backupSnapshot, fromBackup: true };
+}
+
+function appendFileBackupMoves(
+  moves: BackupMove[],
+  sourcePaths: string[],
+  sourceRoot: string,
+  backupRoot: string,
+): void {
+  const resolvedRoot = resolve(sourceRoot);
+  for (const source of sourcePaths) {
+    moves.push({
+      source,
+      target: join(backupRoot, portableRelative(resolvedRoot, resolve(source))),
+    });
+  }
+}
+
+function plannedVaultGrants(
+  snapshot: LegacyVaultMigrationSnapshot,
+): LegacyRecordVaultGrantImport[] {
+  const identities = new Set<string>();
+  return snapshot.grants.map((grant) => {
+    const identity = JSON.stringify([grant.capletId, grant.referenceName]);
+    if (identities.has(identity)) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        "Legacy Vault grants cannot be bound uniquely to immutable Caplet Records.",
+      );
+    }
+    identities.add(identity);
+    return {
+      capletId: grant.capletId,
+      vaultKey: grant.storedKey,
+      referenceName: grant.referenceName,
+      createdAt: grant.createdAt,
+    };
+  });
+}
+
+async function assertRequiredVaultRecords(
+  storage: HostStorage,
+  grants: LegacyRecordVaultGrantImport[],
+  artifacts: PlannedArtifact[],
+): Promise<LegacyRecordVaultGrantImport[]> {
+  const plannedIds = new Set(artifacts.map((artifact) => artifact.id));
+  const existing: LegacyRecordVaultGrantImport[] = [];
+  for (const grant of grants) {
+    const record = await storage.caplets.get(grant.capletId);
+    if (!record && !plannedIds.has(grant.capletId)) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        `Caplet Record ${grant.capletId} required by a legacy Vault grant was not found.`,
+      );
+    }
+    if (record) existing.push(grant);
+  }
+  return existing;
+}
+
+function reportForPlan(
+  status: LegacyMigrationReport["status"],
+  backupPath: string | null,
+  plan: PlannedLegacyState,
+): LegacyMigrationReport {
+  const report: LegacyMigrationReport = {
+    status,
+    records: plan.artifacts.length,
+    installations: plan.artifacts.length,
+    backupPath,
+  };
+  if (plan.includeDomainReport) {
+    report.domains = {
+      backendAuthTokenBundles: plan.backendAuth.bundles.length,
+      vaultValues: plan.vault.values.length,
+      vaultGrants: plan.vaultGrants.length,
+      remotePairingCodes: plan.remoteSecurity.pairingCodes.length,
+      remoteClients: plan.remoteSecurity.clients.length,
+      remotePendingLogins: plan.remoteSecurity.pendingLogins.length,
+      setupApprovals: plan.setup.approvals.length,
+      setupAttempts: plan.setup.attempts.length,
+      operatorActivityEntries: plan.operatorActivity.length,
+      dashboardSessions: "not_applicable_no_legacy_format",
+      projectBindings: "not_applicable_no_legacy_format",
+    };
+  }
+  return report;
+}
+
+function planArtifacts(capletsRoot: string, lockfilePath: string): PlannedArtifact[] {
+  const lockfile = readCapletsLockfile(lockfilePath);
+  return lockfile.entries.map((entry) => {
+    const destination = validateLockfileDestination(capletsRoot, entry.destination);
+    if (!existsSync(destination)) {
+      throw new CapletsError("CONFIG_NOT_FOUND", `Tracked Caplet ${entry.id} is missing.`);
+    }
+    const stats = lstatSync(destination);
+    if (
+      (entry.kind === "file" && !stats.isFile()) ||
+      (entry.kind === "directory" && !stats.isDirectory())
+    ) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        `Tracked Caplet ${entry.id} does not match lockfile kind ${entry.kind}.`,
+      );
+    }
+    const installedHash = hashInstalledArtifact(destination);
+    if (installedHash !== entry.installedHash) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        `Tracked Caplet ${entry.id} differs from its lockfile; restore or update it before migration.`,
+      );
+    }
+    return {
+      id: entry.id,
+      destination,
+      installedHash,
+      sourceKind: entry.source.type,
+      sourceIdentity: JSON.stringify(entry.source),
+      files:
+        entry.kind === "file"
+          ? [fileInput(destination, "CAPLET.md")]
+          : collectBundleFiles(destination),
+    };
+  });
+}
+
+function collectBundleFiles(root: string): PlannedArtifact["files"] {
+  if (!existsSync(join(root, "CAPLET.md"))) {
+    throw new CapletsError("CONFIG_INVALID", `Tracked Caplet bundle ${root} has no CAPLET.md.`);
+  }
+  const files: PlannedArtifact["files"] = [];
+  const visit = (directory: string): void => {
+    for (const name of readdirSync(directory).sort()) {
+      const path = join(directory, name);
+      const stats = lstatSync(path);
+      if (stats.isSymbolicLink()) {
+        throw new CapletsError(
+          "CONFIG_INVALID",
+          `Tracked Caplet bundle ${root} contains an unsupported symbolic link.`,
+        );
+      }
+      if (stats.isDirectory()) visit(path);
+      else if (stats.isFile()) files.push(fileInput(path, portableRelative(root, path)));
+    }
+  };
+  visit(root);
+  return files;
+}
+
+function fileInput(path: string, bundlePath: string): PlannedArtifact["files"][number] {
+  const stats = lstatSync(path);
+  return {
+    path: bundlePath,
+    content: readFileSync(path),
+    executable: (stats.mode & 0o111) !== 0,
+  };
+}
+
+function portableRelative(root: string, path: string): string {
+  const value = relative(root, path).split(sep).join("/");
+  if (value === ".." || value.startsWith("../")) {
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      "Legacy migration source escaped its configured root.",
+    );
+  }
+  return value;
+}
+
+function hashInstalledArtifact(path: string): string {
+  const hash = createHash("sha256");
+  hashPath(path, "", hash);
+  return `sha256:${hash.digest("hex")}`;
+}
+
+function hashPath(path: string, relativePath: string, hash: Hash): void {
+  const stats = lstatSync(path);
+  const mode = stats.mode & 0o111 ? "executable" : "plain";
+  if (stats.isDirectory()) {
+    hash.update(`dir\0${relativePath}\0`);
+    for (const entry of readdirSync(path).sort()) {
+      hashPath(join(path, entry), relativePath ? `${relativePath}/${entry}` : entry, hash);
+    }
+    return;
+  }
+  if (stats.isSymbolicLink()) {
+    hash.update(`symlink\0${relativePath}\0${readlinkSync(path)}\0`);
+    return;
+  }
+  hash.update(`file\0${relativePath}\0${mode}\0`);
+  hash.update(readFileSync(path));
+  hash.update("\0");
+}
+
+async function verifyImportedArtifacts(
+  storage: HostStorage,
+  artifacts: PlannedArtifact[],
+): Promise<void> {
+  for (const artifact of artifacts) {
+    const record = await storage.caplets.get(artifact.id);
+    if (record?.currentRevision.sourceContentHash !== artifact.installedHash) {
+      throw new CapletsError(
+        "INTERNAL_ERROR",
+        `Caplet Record ${artifact.id} failed post-migration verification.`,
+      );
+    }
+    const installation = await storage.installations.getActive(artifact.id);
+    if (!installation || installation.sourceIdentity !== artifact.sourceIdentity) {
+      throw new CapletsError(
+        "INTERNAL_ERROR",
+        `Caplet installation ${artifact.id} failed post-migration verification.`,
+      );
+    }
+  }
+}
+
+function moveLegacyArtifactsToBackup(moves: BackupMove[]): void {
+  const uniqueSources = new Set<string>();
+  const uniqueTargets = new Set<string>();
+  for (const move of moves) {
+    const source = resolve(move.source);
+    const target = resolve(move.target);
+    if (!existsSync(source)) {
+      throw new CapletsError(
+        "CONFIG_NOT_FOUND",
+        `Legacy migration source ${basename(source)} disappeared before backup.`,
+      );
+    }
+    if (uniqueSources.has(source) || uniqueTargets.has(target) || existsSync(target)) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        `Legacy migration backup target for ${basename(source)} already exists.`,
+      );
+    }
+    uniqueSources.add(source);
+    uniqueTargets.add(target);
+  }
+
+  const moved: BackupMove[] = [];
+  try {
+    for (const move of moves) {
+      mkdirSync(dirname(move.target), { recursive: true, mode: 0o700 });
+      renameSync(move.source, move.target);
+      moved.push(move);
+    }
+  } catch (error) {
+    for (const entry of moved.reverse()) {
+      if (!existsSync(entry.target)) continue;
+      mkdirSync(dirname(entry.source), { recursive: true, mode: 0o700 });
+      renameSync(entry.target, entry.source);
+    }
+    throw error;
+  }
+}
+
+function timestampForPath(date: Date): string {
+  return date.toISOString().replaceAll(":", "-").replaceAll(".", "-");
+}

--- a/packages/core/src/storage/legacy-migration.ts
+++ b/packages/core/src/storage/legacy-migration.ts
@@ -25,9 +25,16 @@ import {
 } from "../remote/server-credential-store";
 import { LocalSetupStore, type LegacySetupMigrationSnapshot } from "../setup/local-store";
 import { FileVaultStore, type LegacyVaultMigrationSnapshot } from "../vault";
+import type { ImportCapletBundleInput } from "./caplet-records";
+import type { OperatorPrincipal } from "./installations";
 import { createHostStorage, type HostStorage } from "./database";
 import type { LegacyRecordVaultGrantImport } from "./vault-grants";
-import type { HostStorageConfig } from "./types";
+import type {
+  HostDatabaseTransaction,
+  HostStorageConfig,
+  PostgresHostTransaction,
+  SqliteHostTransaction,
+} from "./types";
 
 export type LegacyMigrationOptions = {
   storage: HostStorageConfig;
@@ -187,36 +194,43 @@ export async function migrateLegacyHostState(
       return reportForPlan("verified", null, plan);
     }
 
-    if (pending.length > 0) {
-      await storage.caplets.importBundles(
-        pending.map((artifact) => ({
-          id: artifact.id,
-          operator: { clientId: options.operatorClientId, role: "operator" as const },
-          files: artifact.files,
-          sourceContentHash: artifact.installedHash,
-          installation: {
-            sourceKind: artifact.sourceKind,
-            sourceIdentity: artifact.sourceIdentity,
-          },
-        })),
+    const pendingBundles = pending.map(
+      (artifact): ImportCapletBundleInput => ({
+        id: artifact.id,
+        operator,
+        files: artifact.files,
+        sourceContentHash: artifact.installedHash,
+        installation: {
+          sourceKind: artifact.sourceKind,
+          sourceIdentity: artifact.sourceIdentity,
+        },
+      }),
+    );
+    await storage.caplets.prepareBundleAssetsForImport(pendingBundles);
+    const transactionStorage = storage;
+
+    if (storage.database.dialect === "sqlite") {
+      storage.database.db.transaction((transaction) => {
+        importAndVerifyLegacySqlite(
+          transactionStorage,
+          transaction,
+          pendingBundles,
+          plan,
+          operator,
+        );
+      });
+    } else {
+      await storage.database.db.transaction(
+        async (transaction) =>
+          await importAndVerifyLegacyPostgres(
+            transactionStorage,
+            transaction,
+            pendingBundles,
+            plan,
+            operator,
+          ),
       );
     }
-
-    await storage.vaultGrants.assertLegacyRecordGrantsImportable(plan.vaultGrants, operator);
-    await storage.backendAuth.importLegacyBundles(plan.backendAuth.bundles);
-    await storage.vaultValues.importLegacyValues(plan.vault.values);
-    await storage.vaultGrants.importLegacyRecordGrants(plan.vaultGrants, operator);
-    await storage.remoteSecurity.importLegacySnapshot(plan.remoteSecurity);
-    await storage.setupState.importLegacySnapshot(plan.setup);
-    await storage.operatorActivity.importLegacyEntries(plan.operatorActivity);
-
-    await verifyImportedArtifacts(storage, plan.artifacts);
-    await storage.backendAuth.verifyLegacyBundles(plan.backendAuth.bundles);
-    await storage.vaultValues.verifyLegacyValues(plan.vault.values);
-    await storage.vaultGrants.verifyLegacyRecordGrants(plan.vaultGrants, operator);
-    await storage.remoteSecurity.verifyLegacySnapshot(plan.remoteSecurity);
-    await storage.setupState.verifyLegacySnapshot(plan.setup);
-    await storage.operatorActivity.verifyLegacyEntries(plan.operatorActivity);
 
     moveLegacyArtifactsToBackup(plan.backupMoves);
     return reportForPlan("migrated", backupPath, plan);
@@ -225,6 +239,90 @@ export async function migrateLegacyHostState(
     closeSync(lock);
     rmSync(lockPath, { force: true });
   }
+}
+
+function importAndVerifyLegacySqlite(
+  storage: HostStorage,
+  transaction: SqliteHostTransaction,
+  pendingBundles: ImportCapletBundleInput[],
+  plan: PlannedLegacyState,
+  operator: OperatorPrincipal,
+): void {
+  const adapter = { dialect: "sqlite", db: transaction } as const;
+  runSynchronous(storage.caplets.importBundlesInTransaction(pendingBundles, adapter));
+  runSynchronous(
+    storage.backendAuth.importLegacyBundlesInTransaction(plan.backendAuth.bundles, adapter),
+  );
+  runSynchronous(storage.vaultValues.importLegacyValuesInTransaction(plan.vault.values, adapter));
+  runSynchronous(
+    storage.vaultGrants.importLegacyRecordGrantsInTransaction(plan.vaultGrants, operator, adapter),
+  );
+  runSynchronous(
+    storage.remoteSecurity.importLegacySnapshotInTransaction(plan.remoteSecurity, adapter),
+  );
+  runSynchronous(storage.setupState.importLegacySnapshotInTransaction(plan.setup, adapter));
+  runSynchronous(
+    storage.operatorActivity.importLegacyEntriesInTransaction(plan.operatorActivity, adapter),
+  );
+
+  verifyImportedArtifactsSqlite(storage, plan.artifacts, adapter);
+  runSynchronous(
+    storage.backendAuth.verifyLegacyBundlesInTransaction(plan.backendAuth.bundles, adapter),
+  );
+  runSynchronous(storage.vaultValues.verifyLegacyValuesInTransaction(plan.vault.values, adapter));
+  runSynchronous(
+    storage.vaultGrants.verifyLegacyRecordGrantsInTransaction(plan.vaultGrants, operator, adapter),
+  );
+  runSynchronous(
+    storage.remoteSecurity.verifyLegacySnapshotInTransaction(plan.remoteSecurity, adapter),
+  );
+  runSynchronous(storage.setupState.verifyLegacySnapshotInTransaction(plan.setup, adapter));
+  runSynchronous(
+    storage.operatorActivity.verifyLegacyEntriesInTransaction(plan.operatorActivity, adapter),
+  );
+}
+
+async function importAndVerifyLegacyPostgres(
+  storage: HostStorage,
+  transaction: PostgresHostTransaction,
+  pendingBundles: ImportCapletBundleInput[],
+  plan: PlannedLegacyState,
+  operator: OperatorPrincipal,
+): Promise<void> {
+  const adapter = { dialect: "postgres", db: transaction } as const;
+  await storage.caplets.importBundlesInTransaction(pendingBundles, adapter);
+  await storage.backendAuth.importLegacyBundlesInTransaction(plan.backendAuth.bundles, adapter);
+  await storage.vaultValues.importLegacyValuesInTransaction(plan.vault.values, adapter);
+  await storage.vaultGrants.importLegacyRecordGrantsInTransaction(
+    plan.vaultGrants,
+    operator,
+    adapter,
+  );
+  await storage.remoteSecurity.importLegacySnapshotInTransaction(plan.remoteSecurity, adapter);
+  await storage.setupState.importLegacySnapshotInTransaction(plan.setup, adapter);
+  await storage.operatorActivity.importLegacyEntriesInTransaction(plan.operatorActivity, adapter);
+
+  await verifyImportedArtifactsPostgres(storage, plan.artifacts, adapter);
+  await storage.backendAuth.verifyLegacyBundlesInTransaction(plan.backendAuth.bundles, adapter);
+  await storage.vaultValues.verifyLegacyValuesInTransaction(plan.vault.values, adapter);
+  await storage.vaultGrants.verifyLegacyRecordGrantsInTransaction(
+    plan.vaultGrants,
+    operator,
+    adapter,
+  );
+  await storage.remoteSecurity.verifyLegacySnapshotInTransaction(plan.remoteSecurity, adapter);
+  await storage.setupState.verifyLegacySnapshotInTransaction(plan.setup, adapter);
+  await storage.operatorActivity.verifyLegacyEntriesInTransaction(plan.operatorActivity, adapter);
+}
+
+function runSynchronous<T>(result: T | Promise<T>): T {
+  if (result instanceof Promise) {
+    throw new CapletsError(
+      "INTERNAL_ERROR",
+      "SQLite legacy migration attempted an asynchronous transaction operation.",
+    );
+  }
+  return result;
 }
 
 function planLegacyState(options: LegacyMigrationOptions, backupPath: string): PlannedLegacyState {
@@ -576,19 +674,48 @@ function hashPath(path: string, relativePath: string, hash: Hash): void {
   hash.update("\0");
 }
 
-async function verifyImportedArtifacts(
+function verifyImportedArtifactsSqlite(
   storage: HostStorage,
   artifacts: PlannedArtifact[],
-): Promise<void> {
+  transaction: Extract<HostDatabaseTransaction, { dialect: "sqlite" }>,
+): void {
   for (const artifact of artifacts) {
-    const record = await storage.caplets.get(artifact.id);
+    const record = runSynchronous(storage.caplets.getInTransaction(artifact.id, transaction));
     if (record?.currentRevision.sourceContentHash !== artifact.installedHash) {
       throw new CapletsError(
         "INTERNAL_ERROR",
         `Caplet Record ${artifact.id} failed post-migration verification.`,
       );
     }
-    const installation = await storage.installations.getActive(artifact.id);
+    const installation = runSynchronous(
+      storage.installations.getActiveInTransaction(artifact.id, transaction),
+    );
+    if (!installation || installation.sourceIdentity !== artifact.sourceIdentity) {
+      throw new CapletsError(
+        "INTERNAL_ERROR",
+        `Caplet installation ${artifact.id} failed post-migration verification.`,
+      );
+    }
+  }
+}
+
+async function verifyImportedArtifactsPostgres(
+  storage: HostStorage,
+  artifacts: PlannedArtifact[],
+  transaction: Extract<HostDatabaseTransaction, { dialect: "postgres" }>,
+): Promise<void> {
+  for (const artifact of artifacts) {
+    const record = await storage.caplets.getInTransaction(artifact.id, transaction);
+    if (record?.currentRevision.sourceContentHash !== artifact.installedHash) {
+      throw new CapletsError(
+        "INTERNAL_ERROR",
+        `Caplet Record ${artifact.id} failed post-migration verification.`,
+      );
+    }
+    const installation = await storage.installations.getActiveInTransaction(
+      artifact.id,
+      transaction,
+    );
     if (!installation || installation.sourceIdentity !== artifact.sourceIdentity) {
       throw new CapletsError(
         "INTERNAL_ERROR",

--- a/packages/core/src/storage/migrations.ts
+++ b/packages/core/src/storage/migrations.ts
@@ -36,7 +36,12 @@ function migrateSqliteExclusively(
   database: Extract<HostDatabase, { dialect: "sqlite" }>,
   appliedAt: string,
 ): void {
+  type AppliedMigration = {
+    hash: string;
+    created_at: number;
+  };
   type Statement = {
+    all(...params: unknown[]): unknown[];
     get(...params: unknown[]): unknown;
     run(...params: unknown[]): unknown;
   };
@@ -63,13 +68,38 @@ function migrateSqliteExclusively(
         }
       }
       client.exec(
-        "CREATE TABLE IF NOT EXISTS caplets_migrations (id SERIAL PRIMARY KEY, hash text NOT NULL, created_at numeric)",
+        "CREATE TABLE IF NOT EXISTS caplets_migrations (id INTEGER PRIMARY KEY, hash text NOT NULL, created_at numeric NOT NULL)",
       );
-      const last = client
-        .prepare("SELECT created_at FROM caplets_migrations ORDER BY created_at DESC LIMIT 1")
-        .get() as { created_at?: number } | undefined;
+      const appliedMigrations = client
+        .prepare("SELECT hash, created_at FROM caplets_migrations ORDER BY created_at")
+        .all() as AppliedMigration[];
+      const appliedByCreatedAt = new Map<number, string>();
+      for (const migration of appliedMigrations) {
+        if (
+          typeof migration.hash !== "string" ||
+          typeof migration.created_at !== "number" ||
+          appliedByCreatedAt.has(migration.created_at)
+        ) {
+          throw invalidSqliteMigrationHistory("contains malformed or duplicate entries");
+        }
+        appliedByCreatedAt.set(migration.created_at, migration.hash);
+      }
+      const latestApplied = appliedMigrations.at(-1)?.created_at;
       for (const migration of migrations) {
-        if (last?.created_at !== undefined && last.created_at >= migration.folderMillis) continue;
+        const appliedHash = appliedByCreatedAt.get(migration.folderMillis);
+        if (appliedHash !== undefined) {
+          if (appliedHash !== migration.hash) {
+            throw invalidSqliteMigrationHistory(
+              `hash mismatch for migration ${migration.folderMillis}`,
+            );
+          }
+          continue;
+        }
+        if (latestApplied !== undefined && migration.folderMillis < latestApplied) {
+          throw invalidSqliteMigrationHistory(
+            `migration ${migration.folderMillis} is missing before ${latestApplied}`,
+          );
+        }
         for (const statement of migration.sql) client.exec(statement);
         client
           .prepare("INSERT INTO caplets_migrations (hash, created_at) VALUES (?, ?)")
@@ -142,6 +172,10 @@ function schemaNewerError(version: number | undefined): CapletsError {
     "CONFIG_INVALID",
     `Host storage schema ${version} is newer than supported schema ${HOST_STORAGE_SCHEMA_VERSION}.`,
   );
+}
+
+function invalidSqliteMigrationHistory(reason: string): CapletsError {
+  return new CapletsError("CONFIG_INVALID", `SQLite migration history ${reason}.`);
 }
 
 function errorCode(error: unknown): string | undefined {

--- a/packages/core/src/storage/migrations.ts
+++ b/packages/core/src/storage/migrations.ts
@@ -1,0 +1,155 @@
+import { fileURLToPath } from "node:url";
+import { eq } from "drizzle-orm";
+import { readMigrationFiles } from "drizzle-orm/migrator";
+import { migrate as migratePostgres } from "drizzle-orm/node-postgres/migrator";
+import { CapletsError } from "../errors";
+import { capletsSchema as postgresCapletsSchema } from "./schema/postgres";
+import { capletsSchema as sqliteCapletsSchema } from "./schema/sqlite";
+import { HOST_STORAGE_SCHEMA_VERSION, type HostDatabase, type HostStorageHealth } from "./types";
+
+const SQLITE_MIGRATIONS_FOLDER = fileURLToPath(new URL("./drizzle/sqlite", import.meta.url));
+const POSTGRES_MIGRATIONS_FOLDER = fileURLToPath(new URL("./drizzle/postgres", import.meta.url));
+
+export async function migrateHostDatabase(database: HostDatabase): Promise<void> {
+  const appliedAt = new Date().toISOString();
+  if (database.dialect === "sqlite") {
+    migrateSqliteExclusively(database, appliedAt);
+    return;
+  }
+
+  assertSchemaIsNotNewer(await inspectHostDatabase(database));
+  await migratePostgres(database.db, {
+    migrationsFolder: POSTGRES_MIGRATIONS_FOLDER,
+    migrationsTable: "caplets_migrations",
+    migrationsSchema: database.schema,
+  });
+  await database.db
+    .insert(postgresCapletsSchema)
+    .values({ singleton: 1, version: HOST_STORAGE_SCHEMA_VERSION, appliedAt })
+    .onConflictDoUpdate({
+      target: postgresCapletsSchema.singleton,
+      set: { version: HOST_STORAGE_SCHEMA_VERSION, appliedAt },
+    });
+}
+
+function migrateSqliteExclusively(
+  database: Extract<HostDatabase, { dialect: "sqlite" }>,
+  appliedAt: string,
+): void {
+  type Statement = {
+    get(...params: unknown[]): unknown;
+    run(...params: unknown[]): unknown;
+  };
+  type Client = {
+    exec(source: string): void;
+    prepare(source: string): Statement;
+    transaction<T>(run: () => T): { exclusive(): T };
+  };
+  const client = (database.db as typeof database.db & { $client: Client }).$client;
+  const migrations = readMigrationFiles({ migrationsFolder: SQLITE_MIGRATIONS_FOLDER });
+  client
+    .transaction(() => {
+      const schemaTable = client
+        .prepare(
+          "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'caplets_schema'",
+        )
+        .get() as { present?: number } | undefined;
+      if (schemaTable?.present === 1) {
+        const row = client
+          .prepare("SELECT version FROM caplets_schema WHERE singleton = 1")
+          .get() as { version?: number } | undefined;
+        if (row?.version !== undefined && row.version > HOST_STORAGE_SCHEMA_VERSION) {
+          throw schemaNewerError(row.version);
+        }
+      }
+      client.exec(
+        "CREATE TABLE IF NOT EXISTS caplets_migrations (id SERIAL PRIMARY KEY, hash text NOT NULL, created_at numeric)",
+      );
+      const last = client
+        .prepare("SELECT created_at FROM caplets_migrations ORDER BY created_at DESC LIMIT 1")
+        .get() as { created_at?: number } | undefined;
+      for (const migration of migrations) {
+        if (last?.created_at !== undefined && last.created_at >= migration.folderMillis) continue;
+        for (const statement of migration.sql) client.exec(statement);
+        client
+          .prepare("INSERT INTO caplets_migrations (hash, created_at) VALUES (?, ?)")
+          .run(migration.hash, migration.folderMillis);
+      }
+      client
+        .prepare(
+          "INSERT INTO caplets_schema (singleton, version, applied_at) VALUES (1, ?, ?) ON CONFLICT(singleton) DO UPDATE SET version = excluded.version, applied_at = excluded.applied_at",
+        )
+        .run(HOST_STORAGE_SCHEMA_VERSION, appliedAt);
+    })
+    .exclusive();
+}
+
+export async function inspectHostDatabase(database: HostDatabase): Promise<HostStorageHealth> {
+  try {
+    const version =
+      database.dialect === "sqlite"
+        ? database.db
+            .select({ version: sqliteCapletsSchema.version })
+            .from(sqliteCapletsSchema)
+            .where(eq(sqliteCapletsSchema.singleton, 1))
+            .get()?.version
+        : (
+            await database.db
+              .select({ version: postgresCapletsSchema.version })
+              .from(postgresCapletsSchema)
+              .where(eq(postgresCapletsSchema.singleton, 1))
+              .limit(1)
+          )[0]?.version;
+    if (version === undefined) {
+      return { backend: database.dialect, ready: false, reason: "schema_missing" };
+    }
+    if (version < HOST_STORAGE_SCHEMA_VERSION) {
+      return {
+        backend: database.dialect,
+        ready: false,
+        schemaVersion: version,
+        reason: "schema_outdated",
+      };
+    }
+    if (version > HOST_STORAGE_SCHEMA_VERSION) {
+      return {
+        backend: database.dialect,
+        ready: false,
+        schemaVersion: version,
+        reason: "schema_newer",
+      };
+    }
+    return { backend: database.dialect, ready: true, schemaVersion: version };
+  } catch (error) {
+    return {
+      backend: database.dialect,
+      ready: false,
+      reason:
+        database.dialect === "postgres" && errorCode(error) === "42P01"
+          ? "schema_missing"
+          : "database_unavailable",
+    };
+  }
+}
+
+function assertSchemaIsNotNewer(health: HostStorageHealth): void {
+  if (health.reason !== "schema_newer") return;
+  throw schemaNewerError(health.schemaVersion);
+}
+
+function schemaNewerError(version: number | undefined): CapletsError {
+  return new CapletsError(
+    "CONFIG_INVALID",
+    `Host storage schema ${version} is newer than supported schema ${HOST_STORAGE_SCHEMA_VERSION}.`,
+  );
+}
+
+function errorCode(error: unknown): string | undefined {
+  let current = error;
+  while (current && typeof current === "object") {
+    const candidate = current as { code?: unknown; cause?: unknown };
+    if (typeof candidate.code === "string") return candidate.code;
+    current = candidate.cause;
+  }
+  return undefined;
+}

--- a/packages/core/src/storage/operator-activity.ts
+++ b/packages/core/src/storage/operator-activity.ts
@@ -4,7 +4,12 @@ import { CapletsError } from "../errors";
 import { stableJsonStringify } from "../stable-json";
 import * as postgres from "./schema/postgres";
 import * as sqlite from "./schema/sqlite";
-import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+import type {
+  HostDatabase,
+  HostDatabaseTransaction,
+  PostgresHostDatabase,
+  SqliteHostDatabase,
+} from "./types";
 
 export type OperatorActivityOutcome = "success" | "failure";
 
@@ -121,6 +126,16 @@ export class OperatorActivityStore {
       }
     });
   }
+  importLegacyEntriesInTransaction(
+    entries: OperatorActivityEntry[],
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    const rows = validateLegacyActivityEntries(entries);
+    if (rows.length === 0) return;
+    return transaction.dialect === "sqlite"
+      ? importLegacyActivitySqlite(transaction.db, rows)
+      : importLegacyActivityPostgres(transaction.db, rows);
+  }
 
   async verifyLegacyEntries(entries: OperatorActivityEntry[]): Promise<void> {
     const rows = validateLegacyActivityEntries(entries);
@@ -134,6 +149,17 @@ export class OperatorActivityStore {
         "Operator Activity failed post-migration verification.",
       );
     }
+  }
+  verifyLegacyEntriesInTransaction(
+    entries: OperatorActivityEntry[],
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    const rows = validateLegacyActivityEntries(entries);
+    if (transaction.dialect === "sqlite") {
+      verifyLegacyActivityPending(inspectLegacyActivitySqlite(transaction.db, rows));
+      return;
+    }
+    return inspectLegacyActivityPostgres(transaction.db, rows).then(verifyLegacyActivityPending);
   }
 
   async list(input: ListOperatorActivityInput = {}): Promise<OperatorActivityPage> {
@@ -241,6 +267,27 @@ type SqliteActivityDatabase =
 type PostgresActivityDatabase =
   | PostgresHostDatabase
   | Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0];
+function importLegacyActivitySqlite(database: SqliteActivityDatabase, rows: ActivityRow[]): void {
+  const pending = inspectLegacyActivitySqlite(database, rows);
+  if (pending.length > 0) database.insert(sqlite.operatorActivity).values(pending).run();
+}
+
+async function importLegacyActivityPostgres(
+  database: PostgresActivityDatabase,
+  rows: ActivityRow[],
+): Promise<void> {
+  const pending = await inspectLegacyActivityPostgres(database, rows);
+  if (pending.length > 0) await database.insert(postgres.operatorActivity).values(pending);
+}
+
+function verifyLegacyActivityPending(pending: ActivityRow[]): void {
+  if (pending.length > 0) {
+    throw new CapletsError(
+      "INTERNAL_ERROR",
+      "Operator Activity failed post-migration verification.",
+    );
+  }
+}
 
 function validateLegacyActivityEntries(entries: OperatorActivityEntry[]): ActivityRow[] {
   const ids = new Set<string>();

--- a/packages/core/src/storage/operator-activity.ts
+++ b/packages/core/src/storage/operator-activity.ts
@@ -1,0 +1,415 @@
+import { randomUUID } from "node:crypto";
+import { and, desc, eq, lt, or, type SQL } from "drizzle-orm";
+import { CapletsError } from "../errors";
+import { stableJsonStringify } from "../stable-json";
+import * as postgres from "./schema/postgres";
+import * as sqlite from "./schema/sqlite";
+import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+
+export type OperatorActivityOutcome = "success" | "failure";
+
+export type OperatorActivityMetadata = Record<string, string | number | boolean | null>;
+
+export type OperatorActivityTarget = {
+  type: string;
+  id: string;
+  label?: string | undefined;
+};
+
+export type OperatorActivityEntry = {
+  id: string;
+  createdAt: string;
+  actorClientId: string;
+  action: string;
+  outcome: OperatorActivityOutcome;
+  target: OperatorActivityTarget;
+  metadata?: OperatorActivityMetadata | undefined;
+};
+
+export type AppendOperatorActivityInput = {
+  actorClientId: string;
+  action: string;
+  outcome?: OperatorActivityOutcome | undefined;
+  target: OperatorActivityTarget;
+  metadata?: OperatorActivityMetadata | undefined;
+  now?: Date | undefined;
+};
+
+export type ListOperatorActivityInput = {
+  limit?: number | undefined;
+  after?: string | undefined;
+  action?: string | undefined;
+};
+
+export type OperatorActivityPage = {
+  entries: OperatorActivityEntry[];
+  nextCursor?: string | undefined;
+};
+
+const DEFAULT_ACTIVITY_LIMIT = 100;
+const MAX_ACTIVITY_LIMIT = 500;
+const TARGET_LABEL_METADATA_KEY = "__capletsTargetLabel";
+
+type ActivityRow = {
+  activityKey: string;
+  operatorClientId: string;
+  action: string;
+  targetKind: string;
+  targetKey: string;
+  outcome: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+};
+
+type ActivityCursor = Pick<ActivityRow, "activityKey" | "createdAt">;
+
+/**
+ * SQL-authoritative Operator activity with a dashboard-compatible projection.
+ * Metadata is sanitized on append and again on read so unsafe fields are never exposed.
+ */
+export class OperatorActivityStore {
+  constructor(private readonly database: HostDatabase) {}
+
+  async append(input: AppendOperatorActivityInput): Promise<OperatorActivityEntry> {
+    validateAppendInput(input);
+    const metadata = sanitizeMetadata(input.metadata ?? {});
+    if (input.target.label !== undefined) metadata[TARGET_LABEL_METADATA_KEY] = input.target.label;
+    const row: ActivityRow = {
+      activityKey: randomUUID(),
+      operatorClientId: input.actorClientId,
+      action: input.action,
+      targetKind: input.target.type,
+      targetKey: input.target.id,
+      outcome: input.outcome === "failure" ? "failed" : "succeeded",
+      metadata,
+      createdAt: (input.now ?? new Date()).toISOString(),
+    };
+
+    if (this.database.dialect === "sqlite") {
+      this.database.db.insert(sqlite.operatorActivity).values(row).run();
+    } else {
+      await this.database.db.insert(postgres.operatorActivity).values(row);
+    }
+    return activityEntry(row);
+  }
+
+  async assertLegacyEntriesImportable(entries: OperatorActivityEntry[]): Promise<void> {
+    const rows = validateLegacyActivityEntries(entries);
+    if (this.database.dialect === "sqlite") {
+      inspectLegacyActivitySqlite(this.database.db, rows);
+    } else {
+      await inspectLegacyActivityPostgres(this.database.db, rows);
+    }
+  }
+
+  async importLegacyEntries(entries: OperatorActivityEntry[]): Promise<void> {
+    const rows = validateLegacyActivityEntries(entries);
+    if (rows.length === 0) return;
+    if (this.database.dialect === "sqlite") {
+      this.database.db.transaction((transaction) => {
+        const pending = inspectLegacyActivitySqlite(transaction, rows);
+        if (pending.length > 0) {
+          transaction.insert(sqlite.operatorActivity).values(pending).run();
+        }
+      });
+      return;
+    }
+    await this.database.db.transaction(async (transaction) => {
+      const pending = await inspectLegacyActivityPostgres(transaction, rows);
+      if (pending.length > 0) {
+        await transaction.insert(postgres.operatorActivity).values(pending);
+      }
+    });
+  }
+
+  async verifyLegacyEntries(entries: OperatorActivityEntry[]): Promise<void> {
+    const rows = validateLegacyActivityEntries(entries);
+    const pending =
+      this.database.dialect === "sqlite"
+        ? inspectLegacyActivitySqlite(this.database.db, rows)
+        : await inspectLegacyActivityPostgres(this.database.db, rows);
+    if (pending.length > 0) {
+      throw new CapletsError(
+        "INTERNAL_ERROR",
+        "Operator Activity failed post-migration verification.",
+      );
+    }
+  }
+
+  async list(input: ListOperatorActivityInput = {}): Promise<OperatorActivityPage> {
+    const limit = boundedLimit(input.limit);
+    const cursor = input.after ? await this.findCursor(input.after) : undefined;
+    const rows =
+      this.database.dialect === "sqlite"
+        ? this.listSqlite(limit + 1, cursor, input.action)
+        : await this.listPostgres(limit + 1, cursor, input.action);
+    const hasMore = rows.length > limit;
+    const entries = rows.slice(0, limit).map(activityEntry);
+    const nextCursor = hasMore ? entries.at(-1)?.id : undefined;
+    return { entries, ...(nextCursor ? { nextCursor } : {}) };
+  }
+
+  private async findCursor(activityKey: string): Promise<ActivityCursor | undefined> {
+    if (this.database.dialect === "sqlite") {
+      return this.database.db
+        .select({
+          activityKey: sqlite.operatorActivity.activityKey,
+          createdAt: sqlite.operatorActivity.createdAt,
+        })
+        .from(sqlite.operatorActivity)
+        .where(eq(sqlite.operatorActivity.activityKey, activityKey))
+        .get();
+    }
+    const [cursor] = await this.database.db
+      .select({
+        activityKey: postgres.operatorActivity.activityKey,
+        createdAt: postgres.operatorActivity.createdAt,
+      })
+      .from(postgres.operatorActivity)
+      .where(eq(postgres.operatorActivity.activityKey, activityKey))
+      .limit(1);
+    return cursor;
+  }
+
+  private listSqlite(
+    limit: number,
+    cursor: ActivityCursor | undefined,
+    action: string | undefined,
+  ): ActivityRow[] {
+    const conditions: SQL[] = [];
+    if (action !== undefined) conditions.push(eq(sqlite.operatorActivity.action, action));
+    if (cursor) {
+      conditions.push(
+        or(
+          lt(sqlite.operatorActivity.createdAt, cursor.createdAt),
+          and(
+            eq(sqlite.operatorActivity.createdAt, cursor.createdAt),
+            lt(sqlite.operatorActivity.activityKey, cursor.activityKey),
+          ),
+        )!,
+      );
+    }
+    return this.database.dialect === "sqlite"
+      ? this.database.db
+          .select()
+          .from(sqlite.operatorActivity)
+          .where(and(...conditions))
+          .orderBy(
+            desc(sqlite.operatorActivity.createdAt),
+            desc(sqlite.operatorActivity.activityKey),
+          )
+          .limit(limit)
+          .all()
+      : [];
+  }
+
+  private async listPostgres(
+    limit: number,
+    cursor: ActivityCursor | undefined,
+    action: string | undefined,
+  ): Promise<ActivityRow[]> {
+    const conditions: SQL[] = [];
+    if (action !== undefined) conditions.push(eq(postgres.operatorActivity.action, action));
+    if (cursor) {
+      conditions.push(
+        or(
+          lt(postgres.operatorActivity.createdAt, cursor.createdAt),
+          and(
+            eq(postgres.operatorActivity.createdAt, cursor.createdAt),
+            lt(postgres.operatorActivity.activityKey, cursor.activityKey),
+          ),
+        )!,
+      );
+    }
+    return this.database.dialect === "postgres"
+      ? await this.database.db
+          .select()
+          .from(postgres.operatorActivity)
+          .where(and(...conditions))
+          .orderBy(
+            desc(postgres.operatorActivity.createdAt),
+            desc(postgres.operatorActivity.activityKey),
+          )
+          .limit(limit)
+      : [];
+  }
+}
+
+type SqliteActivityDatabase =
+  | SqliteHostDatabase
+  | Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0];
+type PostgresActivityDatabase =
+  | PostgresHostDatabase
+  | Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0];
+
+function validateLegacyActivityEntries(entries: OperatorActivityEntry[]): ActivityRow[] {
+  const ids = new Set<string>();
+  return entries.map((entry) => {
+    validateAppendInput(entry);
+    if (
+      !entry.id ||
+      ids.has(entry.id) ||
+      !Number.isFinite(Date.parse(entry.createdAt)) ||
+      new Date(entry.createdAt).toISOString() !== entry.createdAt
+    ) {
+      throw new CapletsError("CONFIG_INVALID", "Legacy Operator Activity is invalid.");
+    }
+    ids.add(entry.id);
+    const row = legacyActivityRow(entry);
+    if (stableJsonStringify(activityEntry(row)) !== stableJsonStringify(entry)) {
+      throw new CapletsError("CONFIG_INVALID", "Legacy Operator Activity is invalid.");
+    }
+    return row;
+  });
+}
+
+function legacyActivityRow(entry: OperatorActivityEntry): ActivityRow {
+  const metadata = sanitizeMetadata(entry.metadata ?? {});
+  if (entry.target.label !== undefined) metadata[TARGET_LABEL_METADATA_KEY] = entry.target.label;
+  return {
+    activityKey: entry.id,
+    operatorClientId: entry.actorClientId,
+    action: entry.action,
+    targetKind: entry.target.type,
+    targetKey: entry.target.id,
+    outcome: entry.outcome === "failure" ? "failed" : "succeeded",
+    metadata,
+    createdAt: entry.createdAt,
+  };
+}
+
+function inspectLegacyActivitySqlite(
+  database: SqliteActivityDatabase,
+  rows: ActivityRow[],
+): ActivityRow[] {
+  return rows.filter((row) => {
+    const existing = database
+      .select()
+      .from(sqlite.operatorActivity)
+      .where(eq(sqlite.operatorActivity.activityKey, row.activityKey))
+      .get();
+    if (
+      existing &&
+      stableJsonStringify(activityEntry(existing)) !== stableJsonStringify(activityEntry(row))
+    ) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        "Operator Activity conflicts with the legacy snapshot.",
+      );
+    }
+    return existing === undefined;
+  });
+}
+
+async function inspectLegacyActivityPostgres(
+  database: PostgresActivityDatabase,
+  rows: ActivityRow[],
+): Promise<ActivityRow[]> {
+  const pending: ActivityRow[] = [];
+  for (const row of rows) {
+    const [existing] = await database
+      .select()
+      .from(postgres.operatorActivity)
+      .where(eq(postgres.operatorActivity.activityKey, row.activityKey))
+      .limit(1);
+    if (
+      existing &&
+      stableJsonStringify(activityEntry(existing)) !== stableJsonStringify(activityEntry(row))
+    ) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        "Operator Activity conflicts with the legacy snapshot.",
+      );
+    }
+    if (!existing) pending.push(row);
+  }
+  return pending;
+}
+
+function activityEntry(row: ActivityRow): OperatorActivityEntry {
+  if (
+    typeof row.activityKey !== "string" ||
+    typeof row.operatorClientId !== "string" ||
+    typeof row.action !== "string" ||
+    typeof row.targetKind !== "string" ||
+    typeof row.targetKey !== "string" ||
+    typeof row.createdAt !== "string" ||
+    !row.metadata ||
+    typeof row.metadata !== "object" ||
+    Array.isArray(row.metadata)
+  ) {
+    throw new Error("Invalid SQL Operator activity entry.");
+  }
+  const outcome = dashboardOutcome(row.outcome);
+  const targetLabel = row.metadata[TARGET_LABEL_METADATA_KEY];
+  if (targetLabel !== undefined && typeof targetLabel !== "string") {
+    throw new Error("Invalid SQL Operator activity entry.");
+  }
+  const metadata = sanitizeMetadata(row.metadata);
+  delete metadata[TARGET_LABEL_METADATA_KEY];
+  return {
+    id: row.activityKey,
+    createdAt: row.createdAt,
+    actorClientId: row.operatorClientId,
+    action: row.action,
+    outcome,
+    target: {
+      type: row.targetKind,
+      id: row.targetKey,
+      ...(targetLabel !== undefined ? { label: targetLabel } : {}),
+    },
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  };
+}
+
+function dashboardOutcome(outcome: string): OperatorActivityOutcome {
+  if (outcome === "success" || outcome === "succeeded") return "success";
+  if (outcome === "failure" || outcome === "failed") return "failure";
+  throw new Error("Invalid SQL Operator activity outcome.");
+}
+
+function validateAppendInput(input: AppendOperatorActivityInput): void {
+  if (
+    typeof input.actorClientId !== "string" ||
+    typeof input.action !== "string" ||
+    !input.target ||
+    typeof input.target.type !== "string" ||
+    typeof input.target.id !== "string" ||
+    (input.target.label !== undefined && typeof input.target.label !== "string") ||
+    (input.outcome !== undefined && input.outcome !== "success" && input.outcome !== "failure")
+  ) {
+    throw new Error("Invalid Operator activity input.");
+  }
+}
+
+function sanitizeMetadata(metadata: Record<string, unknown>): OperatorActivityMetadata {
+  const safe: OperatorActivityMetadata = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (!isMetadataValue(value)) throw new Error("Invalid Operator activity metadata.");
+    if (
+      key === TARGET_LABEL_METADATA_KEY ||
+      /(secret|token|credential|bearer|refresh|value|payload|argument|output|path)/iu.test(key) ||
+      (typeof value === "string" &&
+        (value.length > 256 ||
+          /(cap_remote_access_|cap_remote_refresh_|cap_pending_|cap_login_)/u.test(value)))
+    ) {
+      continue;
+    }
+    safe[key] = value;
+  }
+  return safe;
+}
+
+function isMetadataValue(value: unknown): value is string | number | boolean | null {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+function boundedLimit(limit: number | undefined): number {
+  if (limit === undefined || !Number.isFinite(limit)) return DEFAULT_ACTIVITY_LIMIT;
+  return Math.min(MAX_ACTIVITY_LIMIT, Math.max(1, Math.trunc(limit)));
+}

--- a/packages/core/src/storage/project-bindings.ts
+++ b/packages/core/src/storage/project-bindings.ts
@@ -1,0 +1,554 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import { CapletsError } from "../errors";
+import { projectBindingError } from "../project-binding/errors";
+import {
+  isProjectBindingReadiness,
+  isProjectBindingState,
+  isProjectBindingSyncState,
+  type ProjectBindingAuthoritativeView,
+  type ProjectBindingState,
+  type ProjectBindingSyncState,
+} from "../project-binding/types";
+import * as postgres from "./schema/postgres";
+import * as sqlite from "./schema/sqlite";
+import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+
+export const PROJECT_BINDINGS_NAMESPACE = "project-bindings";
+
+const DEFAULT_LEASE_TTL_MS = 60_000;
+
+export type ProjectBindingStoreOptions = {
+  now?: () => Date;
+  leaseTtlMs?: number;
+};
+
+export type CreateProjectBindingInput = {
+  bindingId: string;
+  sessionId: string;
+  projectFingerprint: string;
+  projectRoot: string;
+  serverProjectRoot: string;
+  ownerNodeId: string;
+  state?: ProjectBindingState | undefined;
+  syncState?: ProjectBindingSyncState | undefined;
+  leaseTtlMs?: number | undefined;
+};
+
+export type HeartbeatProjectBindingInput = {
+  bindingId: string;
+  ownerNodeId: string;
+  sessionId?: string | undefined;
+  expectedGeneration: number;
+  state: ProjectBindingState;
+  syncState: ProjectBindingSyncState;
+  leaseTtlMs?: number | undefined;
+};
+
+export type QuarantineProjectBindingOwnerLossInput = {
+  bindingId: string;
+  ownerNodeId: string;
+  expectedGeneration: number;
+};
+
+export type RebindProjectBindingInput = {
+  bindingId: string;
+  expectedGeneration: number;
+  newOwnerNodeId: string;
+  sessionId?: string | undefined;
+  leaseTtlMs?: number | undefined;
+  operatorClientId: string;
+};
+
+export type EndProjectBindingInput = {
+  bindingId: string;
+  ownerNodeId: string;
+  expectedGeneration: number;
+};
+
+type BindingActivity = {
+  operatorClientId: string;
+  action: string;
+  targetKind: string;
+  targetKey: string;
+  metadata: Record<string, unknown>;
+};
+
+type BindingMutation<R> = {
+  value: R;
+  next?: ProjectBindingAuthoritativeView | undefined;
+  expectedGeneration?: number | undefined;
+  activity?: BindingActivity | undefined;
+};
+
+export class ProjectBindingStore {
+  private readonly now: () => Date;
+  private readonly leaseTtlMs: number;
+
+  constructor(
+    private readonly database: HostDatabase,
+    options: ProjectBindingStoreOptions = {},
+  ) {
+    this.now = options.now ?? (() => new Date());
+    this.leaseTtlMs = checkedLeaseTtl(options.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS);
+  }
+
+  async create(input: CreateProjectBindingInput): Promise<ProjectBindingAuthoritativeView> {
+    requireIdentity(input.bindingId, "bindingId");
+    requireIdentity(input.sessionId, "sessionId");
+    requireIdentity(input.projectFingerprint, "projectFingerprint");
+    requireIdentity(input.projectRoot, "projectRoot");
+    requireIdentity(input.serverProjectRoot, "serverProjectRoot");
+    requireIdentity(input.ownerNodeId, "ownerNodeId");
+    const state = input.state ?? "attaching";
+    const syncState = input.syncState ?? "pending";
+    if (!isProjectBindingState(state) || !isProjectBindingSyncState(syncState)) {
+      throw new CapletsError("REQUEST_INVALID", "Project Binding state is invalid.");
+    }
+    const ttlMs = checkedLeaseTtl(input.leaseTtlMs ?? this.leaseTtlMs);
+    return await this.mutate(input.bindingId, (current) => {
+      if (current) {
+        throw new CapletsError(
+          "CONFIG_EXISTS",
+          `Project Binding ${input.bindingId} already exists.`,
+        );
+      }
+      const now = this.now();
+      const timestamp = now.toISOString();
+      const next: ProjectBindingAuthoritativeView = {
+        bindingId: input.bindingId,
+        sessionId: input.sessionId,
+        projectFingerprint: input.projectFingerprint,
+        projectRoot: input.projectRoot,
+        serverProjectRoot: input.serverProjectRoot,
+        ownerNodeId: input.ownerNodeId,
+        generation: 1,
+        revision: 1,
+        state,
+        syncState,
+        readiness: readinessFor(state, syncState),
+        active: true,
+        lastHeartbeatAt: timestamp,
+        expiresAt: new Date(now.getTime() + ttlMs).toISOString(),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+      return { value: next, next };
+    });
+  }
+
+  async get(bindingId: string): Promise<ProjectBindingAuthoritativeView | undefined> {
+    const row =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select()
+            .from(sqlite.projectBindings)
+            .where(eq(sqlite.projectBindings.bindingId, bindingId))
+            .get()
+        : (
+            await this.database.db
+              .select()
+              .from(postgres.projectBindings)
+              .where(eq(postgres.projectBindings.bindingId, bindingId))
+              .limit(1)
+          )[0];
+    return row ? bindingView(row) : undefined;
+  }
+
+  async list(): Promise<ProjectBindingAuthoritativeView[]> {
+    const rows =
+      this.database.dialect === "sqlite"
+        ? this.database.db.select().from(sqlite.projectBindings).all()
+        : await this.database.db.select().from(postgres.projectBindings);
+    return rows.map(bindingView);
+  }
+
+  async heartbeat(input: HeartbeatProjectBindingInput): Promise<ProjectBindingAuthoritativeView> {
+    if (!isProjectBindingState(input.state) || !isProjectBindingSyncState(input.syncState)) {
+      throw new CapletsError("REQUEST_INVALID", "Project Binding state is invalid.");
+    }
+    const ttlMs = checkedLeaseTtl(input.leaseTtlMs ?? this.leaseTtlMs);
+    return await this.mutate(input.bindingId, (current) => {
+      const view = requiredBindingView(current, input.bindingId);
+      assertCurrentOwner(view, input.ownerNodeId);
+      if (input.sessionId !== undefined && input.sessionId !== view.sessionId) {
+        throw new CapletsError("AUTH_FAILED", "Project Binding session owner does not match.");
+      }
+      if (!view.active || view.readiness === "quarantined") {
+        throw projectBindingError("lease_expired");
+      }
+      const now = this.now();
+      if (Date.parse(view.expiresAt) <= now.getTime()) {
+        throw projectBindingError("lease_expired");
+      }
+      const timestamp = now.toISOString();
+      const next: ProjectBindingAuthoritativeView = {
+        ...view,
+        generation: view.generation + 1,
+        revision: view.revision + 1,
+        state: input.state,
+        syncState: input.syncState,
+        readiness: readinessFor(input.state, input.syncState),
+        lastHeartbeatAt: timestamp,
+        expiresAt: new Date(now.getTime() + ttlMs).toISOString(),
+        updatedAt: timestamp,
+      };
+      return { value: next, next, expectedGeneration: input.expectedGeneration };
+    });
+  }
+
+  async quarantineOwnerLoss(
+    input: QuarantineProjectBindingOwnerLossInput,
+  ): Promise<ProjectBindingAuthoritativeView> {
+    return await this.mutate(input.bindingId, (current) => {
+      const view = requiredBindingView(current, input.bindingId);
+      assertCurrentOwner(view, input.ownerNodeId);
+      const timestamp = this.now().toISOString();
+      const next: ProjectBindingAuthoritativeView = {
+        ...view,
+        generation: view.generation + 1,
+        revision: view.revision + 1,
+        state: "offline",
+        readiness: "quarantined",
+        active: false,
+        expiresAt: timestamp,
+        updatedAt: timestamp,
+        quarantinedAt: timestamp,
+        quarantineReason: "owner_lost",
+      };
+      return { value: next, next, expectedGeneration: input.expectedGeneration };
+    });
+  }
+
+  async rebind(input: RebindProjectBindingInput): Promise<ProjectBindingAuthoritativeView> {
+    requireIdentity(input.newOwnerNodeId, "newOwnerNodeId");
+    const operatorClientId = requireIdentity(input.operatorClientId, "operatorClientId");
+    const ttlMs = checkedLeaseTtl(input.leaseTtlMs ?? this.leaseTtlMs);
+    return await this.mutate(input.bindingId, (current) => {
+      const view = requiredBindingView(current, input.bindingId);
+      if (view.readiness !== "quarantined") {
+        throw new CapletsError(
+          "REQUEST_INVALID",
+          `Project Binding ${input.bindingId} is not quarantined.`,
+        );
+      }
+      if (input.sessionId !== undefined) requireIdentity(input.sessionId, "sessionId");
+      const now = this.now();
+      const timestamp = now.toISOString();
+      const next: ProjectBindingAuthoritativeView = {
+        ...view,
+        ownerNodeId: input.newOwnerNodeId,
+        ...(input.sessionId === undefined ? {} : { sessionId: input.sessionId }),
+        generation: view.generation + 1,
+        revision: view.revision + 1,
+        state: "attaching",
+        syncState: "pending",
+        readiness: "not_ready",
+        active: true,
+        lastHeartbeatAt: timestamp,
+        expiresAt: new Date(now.getTime() + ttlMs).toISOString(),
+        updatedAt: timestamp,
+      };
+      delete next.quarantinedAt;
+      delete next.quarantineReason;
+      return {
+        value: next,
+        next,
+        expectedGeneration: input.expectedGeneration,
+        activity: {
+          operatorClientId,
+          action: "project_binding.rebind",
+          targetKind: "project_binding",
+          targetKey: input.bindingId,
+          metadata: {
+            previousOwnerNodeId: view.ownerNodeId,
+            ownerNodeId: input.newOwnerNodeId,
+            previousGeneration: view.generation,
+          },
+        },
+      };
+    });
+  }
+
+  async end(input: EndProjectBindingInput): Promise<ProjectBindingAuthoritativeView> {
+    return await this.mutate(input.bindingId, (current) => {
+      const view = requiredBindingView(current, input.bindingId);
+      assertCurrentOwner(view, input.ownerNodeId);
+      const timestamp = this.now().toISOString();
+      const next: ProjectBindingAuthoritativeView = {
+        ...view,
+        generation: view.generation + 1,
+        revision: view.revision + 1,
+        state: "ended",
+        readiness: "not_ready",
+        active: false,
+        expiresAt: timestamp,
+        updatedAt: timestamp,
+      };
+      return { value: next, next, expectedGeneration: input.expectedGeneration };
+    });
+  }
+
+  private async mutate<R>(
+    bindingId: string,
+    transition: (current: ProjectBindingAuthoritativeView | undefined) => BindingMutation<R>,
+  ): Promise<R> {
+    return this.database.dialect === "sqlite"
+      ? mutateBindingSqlite(this.database.db, bindingId, transition)
+      : await mutateBindingPostgres(this.database.db, bindingId, transition);
+  }
+}
+
+function mutateBindingSqlite<R>(
+  db: SqliteHostDatabase,
+  bindingId: string,
+  transition: (current: ProjectBindingAuthoritativeView | undefined) => BindingMutation<R>,
+): R {
+  return db.transaction((transaction) => {
+    const row = transaction
+      .select()
+      .from(sqlite.projectBindings)
+      .where(eq(sqlite.projectBindings.bindingId, bindingId))
+      .get();
+    const current = row ? bindingView(row) : undefined;
+    const mutation = transition(current);
+    assertExpectedGeneration(current?.generation, mutation.expectedGeneration);
+    if (mutation.next) {
+      if (current) {
+        transaction
+          .update(sqlite.projectBindings)
+          .set(bindingRow(mutation.next))
+          .where(
+            and(
+              eq(sqlite.projectBindings.bindingId, bindingId),
+              eq(sqlite.projectBindings.generation, current.generation),
+            ),
+          )
+          .run();
+      } else {
+        transaction.insert(sqlite.projectBindings).values(bindingRow(mutation.next)).run();
+      }
+    }
+    if (mutation.activity) {
+      transaction
+        .insert(sqlite.operatorActivity)
+        .values(
+          activityValues(mutation.activity, mutation.next?.updatedAt ?? new Date().toISOString()),
+        )
+        .run();
+    }
+    return mutation.value;
+  });
+}
+
+async function mutateBindingPostgres<R>(
+  db: PostgresHostDatabase,
+  bindingId: string,
+  transition: (current: ProjectBindingAuthoritativeView | undefined) => BindingMutation<R>,
+): Promise<R> {
+  return await db.transaction(async (transaction) => {
+    await transaction.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify(["project-binding", bindingId])}, 0))`,
+    );
+    const [row] = await transaction
+      .select()
+      .from(postgres.projectBindings)
+      .where(eq(postgres.projectBindings.bindingId, bindingId))
+      .for("update")
+      .limit(1);
+    const current = row ? bindingView(row) : undefined;
+    const mutation = transition(current);
+    assertExpectedGeneration(current?.generation, mutation.expectedGeneration);
+    if (mutation.next) {
+      if (current) {
+        await transaction
+          .update(postgres.projectBindings)
+          .set(bindingRow(mutation.next))
+          .where(
+            and(
+              eq(postgres.projectBindings.bindingId, bindingId),
+              eq(postgres.projectBindings.generation, current.generation),
+            ),
+          );
+      } else {
+        await transaction.insert(postgres.projectBindings).values(bindingRow(mutation.next));
+      }
+    }
+    if (mutation.activity) {
+      await transaction
+        .insert(postgres.operatorActivity)
+        .values(
+          activityValues(mutation.activity, mutation.next?.updatedAt ?? new Date().toISOString()),
+        );
+    }
+    return mutation.value;
+  });
+}
+
+function bindingRow(view: ProjectBindingAuthoritativeView) {
+  return {
+    bindingId: view.bindingId,
+    sessionId: view.sessionId,
+    projectFingerprint: view.projectFingerprint,
+    projectRoot: view.projectRoot,
+    serverProjectRoot: view.serverProjectRoot,
+    ownerNodeId: view.ownerNodeId,
+    generation: view.generation,
+    revision: view.revision,
+    state: view.state,
+    syncState: view.syncState,
+    readiness: view.readiness,
+    active: view.active,
+    lastHeartbeatAt: view.lastHeartbeatAt,
+    expiresAt: view.expiresAt,
+    quarantinedAt: view.quarantinedAt ?? null,
+    quarantineReason: view.quarantineReason ?? null,
+    createdAt: view.createdAt,
+    updatedAt: view.updatedAt,
+  };
+}
+
+function bindingView(value: unknown): ProjectBindingAuthoritativeView {
+  if (
+    !isRecord(value) ||
+    !hasBindingStringFields(value) ||
+    typeof value.generation !== "number" ||
+    !Number.isSafeInteger(value.generation) ||
+    value.generation < 1 ||
+    typeof value.revision !== "number" ||
+    !Number.isSafeInteger(value.revision) ||
+    value.revision !== value.generation ||
+    !isProjectBindingState(value.state) ||
+    !isProjectBindingSyncState(value.syncState) ||
+    !isProjectBindingReadiness(value.readiness) ||
+    typeof value.active !== "boolean" ||
+    (value.quarantinedAt !== undefined &&
+      value.quarantinedAt !== null &&
+      typeof value.quarantinedAt !== "string") ||
+    (value.quarantineReason !== undefined &&
+      value.quarantineReason !== null &&
+      value.quarantineReason !== "owner_lost")
+  ) {
+    throw new CapletsError("INTERNAL_ERROR", "Persisted Project Binding metadata is invalid.");
+  }
+  const view: ProjectBindingAuthoritativeView = {
+    bindingId: value.bindingId,
+    sessionId: value.sessionId,
+    projectFingerprint: value.projectFingerprint,
+    projectRoot: value.projectRoot,
+    serverProjectRoot: value.serverProjectRoot,
+    ownerNodeId: value.ownerNodeId,
+    generation: value.generation,
+    revision: value.revision,
+    state: value.state,
+    syncState: value.syncState,
+    readiness: value.readiness,
+    active: value.active,
+    lastHeartbeatAt: value.lastHeartbeatAt,
+    expiresAt: value.expiresAt,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+  };
+  if (typeof value.quarantinedAt === "string") view.quarantinedAt = value.quarantinedAt;
+  if (value.quarantineReason === "owner_lost") view.quarantineReason = value.quarantineReason;
+  return view;
+}
+
+function requiredBindingView(
+  view: ProjectBindingAuthoritativeView | undefined,
+  bindingId: string,
+): ProjectBindingAuthoritativeView {
+  if (!view) {
+    throw new CapletsError("CONFIG_NOT_FOUND", `Project Binding ${bindingId} was not found.`);
+  }
+  return view;
+}
+
+function readinessFor(
+  state: ProjectBindingState,
+  syncState: ProjectBindingSyncState,
+): "not_ready" | "ready" {
+  return state === "ready" && syncState === "idle" ? "ready" : "not_ready";
+}
+
+function assertCurrentOwner(view: ProjectBindingAuthoritativeView, ownerNodeId: string): void {
+  if (view.ownerNodeId !== ownerNodeId) {
+    throw new CapletsError("AUTH_FAILED", "Project Binding lease belongs to another host node.");
+  }
+}
+
+function assertExpectedGeneration(
+  currentGeneration: number | undefined,
+  expectedGeneration: number | undefined,
+): void {
+  if (expectedGeneration === undefined || currentGeneration === expectedGeneration) return;
+  throw new CapletsError(
+    "REQUEST_INVALID",
+    "Authoritative Project Binding changed after it was read; reload and retry.",
+    {
+      kind: "stale_generation",
+      expectedGeneration,
+      currentGeneration: currentGeneration ?? 0,
+    },
+  );
+}
+
+function checkedLeaseTtl(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new CapletsError("REQUEST_INVALID", "Project Binding lease TTL must be positive.");
+  }
+  return value;
+}
+
+function requireIdentity(value: string, field: string): string {
+  if (!value.trim()) {
+    throw new CapletsError("REQUEST_INVALID", `${field} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function activityValues(activity: BindingActivity, timestamp: string) {
+  return {
+    activityKey: randomUUID(),
+    operatorClientId: activity.operatorClientId,
+    action: activity.action,
+    targetKind: activity.targetKind,
+    targetKey: activity.targetKey,
+    outcome: "succeeded",
+    metadata: activity.metadata,
+    createdAt: timestamp,
+  };
+}
+
+function hasBindingStringFields(value: Record<string, unknown>): value is Record<
+  string,
+  unknown
+> & {
+  bindingId: string;
+  sessionId: string;
+  projectFingerprint: string;
+  projectRoot: string;
+  serverProjectRoot: string;
+  ownerNodeId: string;
+  lastHeartbeatAt: string;
+  expiresAt: string;
+  createdAt: string;
+  updatedAt: string;
+} {
+  return [
+    "bindingId",
+    "sessionId",
+    "projectFingerprint",
+    "projectRoot",
+    "serverProjectRoot",
+    "ownerNodeId",
+    "lastHeartbeatAt",
+    "expiresAt",
+    "createdAt",
+    "updatedAt",
+  ].every((field) => typeof value[field] === "string" && value[field].length > 0);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/core/src/storage/remote-security.ts
+++ b/packages/core/src/storage/remote-security.ts
@@ -27,7 +27,12 @@ import { decryptVaultValue, encryptVaultValue, type VaultEncryptedRecord } from 
 import { stableJsonStringify } from "../stable-json";
 import * as postgres from "./schema/postgres";
 import * as sqlite from "./schema/sqlite";
-import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+import type {
+  HostDatabase,
+  HostDatabaseTransaction,
+  PostgresHostDatabase,
+  SqliteHostDatabase,
+} from "./types";
 
 export type {
   CreatePairingCodeInput,
@@ -652,6 +657,15 @@ export class RemoteSecurityStore {
       return { value: undefined, save: merged.changed };
     });
   }
+  importLegacySnapshotInTransaction(
+    snapshot: RemoteServerCredentialState,
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    const validated = parseRemoteServerCredentialState(snapshot);
+    return transaction.dialect === "sqlite"
+      ? importLegacyRemoteSecuritySqlite(transaction.db, validated)
+      : importLegacyRemoteSecurityPostgres(transaction.db, validated);
+  }
 
   async verifyLegacySnapshot(snapshot: RemoteServerCredentialState): Promise<void> {
     const result = mergeLegacyRemoteSecurityState(
@@ -664,6 +678,15 @@ export class RemoteSecurityStore {
         "Remote security state failed post-migration verification.",
       );
     }
+  }
+  verifyLegacySnapshotInTransaction(
+    snapshot: RemoteServerCredentialState,
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    const validated = parseRemoteServerCredentialState(snapshot);
+    return transaction.dialect === "sqlite"
+      ? verifyLegacyRemoteSecurityState(loadSqliteState(transaction.db), validated)
+      : verifyLegacyRemoteSecurityPostgres(transaction.db, validated);
   }
 
   async dumpForTest(): Promise<RemoteSecurityState> {
@@ -816,6 +839,51 @@ type OperatorTransitionResult<R> = {
 
 type SqliteTransaction = Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0];
 type PostgresTransaction = Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0];
+function importLegacyRemoteSecuritySqlite(
+  database: SqliteTransaction,
+  snapshot: RemoteServerCredentialState,
+): void {
+  const current = loadSqliteState(database);
+  const merged = mergeLegacyRemoteSecurityState(current, snapshot);
+  if (!merged.changed) return;
+  current.pairingCodes = merged.state.pairingCodes;
+  current.pendingLogins = merged.state.pendingLogins;
+  current.clients = merged.state.clients;
+  saveSqliteState(database, current);
+}
+
+async function importLegacyRemoteSecurityPostgres(
+  database: PostgresTransaction,
+  snapshot: RemoteServerCredentialState,
+): Promise<void> {
+  await lockPostgresRemoteSecurity(database);
+  const current = await loadPostgresState(database, true);
+  const merged = mergeLegacyRemoteSecurityState(current, snapshot);
+  if (!merged.changed) return;
+  current.pairingCodes = merged.state.pairingCodes;
+  current.pendingLogins = merged.state.pendingLogins;
+  current.clients = merged.state.clients;
+  await savePostgresState(database, current);
+}
+
+function verifyLegacyRemoteSecurityState(
+  current: RemoteSecurityState,
+  snapshot: RemoteServerCredentialState,
+): void {
+  if (mergeLegacyRemoteSecurityState(current, snapshot).changed) {
+    throw new CapletsError(
+      "INTERNAL_ERROR",
+      "Remote security state failed post-migration verification.",
+    );
+  }
+}
+
+async function verifyLegacyRemoteSecurityPostgres(
+  database: PostgresTransaction,
+  snapshot: RemoteServerCredentialState,
+): Promise<void> {
+  verifyLegacyRemoteSecurityState(await loadPostgresState(database), snapshot);
+}
 
 function loadSqliteState(database: SqliteHostDatabase | SqliteTransaction): RemoteSecurityState {
   return assembleState({

--- a/packages/core/src/storage/remote-security.ts
+++ b/packages/core/src/storage/remote-security.ts
@@ -15,13 +15,14 @@ import {
   type RemoteServerCredentialState,
   type ValidateAccessTokenInput,
 } from "../remote/server-credential-store";
-import type {
-  IssuedRemoteClientCredentials,
-  RemoteClientRole,
-  RemoteClientStatus,
-  RemotePendingLoginState,
-  RemotePendingLoginStatus,
-  ValidatedRemoteClient,
+import {
+  remoteClientRoleSatisfies,
+  type IssuedRemoteClientCredentials,
+  type RemoteClientRole,
+  type RemoteClientStatus,
+  type RemotePendingLoginState,
+  type RemotePendingLoginStatus,
+  type ValidatedRemoteClient,
 } from "../remote/server-credentials";
 import { decryptVaultValue, encryptVaultValue, type VaultEncryptedRecord } from "../vault/crypto";
 import { stableJsonStringify } from "../stable-json";
@@ -428,7 +429,7 @@ export class RemoteSecurityStore {
         );
       }
       const role = flow.grantedRole ?? flow.requestedRole;
-      if (input.requiredRole !== undefined && role !== input.requiredRole)
+      if (input.requiredRole !== undefined && !remoteClientRoleSatisfies(role, input.requiredRole))
         throw new CapletsError("AUTH_FAILED", `${input.requiredRole} role is required.`);
       const accessToken = `cap_remote_access_${randomToken(32)}`;
       const refreshToken = `cap_remote_refresh_${randomToken(32)}`;

--- a/packages/core/src/storage/remote-security.ts
+++ b/packages/core/src/storage/remote-security.ts
@@ -1,0 +1,1515 @@
+import { Buffer } from "node:buffer";
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { CapletsError } from "../errors";
+import { normalizeRemoteProfileHostUrl } from "../remote/options";
+import { createPairingCode, parsePairingCode, randomToken } from "../remote/pairing";
+import {
+  parseRemoteServerCredentialState,
+  type CreatePairingCodeInput,
+  type CreatePendingLoginInput,
+  type ExchangePairingCodeInput,
+  type PendingLoginPossessionInput,
+  type RefreshClientCredentialsInput,
+  type RefreshPendingLoginInput,
+  type RemoteServerCredentialState,
+  type ValidateAccessTokenInput,
+} from "../remote/server-credential-store";
+import type {
+  IssuedRemoteClientCredentials,
+  RemoteClientRole,
+  RemoteClientStatus,
+  RemotePendingLoginState,
+  RemotePendingLoginStatus,
+  ValidatedRemoteClient,
+} from "../remote/server-credentials";
+import { decryptVaultValue, encryptVaultValue, type VaultEncryptedRecord } from "../vault/crypto";
+import { stableJsonStringify } from "../stable-json";
+import * as postgres from "./schema/postgres";
+import * as sqlite from "./schema/sqlite";
+import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+
+export type {
+  CreatePairingCodeInput,
+  CreatePendingLoginInput,
+  ExchangePairingCodeInput,
+  PendingLoginPossessionInput,
+  RefreshClientCredentialsInput,
+  RefreshPendingLoginInput,
+  ValidateAccessTokenInput,
+};
+
+export type OperatorPendingLoginInput = {
+  operatorClientId: string;
+  operatorCode: string;
+  grantedRole?: RemoteClientRole | undefined;
+  now?: Date | undefined;
+};
+
+export type OperatorPendingLoginFlowInput = {
+  operatorClientId: string;
+  flowId: string;
+  grantedRole?: RemoteClientRole | undefined;
+  now?: Date | undefined;
+};
+
+export type CompletePendingLoginInput = PendingLoginPossessionInput & {
+  hostUrl: string;
+  requiredRole?: RemoteClientRole | undefined;
+};
+
+export type RevokeRemoteClientInput = {
+  operatorClientId: string;
+  clientId: string;
+  now?: Date | undefined;
+};
+
+export type ChangeRemoteClientRoleInput = {
+  operatorClientId: string;
+  clientId: string;
+  role: RemoteClientRole;
+  now?: Date | undefined;
+};
+
+type SupersededRefreshToken = { hash: string; supersededAt: string };
+type PendingRefreshReplay = {
+  refreshHash: string;
+  expiresAt: string;
+  encryptedResponse: VaultEncryptedRecord;
+};
+type CompletionReplay = { expiresAt: string; encryptedCredentials: VaultEncryptedRecord };
+type StoredPairingCode = {
+  codeId: string;
+  hostUrl: string;
+  secretHash: string;
+  clientLabel?: string | undefined;
+  createdAt: string;
+  expiresAt: string;
+  attempts: number;
+  maxAttempts: number;
+  usedAt?: string | undefined;
+};
+type StoredRemoteClient = {
+  clientId: string;
+  clientLabel: string;
+  role: RemoteClientRole;
+  hostUrl: string;
+  accessTokenHash: string;
+  accessExpiresAt: string;
+  refreshTokenHash: string;
+  supersededRefreshTokenHashes: SupersededRefreshToken[];
+  refreshFamilyId: string;
+  createdAt: string;
+  lastUsedAt?: string | undefined;
+  revokedAt?: string | undefined;
+};
+type StoredPendingLogin = {
+  flowId: string;
+  hostUrl: string;
+  hostIdentity?: string | undefined;
+  operatorCodeHash: string;
+  pendingRefreshHash: string;
+  supersededPendingRefreshHashes: SupersededRefreshToken[];
+  pendingRefreshReplay?: PendingRefreshReplay | undefined;
+  pendingCompletionHash: string;
+  completionReplay?: CompletionReplay | undefined;
+  clientLabel: string;
+  requestedRole: RemoteClientRole;
+  grantedRole?: RemoteClientRole | undefined;
+  clientFingerprint?: string | undefined;
+  sourceHint?: string | undefined;
+  createdAt: string;
+  codeExpiresAt: string;
+  flowExpiresAt: string;
+  status: RemotePendingLoginState;
+  operatorCodeFingerprint?: string | undefined;
+  approvedAt?: string | undefined;
+  deniedAt?: string | undefined;
+  cancelledAt?: string | undefined;
+  exchangedAt?: string | undefined;
+};
+type RemoteSecurityState = {
+  version: 1;
+  pairingCodes: StoredPairingCode[];
+  pendingLogins: StoredPendingLogin[];
+  clients: StoredRemoteClient[];
+};
+
+const DEFAULT_PAIRING_CODE_TTL_MS = 10 * 60_000;
+const DEFAULT_PAIRING_CODE_MAX_ATTEMPTS = 5;
+const DEFAULT_ACCESS_TOKEN_TTL_MS = 15 * 60_000;
+const DEFAULT_PENDING_OPERATOR_CODE_TTL_MS = 10 * 60_000;
+const DEFAULT_PENDING_FLOW_TTL_MS = 24 * 60 * 60_000;
+const DEFAULT_PENDING_POLL_INTERVAL_SECONDS = 5;
+const DEFAULT_PENDING_MAX_ACTIVE_FLOWS = 64;
+const DEFAULT_PENDING_MAX_ACTIVE_FLOWS_PER_SOURCE = 8;
+const PENDING_TERMINAL_RETENTION_MS = 24 * 60 * 60_000;
+const STALE_REFRESH_REVOKE_GRACE_MS = 30_000;
+const PENDING_SUPERSEDED_REFRESH_HASH_MAX = 16;
+const SUPERSEDED_REFRESH_TOKEN_RETENTION_MS = 24 * 60 * 60_000;
+const PENDING_CLIENT_LABEL_MAX_LENGTH = 120;
+const PENDING_CLIENT_FINGERPRINT_MAX_LENGTH = 256;
+const PENDING_SOURCE_HINT_MAX_LENGTH = 256;
+
+export class RemoteSecurityStore {
+  constructor(private readonly database: HostDatabase) {}
+
+  async createPendingLogin(input: CreatePendingLoginInput) {
+    return await this.update((state) => {
+      const now = input.now ?? new Date();
+      cleanupPendingLogins(state, now);
+      const flowId = `rlogin_${randomToken(12)}`;
+      const operatorCode = `cap_login_${randomToken(5)}`;
+      const pendingRefreshSecret = `cap_pending_refresh_${randomToken(32)}`;
+      const pendingCompletionSecret = `cap_pending_complete_${randomToken(32)}`;
+      const codeExpiresAt = new Date(
+        now.getTime() + DEFAULT_PENDING_OPERATOR_CODE_TTL_MS,
+      ).toISOString();
+      const flowExpiresAt = new Date(now.getTime() + DEFAULT_PENDING_FLOW_TTL_MS).toISOString();
+      const clientLabel =
+        bounded(input.clientLabel, PENDING_CLIENT_LABEL_MAX_LENGTH) ?? "Caplets Remote Client";
+      const clientFingerprint = bounded(
+        input.clientFingerprint,
+        PENDING_CLIENT_FINGERPRINT_MAX_LENGTH,
+      );
+      const sourceHint = bounded(input.sourceHint, PENDING_SOURCE_HINT_MAX_LENGTH);
+      enforcePendingLoginQuota(state, sourceHint);
+      state.pendingLogins.push({
+        flowId,
+        hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
+        ...(input.hostIdentity ? { hostIdentity: input.hostIdentity } : {}),
+        operatorCodeHash: hashSecret(operatorCode),
+        pendingRefreshHash: hashSecret(pendingRefreshSecret),
+        supersededPendingRefreshHashes: [],
+        pendingCompletionHash: hashSecret(pendingCompletionSecret),
+        clientLabel,
+        requestedRole: input.requestedRole ?? "access",
+        ...(clientFingerprint ? { clientFingerprint } : {}),
+        ...(sourceHint ? { sourceHint } : {}),
+        createdAt: now.toISOString(),
+        codeExpiresAt,
+        flowExpiresAt,
+        status: "pending",
+        operatorCodeFingerprint: operatorCodeFingerprint(operatorCode),
+      });
+      return {
+        value: {
+          flowId,
+          operatorCode,
+          operatorCodeFingerprint: operatorCodeFingerprint(operatorCode),
+          pendingRefreshSecret,
+          pendingCompletionSecret,
+          codeExpiresAt,
+          flowExpiresAt,
+          intervalSeconds: DEFAULT_PENDING_POLL_INTERVAL_SECONDS,
+        },
+      };
+    });
+  }
+
+  async pollPendingLogin(
+    input: PendingLoginPossessionInput,
+  ): Promise<{ flowId: string; status: RemotePendingLoginState }> {
+    const now = input.now ?? new Date();
+    const state = await this.readState();
+    const flow = pendingLoginForCompletion(state, input.flowId, input.pendingCompletionSecret, now);
+    return { flowId: flow.flowId, status: flow.status };
+  }
+
+  async refreshPendingLogin(input: RefreshPendingLoginInput) {
+    return await this.update((state) => {
+      const now = input.now ?? new Date();
+      cleanupPendingLogins(state, now);
+      const flow = pendingLoginForCompletion(
+        state,
+        input.flowId,
+        input.pendingCompletionSecret,
+        now,
+      );
+      if (flow.status !== "pending")
+        throw new CapletsError("AUTH_FAILED", `Pending login is already ${flow.status}.`);
+      const refreshHash = hashSecret(input.pendingRefreshSecret);
+      if (!safeHashEqual(refreshHash, flow.pendingRefreshHash)) {
+        if (
+          flow.pendingRefreshReplay &&
+          safeHashEqual(refreshHash, flow.pendingRefreshReplay.refreshHash) &&
+          Date.parse(flow.pendingRefreshReplay.expiresAt) > now.getTime()
+        ) {
+          return {
+            value: decryptPendingRefreshReplay(
+              flow.pendingRefreshReplay,
+              input.pendingCompletionSecret,
+            ),
+            save: false,
+          };
+        }
+        if (
+          flow.supersededPendingRefreshHashes.some((entry) =>
+            safeHashEqual(refreshHash, entry.hash),
+          )
+        ) {
+          throw new CapletsError("AUTH_FAILED", "Pending login refresh material is stale.");
+        }
+        throw new CapletsError("AUTH_FAILED", "Pending login refresh material is invalid.");
+      }
+      const operatorCode = `cap_login_${randomToken(5)}`;
+      const pendingRefreshSecret = `cap_pending_refresh_${randomToken(32)}`;
+      const codeExpiresAt = new Date(
+        now.getTime() + DEFAULT_PENDING_OPERATOR_CODE_TTL_MS,
+      ).toISOString();
+      const response = {
+        flowId: flow.flowId,
+        operatorCode,
+        operatorCodeFingerprint: operatorCodeFingerprint(operatorCode),
+        pendingRefreshSecret,
+        codeExpiresAt,
+        flowExpiresAt: flow.flowExpiresAt,
+        intervalSeconds: DEFAULT_PENDING_POLL_INTERVAL_SECONDS,
+      };
+      flow.operatorCodeHash = hashSecret(operatorCode);
+      flow.operatorCodeFingerprint = response.operatorCodeFingerprint;
+      flow.supersededPendingRefreshHashes = pruneSupersededRefreshTokens(
+        flow.supersededPendingRefreshHashes,
+        now,
+      );
+      flow.pendingRefreshReplay = {
+        refreshHash: flow.pendingRefreshHash,
+        expiresAt: new Date(now.getTime() + STALE_REFRESH_REVOKE_GRACE_MS).toISOString(),
+        encryptedResponse: encryptReplayValue(response, input.pendingCompletionSecret, now),
+      };
+      flow.supersededPendingRefreshHashes.push({
+        hash: flow.pendingRefreshHash,
+        supersededAt: now.toISOString(),
+      });
+      flow.supersededPendingRefreshHashes = capSupersededRefreshTokens(
+        flow.supersededPendingRefreshHashes,
+      );
+      flow.pendingRefreshHash = hashSecret(pendingRefreshSecret);
+      flow.codeExpiresAt = codeExpiresAt;
+      return { value: response };
+    });
+  }
+
+  async denyPendingLogin(input: OperatorPendingLoginInput): Promise<RemotePendingLoginStatus> {
+    return await this.operatorUpdate(
+      input.operatorClientId,
+      "remote_pending_login_denied",
+      "pending_login",
+      (state) => {
+        const now = input.now ?? new Date();
+        cleanupPendingLogins(state, now);
+        const codeHash = hashSecret(input.operatorCode);
+        const flow = state.pendingLogins.find((candidate) =>
+          safeHashEqual(codeHash, candidate.operatorCodeHash),
+        );
+        if (!flow) throw new CapletsError("AUTH_FAILED", "Pending login code is unknown.");
+        denyFlow(flow, now);
+        return { value: pendingLoginStatus(flow), targetKey: flow.flowId };
+      },
+    );
+  }
+
+  async denyPendingLoginFlow(
+    input: OperatorPendingLoginFlowInput,
+  ): Promise<RemotePendingLoginStatus> {
+    return await this.operatorUpdate(
+      input.operatorClientId,
+      "remote_pending_login_denied",
+      "pending_login",
+      (state) => {
+        const now = input.now ?? new Date();
+        cleanupPendingLogins(state, now);
+        const flow = requireFlow(state, input.flowId);
+        denyFlow(flow, now);
+        return { value: pendingLoginStatus(flow), targetKey: flow.flowId };
+      },
+    );
+  }
+
+  async cancelPendingLogin(
+    input: PendingLoginPossessionInput,
+  ): Promise<{ flowId: string; status: "cancelled" }> {
+    return await this.update((state) => {
+      const now = input.now ?? new Date();
+      cleanupPendingLogins(state, now);
+      const flow = pendingLoginForCompletion(
+        state,
+        input.flowId,
+        input.pendingCompletionSecret,
+        now,
+      );
+      if (flow.status !== "pending" && flow.status !== "approved")
+        throw new CapletsError("AUTH_FAILED", `Pending login is already ${flow.status}.`);
+      flow.status = "cancelled";
+      flow.cancelledAt = now.toISOString();
+      return { value: { flowId: flow.flowId, status: "cancelled" as const } };
+    });
+  }
+
+  async approvePendingLogin(input: OperatorPendingLoginInput) {
+    return await this.operatorUpdate(
+      input.operatorClientId,
+      "remote_pending_login_approved",
+      "pending_login",
+      (state) => {
+        const now = input.now ?? new Date();
+        cleanupPendingLogins(state, now);
+        const codeHash = hashSecret(input.operatorCode);
+        const flow = state.pendingLogins.find((candidate) =>
+          safeHashEqual(codeHash, candidate.operatorCodeHash),
+        );
+        if (!flow) throw new CapletsError("AUTH_FAILED", "Pending login code is unknown.");
+        approveFlow(flow, input.grantedRole, now);
+        return {
+          value: pendingApprovalStatus(flow),
+          targetKey: flow.flowId,
+          metadata: { grantedRole: flow.grantedRole },
+        };
+      },
+    );
+  }
+
+  async approvePendingLoginFlow(
+    input: OperatorPendingLoginFlowInput,
+  ): Promise<RemotePendingLoginStatus> {
+    return await this.operatorUpdate(
+      input.operatorClientId,
+      "remote_pending_login_approved",
+      "pending_login",
+      (state) => {
+        const now = input.now ?? new Date();
+        cleanupPendingLogins(state, now);
+        const flow = requireFlow(state, input.flowId);
+        approveFlow(flow, input.grantedRole, now);
+        return {
+          value: pendingLoginStatus(flow),
+          targetKey: flow.flowId,
+          metadata: { grantedRole: flow.grantedRole },
+        };
+      },
+    );
+  }
+
+  async completePendingLogin(
+    input: CompletePendingLoginInput,
+  ): Promise<IssuedRemoteClientCredentials> {
+    return await this.update((state) => {
+      const now = input.now ?? new Date();
+      cleanupPendingLogins(state, now);
+      const flow = pendingLoginForCompletion(
+        state,
+        input.flowId,
+        input.pendingCompletionSecret,
+        now,
+      );
+      if (flow.hostUrl !== normalizeRemoteProfileHostUrl(input.hostUrl))
+        throw new CapletsError("AUTH_FAILED", "Pending login belongs to a different host.");
+      if (flow.status !== "approved") {
+        if (
+          flow.status === "exchanged" &&
+          flow.completionReplay &&
+          Date.parse(flow.completionReplay.expiresAt) > now.getTime()
+        ) {
+          return {
+            value: decryptCompletionReplay(flow.completionReplay, input.pendingCompletionSecret),
+            save: false,
+          };
+        }
+        throw new CapletsError(
+          "AUTH_FAILED",
+          flow.status === "exchanged"
+            ? "Pending login has already been exchanged."
+            : `Pending login is ${flow.status}, not approved.`,
+        );
+      }
+      const role = flow.grantedRole ?? flow.requestedRole;
+      if (input.requiredRole !== undefined && role !== input.requiredRole)
+        throw new CapletsError("AUTH_FAILED", `${input.requiredRole} role is required.`);
+      const accessToken = `cap_remote_access_${randomToken(32)}`;
+      const refreshToken = `cap_remote_refresh_${randomToken(32)}`;
+      const client = createClient(
+        flow.hostUrl,
+        flow.clientLabel,
+        role,
+        accessToken,
+        refreshToken,
+        now,
+      );
+      state.clients.push(client);
+      flow.status = "exchanged";
+      flow.exchangedAt = now.toISOString();
+      const credentials = credentialsFromClient(client, accessToken, refreshToken);
+      flow.completionReplay = {
+        expiresAt: new Date(now.getTime() + STALE_REFRESH_REVOKE_GRACE_MS).toISOString(),
+        encryptedCredentials: encryptReplayValue(credentials, input.pendingCompletionSecret, now),
+      };
+      return { value: credentials };
+    });
+  }
+
+  async createPairingCode(
+    input: CreatePairingCodeInput,
+  ): Promise<{ codeId: string; code: string; expiresAt: string }> {
+    return await this.update((state) => {
+      const now = input.now ?? new Date();
+      const issued = createPairingCode();
+      const expiresAt = new Date(
+        now.getTime() + (input.ttlMs ?? DEFAULT_PAIRING_CODE_TTL_MS),
+      ).toISOString();
+      state.pairingCodes.push({
+        codeId: issued.codeId,
+        hostUrl: normalizeRemoteProfileHostUrl(input.hostUrl),
+        secretHash: hashSecret(issued.secret),
+        ...(input.clientLabel ? { clientLabel: input.clientLabel } : {}),
+        createdAt: now.toISOString(),
+        expiresAt,
+        attempts: 0,
+        maxAttempts: input.maxAttempts ?? DEFAULT_PAIRING_CODE_MAX_ATTEMPTS,
+      });
+      return { value: { codeId: issued.codeId, code: issued.code, expiresAt } };
+    });
+  }
+
+  async exchangePairingCode(
+    input: ExchangePairingCodeInput,
+  ): Promise<IssuedRemoteClientCredentials> {
+    return await this.update<IssuedRemoteClientCredentials>((state) => {
+      const now = input.now ?? new Date();
+      const parsed = parsePairingCode(input.code);
+      if (!parsed) throw new CapletsError("AUTH_FAILED", "Pairing Code format is invalid.");
+      const pairingCode = state.pairingCodes.find(
+        (candidate) => candidate.codeId === parsed.codeId,
+      );
+      if (!pairingCode) throw new CapletsError("AUTH_FAILED", "Pairing Code is unknown.");
+      const hostUrl = normalizeRemoteProfileHostUrl(input.hostUrl);
+      if (pairingCode.hostUrl !== hostUrl)
+        throw new CapletsError("AUTH_FAILED", "Pairing Code belongs to a different host.");
+      if (pairingCode.usedAt)
+        throw new CapletsError("AUTH_FAILED", "Pairing Code has already been used.");
+      if (Date.parse(pairingCode.expiresAt) <= now.getTime())
+        throw new CapletsError("AUTH_FAILED", "Pairing Code has expired.");
+      if (pairingCode.attempts >= pairingCode.maxAttempts)
+        throw new CapletsError("AUTH_FAILED", "Pairing Code attempts exhausted.");
+      if (!safeHashEqual(hashSecret(parsed.secret), pairingCode.secretHash)) {
+        pairingCode.attempts += 1;
+        return {
+          error: new CapletsError(
+            "AUTH_FAILED",
+            pairingCode.attempts >= pairingCode.maxAttempts
+              ? "Pairing Code attempts exhausted."
+              : "Pairing Code is invalid.",
+          ),
+        };
+      }
+      pairingCode.usedAt = now.toISOString();
+      const accessToken = `cap_remote_access_${randomToken(32)}`;
+      const refreshToken = `cap_remote_refresh_${randomToken(32)}`;
+      const client = createClient(
+        hostUrl,
+        input.clientLabel ?? pairingCode.clientLabel ?? "Caplets Remote Client",
+        "access",
+        accessToken,
+        refreshToken,
+        now,
+      );
+      state.clients.push(client);
+      return { value: credentialsFromClient(client, accessToken, refreshToken) };
+    });
+  }
+
+  async listClients(): Promise<RemoteClientStatus[]> {
+    const state = await this.readState();
+    return state.clients
+      .map(clientStatus)
+      .sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+  }
+
+  async listPendingLogins(now = new Date()): Promise<RemotePendingLoginStatus[]> {
+    return await this.update((state) => {
+      const changed = cleanupPendingLogins(state, now);
+      return {
+        value: state.pendingLogins
+          .map(pendingLoginStatus)
+          .sort((left, right) => left.createdAt.localeCompare(right.createdAt)),
+        save: changed,
+      };
+    });
+  }
+
+  async revokeClient(input: RevokeRemoteClientInput): Promise<boolean> {
+    return await this.operatorUpdate(
+      input.operatorClientId,
+      "remote_client_revoked",
+      "remote_client",
+      (state) => {
+        const client = state.clients.find((candidate) => candidate.clientId === input.clientId);
+        if (!client) return { value: false, save: false };
+        client.revokedAt ??= (input.now ?? new Date()).toISOString();
+        return { value: true, targetKey: client.clientId };
+      },
+    );
+  }
+
+  async changeClientRole(
+    input: ChangeRemoteClientRoleInput,
+  ): Promise<RemoteClientStatus | undefined> {
+    return await this.operatorUpdate(
+      input.operatorClientId,
+      "remote_client_role_changed",
+      "remote_client",
+      (state) => {
+        const client = state.clients.find((candidate) => candidate.clientId === input.clientId);
+        if (!client) return { value: undefined, save: false };
+        const previousRole = client.role;
+        client.role = input.role;
+        return {
+          value: clientStatus(client),
+          targetKey: client.clientId,
+          metadata: { previousRole, role: input.role },
+        };
+      },
+    );
+  }
+
+  async validateAccessToken(input: ValidateAccessTokenInput): Promise<ValidatedRemoteClient> {
+    const state = await this.readState();
+    const tokenHash = hashSecret(input.accessToken);
+    const client = state.clients.find((candidate) =>
+      safeHashEqual(tokenHash, candidate.accessTokenHash),
+    );
+    if (!client) throw new CapletsError("AUTH_FAILED", "Remote client credential is invalid.");
+    validateClient(client, normalizeRemoteProfileHostUrl(input.hostUrl), input.now ?? new Date());
+    return { ...clientStatus(client), tokenType: "Bearer" };
+  }
+
+  async refreshClientCredentials(
+    input: RefreshClientCredentialsInput,
+  ): Promise<IssuedRemoteClientCredentials> {
+    return await this.update<IssuedRemoteClientCredentials>((state) => {
+      const now = input.now ?? new Date();
+      const tokenHash = hashSecret(input.refreshToken);
+      const client = state.clients.find((candidate) =>
+        safeHashEqual(tokenHash, candidate.refreshTokenHash),
+      );
+      if (!client) {
+        const replayed = state.clients.find((candidate) =>
+          candidate.supersededRefreshTokenHashes.some((entry) =>
+            safeHashEqual(tokenHash, entry.hash),
+          ),
+        );
+        if (replayed) {
+          const entry = replayed.supersededRefreshTokenHashes.find((candidate) =>
+            safeHashEqual(tokenHash, candidate.hash),
+          );
+          const supersededAt = Date.parse(entry?.supersededAt ?? "");
+          if (
+            Number.isFinite(supersededAt) &&
+            now.getTime() - supersededAt >= STALE_REFRESH_REVOKE_GRACE_MS
+          )
+            replayed.revokedAt = now.toISOString();
+          return {
+            error: new CapletsError(
+              "REMOTE_CREDENTIALS_REVOKED",
+              "Remote refresh credential is stale.",
+            ),
+          };
+        }
+        throw new CapletsError("AUTH_FAILED", "Remote refresh credential is invalid.");
+      }
+      validateClient(client, normalizeRemoteProfileHostUrl(input.hostUrl), now, true);
+      const accessToken = `cap_remote_access_${randomToken(32)}`;
+      const refreshToken = `cap_remote_refresh_${randomToken(32)}`;
+      client.accessTokenHash = hashSecret(accessToken);
+      client.accessExpiresAt = new Date(now.getTime() + DEFAULT_ACCESS_TOKEN_TTL_MS).toISOString();
+      client.supersededRefreshTokenHashes = pruneSupersededRefreshTokens(
+        client.supersededRefreshTokenHashes,
+        now,
+      );
+      client.supersededRefreshTokenHashes.push({
+        hash: client.refreshTokenHash,
+        supersededAt: now.toISOString(),
+      });
+      client.refreshTokenHash = hashSecret(refreshToken);
+      client.lastUsedAt = now.toISOString();
+      return { value: credentialsFromClient(client, accessToken, refreshToken) };
+    });
+  }
+
+  async assertLegacySnapshotImportable(snapshot: RemoteServerCredentialState): Promise<void> {
+    mergeLegacyRemoteSecurityState(
+      await this.readState(),
+      parseRemoteServerCredentialState(snapshot),
+    );
+  }
+
+  async importLegacySnapshot(snapshot: RemoteServerCredentialState): Promise<void> {
+    const validated = parseRemoteServerCredentialState(snapshot);
+    await this.update((current) => {
+      const merged = mergeLegacyRemoteSecurityState(current, validated);
+      current.pairingCodes = merged.state.pairingCodes;
+      current.pendingLogins = merged.state.pendingLogins;
+      current.clients = merged.state.clients;
+      return { value: undefined, save: merged.changed };
+    });
+  }
+
+  async verifyLegacySnapshot(snapshot: RemoteServerCredentialState): Promise<void> {
+    const result = mergeLegacyRemoteSecurityState(
+      await this.readState(),
+      parseRemoteServerCredentialState(snapshot),
+    );
+    if (result.changed) {
+      throw new CapletsError(
+        "INTERNAL_ERROR",
+        "Remote security state failed post-migration verification.",
+      );
+    }
+  }
+
+  async dumpForTest(): Promise<RemoteSecurityState> {
+    return await this.readState();
+  }
+
+  private async readState(): Promise<RemoteSecurityState> {
+    return this.database.dialect === "sqlite"
+      ? loadSqliteState(this.database.db)
+      : await loadPostgresState(this.database.db);
+  }
+
+  private async update<R>(
+    transition: (state: RemoteSecurityState) => TransitionResult<R>,
+  ): Promise<R> {
+    const result =
+      this.database.dialect === "sqlite"
+        ? this.database.db.transaction((transaction) => {
+            const state = loadSqliteState(transaction);
+            const transitionResult = transition(state);
+            if ("error" in transitionResult) {
+              saveSqliteState(transaction, state);
+              return transitionResult.error;
+            }
+            if (transitionResult.save !== false) saveSqliteState(transaction, state);
+            return transitionResult.value;
+          })
+        : await this.database.db.transaction(async (transaction) => {
+            await lockPostgresRemoteSecurity(transaction);
+            const state = await loadPostgresState(transaction, true);
+            const transitionResult = transition(state);
+            if ("error" in transitionResult) {
+              await savePostgresState(transaction, state);
+              return transitionResult.error;
+            }
+            if (transitionResult.save !== false) await savePostgresState(transaction, state);
+            return transitionResult.value;
+          });
+    if (result instanceof Error) throw result;
+    return result;
+  }
+
+  private async operatorUpdate<R>(
+    operatorClientId: string,
+    action: string,
+    targetKind: string,
+    transition: (state: RemoteSecurityState) => OperatorTransitionResult<R>,
+  ): Promise<R> {
+    if (this.database.dialect === "sqlite") {
+      return this.database.db.transaction((transaction) => {
+        const state = loadSqliteState(transaction);
+        const result = transition(state);
+        if (result.save === false) return result.value;
+        saveSqliteState(transaction, state);
+        transaction
+          .insert(sqlite.operatorActivity)
+          .values(
+            activityValues(
+              operatorClientId,
+              action,
+              targetKind,
+              result.targetKey!,
+              result.metadata,
+            ),
+          )
+          .run();
+        return result.value;
+      });
+    }
+    return await this.database.db.transaction(async (transaction) => {
+      await lockPostgresRemoteSecurity(transaction);
+      const state = await loadPostgresState(transaction, true);
+      const result = transition(state);
+      if (result.save === false) return result.value;
+      await savePostgresState(transaction, state);
+      await transaction
+        .insert(postgres.operatorActivity)
+        .values(
+          activityValues(operatorClientId, action, targetKind, result.targetKey!, result.metadata),
+        );
+      return result.value;
+    });
+  }
+}
+
+function mergeLegacyRemoteSecurityState(
+  current: RemoteSecurityState,
+  legacy: RemoteServerCredentialState,
+): { state: RemoteSecurityState; changed: boolean } {
+  const pairingCodes = mergeLegacyRemoteCollection(
+    current.pairingCodes,
+    legacy.pairingCodes,
+    (entry) => entry.codeId,
+  );
+  const pendingLogins = mergeLegacyRemoteCollection(
+    current.pendingLogins,
+    legacy.pendingLogins,
+    (entry) => entry.flowId,
+  );
+  const clients = mergeLegacyRemoteCollection(
+    current.clients,
+    legacy.clients,
+    (entry) => entry.clientId,
+  );
+  const state = parseRemoteServerCredentialState({
+    version: 1,
+    pairingCodes: pairingCodes.values,
+    pendingLogins: pendingLogins.values,
+    clients: clients.values,
+  });
+  return {
+    state,
+    changed: pairingCodes.changed || pendingLogins.changed || clients.changed,
+  };
+}
+
+function mergeLegacyRemoteCollection<T>(
+  current: T[],
+  legacy: T[],
+  identity: (entry: T) => string,
+): { values: T[]; changed: boolean } {
+  const values = [...current];
+  const byIdentity = new Map(current.map((entry) => [identity(entry), entry]));
+  let changed = false;
+  for (const entry of legacy) {
+    const key = identity(entry);
+    const existing = byIdentity.get(key);
+    if (existing && stableJsonStringify(existing) !== stableJsonStringify(entry)) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        "Remote security state conflicts with the legacy snapshot.",
+      );
+    }
+    if (!existing) {
+      values.push(entry);
+      byIdentity.set(key, entry);
+      changed = true;
+    }
+  }
+  return { values, changed };
+}
+
+type TransitionResult<R> = { value: R; save?: boolean } | { error: Error };
+type OperatorTransitionResult<R> = {
+  value: R;
+  save?: boolean;
+  targetKey?: string;
+  metadata?: Record<string, unknown>;
+};
+
+type SqliteTransaction = Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0];
+type PostgresTransaction = Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0];
+
+function loadSqliteState(database: SqliteHostDatabase | SqliteTransaction): RemoteSecurityState {
+  return assembleState({
+    pairingCodes: database.select().from(sqlite.remotePairingCodes).all(),
+    clients: database.select().from(sqlite.remoteClients).all(),
+    tokenFamilies: database.select().from(sqlite.remoteClientTokenFamilies).all(),
+    supersededRefreshes: database.select().from(sqlite.remoteClientSupersededRefreshTokens).all(),
+    pendingLogins: database.select().from(sqlite.remotePendingLogins).all(),
+    pendingSupersededRefreshes: database
+      .select()
+      .from(sqlite.remotePendingSupersededRefreshTokens)
+      .all(),
+  });
+}
+
+async function loadPostgresState(
+  database: PostgresHostDatabase | PostgresTransaction,
+  forUpdate = false,
+): Promise<RemoteSecurityState> {
+  const pairingQuery = database.select().from(postgres.remotePairingCodes);
+  const clientsQuery = database.select().from(postgres.remoteClients);
+  const familiesQuery = database.select().from(postgres.remoteClientTokenFamilies);
+  const supersededQuery = database.select().from(postgres.remoteClientSupersededRefreshTokens);
+  const pendingQuery = database.select().from(postgres.remotePendingLogins);
+  const pendingSupersededQuery = database
+    .select()
+    .from(postgres.remotePendingSupersededRefreshTokens);
+  const [
+    pairingCodes,
+    clients,
+    tokenFamilies,
+    supersededRefreshes,
+    pendingLogins,
+    pendingSupersededRefreshes,
+  ] = await Promise.all([
+    forUpdate ? pairingQuery.for("update") : pairingQuery,
+    forUpdate ? clientsQuery.for("update") : clientsQuery,
+    forUpdate ? familiesQuery.for("update") : familiesQuery,
+    forUpdate ? supersededQuery.for("update") : supersededQuery,
+    forUpdate ? pendingQuery.for("update") : pendingQuery,
+    forUpdate ? pendingSupersededQuery.for("update") : pendingSupersededQuery,
+  ]);
+  return assembleState({
+    pairingCodes,
+    clients,
+    tokenFamilies,
+    supersededRefreshes,
+    pendingLogins,
+    pendingSupersededRefreshes,
+  });
+}
+
+type RelationalRemoteSecurityRows = {
+  pairingCodes: Array<typeof sqlite.remotePairingCodes.$inferSelect>;
+  clients: Array<typeof sqlite.remoteClients.$inferSelect>;
+  tokenFamilies: Array<typeof sqlite.remoteClientTokenFamilies.$inferSelect>;
+  supersededRefreshes: Array<typeof sqlite.remoteClientSupersededRefreshTokens.$inferSelect>;
+  pendingLogins: Array<typeof sqlite.remotePendingLogins.$inferSelect>;
+  pendingSupersededRefreshes: Array<
+    typeof sqlite.remotePendingSupersededRefreshTokens.$inferSelect
+  >;
+};
+
+function assembleState(rows: RelationalRemoteSecurityRows): RemoteSecurityState {
+  const families = new Map(rows.tokenFamilies.map((family) => [family.clientId, family]));
+  const supersededByFamily = groupBy(rows.supersededRefreshes, (entry) => entry.familyId);
+  const pendingSupersededByFlow = groupBy(rows.pendingSupersededRefreshes, (entry) => entry.flowId);
+  return {
+    version: 1,
+    pairingCodes: rows.pairingCodes.map((row) => ({
+      codeId: row.codeId,
+      hostUrl: row.hostUrl,
+      secretHash: row.secretHash,
+      ...(row.clientLabel ? { clientLabel: row.clientLabel } : {}),
+      createdAt: row.createdAt,
+      expiresAt: row.expiresAt,
+      attempts: row.attempts,
+      maxAttempts: row.maxAttempts,
+      ...(row.usedAt ? { usedAt: row.usedAt } : {}),
+    })),
+    clients: rows.clients.map((row) => {
+      const family = families.get(row.clientId);
+      if (!family) {
+        throw new CapletsError(
+          "CONFIG_INVALID",
+          `Remote client ${row.clientId} has no token family.`,
+        );
+      }
+      return {
+        clientId: row.clientId,
+        clientLabel: row.clientLabel,
+        role: parseRole(row.role),
+        hostUrl: row.hostUrl,
+        accessTokenHash: row.accessTokenHash,
+        accessExpiresAt: row.accessExpiresAt,
+        refreshTokenHash: family.refreshTokenHash,
+        supersededRefreshTokenHashes: (supersededByFamily.get(family.familyId) ?? []).map(
+          (entry) => ({ hash: entry.tokenHash, supersededAt: entry.supersededAt }),
+        ),
+        refreshFamilyId: family.familyId,
+        createdAt: row.createdAt,
+        ...(row.lastUsedAt ? { lastUsedAt: row.lastUsedAt } : {}),
+        ...(row.revokedAt || family.revokedAt
+          ? { revokedAt: row.revokedAt ?? family.revokedAt! }
+          : {}),
+      };
+    }),
+    pendingLogins: rows.pendingLogins.map((row) => ({
+      flowId: row.flowId,
+      hostUrl: row.hostUrl,
+      ...(row.hostIdentity ? { hostIdentity: row.hostIdentity } : {}),
+      operatorCodeHash: row.operatorCodeHash,
+      pendingRefreshHash: row.pendingRefreshHash,
+      supersededPendingRefreshHashes: (pendingSupersededByFlow.get(row.flowId) ?? []).map(
+        (entry) => ({ hash: entry.tokenHash, supersededAt: entry.supersededAt }),
+      ),
+      ...(row.pendingRefreshReplay
+        ? { pendingRefreshReplay: parsePendingRefreshReplay(row.pendingRefreshReplay) }
+        : {}),
+      pendingCompletionHash: row.pendingCompletionHash,
+      ...(row.completionReplay
+        ? { completionReplay: parseCompletionReplay(row.completionReplay) }
+        : {}),
+      clientLabel: row.clientLabel,
+      requestedRole: parseRole(row.requestedRole),
+      ...(row.grantedRole ? { grantedRole: parseRole(row.grantedRole) } : {}),
+      ...(row.clientFingerprint ? { clientFingerprint: row.clientFingerprint } : {}),
+      ...(row.sourceHint ? { sourceHint: row.sourceHint } : {}),
+      createdAt: row.createdAt,
+      codeExpiresAt: row.codeExpiresAt,
+      flowExpiresAt: row.flowExpiresAt,
+      status: parsePendingStatus(row.status),
+      ...(row.operatorCodeFingerprint
+        ? { operatorCodeFingerprint: row.operatorCodeFingerprint }
+        : {}),
+      ...(row.approvedAt ? { approvedAt: row.approvedAt } : {}),
+      ...(row.deniedAt ? { deniedAt: row.deniedAt } : {}),
+      ...(row.cancelledAt ? { cancelledAt: row.cancelledAt } : {}),
+      ...(row.exchangedAt ? { exchangedAt: row.exchangedAt } : {}),
+    })),
+  };
+}
+function groupBy<T>(values: T[], keyFor: (value: T) => string): Map<string, T[]> {
+  const grouped = new Map<string, T[]>();
+  for (const value of values) {
+    const key = keyFor(value);
+    const group = grouped.get(key);
+    if (group) group.push(value);
+    else grouped.set(key, [value]);
+  }
+  return grouped;
+}
+
+function saveSqliteState(database: SqliteTransaction, state: RemoteSecurityState): void {
+  database.delete(sqlite.remotePendingSupersededRefreshTokens).run();
+  database.delete(sqlite.remoteClientSupersededRefreshTokens).run();
+  database.delete(sqlite.remoteClientTokenFamilies).run();
+  database.delete(sqlite.remotePendingLogins).run();
+  database.delete(sqlite.remotePairingCodes).run();
+  database.delete(sqlite.remoteClients).run();
+  const values = relationalValues(state);
+  if (values.pairingCodes.length > 0) {
+    database.insert(sqlite.remotePairingCodes).values(values.pairingCodes).run();
+  }
+  if (values.clients.length > 0) {
+    database.insert(sqlite.remoteClients).values(values.clients).run();
+    database.insert(sqlite.remoteClientTokenFamilies).values(values.tokenFamilies).run();
+  }
+  if (values.supersededRefreshes.length > 0) {
+    database
+      .insert(sqlite.remoteClientSupersededRefreshTokens)
+      .values(values.supersededRefreshes)
+      .run();
+  }
+  if (values.pendingLogins.length > 0) {
+    database.insert(sqlite.remotePendingLogins).values(values.pendingLogins).run();
+  }
+  if (values.pendingSupersededRefreshes.length > 0) {
+    database
+      .insert(sqlite.remotePendingSupersededRefreshTokens)
+      .values(values.pendingSupersededRefreshes)
+      .run();
+  }
+}
+
+async function savePostgresState(
+  database: PostgresTransaction,
+  state: RemoteSecurityState,
+): Promise<void> {
+  await database.delete(postgres.remotePendingSupersededRefreshTokens);
+  await database.delete(postgres.remoteClientSupersededRefreshTokens);
+  await database.delete(postgres.remoteClientTokenFamilies);
+  await database.delete(postgres.remotePendingLogins);
+  await database.delete(postgres.remotePairingCodes);
+  await database.delete(postgres.remoteClients);
+  const values = relationalValues(state);
+  if (values.pairingCodes.length > 0) {
+    await database.insert(postgres.remotePairingCodes).values(values.pairingCodes);
+  }
+  if (values.clients.length > 0) {
+    await database.insert(postgres.remoteClients).values(values.clients);
+    await database.insert(postgres.remoteClientTokenFamilies).values(values.tokenFamilies);
+  }
+  if (values.supersededRefreshes.length > 0) {
+    await database
+      .insert(postgres.remoteClientSupersededRefreshTokens)
+      .values(values.supersededRefreshes);
+  }
+  if (values.pendingLogins.length > 0) {
+    await database.insert(postgres.remotePendingLogins).values(values.pendingLogins);
+  }
+  if (values.pendingSupersededRefreshes.length > 0) {
+    await database
+      .insert(postgres.remotePendingSupersededRefreshTokens)
+      .values(values.pendingSupersededRefreshes);
+  }
+}
+
+function relationalValues(state: RemoteSecurityState) {
+  return {
+    pairingCodes: state.pairingCodes.map((code) => ({
+      codeId: code.codeId,
+      hostUrl: code.hostUrl,
+      secretHash: code.secretHash,
+      clientLabel: code.clientLabel ?? null,
+      createdAt: code.createdAt,
+      expiresAt: code.expiresAt,
+      attempts: code.attempts,
+      maxAttempts: code.maxAttempts,
+      usedAt: code.usedAt ?? null,
+    })),
+    clients: state.clients.map((client) => ({
+      clientId: client.clientId,
+      clientLabel: client.clientLabel,
+      role: client.role,
+      hostUrl: client.hostUrl,
+      accessTokenHash: client.accessTokenHash,
+      accessExpiresAt: client.accessExpiresAt,
+      createdAt: client.createdAt,
+      lastUsedAt: client.lastUsedAt ?? null,
+      revokedAt: client.revokedAt ?? null,
+    })),
+    tokenFamilies: state.clients.map((client) => ({
+      familyId: client.refreshFamilyId,
+      clientId: client.clientId,
+      refreshTokenHash: client.refreshTokenHash,
+      createdAt: client.createdAt,
+      revokedAt: client.revokedAt ?? null,
+    })),
+    supersededRefreshes: state.clients.flatMap((client) =>
+      client.supersededRefreshTokenHashes.map((entry) => ({
+        familyId: client.refreshFamilyId,
+        tokenHash: entry.hash,
+        supersededAt: entry.supersededAt,
+      })),
+    ),
+    pendingLogins: state.pendingLogins.map((flow) => ({
+      flowId: flow.flowId,
+      hostUrl: flow.hostUrl,
+      hostIdentity: flow.hostIdentity ?? null,
+      operatorCodeHash: flow.operatorCodeHash,
+      pendingRefreshHash: flow.pendingRefreshHash,
+      pendingRefreshReplay: flow.pendingRefreshReplay ?? null,
+      pendingCompletionHash: flow.pendingCompletionHash,
+      completionReplay: flow.completionReplay ?? null,
+      clientLabel: flow.clientLabel,
+      requestedRole: flow.requestedRole,
+      grantedRole: flow.grantedRole ?? null,
+      clientFingerprint: flow.clientFingerprint ?? null,
+      sourceHint: flow.sourceHint ?? null,
+      createdAt: flow.createdAt,
+      codeExpiresAt: flow.codeExpiresAt,
+      flowExpiresAt: flow.flowExpiresAt,
+      status: flow.status,
+      operatorCodeFingerprint: flow.operatorCodeFingerprint ?? null,
+      approvedAt: flow.approvedAt ?? null,
+      deniedAt: flow.deniedAt ?? null,
+      cancelledAt: flow.cancelledAt ?? null,
+      exchangedAt: flow.exchangedAt ?? null,
+    })),
+    pendingSupersededRefreshes: state.pendingLogins.flatMap((flow) =>
+      flow.supersededPendingRefreshHashes.map((entry) => ({
+        flowId: flow.flowId,
+        tokenHash: entry.hash,
+        supersededAt: entry.supersededAt,
+      })),
+    ),
+  };
+}
+
+async function lockPostgresRemoteSecurity(database: PostgresTransaction): Promise<void> {
+  await database.execute(sql`select pg_advisory_xact_lock(hashtextextended('remote_security', 0))`);
+}
+
+function activityValues(
+  operatorClientId: string,
+  action: string,
+  targetKind: string,
+  targetKey: string,
+  metadata?: Record<string, unknown>,
+) {
+  return {
+    activityKey: randomUUID(),
+    operatorClientId,
+    action,
+    targetKind,
+    targetKey,
+    outcome: "succeeded",
+    metadata: metadata ?? {},
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function parseRole(value: unknown): RemoteClientRole {
+  if (value === "access" || value === "operator") return value;
+  throw new CapletsError("CONFIG_INVALID", "Stored remote client role is malformed.");
+}
+
+function parsePendingStatus(value: unknown): RemotePendingLoginState {
+  if (
+    value === "pending" ||
+    value === "approved" ||
+    value === "denied" ||
+    value === "cancelled" ||
+    value === "exchanged" ||
+    value === "expired"
+  ) {
+    return value;
+  }
+  throw new CapletsError("CONFIG_INVALID", "Stored pending login status is malformed.");
+}
+
+function parsePendingRefreshReplay(value: unknown): PendingRefreshReplay {
+  if (
+    !isObject(value) ||
+    typeof value.refreshHash !== "string" ||
+    typeof value.expiresAt !== "string" ||
+    !isEncryptedRecord(value.encryptedResponse)
+  ) {
+    throw new CapletsError("CONFIG_INVALID", "Pending refresh replay is malformed.");
+  }
+  return {
+    refreshHash: value.refreshHash,
+    expiresAt: value.expiresAt,
+    encryptedResponse: value.encryptedResponse,
+  };
+}
+
+function parseCompletionReplay(value: unknown): CompletionReplay {
+  if (
+    !isObject(value) ||
+    typeof value.expiresAt !== "string" ||
+    !isEncryptedRecord(value.encryptedCredentials)
+  ) {
+    throw new CapletsError("CONFIG_INVALID", "Pending completion replay is malformed.");
+  }
+  return {
+    expiresAt: value.expiresAt,
+    encryptedCredentials: value.encryptedCredentials,
+  };
+}
+
+function isEncryptedRecord(value: unknown): value is VaultEncryptedRecord {
+  return (
+    isObject(value) &&
+    value.version === 1 &&
+    value.algorithm === "aes-256-gcm" &&
+    typeof value.nonce === "string" &&
+    typeof value.ciphertext === "string" &&
+    typeof value.authTag === "string" &&
+    typeof value.valueBytes === "number" &&
+    typeof value.createdAt === "string" &&
+    typeof value.updatedAt === "string"
+  );
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function strings(value: Record<string, unknown>, ...keys: string[]): boolean {
+  return keys.every((key) => typeof value[key] === "string");
+}
+
+function isRole(value: unknown): value is RemoteClientRole {
+  return value === "access" || value === "operator";
+}
+
+function createClient(
+  hostUrl: string,
+  clientLabel: string,
+  role: RemoteClientRole,
+  accessToken: string,
+  refreshToken: string,
+  now: Date,
+): StoredRemoteClient {
+  return {
+    clientId: `rcli_${randomToken(12)}`,
+    clientLabel,
+    role,
+    hostUrl,
+    accessTokenHash: hashSecret(accessToken),
+    accessExpiresAt: new Date(now.getTime() + DEFAULT_ACCESS_TOKEN_TTL_MS).toISOString(),
+    refreshTokenHash: hashSecret(refreshToken),
+    supersededRefreshTokenHashes: [],
+    refreshFamilyId: randomUUID(),
+    createdAt: now.toISOString(),
+  };
+}
+function requireFlow(state: RemoteSecurityState, flowId: string): StoredPendingLogin {
+  const flow = state.pendingLogins.find((candidate) => candidate.flowId === flowId);
+  if (!flow) throw new CapletsError("AUTH_FAILED", "Pending login flow is unknown.");
+  return flow;
+}
+function pendingLoginForCompletion(
+  state: RemoteSecurityState,
+  flowId: string,
+  secret: string,
+  now: Date,
+): StoredPendingLogin {
+  const flow = state.pendingLogins.find((candidate) => candidate.flowId === flowId);
+  if (!flow) throw new CapletsError("AUTH_FAILED", "Pending login is unknown.");
+  if (!safeHashEqual(hashSecret(secret), flow.pendingCompletionHash))
+    throw new CapletsError("AUTH_FAILED", "Pending login possession material is invalid.");
+  if (Date.parse(flow.flowExpiresAt) <= now.getTime() && isActivePendingLogin(flow))
+    flow.status = "expired";
+  return flow;
+}
+function denyFlow(flow: StoredPendingLogin, now: Date): void {
+  if (flow.status !== "pending")
+    throw new CapletsError("AUTH_FAILED", `Pending login is already ${flow.status}.`);
+  if (Date.parse(flow.flowExpiresAt) <= now.getTime()) {
+    flow.status = "expired";
+    throw new CapletsError("AUTH_FAILED", "Pending login has expired.");
+  }
+  flow.status = "denied";
+  flow.deniedAt = now.toISOString();
+}
+function approveFlow(
+  flow: StoredPendingLogin,
+  role: RemoteClientRole | undefined,
+  now: Date,
+): void {
+  if (flow.status !== "pending")
+    throw new CapletsError("AUTH_FAILED", `Pending login is already ${flow.status}.`);
+  if (Date.parse(flow.flowExpiresAt) <= now.getTime()) {
+    flow.status = "expired";
+    throw new CapletsError("AUTH_FAILED", "Pending login has expired.");
+  }
+  assertPendingOperatorCodeFresh(flow, now);
+  flow.status = "approved";
+  flow.grantedRole = role ?? flow.requestedRole;
+  flow.approvedAt = now.toISOString();
+}
+function assertPendingOperatorCodeFresh(flow: StoredPendingLogin, now: Date): void {
+  if (Date.parse(flow.codeExpiresAt) <= now.getTime())
+    throw new CapletsError(
+      "AUTH_FAILED",
+      "Pending login code has expired. Refresh the pending login for a new code.",
+    );
+}
+
+function cleanupPendingLogins(state: RemoteSecurityState, now: Date): boolean {
+  let changed = false;
+  for (const flow of state.pendingLogins)
+    if (isActivePendingLogin(flow) && Date.parse(flow.flowExpiresAt) <= now.getTime()) {
+      flow.status = "expired";
+      changed = true;
+    }
+  const retained = state.pendingLogins.filter((flow) => shouldRetain(flow, now));
+  if (retained.length !== state.pendingLogins.length) changed = true;
+  state.pendingLogins = retained;
+  return changed;
+}
+function isActivePendingLogin(flow: StoredPendingLogin): boolean {
+  return flow.status === "pending" || flow.status === "approved";
+}
+function shouldRetain(flow: StoredPendingLogin, now: Date): boolean {
+  if (isActivePendingLogin(flow)) return true;
+  const terminal = terminalTime(flow);
+  return Number.isFinite(terminal) && now.getTime() - terminal < PENDING_TERMINAL_RETENTION_MS;
+}
+function terminalTime(flow: StoredPendingLogin): number {
+  switch (flow.status) {
+    case "denied":
+      return Date.parse(flow.deniedAt ?? flow.flowExpiresAt);
+    case "cancelled":
+      return Date.parse(flow.cancelledAt ?? flow.flowExpiresAt);
+    case "exchanged":
+      return Date.parse(flow.exchangedAt ?? flow.flowExpiresAt);
+    case "expired":
+      return Date.parse(flow.flowExpiresAt);
+    default:
+      return Number.NaN;
+  }
+}
+function enforcePendingLoginQuota(
+  state: RemoteSecurityState,
+  sourceHint: string | undefined,
+): void {
+  const active = state.pendingLogins.filter(isActivePendingLogin);
+  if (active.length >= DEFAULT_PENDING_MAX_ACTIVE_FLOWS)
+    throw new CapletsError("AUTH_FAILED", "Too many active pending logins.");
+  if (
+    sourceHint &&
+    active.filter((flow) => flow.sourceHint === sourceHint).length >=
+      DEFAULT_PENDING_MAX_ACTIVE_FLOWS_PER_SOURCE
+  )
+    throw new CapletsError("AUTH_FAILED", "Too many active pending logins for this source.");
+}
+function pruneSupersededRefreshTokens(
+  entries: SupersededRefreshToken[],
+  now: Date,
+): SupersededRefreshToken[] {
+  return capSupersededRefreshTokens(
+    entries.filter((entry) => {
+      const time = Date.parse(entry.supersededAt);
+      return Number.isFinite(time) && now.getTime() - time < SUPERSEDED_REFRESH_TOKEN_RETENTION_MS;
+    }),
+  );
+}
+function capSupersededRefreshTokens(entries: SupersededRefreshToken[]): SupersededRefreshToken[] {
+  return entries.slice(-PENDING_SUPERSEDED_REFRESH_HASH_MAX);
+}
+
+function encryptReplayValue(value: unknown, secret: string, now: Date): VaultEncryptedRecord {
+  return encryptVaultValue({
+    plaintext: JSON.stringify(value),
+    key: replayEncryptionKey(secret),
+    now,
+  });
+}
+function replayEncryptionKey(secret: string): Buffer {
+  return createHash("sha256").update(`caplets-pending-login-replay:${secret}`).digest();
+}
+function decryptPendingRefreshReplay(replay: PendingRefreshReplay, secret: string) {
+  const parsed: unknown = JSON.parse(
+    decryptVaultValue(replay.encryptedResponse, replayEncryptionKey(secret)),
+  );
+  if (
+    !isObject(parsed) ||
+    !strings(
+      parsed,
+      "flowId",
+      "operatorCode",
+      "pendingRefreshSecret",
+      "codeExpiresAt",
+      "flowExpiresAt",
+    ) ||
+    typeof parsed.intervalSeconds !== "number"
+  )
+    throw new CapletsError("CONFIG_INVALID", "Pending login refresh replay record is malformed.");
+  return {
+    flowId: parsed.flowId as string,
+    operatorCode: parsed.operatorCode as string,
+    operatorCodeFingerprint:
+      typeof parsed.operatorCodeFingerprint === "string"
+        ? parsed.operatorCodeFingerprint
+        : operatorCodeFingerprint(parsed.operatorCode as string),
+    pendingRefreshSecret: parsed.pendingRefreshSecret as string,
+    codeExpiresAt: parsed.codeExpiresAt as string,
+    flowExpiresAt: parsed.flowExpiresAt as string,
+    intervalSeconds: parsed.intervalSeconds,
+  };
+}
+function decryptCompletionReplay(
+  replay: CompletionReplay,
+  secret: string,
+): IssuedRemoteClientCredentials {
+  const parsed: unknown = JSON.parse(
+    decryptVaultValue(replay.encryptedCredentials, replayEncryptionKey(secret)),
+  );
+  if (
+    !isObject(parsed) ||
+    !strings(
+      parsed,
+      "clientId",
+      "clientLabel",
+      "hostUrl",
+      "accessToken",
+      "refreshToken",
+      "expiresAt",
+      "createdAt",
+    ) ||
+    !isRole(parsed.role) ||
+    parsed.tokenType !== "Bearer"
+  )
+    throw new CapletsError(
+      "CONFIG_INVALID",
+      "Pending login completion replay record is malformed.",
+    );
+  return {
+    clientId: parsed.clientId,
+    clientLabel: parsed.clientLabel,
+    hostUrl: parsed.hostUrl,
+    role: parsed.role,
+    accessToken: parsed.accessToken,
+    refreshToken: parsed.refreshToken,
+    expiresAt: parsed.expiresAt,
+    createdAt: parsed.createdAt,
+    tokenType: "Bearer",
+  } as IssuedRemoteClientCredentials;
+}
+function validateClient(
+  client: StoredRemoteClient,
+  hostUrl: string,
+  now: Date,
+  allowExpiredAccess = false,
+): void {
+  if (client.hostUrl !== hostUrl)
+    throw new CapletsError("AUTH_FAILED", "Remote client credential is for a different host.");
+  if (client.revokedAt)
+    throw new CapletsError(
+      "REMOTE_CREDENTIALS_REVOKED",
+      "Remote client credential has been revoked.",
+    );
+  if (!allowExpiredAccess && Date.parse(client.accessExpiresAt) <= now.getTime())
+    throw new CapletsError("AUTH_FAILED", "Remote client credential has expired.");
+}
+function credentialsFromClient(
+  client: StoredRemoteClient,
+  accessToken: string,
+  refreshToken: string,
+): IssuedRemoteClientCredentials {
+  return {
+    hostUrl: client.hostUrl,
+    clientId: client.clientId,
+    clientLabel: client.clientLabel,
+    role: client.role,
+    accessToken,
+    refreshToken,
+    tokenType: "Bearer",
+    expiresAt: client.accessExpiresAt,
+    createdAt: client.createdAt,
+  };
+}
+function clientStatus(client: StoredRemoteClient): RemoteClientStatus {
+  return {
+    clientId: client.clientId,
+    clientLabel: client.clientLabel,
+    role: client.role,
+    hostUrl: client.hostUrl,
+    createdAt: client.createdAt,
+    ...(client.lastUsedAt ? { lastUsedAt: client.lastUsedAt } : {}),
+    ...(client.revokedAt ? { revokedAt: client.revokedAt } : {}),
+  };
+}
+function pendingLoginStatus(flow: StoredPendingLogin): RemotePendingLoginStatus {
+  return {
+    flowId: flow.flowId,
+    hostUrl: flow.hostUrl,
+    ...(flow.hostIdentity ? { hostIdentity: flow.hostIdentity } : {}),
+    status: flow.status,
+    requestedRole: flow.requestedRole,
+    ...(flow.grantedRole ? { grantedRole: flow.grantedRole } : {}),
+    ...(flow.operatorCodeFingerprint
+      ? { operatorCodeFingerprint: flow.operatorCodeFingerprint }
+      : {}),
+    clientLabel: flow.clientLabel,
+    ...(flow.clientFingerprint ? { clientFingerprint: flow.clientFingerprint } : {}),
+    ...(flow.sourceHint ? { sourceHint: flow.sourceHint } : {}),
+    createdAt: flow.createdAt,
+    codeExpiresAt: flow.codeExpiresAt,
+    flowExpiresAt: flow.flowExpiresAt,
+    ...(flow.approvedAt ? { approvedAt: flow.approvedAt } : {}),
+    ...(flow.deniedAt ? { deniedAt: flow.deniedAt } : {}),
+    ...(flow.cancelledAt ? { cancelledAt: flow.cancelledAt } : {}),
+    ...(flow.exchangedAt ? { exchangedAt: flow.exchangedAt } : {}),
+  };
+}
+function pendingApprovalStatus(flow: StoredPendingLogin) {
+  return {
+    flowId: flow.flowId,
+    status: "approved" as const,
+    clientLabel: flow.clientLabel,
+    requestedRole: flow.requestedRole,
+    grantedRole: flow.grantedRole ?? flow.requestedRole,
+    ...(flow.clientFingerprint ? { clientFingerprint: flow.clientFingerprint } : {}),
+    ...(flow.sourceHint ? { sourceHint: flow.sourceHint } : {}),
+  };
+}
+function bounded(value: string | undefined, maxLength: number): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > maxLength ? trimmed.slice(0, maxLength) : trimmed;
+}
+function hashSecret(secret: string): string {
+  return createHash("sha256").update(secret).digest("base64url");
+}
+function operatorCodeFingerprint(code: string): string {
+  return hashSecret(code).slice(0, 8);
+}
+function safeHashEqual(left: string, right: string): boolean {
+  const a = Buffer.from(left);
+  const b = Buffer.from(right);
+  return a.length === b.length && timingSafeEqual(a, b);
+}

--- a/packages/core/src/storage/schema/postgres.ts
+++ b/packages/core/src/storage/schema/postgres.ts
@@ -1,0 +1,465 @@
+import {
+  boolean,
+  customType,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+
+const bytea = customType<{ data: Buffer; driverData: Buffer }>({ dataType: () => "bytea" });
+
+export const capletsSchema = pgTable("caplets_schema", {
+  singleton: integer("singleton").primaryKey(),
+  version: integer("version").notNull(),
+  appliedAt: text("applied_at").notNull(),
+});
+
+export const capletRecords = pgTable(
+  "caplet_records",
+  {
+    recordKey: text("record_key").primaryKey(),
+    capletId: text("caplet_id").notNull(),
+    currentRevisionKey: text("current_revision_key"),
+    headGeneration: integer("head_generation").notNull(),
+    historyLimit: integer("history_limit"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [uniqueIndex("caplet_records_caplet_id_unique").on(table.capletId)],
+);
+
+export const capletRevisions = pgTable(
+  "caplet_revisions",
+  {
+    revisionKey: text("revision_key").primaryKey(),
+    recordKey: text("record_key")
+      .notNull()
+      .references(() => capletRecords.recordKey, { onDelete: "cascade" }),
+    sequence: integer("sequence").notNull(),
+    name: text("name").notNull(),
+    description: text("description").notNull(),
+    body: text("body").notNull(),
+    schemaUrl: text("schema_url"),
+    content: jsonb("content").$type<Record<string, unknown>>().notNull(),
+    contentHash: text("content_hash").notNull(),
+    sourceRevision: text("source_revision"),
+    sourceContentHash: text("source_content_hash"),
+    createdAt: text("created_at").notNull(),
+    actor: text("actor").notNull(),
+  },
+  (table) => [
+    uniqueIndex("caplet_revisions_record_sequence_unique").on(table.recordKey, table.sequence),
+  ],
+);
+
+export const capletRevisionTags = pgTable(
+  "caplet_revision_tags",
+  {
+    revisionKey: text("revision_key")
+      .notNull()
+      .references(() => capletRevisions.revisionKey, { onDelete: "cascade" }),
+    position: integer("position").notNull(),
+    value: text("value").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.revisionKey, table.position] })],
+);
+
+export const capletRevisionBackends = pgTable(
+  "caplet_revision_backends",
+  {
+    revisionKey: text("revision_key")
+      .notNull()
+      .references(() => capletRevisions.revisionKey, { onDelete: "cascade" }),
+    position: integer("position").notNull(),
+    family: text("family").notNull(),
+    childId: text("child_id"),
+    config: jsonb("config").$type<Record<string, unknown>>().notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.revisionKey, table.position] })],
+);
+
+export const capletAssetBlobs = pgTable("caplet_asset_blobs", {
+  hash: text("hash").primaryKey(),
+  size: integer("size").notNull(),
+  payload: bytea("payload"),
+  objectKey: text("object_key"),
+  verificationStatus: text("verification_status").notNull(),
+  createdAt: text("created_at").notNull(),
+});
+
+export const capletBundleEntries = pgTable(
+  "caplet_bundle_entries",
+  {
+    revisionKey: text("revision_key")
+      .notNull()
+      .references(() => capletRevisions.revisionKey, { onDelete: "cascade" }),
+    path: text("path").notNull(),
+    blobHash: text("blob_hash")
+      .notNull()
+      .references(() => capletAssetBlobs.hash),
+    mediaType: text("media_type").notNull(),
+    size: integer("size").notNull(),
+    executable: boolean("executable").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.revisionKey, table.path] })],
+);
+
+export const capletInstallations = pgTable(
+  "caplet_installations",
+  {
+    installationKey: text("installation_key").primaryKey(),
+    recordKey: text("record_key")
+      .notNull()
+      .references(() => capletRecords.recordKey, { onDelete: "cascade" }),
+    generation: integer("generation").notNull(),
+    status: text("status").notNull(),
+    sourceKind: text("source_kind").notNull(),
+    sourceIdentity: text("source_identity").notNull(),
+    channel: text("channel"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    detachedAt: text("detached_at"),
+    detachedBy: text("detached_by"),
+  },
+  (table) => [
+    index("caplet_installations_record_status_idx").on(table.recordKey, table.status),
+    uniqueIndex("caplet_installations_key_generation_unique").on(
+      table.installationKey,
+      table.generation,
+    ),
+  ],
+);
+
+export const capletInstallationObservations = pgTable(
+  "caplet_installation_observations",
+  {
+    observationKey: text("observation_key").primaryKey(),
+    installationKey: text("installation_key")
+      .notNull()
+      .references(() => capletInstallations.installationKey, { onDelete: "cascade" }),
+    resolvedRevision: text("resolved_revision"),
+    contentHash: text("content_hash"),
+    risk: jsonb("risk").$type<Record<string, unknown>>(),
+    status: text("status").notNull(),
+    observedAt: text("observed_at").notNull(),
+  },
+  (table) => [
+    index("caplet_installation_observations_installation_idx").on(
+      table.installationKey,
+      table.observedAt,
+    ),
+  ],
+);
+
+export const operatorActivity = pgTable(
+  "operator_activity",
+  {
+    activityKey: text("activity_key").primaryKey(),
+    operatorClientId: text("operator_client_id").notNull(),
+    action: text("action").notNull(),
+    targetKind: text("target_kind").notNull(),
+    targetKey: text("target_key").notNull(),
+    outcome: text("outcome").notNull(),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull(),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [index("operator_activity_created_idx").on(table.createdAt)],
+);
+
+export const vaultAccessGrants = pgTable(
+  "vault_access_grants",
+  {
+    subjectKind: text("subject_kind").notNull(),
+    subjectKey: text("subject_key").notNull(),
+    recordKey: text("record_key").references(() => capletRecords.recordKey, {
+      onDelete: "cascade",
+    }),
+    capletId: text("caplet_id"),
+    vaultKey: text("vault_key").notNull(),
+    referenceName: text("reference_name").notNull(),
+    originKind: text("origin_kind").notNull(),
+    originPath: text("origin_path"),
+    createdAt: text("created_at").notNull(),
+    createdBy: text("created_by").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.subjectKind, table.subjectKey, table.referenceName] })],
+);
+
+export const vaultValues = pgTable("vault_values", {
+  vaultKey: text("vault_key").primaryKey(),
+  generation: integer("generation").notNull(),
+  version: integer("version").notNull(),
+  algorithm: text("algorithm").notNull(),
+  nonce: text("nonce").notNull(),
+  ciphertext: text("ciphertext").notNull(),
+  authTag: text("auth_tag").notNull(),
+  valueBytes: integer("value_bytes").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const remotePairingCodes = pgTable("remote_pairing_codes", {
+  codeId: text("code_id").primaryKey(),
+  hostUrl: text("host_url").notNull(),
+  secretHash: text("secret_hash").notNull(),
+  clientLabel: text("client_label"),
+  createdAt: text("created_at").notNull(),
+  expiresAt: text("expires_at").notNull(),
+  attempts: integer("attempts").notNull(),
+  maxAttempts: integer("max_attempts").notNull(),
+  usedAt: text("used_at"),
+});
+
+export const remoteClients = pgTable(
+  "remote_clients",
+  {
+    clientId: text("client_id").primaryKey(),
+    clientLabel: text("client_label").notNull(),
+    role: text("role").notNull(),
+    hostUrl: text("host_url").notNull(),
+    accessTokenHash: text("access_token_hash").notNull(),
+    accessExpiresAt: text("access_expires_at").notNull(),
+    createdAt: text("created_at").notNull(),
+    lastUsedAt: text("last_used_at"),
+    revokedAt: text("revoked_at"),
+  },
+  (table) => [uniqueIndex("remote_clients_access_token_hash_unique").on(table.accessTokenHash)],
+);
+
+export const remoteClientTokenFamilies = pgTable(
+  "remote_client_token_families",
+  {
+    familyId: text("family_id").primaryKey(),
+    clientId: text("client_id")
+      .notNull()
+      .references(() => remoteClients.clientId, { onDelete: "cascade" }),
+    refreshTokenHash: text("refresh_token_hash").notNull(),
+    createdAt: text("created_at").notNull(),
+    revokedAt: text("revoked_at"),
+  },
+  (table) => [
+    uniqueIndex("remote_client_token_families_client_unique").on(table.clientId),
+    uniqueIndex("remote_client_token_families_refresh_hash_unique").on(table.refreshTokenHash),
+  ],
+);
+
+export const remoteClientSupersededRefreshTokens = pgTable(
+  "remote_client_superseded_refresh_tokens",
+  {
+    familyId: text("family_id")
+      .notNull()
+      .references(() => remoteClientTokenFamilies.familyId, { onDelete: "cascade" }),
+    tokenHash: text("token_hash").notNull(),
+    supersededAt: text("superseded_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.familyId, table.tokenHash] }),
+    uniqueIndex("remote_client_superseded_refresh_hash_unique").on(table.tokenHash),
+  ],
+);
+
+export const remotePendingLogins = pgTable(
+  "remote_pending_logins",
+  {
+    flowId: text("flow_id").primaryKey(),
+    hostUrl: text("host_url").notNull(),
+    hostIdentity: text("host_identity"),
+    operatorCodeHash: text("operator_code_hash").notNull(),
+    pendingRefreshHash: text("pending_refresh_hash").notNull(),
+    pendingRefreshReplay: jsonb("pending_refresh_replay").$type<unknown>(),
+    pendingCompletionHash: text("pending_completion_hash").notNull(),
+    completionReplay: jsonb("completion_replay").$type<unknown>(),
+    clientLabel: text("client_label").notNull(),
+    requestedRole: text("requested_role").notNull(),
+    grantedRole: text("granted_role"),
+    clientFingerprint: text("client_fingerprint"),
+    sourceHint: text("source_hint"),
+    createdAt: text("created_at").notNull(),
+    codeExpiresAt: text("code_expires_at").notNull(),
+    flowExpiresAt: text("flow_expires_at").notNull(),
+    status: text("status").notNull(),
+    operatorCodeFingerprint: text("operator_code_fingerprint"),
+    approvedAt: text("approved_at"),
+    deniedAt: text("denied_at"),
+    cancelledAt: text("cancelled_at"),
+    exchangedAt: text("exchanged_at"),
+  },
+  (table) => [
+    uniqueIndex("remote_pending_logins_operator_code_hash_unique").on(table.operatorCodeHash),
+    uniqueIndex("remote_pending_logins_refresh_hash_unique").on(table.pendingRefreshHash),
+    uniqueIndex("remote_pending_logins_completion_hash_unique").on(table.pendingCompletionHash),
+  ],
+);
+
+export const remotePendingSupersededRefreshTokens = pgTable(
+  "remote_pending_superseded_refresh_tokens",
+  {
+    flowId: text("flow_id")
+      .notNull()
+      .references(() => remotePendingLogins.flowId, { onDelete: "cascade" }),
+    tokenHash: text("token_hash").notNull(),
+    supersededAt: text("superseded_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.flowId, table.tokenHash] }),
+    uniqueIndex("remote_pending_superseded_refresh_hash_unique").on(table.tokenHash),
+  ],
+);
+
+export const dashboardSessions = pgTable(
+  "dashboard_sessions",
+  {
+    sessionId: text("session_id").primaryKey(),
+    secretHash: text("secret_hash").notNull(),
+    operatorClientId: text("operator_client_id").notNull(),
+    role: text("role").notNull(),
+    csrfToken: text("csrf_token").notNull(),
+    createdAt: text("created_at").notNull(),
+    expiresAt: text("expires_at").notNull(),
+    lastUsedAt: text("last_used_at").notNull(),
+  },
+  (table) => [
+    index("dashboard_sessions_expires_at_idx").on(table.expiresAt),
+    index("dashboard_sessions_last_used_at_idx").on(table.lastUsedAt),
+  ],
+);
+
+export const backendAuthStates = pgTable("backend_auth_states", {
+  server: text("server").primaryKey(),
+  generation: integer("generation").notNull(),
+  tokenBundle: jsonb("token_bundle").$type<unknown>().notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const setupApprovals = pgTable(
+  "setup_approvals",
+  {
+    projectFingerprint: text("project_fingerprint").notNull(),
+    capletId: text("caplet_id").notNull(),
+    contentHash: text("content_hash").notNull(),
+    targetKind: text("target_kind").notNull(),
+    generation: integer("generation").notNull(),
+    payload: jsonb("payload").$type<unknown>().notNull(),
+    approvedAt: text("approved_at").notNull(),
+    actor: text("actor").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.projectFingerprint, table.capletId, table.contentHash, table.targetKind],
+    }),
+  ],
+);
+
+export const setupAttemptSets = pgTable(
+  "setup_attempt_sets",
+  {
+    projectFingerprint: text("project_fingerprint").notNull(),
+    capletId: text("caplet_id").notNull(),
+    generation: integer("generation").notNull(),
+    payload: jsonb("payload").$type<unknown>().notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.projectFingerprint, table.capletId] })],
+);
+
+export const projectBindings = pgTable(
+  "project_bindings",
+  {
+    bindingId: text("binding_id").primaryKey(),
+    sessionId: text("session_id").notNull(),
+    projectFingerprint: text("project_fingerprint").notNull(),
+    projectRoot: text("project_root").notNull(),
+    serverProjectRoot: text("server_project_root").notNull(),
+    ownerNodeId: text("owner_node_id").notNull(),
+    generation: integer("generation").notNull(),
+    revision: integer("revision").notNull(),
+    state: text("state").notNull(),
+    syncState: text("sync_state").notNull(),
+    readiness: text("readiness").notNull(),
+    active: boolean("active").notNull(),
+    lastHeartbeatAt: text("last_heartbeat_at").notNull(),
+    expiresAt: text("expires_at").notNull(),
+    quarantinedAt: text("quarantined_at"),
+    quarantineReason: text("quarantine_reason"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("project_bindings_owner_expiry_idx").on(table.ownerNodeId, table.expiresAt),
+    index("project_bindings_active_expiry_idx").on(table.active, table.expiresAt),
+  ],
+);
+
+export const hostIdentity = pgTable("host_identity", {
+  singleton: integer("singleton").primaryKey(),
+  hostId: text("host_id").notNull().unique(),
+  createdAt: text("created_at").notNull(),
+});
+
+export const hostNodes = pgTable("host_nodes", {
+  nodeId: text("node_id").primaryKey(),
+  startedAt: text("started_at").notNull(),
+  heartbeatAt: text("heartbeat_at").notNull(),
+  globalFileManifest: text("global_file_manifest").notNull(),
+  runtimeFingerprint: text("runtime_fingerprint").notNull(),
+  ready: boolean("ready").notNull(),
+});
+
+export const hostConfigGenerations = pgTable("host_config_generations", {
+  generation: integer("generation").primaryKey(),
+  contentHash: text("content_hash").notNull(),
+  createdAt: text("created_at").notNull(),
+  createdBy: text("created_by").notNull(),
+});
+
+export const maintenanceLeases = pgTable("maintenance_leases", {
+  leaseName: text("lease_name").primaryKey(),
+  ownerNodeId: text("owner_node_id").notNull(),
+  fencingToken: integer("fencing_token").notNull(),
+  expiresAt: text("expires_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const maintenanceCursors = pgTable("maintenance_cursors", {
+  jobName: text("job_name").primaryKey(),
+  cursor: text("cursor"),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const postgresSchema = {
+  capletsSchema,
+  capletRecords,
+  capletRevisions,
+  capletRevisionTags,
+  capletRevisionBackends,
+  capletAssetBlobs,
+  capletBundleEntries,
+  capletInstallations,
+  capletInstallationObservations,
+  operatorActivity,
+  vaultAccessGrants,
+  vaultValues,
+  remotePairingCodes,
+  remoteClients,
+  remoteClientTokenFamilies,
+  remoteClientSupersededRefreshTokens,
+  remotePendingLogins,
+  remotePendingSupersededRefreshTokens,
+  dashboardSessions,
+  setupApprovals,
+  setupAttemptSets,
+  projectBindings,
+  hostIdentity,
+  hostNodes,
+  hostConfigGenerations,
+  maintenanceLeases,
+  maintenanceCursors,
+};

--- a/packages/core/src/storage/schema/sqlite.ts
+++ b/packages/core/src/storage/schema/sqlite.ts
@@ -1,0 +1,461 @@
+import {
+  blob,
+  index,
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+export const capletsSchema = sqliteTable("caplets_schema", {
+  singleton: integer("singleton").primaryKey(),
+  version: integer("version").notNull(),
+  appliedAt: text("applied_at").notNull(),
+});
+
+export const capletRecords = sqliteTable(
+  "caplet_records",
+  {
+    recordKey: text("record_key").primaryKey(),
+    capletId: text("caplet_id").notNull(),
+    currentRevisionKey: text("current_revision_key"),
+    headGeneration: integer("head_generation").notNull(),
+    historyLimit: integer("history_limit"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [uniqueIndex("caplet_records_caplet_id_unique").on(table.capletId)],
+);
+
+export const capletRevisions = sqliteTable(
+  "caplet_revisions",
+  {
+    revisionKey: text("revision_key").primaryKey(),
+    recordKey: text("record_key")
+      .notNull()
+      .references(() => capletRecords.recordKey, { onDelete: "cascade" }),
+    sequence: integer("sequence").notNull(),
+    name: text("name").notNull(),
+    description: text("description").notNull(),
+    body: text("body").notNull(),
+    schemaUrl: text("schema_url"),
+    content: text("content", { mode: "json" }).$type<Record<string, unknown>>().notNull(),
+    contentHash: text("content_hash").notNull(),
+    sourceRevision: text("source_revision"),
+    sourceContentHash: text("source_content_hash"),
+    createdAt: text("created_at").notNull(),
+    actor: text("actor").notNull(),
+  },
+  (table) => [
+    uniqueIndex("caplet_revisions_record_sequence_unique").on(table.recordKey, table.sequence),
+  ],
+);
+
+export const capletRevisionTags = sqliteTable(
+  "caplet_revision_tags",
+  {
+    revisionKey: text("revision_key")
+      .notNull()
+      .references(() => capletRevisions.revisionKey, { onDelete: "cascade" }),
+    position: integer("position").notNull(),
+    value: text("value").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.revisionKey, table.position] })],
+);
+
+export const capletRevisionBackends = sqliteTable(
+  "caplet_revision_backends",
+  {
+    revisionKey: text("revision_key")
+      .notNull()
+      .references(() => capletRevisions.revisionKey, { onDelete: "cascade" }),
+    position: integer("position").notNull(),
+    family: text("family").notNull(),
+    childId: text("child_id"),
+    config: text("config", { mode: "json" }).$type<Record<string, unknown>>().notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.revisionKey, table.position] })],
+);
+
+export const capletAssetBlobs = sqliteTable("caplet_asset_blobs", {
+  hash: text("hash").primaryKey(),
+  size: integer("size").notNull(),
+  payload: blob("payload", { mode: "buffer" }),
+  objectKey: text("object_key"),
+  verificationStatus: text("verification_status").notNull(),
+  createdAt: text("created_at").notNull(),
+});
+
+export const capletBundleEntries = sqliteTable(
+  "caplet_bundle_entries",
+  {
+    revisionKey: text("revision_key")
+      .notNull()
+      .references(() => capletRevisions.revisionKey, { onDelete: "cascade" }),
+    path: text("path").notNull(),
+    blobHash: text("blob_hash")
+      .notNull()
+      .references(() => capletAssetBlobs.hash),
+    mediaType: text("media_type").notNull(),
+    size: integer("size").notNull(),
+    executable: integer("executable", { mode: "boolean" }).notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.revisionKey, table.path] })],
+);
+
+export const capletInstallations = sqliteTable(
+  "caplet_installations",
+  {
+    installationKey: text("installation_key").primaryKey(),
+    recordKey: text("record_key")
+      .notNull()
+      .references(() => capletRecords.recordKey, { onDelete: "cascade" }),
+    generation: integer("generation").notNull(),
+    status: text("status").notNull(),
+    sourceKind: text("source_kind").notNull(),
+    sourceIdentity: text("source_identity").notNull(),
+    channel: text("channel"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    detachedAt: text("detached_at"),
+    detachedBy: text("detached_by"),
+  },
+  (table) => [
+    index("caplet_installations_record_status_idx").on(table.recordKey, table.status),
+    uniqueIndex("caplet_installations_key_generation_unique").on(
+      table.installationKey,
+      table.generation,
+    ),
+  ],
+);
+
+export const capletInstallationObservations = sqliteTable(
+  "caplet_installation_observations",
+  {
+    observationKey: text("observation_key").primaryKey(),
+    installationKey: text("installation_key")
+      .notNull()
+      .references(() => capletInstallations.installationKey, { onDelete: "cascade" }),
+    resolvedRevision: text("resolved_revision"),
+    contentHash: text("content_hash"),
+    risk: text("risk", { mode: "json" }).$type<Record<string, unknown>>(),
+    status: text("status").notNull(),
+    observedAt: text("observed_at").notNull(),
+  },
+  (table) => [
+    index("caplet_installation_observations_installation_idx").on(
+      table.installationKey,
+      table.observedAt,
+    ),
+  ],
+);
+
+export const operatorActivity = sqliteTable(
+  "operator_activity",
+  {
+    activityKey: text("activity_key").primaryKey(),
+    operatorClientId: text("operator_client_id").notNull(),
+    action: text("action").notNull(),
+    targetKind: text("target_kind").notNull(),
+    targetKey: text("target_key").notNull(),
+    outcome: text("outcome").notNull(),
+    metadata: text("metadata", { mode: "json" }).$type<Record<string, unknown>>().notNull(),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [index("operator_activity_created_idx").on(table.createdAt)],
+);
+
+export const vaultAccessGrants = sqliteTable(
+  "vault_access_grants",
+  {
+    subjectKind: text("subject_kind").notNull(),
+    subjectKey: text("subject_key").notNull(),
+    recordKey: text("record_key").references(() => capletRecords.recordKey, {
+      onDelete: "cascade",
+    }),
+    capletId: text("caplet_id"),
+    vaultKey: text("vault_key").notNull(),
+    referenceName: text("reference_name").notNull(),
+    originKind: text("origin_kind").notNull(),
+    originPath: text("origin_path"),
+    createdAt: text("created_at").notNull(),
+    createdBy: text("created_by").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.subjectKind, table.subjectKey, table.referenceName] })],
+);
+
+export const vaultValues = sqliteTable("vault_values", {
+  vaultKey: text("vault_key").primaryKey(),
+  generation: integer("generation").notNull(),
+  version: integer("version").notNull(),
+  algorithm: text("algorithm").notNull(),
+  nonce: text("nonce").notNull(),
+  ciphertext: text("ciphertext").notNull(),
+  authTag: text("auth_tag").notNull(),
+  valueBytes: integer("value_bytes").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const remotePairingCodes = sqliteTable("remote_pairing_codes", {
+  codeId: text("code_id").primaryKey(),
+  hostUrl: text("host_url").notNull(),
+  secretHash: text("secret_hash").notNull(),
+  clientLabel: text("client_label"),
+  createdAt: text("created_at").notNull(),
+  expiresAt: text("expires_at").notNull(),
+  attempts: integer("attempts").notNull(),
+  maxAttempts: integer("max_attempts").notNull(),
+  usedAt: text("used_at"),
+});
+
+export const remoteClients = sqliteTable(
+  "remote_clients",
+  {
+    clientId: text("client_id").primaryKey(),
+    clientLabel: text("client_label").notNull(),
+    role: text("role").notNull(),
+    hostUrl: text("host_url").notNull(),
+    accessTokenHash: text("access_token_hash").notNull(),
+    accessExpiresAt: text("access_expires_at").notNull(),
+    createdAt: text("created_at").notNull(),
+    lastUsedAt: text("last_used_at"),
+    revokedAt: text("revoked_at"),
+  },
+  (table) => [uniqueIndex("remote_clients_access_token_hash_unique").on(table.accessTokenHash)],
+);
+
+export const remoteClientTokenFamilies = sqliteTable(
+  "remote_client_token_families",
+  {
+    familyId: text("family_id").primaryKey(),
+    clientId: text("client_id")
+      .notNull()
+      .references(() => remoteClients.clientId, { onDelete: "cascade" }),
+    refreshTokenHash: text("refresh_token_hash").notNull(),
+    createdAt: text("created_at").notNull(),
+    revokedAt: text("revoked_at"),
+  },
+  (table) => [
+    uniqueIndex("remote_client_token_families_client_unique").on(table.clientId),
+    uniqueIndex("remote_client_token_families_refresh_hash_unique").on(table.refreshTokenHash),
+  ],
+);
+
+export const remoteClientSupersededRefreshTokens = sqliteTable(
+  "remote_client_superseded_refresh_tokens",
+  {
+    familyId: text("family_id")
+      .notNull()
+      .references(() => remoteClientTokenFamilies.familyId, { onDelete: "cascade" }),
+    tokenHash: text("token_hash").notNull(),
+    supersededAt: text("superseded_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.familyId, table.tokenHash] }),
+    uniqueIndex("remote_client_superseded_refresh_hash_unique").on(table.tokenHash),
+  ],
+);
+
+export const remotePendingLogins = sqliteTable(
+  "remote_pending_logins",
+  {
+    flowId: text("flow_id").primaryKey(),
+    hostUrl: text("host_url").notNull(),
+    hostIdentity: text("host_identity"),
+    operatorCodeHash: text("operator_code_hash").notNull(),
+    pendingRefreshHash: text("pending_refresh_hash").notNull(),
+    pendingRefreshReplay: text("pending_refresh_replay", { mode: "json" }).$type<unknown>(),
+    pendingCompletionHash: text("pending_completion_hash").notNull(),
+    completionReplay: text("completion_replay", { mode: "json" }).$type<unknown>(),
+    clientLabel: text("client_label").notNull(),
+    requestedRole: text("requested_role").notNull(),
+    grantedRole: text("granted_role"),
+    clientFingerprint: text("client_fingerprint"),
+    sourceHint: text("source_hint"),
+    createdAt: text("created_at").notNull(),
+    codeExpiresAt: text("code_expires_at").notNull(),
+    flowExpiresAt: text("flow_expires_at").notNull(),
+    status: text("status").notNull(),
+    operatorCodeFingerprint: text("operator_code_fingerprint"),
+    approvedAt: text("approved_at"),
+    deniedAt: text("denied_at"),
+    cancelledAt: text("cancelled_at"),
+    exchangedAt: text("exchanged_at"),
+  },
+  (table) => [
+    uniqueIndex("remote_pending_logins_operator_code_hash_unique").on(table.operatorCodeHash),
+    uniqueIndex("remote_pending_logins_refresh_hash_unique").on(table.pendingRefreshHash),
+    uniqueIndex("remote_pending_logins_completion_hash_unique").on(table.pendingCompletionHash),
+  ],
+);
+
+export const remotePendingSupersededRefreshTokens = sqliteTable(
+  "remote_pending_superseded_refresh_tokens",
+  {
+    flowId: text("flow_id")
+      .notNull()
+      .references(() => remotePendingLogins.flowId, { onDelete: "cascade" }),
+    tokenHash: text("token_hash").notNull(),
+    supersededAt: text("superseded_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.flowId, table.tokenHash] }),
+    uniqueIndex("remote_pending_superseded_refresh_hash_unique").on(table.tokenHash),
+  ],
+);
+
+export const dashboardSessions = sqliteTable(
+  "dashboard_sessions",
+  {
+    sessionId: text("session_id").primaryKey(),
+    secretHash: text("secret_hash").notNull(),
+    operatorClientId: text("operator_client_id").notNull(),
+    role: text("role").notNull(),
+    csrfToken: text("csrf_token").notNull(),
+    createdAt: text("created_at").notNull(),
+    expiresAt: text("expires_at").notNull(),
+    lastUsedAt: text("last_used_at").notNull(),
+  },
+  (table) => [
+    index("dashboard_sessions_expires_at_idx").on(table.expiresAt),
+    index("dashboard_sessions_last_used_at_idx").on(table.lastUsedAt),
+  ],
+);
+
+export const backendAuthStates = sqliteTable("backend_auth_states", {
+  server: text("server").primaryKey(),
+  generation: integer("generation").notNull(),
+  tokenBundle: text("token_bundle", { mode: "json" }).$type<unknown>().notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const setupApprovals = sqliteTable(
+  "setup_approvals",
+  {
+    projectFingerprint: text("project_fingerprint").notNull(),
+    capletId: text("caplet_id").notNull(),
+    contentHash: text("content_hash").notNull(),
+    targetKind: text("target_kind").notNull(),
+    generation: integer("generation").notNull(),
+    payload: text("payload", { mode: "json" }).$type<unknown>().notNull(),
+    approvedAt: text("approved_at").notNull(),
+    actor: text("actor").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.projectFingerprint, table.capletId, table.contentHash, table.targetKind],
+    }),
+  ],
+);
+
+export const setupAttemptSets = sqliteTable(
+  "setup_attempt_sets",
+  {
+    projectFingerprint: text("project_fingerprint").notNull(),
+    capletId: text("caplet_id").notNull(),
+    generation: integer("generation").notNull(),
+    payload: text("payload", { mode: "json" }).$type<unknown>().notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.projectFingerprint, table.capletId] })],
+);
+
+export const projectBindings = sqliteTable(
+  "project_bindings",
+  {
+    bindingId: text("binding_id").primaryKey(),
+    sessionId: text("session_id").notNull(),
+    projectFingerprint: text("project_fingerprint").notNull(),
+    projectRoot: text("project_root").notNull(),
+    serverProjectRoot: text("server_project_root").notNull(),
+    ownerNodeId: text("owner_node_id").notNull(),
+    generation: integer("generation").notNull(),
+    revision: integer("revision").notNull(),
+    state: text("state").notNull(),
+    syncState: text("sync_state").notNull(),
+    readiness: text("readiness").notNull(),
+    active: integer("active", { mode: "boolean" }).notNull(),
+    lastHeartbeatAt: text("last_heartbeat_at").notNull(),
+    expiresAt: text("expires_at").notNull(),
+    quarantinedAt: text("quarantined_at"),
+    quarantineReason: text("quarantine_reason"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("project_bindings_owner_expiry_idx").on(table.ownerNodeId, table.expiresAt),
+    index("project_bindings_active_expiry_idx").on(table.active, table.expiresAt),
+  ],
+);
+
+export const hostIdentity = sqliteTable("host_identity", {
+  singleton: integer("singleton").primaryKey(),
+  hostId: text("host_id").notNull().unique(),
+  createdAt: text("created_at").notNull(),
+});
+
+export const hostNodes = sqliteTable("host_nodes", {
+  nodeId: text("node_id").primaryKey(),
+  startedAt: text("started_at").notNull(),
+  heartbeatAt: text("heartbeat_at").notNull(),
+  globalFileManifest: text("global_file_manifest").notNull(),
+  runtimeFingerprint: text("runtime_fingerprint").notNull(),
+  ready: integer("ready", { mode: "boolean" }).notNull(),
+});
+
+export const hostConfigGenerations = sqliteTable("host_config_generations", {
+  generation: integer("generation").primaryKey(),
+  contentHash: text("content_hash").notNull(),
+  createdAt: text("created_at").notNull(),
+  createdBy: text("created_by").notNull(),
+});
+
+export const maintenanceLeases = sqliteTable("maintenance_leases", {
+  leaseName: text("lease_name").primaryKey(),
+  ownerNodeId: text("owner_node_id").notNull(),
+  fencingToken: integer("fencing_token").notNull(),
+  expiresAt: text("expires_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const maintenanceCursors = sqliteTable("maintenance_cursors", {
+  jobName: text("job_name").primaryKey(),
+  cursor: text("cursor"),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const sqliteSchema = {
+  capletsSchema,
+  capletRecords,
+  capletRevisions,
+  capletRevisionTags,
+  capletRevisionBackends,
+  capletAssetBlobs,
+  capletBundleEntries,
+  capletInstallations,
+  capletInstallationObservations,
+  operatorActivity,
+  vaultAccessGrants,
+  vaultValues,
+  remotePairingCodes,
+  remoteClients,
+  remoteClientTokenFamilies,
+  remoteClientSupersededRefreshTokens,
+  remotePendingLogins,
+  remotePendingSupersededRefreshTokens,
+  dashboardSessions,
+  setupApprovals,
+  setupAttemptSets,
+  projectBindings,
+  hostIdentity,
+  hostNodes,
+  hostConfigGenerations,
+  maintenanceLeases,
+  maintenanceCursors,
+};

--- a/packages/core/src/storage/setup-state.ts
+++ b/packages/core/src/storage/setup-state.ts
@@ -1,0 +1,926 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import { CapletsError } from "../errors";
+import {
+  parseSetupApproval,
+  parseSetupAttempt,
+  type LegacySetupMigrationSnapshot,
+  type SetupApprovalInput,
+} from "../setup/local-store";
+import type { SetupApproval, SetupAttempt, SetupTargetKind } from "../setup/types";
+import { stableJsonStringify } from "../stable-json";
+import * as postgres from "./schema/postgres";
+import * as sqlite from "./schema/sqlite";
+import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+
+export const SETUP_APPROVALS_NAMESPACE = "setup-approvals";
+export const SETUP_ATTEMPTS_NAMESPACE = "setup-attempts";
+
+const DEFAULT_PROJECT_FINGERPRINT = "default";
+
+export type SetupStateStoreOptions = {
+  now?: () => Date;
+  maxAttempts?: number;
+  retentionDays?: number;
+};
+
+export type SetupStateMutationOptions = {
+  expectedGeneration?: number | undefined;
+  operatorClientId?: string | undefined;
+};
+
+type SetupAttemptsPayload = {
+  attempts: SetupAttempt[];
+};
+
+export class SetupStateStore {
+  private readonly now: () => Date;
+  private readonly maxAttempts: number;
+  private readonly retentionDays: number;
+
+  constructor(
+    private readonly database: HostDatabase,
+    options: SetupStateStoreOptions = {},
+  ) {
+    this.now = options.now ?? (() => new Date());
+    this.maxAttempts = options.maxAttempts ?? 3;
+    this.retentionDays = options.retentionDays ?? 7;
+  }
+
+  async getApproval(
+    capletId: string,
+    contentHash: string,
+    targetKind: SetupTargetKind,
+  ): Promise<SetupApproval | undefined>;
+  async getApproval(
+    projectFingerprint: string,
+    capletId: string,
+    contentHash: string,
+    targetKind: SetupTargetKind,
+  ): Promise<SetupApproval | undefined>;
+  async getApproval(
+    ...args: [string, string, SetupTargetKind] | [string, string, string, SetupTargetKind]
+  ): Promise<SetupApproval | undefined> {
+    const identity = approvalIdentity(args);
+    const row =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select({ payload: sqlite.setupApprovals.payload })
+            .from(sqlite.setupApprovals)
+            .where(sqliteApprovalWhere(identity))
+            .get()
+        : (
+            await this.database.db
+              .select({ payload: postgres.setupApprovals.payload })
+              .from(postgres.setupApprovals)
+              .where(postgresApprovalWhere(identity))
+              .limit(1)
+          )[0];
+    return row ? parseSetupApproval(row.payload) : undefined;
+  }
+
+  async approve(
+    input: SetupApprovalInput,
+    options: SetupStateMutationOptions = {},
+  ): Promise<SetupApproval> {
+    const approval = parseSetupApproval(input);
+    const timestamp = this.now().toISOString();
+    if (this.database.dialect === "sqlite") {
+      mutateApprovalSqlite(this.database.db, approval, options, timestamp);
+    } else {
+      await mutateApprovalPostgres(this.database.db, approval, options, timestamp);
+    }
+    return approval;
+  }
+
+  async setApproval(
+    input: SetupApprovalInput,
+    options: SetupStateMutationOptions = {},
+  ): Promise<SetupApproval> {
+    return await this.approve(input, options);
+  }
+
+  async recordAttempt(input: SetupAttempt, options: SetupStateMutationOptions = {}): Promise<void> {
+    const attempt = parseSetupAttempt(input);
+    const timestamp = this.now().toISOString();
+    const transition = (payload: unknown | undefined): SetupAttemptsPayload => {
+      const attempts = payload === undefined ? [] : parseAttemptsPayload(payload).attempts;
+      return { attempts: this.prunedAttempts([...attempts, attempt]) };
+    };
+    if (this.database.dialect === "sqlite") {
+      mutateAttemptsSqlite(this.database.db, attempt, options, timestamp, transition);
+    } else {
+      await mutateAttemptsPostgres(this.database.db, attempt, options, timestamp, transition);
+    }
+  }
+
+  async setAttempt(attempt: SetupAttempt, options: SetupStateMutationOptions = {}): Promise<void> {
+    await this.recordAttempt(attempt, options);
+  }
+
+  async getAttempt(
+    projectFingerprint: string,
+    capletId: string,
+    attemptId: string,
+  ): Promise<SetupAttempt | undefined> {
+    const attempts = await this.listAttempts(projectFingerprint, capletId);
+    return attempts.find((attempt) => attempt.attemptId === attemptId);
+  }
+
+  async listAttempts(capletId: string): Promise<SetupAttempt[]>;
+  async listAttempts(projectFingerprint: string, capletId: string): Promise<SetupAttempt[]>;
+  async listAttempts(...args: [string] | [string, string]): Promise<SetupAttempt[]> {
+    const [projectFingerprint, capletId] =
+      args.length === 1 ? [DEFAULT_PROJECT_FINGERPRINT, args[0]] : args;
+    const row =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select({ payload: sqlite.setupAttemptSets.payload })
+            .from(sqlite.setupAttemptSets)
+            .where(
+              and(
+                eq(sqlite.setupAttemptSets.projectFingerprint, projectFingerprint),
+                eq(sqlite.setupAttemptSets.capletId, capletId),
+              ),
+            )
+            .get()
+        : (
+            await this.database.db
+              .select({ payload: postgres.setupAttemptSets.payload })
+              .from(postgres.setupAttemptSets)
+              .where(
+                and(
+                  eq(postgres.setupAttemptSets.projectFingerprint, projectFingerprint),
+                  eq(postgres.setupAttemptSets.capletId, capletId),
+                ),
+              )
+              .limit(1)
+          )[0];
+    return row ? parseAttemptsPayload(row.payload).attempts : [];
+  }
+
+  async clearAttempts(capletId: string, options?: SetupStateMutationOptions): Promise<boolean>;
+  async clearAttempts(
+    projectFingerprint: string,
+    capletId: string,
+    options?: SetupStateMutationOptions,
+  ): Promise<boolean>;
+  async clearAttempts(
+    ...args: [string, (string | SetupStateMutationOptions)?, SetupStateMutationOptions?]
+  ): Promise<boolean> {
+    const [projectFingerprint, capletId, options] =
+      typeof args[1] === "string"
+        ? [args[0], args[1], args[2] ?? {}]
+        : [DEFAULT_PROJECT_FINGERPRINT, args[0], args[1] ?? {}];
+    const timestamp = this.now().toISOString();
+    return this.database.dialect === "sqlite"
+      ? clearAttemptsSqlite(this.database.db, projectFingerprint, capletId, options, timestamp)
+      : await clearAttemptsPostgres(
+          this.database.db,
+          projectFingerprint,
+          capletId,
+          options,
+          timestamp,
+        );
+  }
+
+  async assertLegacySnapshotImportable(snapshot: LegacySetupMigrationSnapshot): Promise<void> {
+    const validated = validateLegacySetupSnapshot(snapshot);
+    if (this.database.dialect === "sqlite") {
+      inspectLegacySetupSqlite(this.database.db, validated);
+    } else {
+      await inspectLegacySetupPostgres(this.database.db, validated);
+    }
+  }
+
+  async importLegacySnapshot(snapshot: LegacySetupMigrationSnapshot): Promise<void> {
+    const validated = validateLegacySetupSnapshot(snapshot);
+    if (validated.approvals.length === 0 && validated.attemptSets.length === 0) return;
+    if (this.database.dialect === "sqlite") {
+      this.database.db.transaction((transaction) => {
+        const pending = inspectLegacySetupSqlite(transaction, validated);
+        if (pending.approvals.length > 0) {
+          transaction.insert(sqlite.setupApprovals).values(pending.approvals).run();
+        }
+        if (pending.attemptSets.length > 0) {
+          transaction.insert(sqlite.setupAttemptSets).values(pending.attemptSets).run();
+        }
+      });
+      return;
+    }
+    await this.database.db.transaction(async (transaction) => {
+      for (const approval of validated.approvals) {
+        await lockPostgresKey(transaction, SETUP_APPROVALS_NAMESPACE, approvalKey(approval));
+      }
+      for (const attempts of validated.attemptSets) {
+        await lockPostgresKey(
+          transaction,
+          SETUP_ATTEMPTS_NAMESPACE,
+          attemptsKey(attempts.projectFingerprint, attempts.capletId),
+        );
+      }
+      const pending = await inspectLegacySetupPostgres(transaction, validated);
+      if (pending.approvals.length > 0) {
+        await transaction.insert(postgres.setupApprovals).values(pending.approvals);
+      }
+      if (pending.attemptSets.length > 0) {
+        await transaction.insert(postgres.setupAttemptSets).values(pending.attemptSets);
+      }
+    });
+  }
+
+  async verifyLegacySnapshot(snapshot: LegacySetupMigrationSnapshot): Promise<void> {
+    const validated = validateLegacySetupSnapshot(snapshot);
+    const pending =
+      this.database.dialect === "sqlite"
+        ? inspectLegacySetupSqlite(this.database.db, validated)
+        : await inspectLegacySetupPostgres(this.database.db, validated);
+    if (pending.approvals.length > 0 || pending.attemptSets.length > 0) {
+      throw new CapletsError("INTERNAL_ERROR", "Setup state failed post-migration verification.");
+    }
+  }
+
+  retention(): { maxAttempts: number; days: number } {
+    return { maxAttempts: this.maxAttempts, days: this.retentionDays };
+  }
+
+  private prunedAttempts(attempts: SetupAttempt[]): SetupAttempt[] {
+    const cutoffMs = this.now().getTime() - this.retentionDays * 24 * 60 * 60 * 1000;
+    return attempts
+      .filter((attempt) => new Date(attempt.finishedAt).getTime() >= cutoffMs)
+      .slice(-this.maxAttempts);
+  }
+}
+
+type LegacySetupAttemptSet = {
+  projectFingerprint: string;
+  capletId: string;
+  attempts: SetupAttempt[];
+};
+
+type ValidatedLegacySetupSnapshot = {
+  approvals: SetupApproval[];
+  attemptSets: LegacySetupAttemptSet[];
+};
+
+type LegacySetupApprovalRow = {
+  projectFingerprint: string;
+  capletId: string;
+  contentHash: string;
+  targetKind: SetupTargetKind;
+  generation: number;
+  payload: SetupApproval;
+  approvedAt: string;
+  actor: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type LegacySetupAttemptSetRow = {
+  projectFingerprint: string;
+  capletId: string;
+  generation: number;
+  payload: SetupAttemptsPayload;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type LegacySetupPendingRows = {
+  approvals: LegacySetupApprovalRow[];
+  attemptSets: LegacySetupAttemptSetRow[];
+};
+
+type SqliteSetupDatabase =
+  | SqliteHostDatabase
+  | Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0];
+type PostgresSetupDatabase =
+  | PostgresHostDatabase
+  | Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0];
+
+function validateLegacySetupSnapshot(
+  snapshot: LegacySetupMigrationSnapshot,
+): ValidatedLegacySetupSnapshot {
+  const approvalIdentities = new Set<string>();
+  const approvals = snapshot.approvals.map((input) => {
+    const approval = parseSetupApproval(input);
+    const identity = approvalKey(approval);
+    if (
+      approvalIdentities.has(identity) ||
+      !Number.isFinite(Date.parse(approval.approvedAt)) ||
+      new Date(approval.approvedAt).toISOString() !== approval.approvedAt
+    ) {
+      throw new CapletsError("CONFIG_INVALID", "Legacy setup approvals are invalid.");
+    }
+    approvalIdentities.add(identity);
+    return approval;
+  });
+  const grouped = new Map<string, LegacySetupAttemptSet>();
+  const attemptIdentities = new Set<string>();
+  for (const input of snapshot.attempts) {
+    const attempt = parseSetupAttempt(input);
+    const identity = JSON.stringify([
+      attempt.projectFingerprint,
+      attempt.capletId,
+      attempt.attemptId,
+    ]);
+    if (
+      attemptIdentities.has(identity) ||
+      !Number.isFinite(Date.parse(attempt.startedAt)) ||
+      !Number.isFinite(Date.parse(attempt.finishedAt)) ||
+      new Date(attempt.startedAt).toISOString() !== attempt.startedAt ||
+      new Date(attempt.finishedAt).toISOString() !== attempt.finishedAt
+    ) {
+      throw new CapletsError("CONFIG_INVALID", "Legacy setup attempts are invalid.");
+    }
+    attemptIdentities.add(identity);
+    const key = attemptsKey(attempt.projectFingerprint, attempt.capletId);
+    const set = grouped.get(key) ?? {
+      projectFingerprint: attempt.projectFingerprint,
+      capletId: attempt.capletId,
+      attempts: [],
+    };
+    set.attempts.push(attempt);
+    grouped.set(key, set);
+  }
+  return {
+    approvals: approvals.sort((left, right) => approvalKey(left).localeCompare(approvalKey(right))),
+    attemptSets: [...grouped.values()].sort((left, right) =>
+      attemptsKey(left.projectFingerprint, left.capletId).localeCompare(
+        attemptsKey(right.projectFingerprint, right.capletId),
+      ),
+    ),
+  };
+}
+
+function inspectLegacySetupSqlite(
+  database: SqliteSetupDatabase,
+  snapshot: ValidatedLegacySetupSnapshot,
+): LegacySetupPendingRows {
+  const pending: LegacySetupPendingRows = { approvals: [], attemptSets: [] };
+  for (const approval of snapshot.approvals) {
+    const existing = database
+      .select({ payload: sqlite.setupApprovals.payload })
+      .from(sqlite.setupApprovals)
+      .where(sqliteApprovalWhere(approval))
+      .get();
+    if (
+      existing &&
+      stableJsonStringify(parseSetupApproval(existing.payload)) !== stableJsonStringify(approval)
+    ) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        `Setup approval for ${approval.capletId} conflicts with the legacy snapshot.`,
+      );
+    }
+    if (!existing) pending.approvals.push(legacySetupApprovalRow(approval));
+  }
+  for (const set of snapshot.attemptSets) {
+    const existing = database
+      .select({ payload: sqlite.setupAttemptSets.payload })
+      .from(sqlite.setupAttemptSets)
+      .where(
+        and(
+          eq(sqlite.setupAttemptSets.projectFingerprint, set.projectFingerprint),
+          eq(sqlite.setupAttemptSets.capletId, set.capletId),
+        ),
+      )
+      .get();
+    if (
+      existing &&
+      stableJsonStringify(parseAttemptsPayload(existing.payload).attempts) !==
+        stableJsonStringify(set.attempts)
+    ) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        `Setup attempts for ${set.capletId} conflict with the legacy snapshot.`,
+      );
+    }
+    if (!existing) pending.attemptSets.push(legacySetupAttemptSetRow(set));
+  }
+  return pending;
+}
+
+async function inspectLegacySetupPostgres(
+  database: PostgresSetupDatabase,
+  snapshot: ValidatedLegacySetupSnapshot,
+): Promise<LegacySetupPendingRows> {
+  const pending: LegacySetupPendingRows = { approvals: [], attemptSets: [] };
+  for (const approval of snapshot.approvals) {
+    const [existing] = await database
+      .select({ payload: postgres.setupApprovals.payload })
+      .from(postgres.setupApprovals)
+      .where(postgresApprovalWhere(approval))
+      .limit(1);
+    if (
+      existing &&
+      stableJsonStringify(parseSetupApproval(existing.payload)) !== stableJsonStringify(approval)
+    ) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        `Setup approval for ${approval.capletId} conflicts with the legacy snapshot.`,
+      );
+    }
+    if (!existing) pending.approvals.push(legacySetupApprovalRow(approval));
+  }
+  for (const set of snapshot.attemptSets) {
+    const [existing] = await database
+      .select({ payload: postgres.setupAttemptSets.payload })
+      .from(postgres.setupAttemptSets)
+      .where(
+        and(
+          eq(postgres.setupAttemptSets.projectFingerprint, set.projectFingerprint),
+          eq(postgres.setupAttemptSets.capletId, set.capletId),
+        ),
+      )
+      .limit(1);
+    if (
+      existing &&
+      stableJsonStringify(parseAttemptsPayload(existing.payload).attempts) !==
+        stableJsonStringify(set.attempts)
+    ) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        `Setup attempts for ${set.capletId} conflict with the legacy snapshot.`,
+      );
+    }
+    if (!existing) pending.attemptSets.push(legacySetupAttemptSetRow(set));
+  }
+  return pending;
+}
+
+function legacySetupApprovalRow(approval: SetupApproval): LegacySetupApprovalRow {
+  return {
+    projectFingerprint: approval.projectFingerprint,
+    capletId: approval.capletId,
+    contentHash: approval.contentHash,
+    targetKind: approval.targetKind,
+    generation: 1,
+    payload: approval,
+    approvedAt: approval.approvedAt,
+    actor: approval.actor,
+    createdAt: approval.approvedAt,
+    updatedAt: approval.approvedAt,
+  };
+}
+
+function legacySetupAttemptSetRow(set: LegacySetupAttemptSet): LegacySetupAttemptSetRow {
+  const createdAt = set.attempts
+    .map((attempt) => attempt.startedAt)
+    .sort((left, right) => left.localeCompare(right))[0] as string;
+  const updatedAt = set.attempts
+    .map((attempt) => attempt.finishedAt)
+    .sort((left, right) => right.localeCompare(left))[0] as string;
+  return {
+    projectFingerprint: set.projectFingerprint,
+    capletId: set.capletId,
+    generation: 1,
+    payload: { attempts: set.attempts },
+    createdAt,
+    updatedAt,
+  };
+}
+
+type ApprovalIdentity = {
+  projectFingerprint: string;
+  capletId: string;
+  contentHash: string;
+  targetKind: SetupTargetKind;
+};
+
+function approvalIdentity(
+  args: [string, string, SetupTargetKind] | [string, string, string, SetupTargetKind],
+): ApprovalIdentity {
+  const [projectFingerprint, capletId, contentHash, targetKind] =
+    args.length === 3 ? [DEFAULT_PROJECT_FINGERPRINT, args[0], args[1], args[2]] : args;
+  return { projectFingerprint, capletId, contentHash, targetKind };
+}
+
+function sqliteApprovalWhere(identity: ApprovalIdentity) {
+  return and(
+    eq(sqlite.setupApprovals.projectFingerprint, identity.projectFingerprint),
+    eq(sqlite.setupApprovals.capletId, identity.capletId),
+    eq(sqlite.setupApprovals.contentHash, identity.contentHash),
+    eq(sqlite.setupApprovals.targetKind, identity.targetKind),
+  );
+}
+
+function postgresApprovalWhere(identity: ApprovalIdentity) {
+  return and(
+    eq(postgres.setupApprovals.projectFingerprint, identity.projectFingerprint),
+    eq(postgres.setupApprovals.capletId, identity.capletId),
+    eq(postgres.setupApprovals.contentHash, identity.contentHash),
+    eq(postgres.setupApprovals.targetKind, identity.targetKind),
+  );
+}
+
+function mutateApprovalSqlite(
+  db: SqliteHostDatabase,
+  approval: SetupApproval,
+  options: SetupStateMutationOptions,
+  timestamp: string,
+): void {
+  db.transaction((transaction) => {
+    const current = transaction
+      .select({ generation: sqlite.setupApprovals.generation })
+      .from(sqlite.setupApprovals)
+      .where(sqliteApprovalWhere(approval))
+      .get();
+    assertExpectedGeneration(current?.generation, options.expectedGeneration);
+    transaction
+      .insert(sqlite.setupApprovals)
+      .values({
+        ...approval,
+        generation: (current?.generation ?? 0) + 1,
+        payload: approval,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+      .onConflictDoUpdate({
+        target: [
+          sqlite.setupApprovals.projectFingerprint,
+          sqlite.setupApprovals.capletId,
+          sqlite.setupApprovals.contentHash,
+          sqlite.setupApprovals.targetKind,
+        ],
+        set: {
+          generation: (current?.generation ?? 0) + 1,
+          payload: approval,
+          approvedAt: approval.approvedAt,
+          actor: approval.actor,
+          updatedAt: timestamp,
+        },
+      })
+      .run();
+    insertSqliteActivity(
+      transaction,
+      options,
+      "setup.approve",
+      "setup_approval",
+      approvalKey(approval),
+      timestamp,
+      {
+        projectFingerprint: approval.projectFingerprint,
+        capletId: approval.capletId,
+        contentHash: approval.contentHash,
+        targetKind: approval.targetKind,
+      },
+    );
+  });
+}
+
+async function mutateApprovalPostgres(
+  db: PostgresHostDatabase,
+  approval: SetupApproval,
+  options: SetupStateMutationOptions,
+  timestamp: string,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const key = approvalKey(approval);
+    await lockPostgresKey(transaction, "setup-approval", key);
+    const [current] = await transaction
+      .select({ generation: postgres.setupApprovals.generation })
+      .from(postgres.setupApprovals)
+      .where(postgresApprovalWhere(approval))
+      .for("update")
+      .limit(1);
+    assertExpectedGeneration(current?.generation, options.expectedGeneration);
+    await transaction
+      .insert(postgres.setupApprovals)
+      .values({
+        ...approval,
+        generation: (current?.generation ?? 0) + 1,
+        payload: approval,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+      .onConflictDoUpdate({
+        target: [
+          postgres.setupApprovals.projectFingerprint,
+          postgres.setupApprovals.capletId,
+          postgres.setupApprovals.contentHash,
+          postgres.setupApprovals.targetKind,
+        ],
+        set: {
+          generation: (current?.generation ?? 0) + 1,
+          payload: approval,
+          approvedAt: approval.approvedAt,
+          actor: approval.actor,
+          updatedAt: timestamp,
+        },
+      });
+    await insertPostgresActivity(
+      transaction,
+      options,
+      "setup.approve",
+      "setup_approval",
+      key,
+      timestamp,
+      {
+        projectFingerprint: approval.projectFingerprint,
+        capletId: approval.capletId,
+        contentHash: approval.contentHash,
+        targetKind: approval.targetKind,
+      },
+    );
+  });
+}
+
+function mutateAttemptsSqlite(
+  db: SqliteHostDatabase,
+  attempt: SetupAttempt,
+  options: SetupStateMutationOptions,
+  timestamp: string,
+  transition: (payload: unknown | undefined) => SetupAttemptsPayload,
+): void {
+  db.transaction((transaction) => {
+    const current = transaction
+      .select({
+        generation: sqlite.setupAttemptSets.generation,
+        payload: sqlite.setupAttemptSets.payload,
+      })
+      .from(sqlite.setupAttemptSets)
+      .where(
+        and(
+          eq(sqlite.setupAttemptSets.projectFingerprint, attempt.projectFingerprint),
+          eq(sqlite.setupAttemptSets.capletId, attempt.capletId),
+        ),
+      )
+      .get();
+    assertExpectedGeneration(current?.generation, options.expectedGeneration);
+    const payload = transition(current?.payload);
+    transaction
+      .insert(sqlite.setupAttemptSets)
+      .values({
+        projectFingerprint: attempt.projectFingerprint,
+        capletId: attempt.capletId,
+        generation: (current?.generation ?? 0) + 1,
+        payload,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+      .onConflictDoUpdate({
+        target: [sqlite.setupAttemptSets.projectFingerprint, sqlite.setupAttemptSets.capletId],
+        set: {
+          generation: (current?.generation ?? 0) + 1,
+          payload,
+          updatedAt: timestamp,
+        },
+      })
+      .run();
+    const key = attemptsKey(attempt.projectFingerprint, attempt.capletId);
+    insertSqliteActivity(
+      transaction,
+      options,
+      "setup.attempt.record",
+      "setup_attempts",
+      key,
+      timestamp,
+      {
+        projectFingerprint: attempt.projectFingerprint,
+        capletId: attempt.capletId,
+        attemptId: attempt.attemptId,
+        status: attempt.status,
+      },
+    );
+  });
+}
+
+async function mutateAttemptsPostgres(
+  db: PostgresHostDatabase,
+  attempt: SetupAttempt,
+  options: SetupStateMutationOptions,
+  timestamp: string,
+  transition: (payload: unknown | undefined) => SetupAttemptsPayload,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const key = attemptsKey(attempt.projectFingerprint, attempt.capletId);
+    await lockPostgresKey(transaction, "setup-attempts", key);
+    const [current] = await transaction
+      .select({
+        generation: postgres.setupAttemptSets.generation,
+        payload: postgres.setupAttemptSets.payload,
+      })
+      .from(postgres.setupAttemptSets)
+      .where(
+        and(
+          eq(postgres.setupAttemptSets.projectFingerprint, attempt.projectFingerprint),
+          eq(postgres.setupAttemptSets.capletId, attempt.capletId),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    assertExpectedGeneration(current?.generation, options.expectedGeneration);
+    const payload = transition(current?.payload);
+    await transaction
+      .insert(postgres.setupAttemptSets)
+      .values({
+        projectFingerprint: attempt.projectFingerprint,
+        capletId: attempt.capletId,
+        generation: (current?.generation ?? 0) + 1,
+        payload,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+      .onConflictDoUpdate({
+        target: [postgres.setupAttemptSets.projectFingerprint, postgres.setupAttemptSets.capletId],
+        set: {
+          generation: (current?.generation ?? 0) + 1,
+          payload,
+          updatedAt: timestamp,
+        },
+      });
+    await insertPostgresActivity(
+      transaction,
+      options,
+      "setup.attempt.record",
+      "setup_attempts",
+      key,
+      timestamp,
+      {
+        projectFingerprint: attempt.projectFingerprint,
+        capletId: attempt.capletId,
+        attemptId: attempt.attemptId,
+        status: attempt.status,
+      },
+    );
+  });
+}
+
+function clearAttemptsSqlite(
+  db: SqliteHostDatabase,
+  projectFingerprint: string,
+  capletId: string,
+  options: SetupStateMutationOptions,
+  timestamp: string,
+): boolean {
+  return db.transaction((transaction) => {
+    const where = and(
+      eq(sqlite.setupAttemptSets.projectFingerprint, projectFingerprint),
+      eq(sqlite.setupAttemptSets.capletId, capletId),
+    );
+    const current = transaction
+      .select({ generation: sqlite.setupAttemptSets.generation })
+      .from(sqlite.setupAttemptSets)
+      .where(where)
+      .get();
+    assertExpectedGeneration(current?.generation, options.expectedGeneration);
+    if (!current) return false;
+    transaction.delete(sqlite.setupAttemptSets).where(where).run();
+    const key = attemptsKey(projectFingerprint, capletId);
+    insertSqliteActivity(
+      transaction,
+      options,
+      "setup.attempt.clear",
+      "setup_attempts",
+      key,
+      timestamp,
+      {
+        projectFingerprint,
+        capletId,
+      },
+    );
+    return true;
+  });
+}
+
+async function clearAttemptsPostgres(
+  db: PostgresHostDatabase,
+  projectFingerprint: string,
+  capletId: string,
+  options: SetupStateMutationOptions,
+  timestamp: string,
+): Promise<boolean> {
+  return await db.transaction(async (transaction) => {
+    const key = attemptsKey(projectFingerprint, capletId);
+    await lockPostgresKey(transaction, "setup-attempts", key);
+    const where = and(
+      eq(postgres.setupAttemptSets.projectFingerprint, projectFingerprint),
+      eq(postgres.setupAttemptSets.capletId, capletId),
+    );
+    const [current] = await transaction
+      .select({ generation: postgres.setupAttemptSets.generation })
+      .from(postgres.setupAttemptSets)
+      .where(where)
+      .for("update")
+      .limit(1);
+    assertExpectedGeneration(current?.generation, options.expectedGeneration);
+    if (!current) return false;
+    await transaction.delete(postgres.setupAttemptSets).where(where);
+    await insertPostgresActivity(
+      transaction,
+      options,
+      "setup.attempt.clear",
+      "setup_attempts",
+      key,
+      timestamp,
+      {
+        projectFingerprint,
+        capletId,
+      },
+    );
+    return true;
+  });
+}
+
+function parseAttemptsPayload(value: unknown): SetupAttemptsPayload {
+  if (!isRecord(value) || !Array.isArray(value.attempts)) {
+    throw new CapletsError("INTERNAL_ERROR", "Persisted setup attempt list is invalid.");
+  }
+  return { attempts: value.attempts.map(parseSetupAttempt) };
+}
+
+function assertExpectedGeneration(
+  currentGeneration: number | undefined,
+  expectedGeneration: number | undefined,
+): void {
+  if (expectedGeneration === undefined || currentGeneration === expectedGeneration) return;
+  throw new CapletsError(
+    "REQUEST_INVALID",
+    "Authoritative Setup State changed after it was read; reload and retry.",
+    {
+      kind: "stale_generation",
+      expectedGeneration,
+      currentGeneration: currentGeneration ?? 0,
+    },
+  );
+}
+
+function approvalKey(identity: ApprovalIdentity): string {
+  return JSON.stringify([
+    identity.projectFingerprint,
+    identity.capletId,
+    identity.contentHash,
+    identity.targetKind,
+  ]);
+}
+
+function attemptsKey(projectFingerprint: string, capletId: string): string {
+  return JSON.stringify([projectFingerprint, capletId]);
+}
+
+function activityValues(
+  operatorClientId: string,
+  action: string,
+  targetKind: string,
+  targetKey: string,
+  timestamp: string,
+  metadata: Record<string, unknown>,
+) {
+  return {
+    activityKey: randomUUID(),
+    operatorClientId,
+    action,
+    targetKind,
+    targetKey,
+    outcome: "succeeded",
+    metadata,
+    createdAt: timestamp,
+  };
+}
+
+function insertSqliteActivity(
+  transaction: Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0],
+  options: SetupStateMutationOptions,
+  action: string,
+  targetKind: string,
+  targetKey: string,
+  timestamp: string,
+  metadata: Record<string, unknown>,
+): void {
+  const operatorClientId = options.operatorClientId?.trim();
+  if (!operatorClientId) return;
+  transaction
+    .insert(sqlite.operatorActivity)
+    .values(activityValues(operatorClientId, action, targetKind, targetKey, timestamp, metadata))
+    .run();
+}
+
+async function insertPostgresActivity(
+  transaction: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  options: SetupStateMutationOptions,
+  action: string,
+  targetKind: string,
+  targetKey: string,
+  timestamp: string,
+  metadata: Record<string, unknown>,
+): Promise<void> {
+  const operatorClientId = options.operatorClientId?.trim();
+  if (!operatorClientId) return;
+  await transaction
+    .insert(postgres.operatorActivity)
+    .values(activityValues(operatorClientId, action, targetKind, targetKey, timestamp, metadata));
+}
+
+async function lockPostgresKey(
+  transaction: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  namespace: string,
+  key: string,
+): Promise<void> {
+  await transaction.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify([namespace, key])}, 0))`,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/core/src/storage/setup-state.ts
+++ b/packages/core/src/storage/setup-state.ts
@@ -11,7 +11,12 @@ import type { SetupApproval, SetupAttempt, SetupTargetKind } from "../setup/type
 import { stableJsonStringify } from "../stable-json";
 import * as postgres from "./schema/postgres";
 import * as sqlite from "./schema/sqlite";
-import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+import type {
+  HostDatabase,
+  HostDatabaseTransaction,
+  PostgresHostDatabase,
+  SqliteHostDatabase,
+} from "./types";
 
 export const SETUP_APPROVALS_NAMESPACE = "setup-approvals";
 export const SETUP_ATTEMPTS_NAMESPACE = "setup-attempts";
@@ -228,6 +233,16 @@ export class SetupStateStore {
       }
     });
   }
+  importLegacySnapshotInTransaction(
+    snapshot: LegacySetupMigrationSnapshot,
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    const validated = validateLegacySetupSnapshot(snapshot);
+    if (validated.approvals.length === 0 && validated.attemptSets.length === 0) return;
+    return transaction.dialect === "sqlite"
+      ? importLegacySetupSqlite(transaction.db, validated)
+      : importLegacySetupPostgres(transaction.db, validated);
+  }
 
   async verifyLegacySnapshot(snapshot: LegacySetupMigrationSnapshot): Promise<void> {
     const validated = validateLegacySetupSnapshot(snapshot);
@@ -238,6 +253,17 @@ export class SetupStateStore {
     if (pending.approvals.length > 0 || pending.attemptSets.length > 0) {
       throw new CapletsError("INTERNAL_ERROR", "Setup state failed post-migration verification.");
     }
+  }
+  verifyLegacySnapshotInTransaction(
+    snapshot: LegacySetupMigrationSnapshot,
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    const validated = validateLegacySetupSnapshot(snapshot);
+    if (transaction.dialect === "sqlite") {
+      verifyLegacySetupPending(inspectLegacySetupSqlite(transaction.db, validated));
+      return;
+    }
+    return inspectLegacySetupPostgres(transaction.db, validated).then(verifyLegacySetupPending);
   }
 
   retention(): { maxAttempts: number; days: number } {
@@ -296,6 +322,50 @@ type SqliteSetupDatabase =
 type PostgresSetupDatabase =
   | PostgresHostDatabase
   | Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0];
+function importLegacySetupSqlite(
+  database: SqliteSetupDatabase,
+  snapshot: ValidatedLegacySetupSnapshot,
+): void {
+  const pending = inspectLegacySetupSqlite(database, snapshot);
+  if (pending.approvals.length > 0) {
+    database.insert(sqlite.setupApprovals).values(pending.approvals).run();
+  }
+  if (pending.attemptSets.length > 0) {
+    database.insert(sqlite.setupAttemptSets).values(pending.attemptSets).run();
+  }
+}
+
+async function importLegacySetupPostgres(
+  database: PostgresSetupDatabase,
+  snapshot: ValidatedLegacySetupSnapshot,
+): Promise<void> {
+  for (const approval of snapshot.approvals) {
+    await lockPostgresKey(database, SETUP_APPROVALS_NAMESPACE, approvalKey(approval));
+  }
+  for (const attempts of snapshot.attemptSets) {
+    await lockPostgresKey(
+      database,
+      SETUP_ATTEMPTS_NAMESPACE,
+      attemptsKey(attempts.projectFingerprint, attempts.capletId),
+    );
+  }
+  const pending = await inspectLegacySetupPostgres(database, snapshot);
+  if (pending.approvals.length > 0) {
+    await database.insert(postgres.setupApprovals).values(pending.approvals);
+  }
+  if (pending.attemptSets.length > 0) {
+    await database.insert(postgres.setupAttemptSets).values(pending.attemptSets);
+  }
+}
+
+function verifyLegacySetupPending(pending: {
+  approvals: LegacySetupApprovalRow[];
+  attemptSets: LegacySetupAttemptSetRow[];
+}): void {
+  if (pending.approvals.length > 0 || pending.attemptSets.length > 0) {
+    throw new CapletsError("INTERNAL_ERROR", "Setup state failed post-migration verification.");
+  }
+}
 
 function validateLegacySetupSnapshot(
   snapshot: LegacySetupMigrationSnapshot,
@@ -912,7 +982,7 @@ async function insertPostgresActivity(
 }
 
 async function lockPostgresKey(
-  transaction: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  transaction: PostgresSetupDatabase,
   namespace: string,
   key: string,
 ): Promise<void> {

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1,0 +1,37 @@
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type { HostStorageConfig } from "../config";
+import type { postgresSchema } from "./schema/postgres";
+import type { sqliteSchema } from "./schema/sqlite";
+
+export const HOST_STORAGE_SCHEMA_VERSION = 12;
+
+export type SqliteHostStorageConfig = Extract<HostStorageConfig, { type: "sqlite" }>;
+export type PostgresHostStorageConfig = Extract<HostStorageConfig, { type: "postgres" }>;
+export type { HostStorageConfig };
+
+export type HostStorageHealth = {
+  backend: HostStorageConfig["type"];
+  ready: boolean;
+  schemaVersion?: number | undefined;
+  reason?:
+    | "database_unavailable"
+    | "schema_missing"
+    | "schema_outdated"
+    | "schema_newer"
+    | "object_store_unavailable"
+    | undefined;
+  assets?:
+    | {
+        backend: "sql" | "s3";
+        ready: boolean;
+      }
+    | undefined;
+};
+
+export type SqliteHostDatabase = BetterSQLite3Database<typeof sqliteSchema>;
+export type PostgresHostDatabase = NodePgDatabase<typeof postgresSchema>;
+
+export type HostDatabase =
+  | { dialect: "sqlite"; db: SqliteHostDatabase }
+  | { dialect: "postgres"; db: PostgresHostDatabase; schema: string };

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -20,17 +20,27 @@ export type HostStorageHealth = {
     | "schema_outdated"
     | "schema_newer"
     | "object_store_unavailable"
+    | "current_record_assets_unavailable"
     | undefined;
   assets?:
     | {
         backend: "sql" | "s3";
         ready: boolean;
+        affectedRecordIds?: string[] | undefined;
       }
     | undefined;
 };
 
 export type SqliteHostDatabase = BetterSQLite3Database<typeof sqliteSchema>;
 export type PostgresHostDatabase = NodePgDatabase<typeof postgresSchema>;
+export type SqliteHostTransaction = Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0];
+export type PostgresHostTransaction = Parameters<
+  Parameters<PostgresHostDatabase["transaction"]>[0]
+>[0];
+
+export type HostDatabaseTransaction =
+  | { dialect: "sqlite"; db: SqliteHostTransaction }
+  | { dialect: "postgres"; db: PostgresHostTransaction };
 
 export type HostDatabase =
   | { dialect: "sqlite"; db: SqliteHostDatabase }

--- a/packages/core/src/storage/vault-grants.ts
+++ b/packages/core/src/storage/vault-grants.ts
@@ -1,0 +1,780 @@
+import { createHash, randomUUID } from "node:crypto";
+import { and, eq, or, sql } from "drizzle-orm";
+import type { ConfigSourceKind } from "../config";
+import { CapletsError } from "../errors";
+import { requireOperator, type OperatorPrincipal } from "./installations";
+import * as postgres from "./schema/postgres";
+import * as sqlite from "./schema/sqlite";
+import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+
+export type StoredVaultGrant = {
+  subjectKind: "record" | "file";
+  recordKey: string | null;
+  capletId: string;
+  vaultKey: string;
+  referenceName: string;
+  originKind: ConfigSourceKind;
+  originPath: string | null;
+  createdAt: string;
+  createdBy: string;
+};
+
+export type VaultGrantInput = {
+  capletId: string;
+  vaultKey: string;
+  referenceName?: string | undefined;
+  originKind: ConfigSourceKind;
+  originPath?: string | undefined;
+  operator: OperatorPrincipal;
+};
+
+export type LegacyRecordVaultGrantImport = {
+  capletId: string;
+  vaultKey: string;
+  referenceName: string;
+  createdAt: string;
+};
+
+export type VaultGrantRevokeInput = {
+  capletId: string;
+  vaultKey: string;
+  referenceName?: string | undefined;
+  originKind?: ConfigSourceKind | undefined;
+  originPath?: string | undefined;
+  operator: OperatorPrincipal;
+};
+
+type NormalizedGrantInput = Omit<VaultGrantInput, "referenceName"> & {
+  referenceName: string;
+};
+
+type NormalizedRevokeInput = Omit<VaultGrantRevokeInput, "referenceName"> & {
+  referenceName: string;
+};
+
+type VaultGrantSubject =
+  | {
+      kind: "record";
+      key: string;
+      recordKey: string;
+      capletId: null;
+    }
+  | {
+      kind: "file";
+      key: string;
+      recordKey: null;
+      capletId: string;
+    };
+
+const CONFIG_SOURCE_KINDS: Record<ConfigSourceKind, true> = {
+  "stored-record": true,
+  "global-config": true,
+  "global-file": true,
+  "project-config": true,
+  "project-file": true,
+};
+
+export class VaultGrantStore {
+  constructor(private readonly database: HostDatabase) {}
+
+  async grant(input: VaultGrantInput): Promise<void> {
+    const operatorId = requireOperator(input.operator);
+    const normalized = normalizeGrantInput(input);
+    if (this.database.dialect === "sqlite") {
+      grantSqlite(this.database.db, normalized, operatorId);
+    } else {
+      await grantPostgres(this.database.db, normalized, operatorId);
+    }
+  }
+
+  async revoke(input: VaultGrantRevokeInput): Promise<boolean> {
+    const operatorId = requireOperator(input.operator);
+    const normalized = normalizeRevokeInput(input);
+    return this.database.dialect === "sqlite"
+      ? revokeSqlite(this.database.db, normalized, operatorId)
+      : await revokePostgres(this.database.db, normalized, operatorId);
+  }
+
+  async assertLegacyRecordGrantsImportable(
+    grants: LegacyRecordVaultGrantImport[],
+    operator: OperatorPrincipal,
+  ): Promise<void> {
+    const operatorId = requireOperator(operator);
+    const validated = validateLegacyRecordGrantImports(grants);
+    if (this.database.dialect === "sqlite") {
+      assertLegacyRecordGrantsMatchSqlite(this.database.db, validated, operatorId);
+    } else {
+      await assertLegacyRecordGrantsMatchPostgres(this.database.db, validated, operatorId);
+    }
+  }
+
+  async importLegacyRecordGrants(
+    grants: LegacyRecordVaultGrantImport[],
+    operator: OperatorPrincipal,
+  ): Promise<void> {
+    const operatorId = requireOperator(operator);
+    const validated = validateLegacyRecordGrantImports(grants);
+    if (validated.length === 0) return;
+    if (this.database.dialect === "sqlite") {
+      this.database.db.transaction((transaction) => {
+        const rows = assertLegacyRecordGrantsMatchSqlite(transaction, validated, operatorId);
+        const pending = rows.filter((row) => row.existing === undefined);
+        if (pending.length > 0) {
+          transaction
+            .insert(sqlite.vaultAccessGrants)
+            .values(pending.map((row) => row.values))
+            .run();
+        }
+      });
+      return;
+    }
+    await this.database.db.transaction(async (transaction) => {
+      for (const grant of validated) {
+        await transaction.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify([
+            "vault-legacy-grant",
+            grant.capletId,
+            grant.referenceName,
+          ])}, 0))`,
+        );
+      }
+      const rows = await assertLegacyRecordGrantsMatchPostgres(transaction, validated, operatorId);
+      const pending = rows.filter((row) => row.existing === undefined);
+      if (pending.length > 0) {
+        await transaction
+          .insert(postgres.vaultAccessGrants)
+          .values(pending.map((row) => row.values));
+      }
+    });
+  }
+
+  async verifyLegacyRecordGrants(
+    grants: LegacyRecordVaultGrantImport[],
+    operator: OperatorPrincipal,
+  ): Promise<void> {
+    const operatorId = requireOperator(operator);
+    const stored = await this.list();
+    for (const grant of validateLegacyRecordGrantImports(grants)) {
+      const match = stored.find(
+        (candidate) =>
+          candidate.subjectKind === "record" &&
+          candidate.capletId === grant.capletId &&
+          candidate.vaultKey === grant.vaultKey &&
+          candidate.referenceName === grant.referenceName &&
+          candidate.originKind === "stored-record" &&
+          candidate.originPath === null &&
+          candidate.createdAt === grant.createdAt &&
+          candidate.createdBy === operatorId,
+      );
+      if (!match) {
+        throw new CapletsError(
+          "INTERNAL_ERROR",
+          `Vault grant for Caplet Record ${grant.capletId} failed post-migration verification.`,
+        );
+      }
+    }
+  }
+
+  async list(capletId?: string): Promise<StoredVaultGrant[]> {
+    if (capletId !== undefined) validateCapletId(capletId);
+    if (this.database.dialect === "sqlite") {
+      const query = this.database.db
+        .select({
+          grant: sqlite.vaultAccessGrants,
+          recordCapletId: sqlite.capletRecords.capletId,
+        })
+        .from(sqlite.vaultAccessGrants)
+        .leftJoin(
+          sqlite.capletRecords,
+          eq(sqlite.capletRecords.recordKey, sqlite.vaultAccessGrants.recordKey),
+        );
+      const rows =
+        capletId === undefined
+          ? query.all()
+          : query
+              .where(
+                or(
+                  eq(sqlite.capletRecords.capletId, capletId),
+                  eq(sqlite.vaultAccessGrants.capletId, capletId),
+                ),
+              )
+              .all();
+      return rows.map(({ grant, recordCapletId }) => storedGrant(grant, recordCapletId));
+    }
+
+    const query = this.database.db
+      .select({
+        grant: postgres.vaultAccessGrants,
+        recordCapletId: postgres.capletRecords.capletId,
+      })
+      .from(postgres.vaultAccessGrants)
+      .leftJoin(
+        postgres.capletRecords,
+        eq(postgres.capletRecords.recordKey, postgres.vaultAccessGrants.recordKey),
+      );
+    const rows =
+      capletId === undefined
+        ? await query
+        : await query.where(
+            or(
+              eq(postgres.capletRecords.capletId, capletId),
+              eq(postgres.vaultAccessGrants.capletId, capletId),
+            ),
+          );
+    return rows.map(({ grant, recordCapletId }) => storedGrant(grant, recordCapletId));
+  }
+}
+
+type SqliteVaultGrantDatabase =
+  | SqliteHostDatabase
+  | Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0];
+type PostgresVaultGrantDatabase =
+  | PostgresHostDatabase
+  | Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0];
+
+function validateLegacyRecordGrantImports(
+  grants: LegacyRecordVaultGrantImport[],
+): LegacyRecordVaultGrantImport[] {
+  const identities = new Set<string>();
+  const validated = grants.map((grant) => {
+    validateCapletId(grant.capletId);
+    const vaultKey = validateGrantName(grant.vaultKey);
+    const referenceName = validateGrantName(grant.referenceName);
+    const identity = JSON.stringify([grant.capletId, referenceName]);
+    if (
+      identities.has(identity) ||
+      !Number.isFinite(Date.parse(grant.createdAt)) ||
+      new Date(grant.createdAt).toISOString() !== grant.createdAt
+    ) {
+      throw new CapletsError("CONFIG_INVALID", "Legacy Vault grants are invalid.");
+    }
+    identities.add(identity);
+    return { ...grant, vaultKey, referenceName };
+  });
+  return validated.sort(
+    (left, right) =>
+      left.capletId.localeCompare(right.capletId) ||
+      left.referenceName.localeCompare(right.referenceName),
+  );
+}
+
+function assertLegacyRecordGrantsMatchSqlite(
+  database: SqliteVaultGrantDatabase,
+  grants: LegacyRecordVaultGrantImport[],
+  operatorId: string,
+) {
+  return grants.map((grant) => {
+    const recordKey = database
+      .select({ recordKey: sqlite.capletRecords.recordKey })
+      .from(sqlite.capletRecords)
+      .where(eq(sqlite.capletRecords.capletId, grant.capletId))
+      .get()?.recordKey;
+    if (!recordKey) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        `Caplet Record ${grant.capletId} required by a legacy Vault grant was not found.`,
+      );
+    }
+    const values = legacyRecordGrantValues(recordKey, grant, operatorId);
+    const existing = database
+      .select()
+      .from(sqlite.vaultAccessGrants)
+      .where(
+        and(
+          eq(sqlite.vaultAccessGrants.subjectKind, "record"),
+          eq(sqlite.vaultAccessGrants.subjectKey, recordKey),
+          eq(sqlite.vaultAccessGrants.referenceName, grant.referenceName),
+        ),
+      )
+      .get();
+    if (existing && !legacyRecordGrantMatches(existing, values)) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        `Vault grant for Caplet Record ${grant.capletId} conflicts with the legacy snapshot.`,
+      );
+    }
+    return { existing, values };
+  });
+}
+
+async function assertLegacyRecordGrantsMatchPostgres(
+  database: PostgresVaultGrantDatabase,
+  grants: LegacyRecordVaultGrantImport[],
+  operatorId: string,
+) {
+  const rows = [];
+  for (const grant of grants) {
+    const [record] = await database
+      .select({ recordKey: postgres.capletRecords.recordKey })
+      .from(postgres.capletRecords)
+      .where(eq(postgres.capletRecords.capletId, grant.capletId))
+      .limit(1);
+    if (!record) {
+      throw new CapletsError(
+        "CONFIG_INVALID",
+        `Caplet Record ${grant.capletId} required by a legacy Vault grant was not found.`,
+      );
+    }
+    const values = legacyRecordGrantValues(record.recordKey, grant, operatorId);
+    const [existing] = await database
+      .select()
+      .from(postgres.vaultAccessGrants)
+      .where(
+        and(
+          eq(postgres.vaultAccessGrants.subjectKind, "record"),
+          eq(postgres.vaultAccessGrants.subjectKey, record.recordKey),
+          eq(postgres.vaultAccessGrants.referenceName, grant.referenceName),
+        ),
+      )
+      .limit(1);
+    if (existing && !legacyRecordGrantMatches(existing, values)) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        `Vault grant for Caplet Record ${grant.capletId} conflicts with the legacy snapshot.`,
+      );
+    }
+    rows.push({ existing, values });
+  }
+  return rows;
+}
+
+type LegacyRecordGrantRow = {
+  subjectKind: "record";
+  subjectKey: string;
+  recordKey: string;
+  capletId: null;
+  vaultKey: string;
+  referenceName: string;
+  originKind: "stored-record";
+  originPath: null;
+  createdAt: string;
+  createdBy: string;
+};
+
+function legacyRecordGrantValues(
+  recordKey: string,
+  grant: LegacyRecordVaultGrantImport,
+  operatorId: string,
+): LegacyRecordGrantRow {
+  return {
+    subjectKind: "record" as const,
+    subjectKey: recordKey,
+    recordKey,
+    capletId: null,
+    vaultKey: grant.vaultKey,
+    referenceName: grant.referenceName,
+    originKind: "stored-record" as const,
+    originPath: null,
+    createdAt: grant.createdAt,
+    createdBy: operatorId,
+  };
+}
+
+function legacyRecordGrantMatches(
+  existing: typeof sqlite.vaultAccessGrants.$inferSelect,
+  expected: LegacyRecordGrantRow,
+): boolean {
+  return (
+    existing.recordKey === expected.recordKey &&
+    existing.capletId === null &&
+    existing.vaultKey === expected.vaultKey &&
+    existing.originKind === "stored-record" &&
+    existing.originPath === null &&
+    existing.createdAt === expected.createdAt &&
+    existing.createdBy === expected.createdBy
+  );
+}
+
+function grantSqlite(
+  db: SqliteHostDatabase,
+  input: NormalizedGrantInput,
+  operatorId: string,
+): void {
+  db.transaction((transaction) => {
+    const subject = sqliteSubject(transaction, input);
+    const now = new Date().toISOString();
+    transaction
+      .insert(sqlite.vaultAccessGrants)
+      .values(grantValues(subject, input, operatorId, now))
+      .onConflictDoUpdate({
+        target: [
+          sqlite.vaultAccessGrants.subjectKind,
+          sqlite.vaultAccessGrants.subjectKey,
+          sqlite.vaultAccessGrants.referenceName,
+        ],
+        set: {
+          vaultKey: input.vaultKey,
+          originKind: input.originKind,
+          originPath: input.originPath ?? null,
+          createdAt: now,
+          createdBy: operatorId,
+        },
+      })
+      .run();
+    transaction
+      .insert(sqlite.operatorActivity)
+      .values(
+        activity(operatorId, "vault.grant", subject, input.vaultKey, input.referenceName, now),
+      )
+      .run();
+  });
+}
+
+async function grantPostgres(
+  db: PostgresHostDatabase,
+  input: NormalizedGrantInput,
+  operatorId: string,
+): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const subject = await postgresSubject(transaction, input);
+    const now = new Date().toISOString();
+    await transaction
+      .insert(postgres.vaultAccessGrants)
+      .values(grantValues(subject, input, operatorId, now))
+      .onConflictDoUpdate({
+        target: [
+          postgres.vaultAccessGrants.subjectKind,
+          postgres.vaultAccessGrants.subjectKey,
+          postgres.vaultAccessGrants.referenceName,
+        ],
+        set: {
+          vaultKey: input.vaultKey,
+          originKind: input.originKind,
+          originPath: input.originPath ?? null,
+          createdAt: now,
+          createdBy: operatorId,
+        },
+      });
+    await transaction
+      .insert(postgres.operatorActivity)
+      .values(
+        activity(operatorId, "vault.grant", subject, input.vaultKey, input.referenceName, now),
+      );
+  });
+}
+
+function revokeSqlite(
+  db: SqliteHostDatabase,
+  input: NormalizedRevokeInput,
+  operatorId: string,
+): boolean {
+  return db.transaction((transaction) => {
+    const subject = input.originKind
+      ? sqliteSubject(transaction, input as NormalizedGrantInput)
+      : undefined;
+    const recordKey = input.originKind
+      ? undefined
+      : sqliteRecordKey(transaction, input.capletId, false);
+    const subjectMatch = subject
+      ? and(
+          eq(sqlite.vaultAccessGrants.subjectKind, subject.kind),
+          eq(sqlite.vaultAccessGrants.subjectKey, subject.key),
+        )
+      : or(
+          recordKey
+            ? and(
+                eq(sqlite.vaultAccessGrants.subjectKind, "record"),
+                eq(sqlite.vaultAccessGrants.recordKey, recordKey),
+              )
+            : undefined,
+          and(
+            eq(sqlite.vaultAccessGrants.subjectKind, "file"),
+            eq(sqlite.vaultAccessGrants.capletId, input.capletId),
+          ),
+        );
+    const removed =
+      transaction
+        .delete(sqlite.vaultAccessGrants)
+        .where(
+          and(
+            subjectMatch,
+            eq(sqlite.vaultAccessGrants.referenceName, input.referenceName),
+            eq(sqlite.vaultAccessGrants.vaultKey, input.vaultKey),
+          ),
+        )
+        .run().changes > 0;
+    if (removed) {
+      const now = new Date().toISOString();
+      transaction
+        .insert(sqlite.operatorActivity)
+        .values(
+          activity(
+            operatorId,
+            "vault.revoke",
+            subject ?? fileSubject(input.capletId, "global-file", ""),
+            input.vaultKey,
+            input.referenceName,
+            now,
+          ),
+        )
+        .run();
+    }
+    return removed;
+  });
+}
+
+async function revokePostgres(
+  db: PostgresHostDatabase,
+  input: NormalizedRevokeInput,
+  operatorId: string,
+): Promise<boolean> {
+  return await db.transaction(async (transaction) => {
+    const subject = input.originKind
+      ? await postgresSubject(transaction, input as NormalizedGrantInput)
+      : undefined;
+    const recordKey = input.originKind
+      ? undefined
+      : await postgresRecordKey(transaction, input.capletId, false);
+    const subjectMatch = subject
+      ? and(
+          eq(postgres.vaultAccessGrants.subjectKind, subject.kind),
+          eq(postgres.vaultAccessGrants.subjectKey, subject.key),
+        )
+      : or(
+          recordKey
+            ? and(
+                eq(postgres.vaultAccessGrants.subjectKind, "record"),
+                eq(postgres.vaultAccessGrants.recordKey, recordKey),
+              )
+            : undefined,
+          and(
+            eq(postgres.vaultAccessGrants.subjectKind, "file"),
+            eq(postgres.vaultAccessGrants.capletId, input.capletId),
+          ),
+        );
+    const removed = await transaction
+      .delete(postgres.vaultAccessGrants)
+      .where(
+        and(
+          subjectMatch,
+          eq(postgres.vaultAccessGrants.referenceName, input.referenceName),
+          eq(postgres.vaultAccessGrants.vaultKey, input.vaultKey),
+        ),
+      )
+      .returning({ subjectKey: postgres.vaultAccessGrants.subjectKey });
+    if (removed.length > 0) {
+      const now = new Date().toISOString();
+      await transaction
+        .insert(postgres.operatorActivity)
+        .values(
+          activity(
+            operatorId,
+            "vault.revoke",
+            subject ?? fileSubject(input.capletId, "global-file", ""),
+            input.vaultKey,
+            input.referenceName,
+            now,
+          ),
+        );
+    }
+    return removed.length > 0;
+  });
+}
+
+function grantValues(
+  subject: VaultGrantSubject,
+  input: NormalizedGrantInput,
+  operatorId: string,
+  createdAt: string,
+) {
+  return {
+    subjectKind: subject.kind,
+    subjectKey: subject.key,
+    recordKey: subject.recordKey,
+    capletId: subject.capletId,
+    vaultKey: input.vaultKey,
+    referenceName: input.referenceName,
+    originKind: input.originKind,
+    originPath: input.originPath ?? null,
+    createdAt,
+    createdBy: operatorId,
+  };
+}
+
+function sqliteSubject(
+  db: Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0],
+  input: NormalizedGrantInput,
+): VaultGrantSubject {
+  if (input.originKind !== "stored-record") {
+    return fileSubject(input.capletId, input.originKind, input.originPath as string);
+  }
+  const recordKey = sqliteRecordKey(db, input.capletId, true) as string;
+  return { kind: "record", key: recordKey, recordKey, capletId: null };
+}
+
+async function postgresSubject(
+  db: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  input: NormalizedGrantInput,
+): Promise<VaultGrantSubject> {
+  if (input.originKind !== "stored-record") {
+    return fileSubject(input.capletId, input.originKind, input.originPath as string);
+  }
+  const recordKey = (await postgresRecordKey(db, input.capletId, true)) as string;
+  return { kind: "record", key: recordKey, recordKey, capletId: null };
+}
+
+function fileSubject(
+  capletId: string,
+  originKind: Exclude<ConfigSourceKind, "stored-record">,
+  originPath: string,
+): VaultGrantSubject {
+  return {
+    kind: "file",
+    key: JSON.stringify([capletId, originKind, originPath]),
+    recordKey: null,
+    capletId,
+  };
+}
+
+function sqliteRecordKey(
+  db: Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0],
+  capletId: string,
+  required: boolean,
+): string | undefined {
+  const recordKey = db
+    .select({ recordKey: sqlite.capletRecords.recordKey })
+    .from(sqlite.capletRecords)
+    .where(eq(sqlite.capletRecords.capletId, capletId))
+    .get()?.recordKey;
+  if (!recordKey && required) {
+    throw new CapletsError("REQUEST_INVALID", `Caplet Record ${capletId} was not found.`);
+  }
+  return recordKey;
+}
+
+async function postgresRecordKey(
+  db: Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0],
+  capletId: string,
+  required: boolean,
+): Promise<string | undefined> {
+  const [record] = await db
+    .select({ recordKey: postgres.capletRecords.recordKey })
+    .from(postgres.capletRecords)
+    .where(eq(postgres.capletRecords.capletId, capletId))
+    .limit(1);
+  if (!record && required) {
+    throw new CapletsError("REQUEST_INVALID", `Caplet Record ${capletId} was not found.`);
+  }
+  return record?.recordKey;
+}
+
+function storedGrant(
+  grant: typeof sqlite.vaultAccessGrants.$inferSelect,
+  recordCapletId: string | null,
+): StoredVaultGrant {
+  const commonValid =
+    (grant.subjectKind === "record" || grant.subjectKind === "file") &&
+    typeof grant.subjectKey === "string" &&
+    typeof grant.vaultKey === "string" &&
+    typeof grant.referenceName === "string" &&
+    grant.originKind in CONFIG_SOURCE_KINDS &&
+    typeof grant.createdAt === "string" &&
+    typeof grant.createdBy === "string";
+  const recordValid =
+    grant.subjectKind === "record" &&
+    grant.recordKey !== null &&
+    grant.capletId === null &&
+    grant.subjectKey === grant.recordKey &&
+    grant.originKind === "stored-record" &&
+    recordCapletId !== null;
+  const fileValid =
+    grant.subjectKind === "file" &&
+    grant.recordKey === null &&
+    grant.capletId !== null &&
+    grant.originKind !== "stored-record" &&
+    grant.originPath !== null &&
+    grant.subjectKey ===
+      fileSubjectKey(
+        grant.capletId,
+        grant.originKind as Exclude<ConfigSourceKind, "stored-record">,
+        grant.originPath,
+      );
+  if (!commonValid || (!recordValid && !fileValid)) {
+    throw new CapletsError("INTERNAL_ERROR", "Persisted Vault Access Grant subject is invalid.");
+  }
+  return {
+    subjectKind: grant.subjectKind as StoredVaultGrant["subjectKind"],
+    recordKey: grant.recordKey,
+    capletId: recordCapletId ?? (grant.capletId as string),
+    vaultKey: grant.vaultKey,
+    referenceName: grant.referenceName,
+    originKind: grant.originKind as ConfigSourceKind,
+    originPath: grant.originPath,
+    createdAt: grant.createdAt,
+    createdBy: grant.createdBy,
+  };
+}
+
+function normalizeGrantInput(input: VaultGrantInput): NormalizedGrantInput {
+  validateCapletId(input.capletId);
+  validateOrigin(input.originKind, input.originPath);
+  return {
+    ...input,
+    vaultKey: validateGrantName(input.vaultKey),
+    referenceName: validateGrantName(input.referenceName ?? input.vaultKey),
+  };
+}
+
+function normalizeRevokeInput(input: VaultGrantRevokeInput): NormalizedRevokeInput {
+  validateCapletId(input.capletId);
+  if (input.originKind !== undefined) validateOrigin(input.originKind, input.originPath);
+  return {
+    ...input,
+    vaultKey: validateGrantName(input.vaultKey),
+    referenceName: validateGrantName(input.referenceName ?? input.vaultKey),
+  };
+}
+
+function validateCapletId(capletId: string): void {
+  if (!capletId.trim()) {
+    throw new CapletsError("REQUEST_INVALID", "Vault grant Caplet ID is required.");
+  }
+}
+
+function validateGrantName(name: string): string {
+  if (!name.trim()) {
+    throw new CapletsError("REQUEST_INVALID", "Vault grant names are required.");
+  }
+  return name;
+}
+
+function validateOrigin(originKind: ConfigSourceKind, originPath: string | undefined): void {
+  if (!(originKind in CONFIG_SOURCE_KINDS)) {
+    throw new CapletsError("REQUEST_INVALID", "Vault grant config origin kind is invalid.");
+  }
+  if (originKind !== "stored-record" && !originPath) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "Vault grants for filesystem Caplets require an exact config origin path.",
+    );
+  }
+}
+
+function fileSubjectKey(
+  capletId: string,
+  originKind: Exclude<ConfigSourceKind, "stored-record">,
+  originPath: string,
+): string {
+  return JSON.stringify([capletId, originKind, originPath]);
+}
+
+function activity(
+  operatorClientId: string,
+  action: string,
+  subject: VaultGrantSubject,
+  vaultKey: string,
+  referenceName: string,
+  createdAt: string,
+) {
+  const subjectFingerprint = createHash("sha256").update(subject.key).digest("hex").slice(0, 24);
+  return {
+    activityKey: randomUUID(),
+    operatorClientId,
+    action,
+    targetKind: "vault_grant",
+    targetKey: `${subject.kind}:${subjectFingerprint}:${vaultKey}`,
+    outcome: "succeeded",
+    metadata: { subjectKind: subject.kind, vaultKey, referenceName },
+    createdAt,
+  };
+}

--- a/packages/core/src/storage/vault-grants.ts
+++ b/packages/core/src/storage/vault-grants.ts
@@ -5,7 +5,12 @@ import { CapletsError } from "../errors";
 import { requireOperator, type OperatorPrincipal } from "./installations";
 import * as postgres from "./schema/postgres";
 import * as sqlite from "./schema/sqlite";
-import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+import type {
+  HostDatabase,
+  HostDatabaseTransaction,
+  PostgresHostDatabase,
+  SqliteHostDatabase,
+} from "./types";
 
 export type StoredVaultGrant = {
   subjectKind: "record" | "file";
@@ -116,36 +121,28 @@ export class VaultGrantStore {
     const validated = validateLegacyRecordGrantImports(grants);
     if (validated.length === 0) return;
     if (this.database.dialect === "sqlite") {
-      this.database.db.transaction((transaction) => {
-        const rows = assertLegacyRecordGrantsMatchSqlite(transaction, validated, operatorId);
-        const pending = rows.filter((row) => row.existing === undefined);
-        if (pending.length > 0) {
-          transaction
-            .insert(sqlite.vaultAccessGrants)
-            .values(pending.map((row) => row.values))
-            .run();
-        }
-      });
+      this.database.db.transaction((transaction) =>
+        importLegacyRecordGrantsSqlite(transaction, validated, operatorId),
+      );
       return;
     }
-    await this.database.db.transaction(async (transaction) => {
-      for (const grant of validated) {
-        await transaction.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify([
-            "vault-legacy-grant",
-            grant.capletId,
-            grant.referenceName,
-          ])}, 0))`,
-        );
-      }
-      const rows = await assertLegacyRecordGrantsMatchPostgres(transaction, validated, operatorId);
-      const pending = rows.filter((row) => row.existing === undefined);
-      if (pending.length > 0) {
-        await transaction
-          .insert(postgres.vaultAccessGrants)
-          .values(pending.map((row) => row.values));
-      }
-    });
+    await this.database.db.transaction(
+      async (transaction) =>
+        await importLegacyRecordGrantsPostgres(transaction, validated, operatorId),
+    );
+  }
+
+  importLegacyRecordGrantsInTransaction(
+    grants: LegacyRecordVaultGrantImport[],
+    operator: OperatorPrincipal,
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    const operatorId = requireOperator(operator);
+    const validated = validateLegacyRecordGrantImports(grants);
+    if (validated.length === 0) return;
+    return transaction.dialect === "sqlite"
+      ? importLegacyRecordGrantsSqlite(transaction.db, validated, operatorId)
+      : importLegacyRecordGrantsPostgres(transaction.db, validated, operatorId);
   }
 
   async verifyLegacyRecordGrants(
@@ -173,6 +170,17 @@ export class VaultGrantStore {
         );
       }
     }
+  }
+  verifyLegacyRecordGrantsInTransaction(
+    grants: LegacyRecordVaultGrantImport[],
+    operator: OperatorPrincipal,
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    const operatorId = requireOperator(operator);
+    const validated = validateLegacyRecordGrantImports(grants);
+    return transaction.dialect === "sqlite"
+      ? verifyLegacyRecordGrantsSqlite(transaction.db, validated, operatorId)
+      : verifyLegacyRecordGrantsPostgres(transaction.db, validated, operatorId);
   }
 
   async list(capletId?: string): Promise<StoredVaultGrant[]> {
@@ -231,6 +239,63 @@ type SqliteVaultGrantDatabase =
 type PostgresVaultGrantDatabase =
   | PostgresHostDatabase
   | Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0];
+function importLegacyRecordGrantsSqlite(
+  database: SqliteVaultGrantDatabase,
+  grants: LegacyRecordVaultGrantImport[],
+  operatorId: string,
+): void {
+  const rows = assertLegacyRecordGrantsMatchSqlite(database, grants, operatorId);
+  const pending = rows.filter((row) => row.existing === undefined);
+  if (pending.length > 0) {
+    database
+      .insert(sqlite.vaultAccessGrants)
+      .values(pending.map((row) => row.values))
+      .run();
+  }
+}
+
+async function importLegacyRecordGrantsPostgres(
+  database: PostgresVaultGrantDatabase,
+  grants: LegacyRecordVaultGrantImport[],
+  operatorId: string,
+): Promise<void> {
+  for (const grant of grants) {
+    await database.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify([
+        "vault-legacy-grant",
+        grant.capletId,
+        grant.referenceName,
+      ])}, 0))`,
+    );
+  }
+  const rows = await assertLegacyRecordGrantsMatchPostgres(database, grants, operatorId);
+  const pending = rows.filter((row) => row.existing === undefined);
+  if (pending.length > 0) {
+    await database.insert(postgres.vaultAccessGrants).values(pending.map((row) => row.values));
+  }
+}
+
+function verifyLegacyRecordGrantsSqlite(
+  database: SqliteVaultGrantDatabase,
+  grants: LegacyRecordVaultGrantImport[],
+  operatorId: string,
+): void {
+  const rows = assertLegacyRecordGrantsMatchSqlite(database, grants, operatorId);
+  if (rows.some((row) => row.existing === undefined)) {
+    throw new CapletsError("INTERNAL_ERROR", "A Vault grant failed post-migration verification.");
+  }
+}
+
+async function verifyLegacyRecordGrantsPostgres(
+  database: PostgresVaultGrantDatabase,
+  grants: LegacyRecordVaultGrantImport[],
+  operatorId: string,
+): Promise<void> {
+  const rows = await assertLegacyRecordGrantsMatchPostgres(database, grants, operatorId);
+  if (rows.some((row) => row.existing === undefined)) {
+    throw new CapletsError("INTERNAL_ERROR", "A Vault grant failed post-migration verification.");
+  }
+}
 
 function validateLegacyRecordGrantImports(
   grants: LegacyRecordVaultGrantImport[],

--- a/packages/core/src/storage/vault-resolver.ts
+++ b/packages/core/src/storage/vault-resolver.ts
@@ -1,0 +1,52 @@
+import type { ConfigVaultResolver } from "../config";
+import type { HostStorage } from "./database";
+
+export async function createHostStorageVaultResolver(
+  storage: HostStorage,
+): Promise<ConfigVaultResolver> {
+  const grants = await storage.vaultGrants.list();
+  const grantedKeys = new Set(grants.map((grant) => grant.vaultKey));
+  const presentKeys = new Set((await storage.vaultValues.listValues()).map((value) => value.key));
+  const values = new Map<string, string>();
+  const unavailable = new Set<string>();
+  for (const storedKey of grantedKeys) {
+    if (!presentKeys.has(storedKey)) continue;
+    try {
+      values.set(storedKey, await storage.vaultValues.resolveValue(storedKey));
+    } catch {
+      unavailable.add(storedKey);
+    }
+  }
+
+  return (reference) => {
+    const grant = grants.find((candidate) => {
+      if (
+        candidate.capletId !== reference.capletId ||
+        candidate.referenceName !== reference.referenceName
+      ) {
+        return false;
+      }
+      return candidate.subjectKind === "record"
+        ? reference.origin.kind === "stored-record"
+        : candidate.originKind === reference.origin.kind &&
+            candidate.originPath === reference.origin.path;
+    });
+    if (!grant) {
+      return {
+        reason: "ungranted",
+        referenceName: reference.referenceName,
+        capletId: reference.capletId,
+        origin: reference.origin,
+      };
+    }
+    const value = values.get(grant.vaultKey);
+    if (value !== undefined) return { storedKey: grant.vaultKey, value };
+    return {
+      reason: unavailable.has(grant.vaultKey) ? "invalid-key-source" : "missing",
+      storedKey: grant.vaultKey,
+      referenceName: reference.referenceName,
+      capletId: reference.capletId,
+      origin: reference.origin,
+    };
+  };
+}

--- a/packages/core/src/storage/vault-values.ts
+++ b/packages/core/src/storage/vault-values.ts
@@ -1,0 +1,690 @@
+import { Buffer } from "node:buffer";
+import { createHash, randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { asc, eq, sql } from "drizzle-orm";
+import { defaultStateBaseDir } from "../config/paths";
+import { CapletsError } from "../errors";
+import {
+  decryptVaultValue,
+  encryptVaultValue,
+  parseEncryptedRecord,
+  type VaultEncryptedRecord,
+} from "../vault/crypto";
+import type { LegacyVaultValueMigrationRecord } from "../vault";
+import {
+  ensureVaultKey,
+  loadVaultKey,
+  validateVaultKeyName,
+  vaultKeySourceStatus,
+} from "../vault/keys";
+import { VAULT_MAX_VALUE_BYTES, type VaultKeySourceStatus } from "../vault/types";
+import * as postgres from "./schema/postgres";
+import * as sqlite from "./schema/sqlite";
+import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+
+export const VAULT_VALUES_NAMESPACE = "vault-values";
+
+export type VaultValueRecordStatus =
+  | {
+      key: string;
+      present: false;
+    }
+  | {
+      key: string;
+      present: true;
+      generation: number;
+      valueBytes: number;
+      createdAt: string;
+      updatedAt: string;
+    };
+
+export type VaultValueSetOptions = {
+  force?: boolean | undefined;
+  expectedGeneration?: number | undefined;
+  operatorClientId?: string | undefined;
+  now?: Date | undefined;
+};
+
+export type VaultValueDeleteOptions = {
+  expectedGeneration?: number | undefined;
+  operatorClientId?: string | undefined;
+};
+
+export type VaultValueDeleteResult =
+  | {
+      key: string;
+      deleted: false;
+    }
+  | {
+      key: string;
+      deleted: true;
+      generation: number;
+    };
+
+export type VaultValueStoreOptions = {
+  root?: string | undefined;
+  keyFile?: string | undefined;
+  env?: Record<string, string | undefined> | undefined;
+};
+
+export interface VaultValueRepository {
+  set(
+    key: string,
+    value: string,
+    options?: VaultValueSetOptions,
+  ): Promise<Extract<VaultValueRecordStatus, { present: true }>>;
+  getStatus(key: string): Promise<VaultValueRecordStatus>;
+  listValues(): Promise<Array<Extract<VaultValueRecordStatus, { present: true }>>>;
+  resolveValue(key: string): Promise<string>;
+  delete(key: string, options?: VaultValueDeleteOptions): Promise<VaultValueDeleteResult>;
+  keySourceStatus(): Promise<VaultKeySourceStatus>;
+  assertLegacyValuesImportable(values: LegacyVaultValueMigrationRecord[]): Promise<void>;
+  importLegacyValues(values: LegacyVaultValueMigrationRecord[]): Promise<void>;
+  verifyLegacyValues(values: LegacyVaultValueMigrationRecord[]): Promise<void>;
+}
+
+type VaultValueRow = typeof sqlite.vaultValues.$inferSelect;
+type PresentVaultValueStatus = Extract<VaultValueRecordStatus, { present: true }>;
+
+export class VaultValueStore implements VaultValueRepository {
+  readonly root: string;
+  readonly keyFile: string;
+  readonly env: Record<string, string | undefined>;
+
+  constructor(
+    private readonly database: HostDatabase,
+    options: VaultValueStoreOptions = {},
+  ) {
+    this.root = options.root ?? join(defaultStateBaseDir(options.env), "caplets", "vault");
+    this.keyFile = options.keyFile ?? join(this.root, "vault-key");
+    this.env = options.env ?? process.env;
+  }
+
+  async set(
+    key: string,
+    value: string,
+    options: VaultValueSetOptions = {},
+  ): Promise<PresentVaultValueStatus> {
+    const normalizedKey = validateVaultKeyName(key);
+    validateValue(value);
+    validateSetOptions(options);
+    const encryptionKey = () => ensureVaultKey({ keyFile: this.keyFile, env: this.env });
+
+    return this.database.dialect === "sqlite"
+      ? setSqlite(this.database.db, normalizedKey, value, options, encryptionKey)
+      : await setPostgres(this.database.db, normalizedKey, value, options, encryptionKey);
+  }
+
+  async getStatus(key: string): Promise<VaultValueRecordStatus> {
+    const normalizedKey = validateVaultKeyName(key);
+    const row =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select()
+            .from(sqlite.vaultValues)
+            .where(eq(sqlite.vaultValues.vaultKey, normalizedKey))
+            .get()
+        : (
+            await this.database.db
+              .select()
+              .from(postgres.vaultValues)
+              .where(eq(postgres.vaultValues.vaultKey, normalizedKey))
+              .limit(1)
+          )[0];
+    return row ? statusForRow(row, normalizedKey) : { key: normalizedKey, present: false };
+  }
+
+  async listValues(): Promise<PresentVaultValueStatus[]> {
+    const rows =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select()
+            .from(sqlite.vaultValues)
+            .orderBy(asc(sqlite.vaultValues.vaultKey))
+            .all()
+        : await this.database.db
+            .select()
+            .from(postgres.vaultValues)
+            .orderBy(asc(postgres.vaultValues.vaultKey));
+    return rows.map((row) => statusForRow(row, row.vaultKey));
+  }
+
+  async resolveValue(key: string): Promise<string> {
+    const normalizedKey = validateVaultKeyName(key);
+    const row =
+      this.database.dialect === "sqlite"
+        ? this.database.db
+            .select()
+            .from(sqlite.vaultValues)
+            .where(eq(sqlite.vaultValues.vaultKey, normalizedKey))
+            .get()
+        : (
+            await this.database.db
+              .select()
+              .from(postgres.vaultValues)
+              .where(eq(postgres.vaultValues.vaultKey, normalizedKey))
+              .limit(1)
+          )[0];
+    if (!row) {
+      throw new CapletsError("CONFIG_INVALID", `Vault key ${normalizedKey} is missing.`);
+    }
+    return decryptVaultValue(
+      encryptedRecordForRow(row, normalizedKey),
+      loadVaultKey({ keyFile: this.keyFile, env: this.env }),
+    );
+  }
+
+  async assertLegacyValuesImportable(values: LegacyVaultValueMigrationRecord[]): Promise<void> {
+    const validated = validateLegacyValueImports(values);
+    if (this.database.dialect === "sqlite") {
+      assertLegacyValuesMatchSqlite(this.database.db, validated, () =>
+        loadVaultKey({ keyFile: this.keyFile, env: this.env }),
+      );
+    } else {
+      await assertLegacyValuesMatchPostgres(this.database.db, validated, () =>
+        loadVaultKey({ keyFile: this.keyFile, env: this.env }),
+      );
+    }
+  }
+
+  async importLegacyValues(values: LegacyVaultValueMigrationRecord[]): Promise<void> {
+    const validated = validateLegacyValueImports(values);
+    if (validated.length === 0) return;
+    if (this.database.dialect === "sqlite") {
+      this.database.db.transaction((transaction) => {
+        assertLegacyValuesMatchSqlite(transaction, validated, () =>
+          loadVaultKey({ keyFile: this.keyFile, env: this.env }),
+        );
+        const pending = validated.filter(
+          (value) =>
+            !transaction
+              .select({ key: sqlite.vaultValues.vaultKey })
+              .from(sqlite.vaultValues)
+              .where(eq(sqlite.vaultValues.vaultKey, value.key))
+              .get(),
+        );
+        if (pending.length === 0) return;
+        const key = ensureVaultKey({ keyFile: this.keyFile, env: this.env });
+        transaction
+          .insert(sqlite.vaultValues)
+          .values(pending.map((value) => legacyValueRow(value, key)))
+          .run();
+      });
+      return;
+    }
+    await this.database.db.transaction(async (transaction) => {
+      for (const value of validated) {
+        await transaction.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify([
+            VAULT_VALUES_NAMESPACE,
+            value.key,
+          ])}, 0))`,
+        );
+      }
+      await assertLegacyValuesMatchPostgres(transaction, validated, () =>
+        loadVaultKey({ keyFile: this.keyFile, env: this.env }),
+      );
+      const existing = await transaction
+        .select({ key: postgres.vaultValues.vaultKey })
+        .from(postgres.vaultValues);
+      const existingKeys = new Set(existing.map((row) => row.key));
+      const pending = validated.filter((value) => !existingKeys.has(value.key));
+      if (pending.length === 0) return;
+      const key = ensureVaultKey({ keyFile: this.keyFile, env: this.env });
+      await transaction
+        .insert(postgres.vaultValues)
+        .values(pending.map((value) => legacyValueRow(value, key)));
+    });
+  }
+
+  async verifyLegacyValues(values: LegacyVaultValueMigrationRecord[]): Promise<void> {
+    for (const value of validateLegacyValueImports(values)) {
+      const status = await this.getStatus(value.key);
+      if (
+        !status.present ||
+        status.valueBytes !== value.valueBytes ||
+        status.createdAt !== value.createdAt ||
+        status.updatedAt !== value.updatedAt ||
+        createHash("sha256")
+          .update(await this.resolveValue(value.key), "utf8")
+          .digest("base64url") !==
+          createHash("sha256").update(value.plaintext, "utf8").digest("base64url")
+      ) {
+        throw new CapletsError(
+          "INTERNAL_ERROR",
+          `Vault key ${value.key} failed post-migration verification.`,
+        );
+      }
+    }
+  }
+
+  async delete(
+    key: string,
+    options: VaultValueDeleteOptions = {},
+  ): Promise<VaultValueDeleteResult> {
+    const normalizedKey = validateVaultKeyName(key);
+    validateDeleteOptions(options);
+    return this.database.dialect === "sqlite"
+      ? deleteSqlite(this.database.db, normalizedKey, options)
+      : await deletePostgres(this.database.db, normalizedKey, options);
+  }
+
+  async keySourceStatus(): Promise<VaultKeySourceStatus> {
+    return vaultKeySourceStatus({ keyFile: this.keyFile, env: this.env });
+  }
+}
+
+type SqliteVaultValueDatabase =
+  | SqliteHostDatabase
+  | Parameters<Parameters<SqliteHostDatabase["transaction"]>[0]>[0];
+type PostgresVaultValueDatabase =
+  | PostgresHostDatabase
+  | Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0];
+
+function validateLegacyValueImports(
+  values: LegacyVaultValueMigrationRecord[],
+): LegacyVaultValueMigrationRecord[] {
+  const keys = new Set<string>();
+  const validated = values.map((value) => {
+    const key = validateVaultKeyName(value.key);
+    validateValue(value.plaintext);
+    if (
+      key !== value.key ||
+      keys.has(key) ||
+      value.valueBytes !== Buffer.byteLength(value.plaintext, "utf8") ||
+      !isCanonicalTimestamp(value.createdAt) ||
+      !isCanonicalTimestamp(value.updatedAt) ||
+      value.updatedAt < value.createdAt
+    ) {
+      throw new CapletsError("CONFIG_INVALID", "A legacy Vault value record is malformed.");
+    }
+    keys.add(key);
+    return value;
+  });
+  return validated.sort((left, right) => left.key.localeCompare(right.key));
+}
+
+function assertLegacyValuesMatchSqlite(
+  database: SqliteVaultValueDatabase,
+  values: LegacyVaultValueMigrationRecord[],
+  encryptionKey: () => Buffer,
+): void {
+  for (const value of values) {
+    const row = database
+      .select()
+      .from(sqlite.vaultValues)
+      .where(eq(sqlite.vaultValues.vaultKey, value.key))
+      .get();
+    if (row && !legacyValueMatches(row, value, encryptionKey())) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        `Vault key ${value.key} conflicts with the legacy snapshot.`,
+      );
+    }
+  }
+}
+
+async function assertLegacyValuesMatchPostgres(
+  database: PostgresVaultValueDatabase,
+  values: LegacyVaultValueMigrationRecord[],
+  encryptionKey: () => Buffer,
+): Promise<void> {
+  for (const value of values) {
+    const [row] = await database
+      .select()
+      .from(postgres.vaultValues)
+      .where(eq(postgres.vaultValues.vaultKey, value.key))
+      .limit(1);
+    if (row && !legacyValueMatches(row, value, encryptionKey())) {
+      throw new CapletsError(
+        "CONFIG_EXISTS",
+        `Vault key ${value.key} conflicts with the legacy snapshot.`,
+      );
+    }
+  }
+}
+
+function legacyValueMatches(
+  row: VaultValueRow,
+  value: LegacyVaultValueMigrationRecord,
+  encryptionKey: Buffer,
+): boolean {
+  const encrypted = encryptedRecordForRow(row, value.key);
+  return (
+    encrypted.valueBytes === value.valueBytes &&
+    encrypted.createdAt === value.createdAt &&
+    encrypted.updatedAt === value.updatedAt &&
+    createHash("sha256")
+      .update(decryptVaultValue(encrypted, encryptionKey), "utf8")
+      .digest("base64url") ===
+      createHash("sha256").update(value.plaintext, "utf8").digest("base64url")
+  );
+}
+
+function legacyValueRow(value: LegacyVaultValueMigrationRecord, key: Buffer) {
+  const encrypted = parseVaultValueRecord({
+    ...encryptVaultValue({ plaintext: value.plaintext, key, now: new Date(value.updatedAt) }),
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+  });
+  return rowValues(value.key, 1, encrypted);
+}
+
+function setSqlite(
+  db: SqliteHostDatabase,
+  key: string,
+  value: string,
+  options: VaultValueSetOptions,
+  encryptionKey: () => Buffer,
+): PresentVaultValueStatus {
+  return db.transaction((transaction) => {
+    const current = transaction
+      .select()
+      .from(sqlite.vaultValues)
+      .where(eq(sqlite.vaultValues.vaultKey, key))
+      .get();
+    const existing = current ? encryptedRecordForRow(current, key) : undefined;
+    if (existing && !options.force) {
+      throw new CapletsError("CONFIG_EXISTS", `Vault key ${key} already exists.`);
+    }
+    assertExpectedGeneration(current?.generation, options.expectedGeneration);
+    const encrypted = encryptVaultValue({
+      plaintext: value,
+      key: encryptionKey(),
+      now: options.now ?? new Date(),
+      ...(existing ? { existing } : {}),
+    });
+    const generation = (current?.generation ?? 0) + 1;
+    transaction
+      .insert(sqlite.vaultValues)
+      .values(rowValues(key, generation, encrypted))
+      .onConflictDoUpdate({
+        target: sqlite.vaultValues.vaultKey,
+        set: rowValues(key, generation, encrypted),
+      })
+      .run();
+    if (options.operatorClientId) {
+      transaction
+        .insert(sqlite.operatorActivity)
+        .values(activity(options.operatorClientId, "vault_value_written", key, generation))
+        .run();
+    }
+    return statusForEncryptedRecord(key, generation, encrypted);
+  });
+}
+
+async function setPostgres(
+  db: PostgresHostDatabase,
+  key: string,
+  value: string,
+  options: VaultValueSetOptions,
+  encryptionKey: () => Buffer,
+): Promise<PresentVaultValueStatus> {
+  return await db.transaction(async (transaction) => {
+    await transaction.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify(["vault-value", key])}, 0))`,
+    );
+    const [current] = await transaction
+      .select()
+      .from(postgres.vaultValues)
+      .where(eq(postgres.vaultValues.vaultKey, key))
+      .for("update")
+      .limit(1);
+    const existing = current ? encryptedRecordForRow(current, key) : undefined;
+    if (existing && !options.force) {
+      throw new CapletsError("CONFIG_EXISTS", `Vault key ${key} already exists.`);
+    }
+    assertExpectedGeneration(current?.generation, options.expectedGeneration);
+    const encrypted = encryptVaultValue({
+      plaintext: value,
+      key: encryptionKey(),
+      now: options.now ?? new Date(),
+      ...(existing ? { existing } : {}),
+    });
+    const generation = (current?.generation ?? 0) + 1;
+    await transaction
+      .insert(postgres.vaultValues)
+      .values(rowValues(key, generation, encrypted))
+      .onConflictDoUpdate({
+        target: postgres.vaultValues.vaultKey,
+        set: rowValues(key, generation, encrypted),
+      });
+    if (options.operatorClientId) {
+      await transaction
+        .insert(postgres.operatorActivity)
+        .values(activity(options.operatorClientId, "vault_value_written", key, generation));
+    }
+    return statusForEncryptedRecord(key, generation, encrypted);
+  });
+}
+
+function deleteSqlite(
+  db: SqliteHostDatabase,
+  key: string,
+  options: VaultValueDeleteOptions,
+): VaultValueDeleteResult {
+  return db.transaction((transaction) => {
+    const current = transaction
+      .select()
+      .from(sqlite.vaultValues)
+      .where(eq(sqlite.vaultValues.vaultKey, key))
+      .get();
+    if (!current) {
+      assertExpectedGeneration(undefined, options.expectedGeneration);
+      return { key, deleted: false };
+    }
+    encryptedRecordForRow(current, key);
+    assertExpectedGeneration(current.generation, options.expectedGeneration);
+    transaction.delete(sqlite.vaultValues).where(eq(sqlite.vaultValues.vaultKey, key)).run();
+    if (options.operatorClientId) {
+      transaction
+        .insert(sqlite.operatorActivity)
+        .values(activity(options.operatorClientId, "vault_value_deleted", key, current.generation))
+        .run();
+    }
+    return { key, deleted: true, generation: current.generation };
+  });
+}
+
+async function deletePostgres(
+  db: PostgresHostDatabase,
+  key: string,
+  options: VaultValueDeleteOptions,
+): Promise<VaultValueDeleteResult> {
+  return await db.transaction(async (transaction) => {
+    await transaction.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify(["vault-value", key])}, 0))`,
+    );
+    const [current] = await transaction
+      .select()
+      .from(postgres.vaultValues)
+      .where(eq(postgres.vaultValues.vaultKey, key))
+      .for("update")
+      .limit(1);
+    if (!current) {
+      assertExpectedGeneration(undefined, options.expectedGeneration);
+      return { key, deleted: false };
+    }
+    encryptedRecordForRow(current, key);
+    assertExpectedGeneration(current.generation, options.expectedGeneration);
+    await transaction.delete(postgres.vaultValues).where(eq(postgres.vaultValues.vaultKey, key));
+    if (options.operatorClientId) {
+      await transaction
+        .insert(postgres.operatorActivity)
+        .values(activity(options.operatorClientId, "vault_value_deleted", key, current.generation));
+    }
+    return { key, deleted: true, generation: current.generation };
+  });
+}
+
+export function parseVaultValueRecord(value: unknown): VaultEncryptedRecord {
+  const parsed = parseEncryptedRecord(value);
+  const actualFields = Object.keys(value as Record<string, unknown>).sort();
+  const expectedFields = [
+    "algorithm",
+    "authTag",
+    "ciphertext",
+    "createdAt",
+    "nonce",
+    "updatedAt",
+    "valueBytes",
+    "version",
+  ];
+  if (
+    actualFields.length !== expectedFields.length ||
+    actualFields.some((field, index) => field !== expectedFields[index]) ||
+    !Number.isSafeInteger(parsed.valueBytes) ||
+    parsed.valueBytes < 0 ||
+    parsed.valueBytes > VAULT_MAX_VALUE_BYTES ||
+    !isCanonicalBase64Url(parsed.nonce, 12) ||
+    !isCanonicalBase64Url(parsed.authTag, 16) ||
+    !isCanonicalBase64Url(parsed.ciphertext, parsed.valueBytes) ||
+    !isCanonicalTimestamp(parsed.createdAt) ||
+    !isCanonicalTimestamp(parsed.updatedAt) ||
+    parsed.updatedAt < parsed.createdAt
+  ) {
+    throw new CapletsError("CONFIG_INVALID", "Persisted Vault value record is malformed.");
+  }
+  return parsed;
+}
+
+function encryptedRecordForRow(row: VaultValueRow, expectedKey: string): VaultEncryptedRecord {
+  if (row.vaultKey !== expectedKey || !Number.isSafeInteger(row.generation) || row.generation < 1) {
+    throw new CapletsError("CONFIG_INVALID", "Persisted Vault value row is malformed.");
+  }
+  return parseVaultValueRecord({
+    version: row.version,
+    algorithm: row.algorithm,
+    nonce: row.nonce,
+    ciphertext: row.ciphertext,
+    authTag: row.authTag,
+    valueBytes: row.valueBytes,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  });
+}
+
+function statusForRow(row: VaultValueRow, expectedKey: string): PresentVaultValueStatus {
+  return statusForEncryptedRecord(
+    expectedKey,
+    row.generation,
+    encryptedRecordForRow(row, expectedKey),
+  );
+}
+
+function statusForEncryptedRecord(
+  key: string,
+  generation: number,
+  record: VaultEncryptedRecord,
+): PresentVaultValueStatus {
+  return {
+    key,
+    present: true,
+    generation,
+    valueBytes: record.valueBytes,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+function rowValues(key: string, generation: number, record: VaultEncryptedRecord) {
+  return {
+    vaultKey: key,
+    generation,
+    version: record.version,
+    algorithm: record.algorithm,
+    nonce: record.nonce,
+    ciphertext: record.ciphertext,
+    authTag: record.authTag,
+    valueBytes: record.valueBytes,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+function activity(
+  operatorClientId: string,
+  action: "vault_value_written" | "vault_value_deleted",
+  key: string,
+  generation: number,
+) {
+  return {
+    activityKey: randomUUID(),
+    operatorClientId,
+    action,
+    targetKind: "vault_value",
+    targetKey: key,
+    outcome: "succeeded",
+    metadata: { generation },
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function validateValue(value: string): void {
+  if (typeof value !== "string") {
+    throw new CapletsError("REQUEST_INVALID", "Vault values must be strings.");
+  }
+  if (Buffer.byteLength(value, "utf8") > VAULT_MAX_VALUE_BYTES) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      `Vault values must be ${VAULT_MAX_VALUE_BYTES} bytes or smaller.`,
+    );
+  }
+}
+
+function validateSetOptions(options: VaultValueSetOptions): void {
+  validateDeleteOptions(options);
+  if (options.force !== undefined && typeof options.force !== "boolean") {
+    throw new CapletsError("REQUEST_INVALID", "Vault force must be a boolean when provided.");
+  }
+  if (
+    options.now !== undefined &&
+    (!(options.now instanceof Date) || !Number.isFinite(options.now.getTime()))
+  ) {
+    throw new CapletsError("REQUEST_INVALID", "Vault mutation time must be a valid date.");
+  }
+}
+
+function validateDeleteOptions(options: VaultValueDeleteOptions): void {
+  if (
+    options.expectedGeneration !== undefined &&
+    (!Number.isSafeInteger(options.expectedGeneration) || options.expectedGeneration < 0)
+  ) {
+    throw new CapletsError(
+      "REQUEST_INVALID",
+      "Vault expected generation must be a non-negative integer.",
+    );
+  }
+  if (options.operatorClientId !== undefined && !options.operatorClientId.trim()) {
+    throw new CapletsError("REQUEST_INVALID", "Operator client ID is required when provided.");
+  }
+}
+
+function assertExpectedGeneration(
+  currentGeneration: number | undefined,
+  expectedGeneration: number | undefined,
+): void {
+  if (expectedGeneration === undefined) return;
+  const normalizedCurrentGeneration = currentGeneration ?? 0;
+  if (normalizedCurrentGeneration === expectedGeneration) return;
+  throw new CapletsError(
+    "REQUEST_INVALID",
+    "Vault value changed after it was read; reload and retry.",
+    {
+      kind: "stale_generation",
+      expectedGeneration,
+      currentGeneration: normalizedCurrentGeneration,
+    },
+  );
+}
+
+function isCanonicalBase64Url(value: string, expectedBytes: number): boolean {
+  if (!/^[A-Za-z0-9_-]*$/.test(value)) return false;
+  const decoded = Buffer.from(value, "base64url");
+  return decoded.byteLength === expectedBytes && decoded.toString("base64url") === value;
+}
+
+function isCanonicalTimestamp(value: string): boolean {
+  const timestamp = new Date(value);
+  return Number.isFinite(timestamp.getTime()) && timestamp.toISOString() === value;
+}

--- a/packages/core/src/storage/vault-values.ts
+++ b/packages/core/src/storage/vault-values.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { createHash, randomUUID } from "node:crypto";
+import { createHash, createHmac, randomUUID } from "node:crypto";
 import { join } from "node:path";
 import { asc, eq, sql } from "drizzle-orm";
 import { defaultStateBaseDir } from "../config/paths";
@@ -20,7 +20,12 @@ import {
 import { VAULT_MAX_VALUE_BYTES, type VaultKeySourceStatus } from "../vault/types";
 import * as postgres from "./schema/postgres";
 import * as sqlite from "./schema/sqlite";
-import type { HostDatabase, PostgresHostDatabase, SqliteHostDatabase } from "./types";
+import type {
+  HostDatabase,
+  HostDatabaseTransaction,
+  PostgresHostDatabase,
+  SqliteHostDatabase,
+} from "./types";
 
 export const VAULT_VALUES_NAMESPACE = "vault-values";
 
@@ -98,6 +103,16 @@ export class VaultValueStore implements VaultValueRepository {
     this.root = options.root ?? join(defaultStateBaseDir(options.env), "caplets", "vault");
     this.keyFile = options.keyFile ?? join(this.root, "vault-key");
     this.env = options.env ?? process.env;
+  }
+
+  hostRuntimeFingerprint(hostConfigurationFingerprint: string): string {
+    const key = ensureVaultKey({ keyFile: this.keyFile, env: this.env });
+    const digest = createHmac("sha256", key)
+      .update("caplets-host-runtime-fingerprint-v1")
+      .update("\0")
+      .update(hostConfigurationFingerprint)
+      .digest("hex");
+    return `hmac-sha256:${digest}`;
   }
 
   async set(
@@ -191,50 +206,26 @@ export class VaultValueStore implements VaultValueRepository {
     const validated = validateLegacyValueImports(values);
     if (validated.length === 0) return;
     if (this.database.dialect === "sqlite") {
-      this.database.db.transaction((transaction) => {
-        assertLegacyValuesMatchSqlite(transaction, validated, () =>
-          loadVaultKey({ keyFile: this.keyFile, env: this.env }),
-        );
-        const pending = validated.filter(
-          (value) =>
-            !transaction
-              .select({ key: sqlite.vaultValues.vaultKey })
-              .from(sqlite.vaultValues)
-              .where(eq(sqlite.vaultValues.vaultKey, value.key))
-              .get(),
-        );
-        if (pending.length === 0) return;
-        const key = ensureVaultKey({ keyFile: this.keyFile, env: this.env });
-        transaction
-          .insert(sqlite.vaultValues)
-          .values(pending.map((value) => legacyValueRow(value, key)))
-          .run();
-      });
+      this.database.db.transaction((transaction) =>
+        importLegacyValuesSqlite(transaction, validated, this.keyFile, this.env),
+      );
       return;
     }
-    await this.database.db.transaction(async (transaction) => {
-      for (const value of validated) {
-        await transaction.execute(
-          sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify([
-            VAULT_VALUES_NAMESPACE,
-            value.key,
-          ])}, 0))`,
-        );
-      }
-      await assertLegacyValuesMatchPostgres(transaction, validated, () =>
-        loadVaultKey({ keyFile: this.keyFile, env: this.env }),
-      );
-      const existing = await transaction
-        .select({ key: postgres.vaultValues.vaultKey })
-        .from(postgres.vaultValues);
-      const existingKeys = new Set(existing.map((row) => row.key));
-      const pending = validated.filter((value) => !existingKeys.has(value.key));
-      if (pending.length === 0) return;
-      const key = ensureVaultKey({ keyFile: this.keyFile, env: this.env });
-      await transaction
-        .insert(postgres.vaultValues)
-        .values(pending.map((value) => legacyValueRow(value, key)));
-    });
+    await this.database.db.transaction(
+      async (transaction) =>
+        await importLegacyValuesPostgres(transaction, validated, this.keyFile, this.env),
+    );
+  }
+
+  importLegacyValuesInTransaction(
+    values: LegacyVaultValueMigrationRecord[],
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    const validated = validateLegacyValueImports(values);
+    if (validated.length === 0) return;
+    return transaction.dialect === "sqlite"
+      ? importLegacyValuesSqlite(transaction.db, validated, this.keyFile, this.env)
+      : importLegacyValuesPostgres(transaction.db, validated, this.keyFile, this.env);
   }
 
   async verifyLegacyValues(values: LegacyVaultValueMigrationRecord[]): Promise<void> {
@@ -256,6 +247,16 @@ export class VaultValueStore implements VaultValueRepository {
         );
       }
     }
+  }
+  verifyLegacyValuesInTransaction(
+    values: LegacyVaultValueMigrationRecord[],
+    transaction: HostDatabaseTransaction,
+  ): void | Promise<void> {
+    const validated = validateLegacyValueImports(values);
+    const encryptionKey = () => loadVaultKey({ keyFile: this.keyFile, env: this.env });
+    return transaction.dialect === "sqlite"
+      ? verifyLegacyValuesSqlite(transaction.db, validated, encryptionKey)
+      : verifyLegacyValuesPostgres(transaction.db, validated, encryptionKey);
   }
 
   async delete(
@@ -280,6 +281,93 @@ type SqliteVaultValueDatabase =
 type PostgresVaultValueDatabase =
   | PostgresHostDatabase
   | Parameters<Parameters<PostgresHostDatabase["transaction"]>[0]>[0];
+function importLegacyValuesSqlite(
+  database: SqliteVaultValueDatabase,
+  values: LegacyVaultValueMigrationRecord[],
+  keyFile: string,
+  env: Record<string, string | undefined>,
+): void {
+  assertLegacyValuesMatchSqlite(database, values, () => loadVaultKey({ keyFile, env }));
+  const pending = values.filter(
+    (value) =>
+      !database
+        .select({ key: sqlite.vaultValues.vaultKey })
+        .from(sqlite.vaultValues)
+        .where(eq(sqlite.vaultValues.vaultKey, value.key))
+        .get(),
+  );
+  if (pending.length === 0) return;
+  const key = ensureVaultKey({ keyFile, env });
+  database
+    .insert(sqlite.vaultValues)
+    .values(pending.map((value) => legacyValueRow(value, key)))
+    .run();
+}
+
+async function importLegacyValuesPostgres(
+  database: PostgresVaultValueDatabase,
+  values: LegacyVaultValueMigrationRecord[],
+  keyFile: string,
+  env: Record<string, string | undefined>,
+): Promise<void> {
+  for (const value of values) {
+    await database.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${JSON.stringify([
+        VAULT_VALUES_NAMESPACE,
+        value.key,
+      ])}, 0))`,
+    );
+  }
+  await assertLegacyValuesMatchPostgres(database, values, () => loadVaultKey({ keyFile, env }));
+  const existing = await database
+    .select({ key: postgres.vaultValues.vaultKey })
+    .from(postgres.vaultValues);
+  const existingKeys = new Set(existing.map((row) => row.key));
+  const pending = values.filter((value) => !existingKeys.has(value.key));
+  if (pending.length === 0) return;
+  const key = ensureVaultKey({ keyFile, env });
+  await database
+    .insert(postgres.vaultValues)
+    .values(pending.map((value) => legacyValueRow(value, key)));
+}
+
+function verifyLegacyValuesSqlite(
+  database: SqliteVaultValueDatabase,
+  values: LegacyVaultValueMigrationRecord[],
+  encryptionKey: () => Buffer,
+): void {
+  for (const value of values) {
+    const row = database
+      .select()
+      .from(sqlite.vaultValues)
+      .where(eq(sqlite.vaultValues.vaultKey, value.key))
+      .get();
+    if (!row || !legacyValueMatches(row, value, encryptionKey())) {
+      throw legacyValueVerificationError(value.key);
+    }
+  }
+}
+
+async function verifyLegacyValuesPostgres(
+  database: PostgresVaultValueDatabase,
+  values: LegacyVaultValueMigrationRecord[],
+  encryptionKey: () => Buffer,
+): Promise<void> {
+  for (const value of values) {
+    const [row] = await database
+      .select()
+      .from(postgres.vaultValues)
+      .where(eq(postgres.vaultValues.vaultKey, value.key))
+      .limit(1);
+    if (!row || !legacyValueMatches(row, value, encryptionKey())) {
+      throw legacyValueVerificationError(value.key);
+    }
+  }
+}
+
+function legacyValueVerificationError(key: string): CapletsError {
+  return new CapletsError("INTERNAL_ERROR", `Vault key ${key} failed post-migration verification.`);
+}
 
 function validateLegacyValueImports(
   values: LegacyVaultValueMigrationRecord[],

--- a/packages/core/src/vault/index.ts
+++ b/packages/core/src/vault/index.ts
@@ -47,6 +47,20 @@ type SetOptions = {
   now?: Date | undefined;
 };
 
+export type LegacyVaultValueMigrationRecord = {
+  key: string;
+  plaintext: string;
+  valueBytes: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type LegacyVaultMigrationSnapshot = {
+  values: LegacyVaultValueMigrationRecord[];
+  grants: VaultAccessGrant[];
+  sourcePaths: string[];
+};
+
 export class FileVaultStore {
   readonly root: string;
   readonly env: Record<string, string | undefined>;
@@ -196,6 +210,57 @@ export class FileVaultStore {
       };
     }
     return { storedKey: grant.storedKey, value: this.resolveValue(grant.storedKey) };
+  }
+
+  /**
+   * Decrypts a fully validated legacy snapshot for immediate re-encryption by
+   * the offline SQL migration. Callers must never serialize this result.
+   */
+  exportForMigration(): LegacyVaultMigrationSnapshot {
+    const statuses = this.listValues();
+    const keys = new Set<string>();
+    const values = statuses.map((status): LegacyVaultValueMigrationRecord => {
+      if (
+        keys.has(status.key) ||
+        !status.present ||
+        !Number.isSafeInteger(status.valueBytes) ||
+        (status.valueBytes as number) < 0 ||
+        typeof status.createdAt !== "string" ||
+        typeof status.updatedAt !== "string" ||
+        !Number.isFinite(Date.parse(status.createdAt)) ||
+        !Number.isFinite(Date.parse(status.updatedAt)) ||
+        status.updatedAt < status.createdAt
+      ) {
+        throw new CapletsError("CONFIG_INVALID", "A legacy Vault value record is malformed.");
+      }
+      keys.add(status.key);
+      const plaintext = this.resolveValue(status.key);
+      if (Buffer.byteLength(plaintext, "utf8") !== status.valueBytes) {
+        throw new CapletsError("CONFIG_INVALID", "A legacy Vault value record is malformed.");
+      }
+      return {
+        key: status.key,
+        plaintext,
+        valueBytes: status.valueBytes,
+        createdAt: status.createdAt,
+        updatedAt: status.updatedAt,
+      };
+    });
+    const grants = this.listAccess();
+    const grantKeys = new Set<string>();
+    for (const grant of grants) {
+      const identity = accessGrantIdentity(grant);
+      if (grantKeys.has(identity)) {
+        throw new CapletsError("CONFIG_INVALID", "Legacy Vault access grants contain duplicates.");
+      }
+      grantKeys.add(identity);
+    }
+    const sourcePaths = [
+      ...(values.length > 0 && existsSync(this.paths.keyFile) ? [this.paths.keyFile] : []),
+      ...(existsSync(this.paths.grantsFile) ? [this.paths.grantsFile] : []),
+      ...values.map((value) => this.valuePath(value.key)),
+    ].sort();
+    return { values, grants, sourcePaths };
   }
 
   private loadValueRecord(key: string): VaultEncryptedRecord | undefined {

--- a/packages/core/test/auth.test.ts
+++ b/packages/core/test/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockMcpAuth = vi.hoisted(() => vi.fn());
 
@@ -18,16 +18,35 @@ import {
   runOAuthFlow,
   runGenericOAuthFlow,
   startGenericOAuthFlow,
-  writeTokenBundle,
 } from "../src/auth";
 import { formatAuthRows, listAuth } from "../src/cli/auth";
 import { runCli } from "../src/cli";
 import { parseConfig } from "../src/config";
 import { DEFAULT_AUTH_DIR } from "../src/config/paths";
+import { createHostStorage, type HostStorage } from "../src/storage";
+import type { BackendAuthStateStore } from "../src/storage/backend-auth";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, parse } from "node:path";
+
+let authStorageDir: string;
+let hostStorage: HostStorage;
+let authStore: BackendAuthStateStore;
+
+beforeEach(async () => {
+  authStorageDir = mkdtempSync(join(tmpdir(), "caplets-auth-sql-"));
+  hostStorage = await createHostStorage({
+    type: "sqlite",
+    path: join(authStorageDir, "host.sqlite3"),
+  });
+  authStore = hostStorage.backendAuth;
+});
+
+afterEach(async () => {
+  await hostStorage.close();
+  rmSync(authStorageDir, { recursive: true, force: true });
+});
 
 describe("auth helpers", () => {
   it("extracts callback code and state together", () => {
@@ -71,7 +90,7 @@ describe("auth helpers", () => {
           tokenUrl: "https://auth.example.com/token",
         },
       },
-      { redirectUri: "http://127.0.0.1/callback" },
+      { redirectUri: "http://127.0.0.1/callback", authStore },
     );
 
     await expect(
@@ -97,7 +116,7 @@ describe("auth helpers", () => {
       },
     }).mcpServers.remote!;
 
-    await expect(oauthHeaders(server, "/tmp/does-not-exist")).rejects.toMatchObject({
+    await expect(oauthHeaders(server, authStore)).rejects.toMatchObject({
       code: "AUTH_REQUIRED",
     });
   });
@@ -116,9 +135,9 @@ describe("auth helpers", () => {
           },
         },
       }).mcpServers.remote!;
-      writeTokenBundle({ server: "remote", accessToken: "secret-token" }, dir);
+      await authStore.writeTokenBundle({ server: "remote", accessToken: "secret-token" });
 
-      await expect(oauthHeaders(server, dir)).resolves.toEqual({
+      await expect(oauthHeaders(server, authStore)).resolves.toEqual({
         authorization: "Bearer secret-token",
       });
     } finally {
@@ -170,18 +189,15 @@ describe("auth helpers", () => {
           },
         },
       });
-      writeTokenBundle(
-        {
-          server: "remote",
-          accessToken: "old-mcp-access-token",
-          refreshToken: "old-mcp-refresh-token",
-          tokenType: "Bearer",
-          expiresAt: "2000-01-01T00:00:00.000Z",
-        },
-        dir,
-      );
+      await authStore.writeTokenBundle({
+        server: "remote",
+        accessToken: "old-mcp-access-token",
+        refreshToken: "old-mcp-refresh-token",
+        tokenType: "Bearer",
+        expiresAt: "2000-01-01T00:00:00.000Z",
+      });
 
-      const headers = await oauthHeaders(config.mcpServers.remote!, dir);
+      const headers = await oauthHeaders(config.mcpServers.remote!, authStore);
 
       expect(headers).toEqual({ authorization: "Bearer new-mcp-access-token" });
       expect(requests).toHaveLength(1);
@@ -190,7 +206,7 @@ describe("auth helpers", () => {
       expect(new URLSearchParams(requests[0]?.body).get("refresh_token")).toBe(
         "old-mcp-refresh-token",
       );
-      expect(readTokenBundle("remote", dir)).toMatchObject({
+      expect((await authStore.readTokenBundle("remote"))?.bundle).toMatchObject({
         accessToken: "new-mcp-access-token",
         refreshToken: "new-mcp-refresh-token",
         clientId: "client",
@@ -246,19 +262,16 @@ describe("auth helpers", () => {
   it("builds generic OAuth headers for OpenAPI and GraphQL auth targets", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
     try {
-      writeTokenBundle(
-        {
-          server: "users",
-          accessToken: "secret-access-token",
-          authType: "oidc",
-          tokenType: "Bearer",
-          expiresAt: "2999-01-01T00:00:00.000Z",
-          idToken: "secret-id-token",
-          issuer: "https://issuer.example",
-          subject: "user-123",
-        },
-        dir,
-      );
+      await authStore.writeTokenBundle({
+        server: "users",
+        accessToken: "secret-access-token",
+        authType: "oidc",
+        tokenType: "Bearer",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        idToken: "secret-id-token",
+        issuer: "https://issuer.example",
+        subject: "user-123",
+      });
 
       expect(
         await genericOAuthHeaders(
@@ -267,7 +280,7 @@ describe("auth helpers", () => {
             backend: "openapi",
             auth: { type: "oidc" },
           },
-          dir,
+          authStore,
         ),
       ).toEqual({ authorization: "Bearer secret-access-token" });
     } finally {
@@ -305,20 +318,17 @@ describe("auth helpers", () => {
         throw new Error("test server did not bind");
       }
       const baseUrl = `http://127.0.0.1:${address.port}`;
-      writeTokenBundle(
-        {
-          server: "users",
-          authType: "oauth2",
-          accessToken: "old-access-token",
-          refreshToken: "old-refresh-token",
-          tokenType: "Bearer",
-          expiresAt: "2000-01-01T00:00:00.000Z",
-          scope: "api:read",
-          clientId: "client",
-          protectedResourceOrigin: baseUrl,
-        },
-        dir,
-      );
+      await authStore.writeTokenBundle({
+        server: "users",
+        authType: "oauth2",
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        tokenType: "Bearer",
+        expiresAt: "2000-01-01T00:00:00.000Z",
+        scope: "api:read",
+        clientId: "client",
+        protectedResourceOrigin: baseUrl,
+      });
 
       const headers = await genericOAuthHeaders(
         {
@@ -331,7 +341,7 @@ describe("auth helpers", () => {
             tokenUrl: `${baseUrl}/token`,
           },
         },
-        dir,
+        authStore,
       );
 
       expect(headers).toEqual({ authorization: "Bearer new-access-token" });
@@ -340,7 +350,7 @@ describe("auth helpers", () => {
       expect(new URLSearchParams(requests[0]?.body).get("grant_type")).toBe("refresh_token");
       expect(new URLSearchParams(requests[0]?.body).get("refresh_token")).toBe("old-refresh-token");
       expect(new URLSearchParams(requests[0]?.body).get("client_id")).toBe("client");
-      expect(readTokenBundle("users", dir)).toMatchObject({
+      expect((await authStore.readTokenBundle("users"))?.bundle).toMatchObject({
         accessToken: "new-access-token",
         refreshToken: "rotated-refresh-token",
         tokenType: "Bearer",
@@ -357,24 +367,21 @@ describe("auth helpers", () => {
   it("rejects token bundles whose granted scopes omit a required scope", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-scope-mismatch-"));
     try {
-      writeTokenBundle(
-        {
-          server: "drive",
-          authType: "oauth2",
-          accessToken: "access-token",
-          tokenType: "Bearer",
-          expiresAt: "2999-01-01T00:00:00.000Z",
-          scope: "https://www.googleapis.com/auth/drive.metadata.readonly",
-          protectedResourceOrigin: "https://www.googleapis.com",
-          metadata: {
-            requestedScopes: [
-              "https://www.googleapis.com/auth/drive",
-              "https://www.googleapis.com/auth/drive.metadata.readonly",
-            ],
-          },
+      await authStore.writeTokenBundle({
+        server: "drive",
+        authType: "oauth2",
+        accessToken: "access-token",
+        tokenType: "Bearer",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        scope: "https://www.googleapis.com/auth/drive.metadata.readonly",
+        protectedResourceOrigin: "https://www.googleapis.com",
+        metadata: {
+          requestedScopes: [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+          ],
         },
-        dir,
-      );
+      });
 
       await expect(
         genericOAuthHeaders(
@@ -387,7 +394,7 @@ describe("auth helpers", () => {
               scopes: ["https://www.googleapis.com/auth/drive"],
             },
           },
-          dir,
+          authStore,
         ),
       ).rejects.toMatchObject({
         code: "AUTH_REQUIRED",
@@ -401,21 +408,18 @@ describe("auth helpers", () => {
   it("accepts broader Google Discovery OAuth scope alternatives", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-google-scope-alternative-"));
     try {
-      writeTokenBundle(
-        {
-          server: "drive",
-          authType: "oauth2",
-          accessToken: "access-token",
-          tokenType: "Bearer",
-          expiresAt: "2999-01-01T00:00:00.000Z",
-          scope: "https://www.googleapis.com/auth/drive",
-          protectedResourceOrigin: "https://www.googleapis.com",
-          metadata: {
-            requestedScopes: ["https://www.googleapis.com/auth/drive"],
-          },
+      await authStore.writeTokenBundle({
+        server: "drive",
+        authType: "oauth2",
+        accessToken: "access-token",
+        tokenType: "Bearer",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        scope: "https://www.googleapis.com/auth/drive",
+        protectedResourceOrigin: "https://www.googleapis.com",
+        metadata: {
+          requestedScopes: ["https://www.googleapis.com/auth/drive"],
         },
-        dir,
-      );
+      });
 
       await expect(
         genericOAuthHeaders(
@@ -426,7 +430,7 @@ describe("auth helpers", () => {
             auth: { type: "oauth2" },
             resolvedScopes: ["https://www.googleapis.com/auth/drive.metadata.readonly"],
           },
-          dir,
+          authStore,
         ),
       ).resolves.toEqual({ authorization: "Bearer access-token" });
     } finally {
@@ -453,18 +457,15 @@ describe("auth helpers", () => {
         throw new Error("test server did not bind");
       }
       const baseUrl = `http://127.0.0.1:${address.port}`;
-      writeTokenBundle(
-        {
-          server: "users",
-          authType: "oauth2",
-          accessToken: "old-access-token",
-          refreshToken: "old-refresh-token",
-          expiresAt: "2000-01-01T00:00:00.000Z",
-          clientId: "client",
-          protectedResourceOrigin: baseUrl,
-        },
-        dir,
-      );
+      await authStore.writeTokenBundle({
+        server: "users",
+        authType: "oauth2",
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2000-01-01T00:00:00.000Z",
+        clientId: "client",
+        protectedResourceOrigin: baseUrl,
+      });
 
       await expect(
         genericOAuthHeaders(
@@ -478,7 +479,7 @@ describe("auth helpers", () => {
               tokenUrl: `${baseUrl}/token`,
             },
           },
-          dir,
+          authStore,
         ),
       ).rejects.toMatchObject({ code: "AUTH_REFRESH_FAILED" });
     } finally {
@@ -506,18 +507,15 @@ describe("auth helpers", () => {
       }
       const baseUrl = `http://127.0.0.1:${address.port}`;
       const expiresAt = "2999-01-01T00:00:00.000Z";
-      writeTokenBundle(
-        {
-          server: "users",
-          authType: "oauth2",
-          accessToken: "",
-          refreshToken: "old-refresh-token",
-          expiresAt,
-          clientId: "client",
-          protectedResourceOrigin: baseUrl,
-        },
-        dir,
-      );
+      await authStore.writeTokenBundle({
+        server: "users",
+        authType: "oauth2",
+        accessToken: "",
+        refreshToken: "old-refresh-token",
+        expiresAt,
+        clientId: "client",
+        protectedResourceOrigin: baseUrl,
+      });
 
       await expect(
         genericOAuthHeaders(
@@ -531,11 +529,11 @@ describe("auth helpers", () => {
               tokenUrl: `${baseUrl}/token`,
             },
           },
-          dir,
+          authStore,
         ),
       ).resolves.toEqual({ authorization: "Bearer new-access-token" });
 
-      expect(readTokenBundle("users", dir)).toMatchObject({
+      expect((await authStore.readTokenBundle("users"))?.bundle).toMatchObject({
         accessToken: "new-access-token",
         expiresAt,
       });
@@ -545,7 +543,7 @@ describe("auth helpers", () => {
     }
   });
 
-  it("includes HTTP APIs in OAuth auth target listing", () => {
+  it("includes HTTP APIs in OAuth auth target listing", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-config-"));
     try {
       const configPath = join(dir, "config.json");
@@ -565,7 +563,7 @@ describe("auth helpers", () => {
       );
       const output: string[] = [];
 
-      listAuth({ configPath, writeOut: (value) => output.push(value) });
+      await listAuth({ configPath, authStore, writeOut: (value) => output.push(value) });
 
       expect(output.join("")).toContain("status\n  Status: missing");
     } finally {
@@ -866,7 +864,7 @@ describe("auth helpers", () => {
       },
     }).mcpServers.remote!;
 
-    await expect(runOAuthFlow(server, { noOpen: true })).rejects.toBe(sdkError);
+    await expect(runOAuthFlow(server, { noOpen: true, authStore })).rejects.toBe(sdkError);
   });
 
   it.each(["oauth2", "oidc"] as const)(
@@ -900,7 +898,7 @@ describe("auth helpers", () => {
     },
   );
 
-  it("persists dynamically registered MCP OAuth client information with saved tokens", () => {
+  it("persists dynamically registered MCP OAuth client information with saved tokens", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-dynamic-client-"));
     try {
       const server = parseConfig({
@@ -914,20 +912,25 @@ describe("auth helpers", () => {
           },
         },
       }).mcpServers.remote!;
-      const provider = new FileOAuthProvider(server, "http://127.0.0.1/callback", () => {}, dir);
+      const provider = new FileOAuthProvider(
+        server,
+        "http://127.0.0.1/callback",
+        () => {},
+        authStore,
+      );
       provider.saveClientInformation({
         client_id: "dynamic-client",
         client_secret: "dynamic-secret",
       });
 
-      provider.saveTokens({
+      await provider.saveTokens({
         access_token: "access-token",
         refresh_token: "refresh-token",
         token_type: "Bearer",
         expires_in: 3600,
       });
 
-      expect(readTokenBundle("remote", dir)).toMatchObject({
+      expect((await authStore.readTokenBundle("remote"))?.bundle).toMatchObject({
         clientId: "dynamic-client",
         clientSecret: "dynamic-secret",
       });
@@ -950,17 +953,20 @@ describe("auth helpers", () => {
           },
         },
       }).mcpServers.remote!;
-      writeTokenBundle(
-        {
-          server: "remote",
-          accessToken: "access-token",
-          refreshToken: "refresh-token",
-          clientId: "stored-client",
-          clientSecret: "stored-secret",
-        },
-        dir,
+      await authStore.writeTokenBundle({
+        server: "remote",
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        clientId: "stored-client",
+        clientSecret: "stored-secret",
+      });
+      const provider = new FileOAuthProvider(
+        server,
+        "http://127.0.0.1/callback",
+        () => {},
+        authStore,
+        await authStore.readTokenBundle("remote"),
       );
-      const provider = new FileOAuthProvider(server, "http://127.0.0.1/callback", () => {}, dir);
       const headers = new Headers();
       const params = new URLSearchParams();
 
@@ -991,17 +997,14 @@ describe("auth helpers", () => {
           },
         },
       }).mcpServers.remote!;
-      writeTokenBundle(
-        {
-          server: "remote",
-          accessToken: "access-token",
-          refreshToken: "refresh-token",
-          expiresAt: "2000-01-01T00:00:00.000Z",
-        },
-        dir,
-      );
+      await authStore.writeTokenBundle({
+        server: "remote",
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        expiresAt: "2000-01-01T00:00:00.000Z",
+      });
 
-      await expect(oauthHeaders(server, dir)).rejects.toThrow(
+      await expect(oauthHeaders(server, authStore)).rejects.toThrow(
         "OAuth client information is missing for remote. Re-run caplets auth login remote.",
       );
     } finally {
@@ -1023,22 +1026,19 @@ describe("auth helpers", () => {
           },
         },
       }).mcpServers.remote!;
-      writeTokenBundle(
-        {
-          server: "remote",
-          accessToken: "old-access-token",
-          refreshToken: "old-refresh-token",
-          expiresAt: "2000-01-01T00:00:00.000Z",
-        },
-        dir,
-      );
+      await authStore.writeTokenBundle({
+        server: "remote",
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2000-01-01T00:00:00.000Z",
+      });
       mockMcpAuth.mockClear();
       mockMcpAuth.mockImplementationOnce(async (provider: FileOAuthProvider) => {
         expect(await provider.tokens()).toBeUndefined();
         return "AUTHORIZED";
       });
 
-      await runOAuthFlow(server, { noOpen: true, authDir: dir });
+      await runOAuthFlow(server, { noOpen: true, authStore });
 
       expect(mockMcpAuth).toHaveBeenCalledOnce();
     } finally {
@@ -1153,7 +1153,7 @@ describe("auth helpers", () => {
           auth: { type: "oidc" },
         },
         {
-          authDir: dir,
+          authStore,
           noOpen: true,
           print: (line) => {
             authorizationUrl = line.match(/https?:\/\/\S+/)?.[0] ?? "";
@@ -1173,7 +1173,7 @@ describe("auth helpers", () => {
       );
       const bundle = await genericOAuthHeaders(
         { server: "users", backend: "openapi", auth: { type: "oidc" } },
-        dir,
+        authStore,
       );
       expect(bundle).toEqual({ authorization: "Bearer new-access-token" });
     } finally {
@@ -1261,7 +1261,7 @@ describe("auth helpers", () => {
           ],
         },
         {
-          authDir: dir,
+          authStore,
           noOpen: true,
           print: (line) => {
             authorizationUrl = line.match(/https?:\/\/\S+/)?.[0] ?? "";
@@ -1276,7 +1276,7 @@ describe("auth helpers", () => {
       expect(new URL(authorizationUrl).searchParams.get("scope")).toBe(
         "openid profile email https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.readonly",
       );
-      expect(readTokenBundle("drive", dir)?.metadata).toMatchObject({
+      expect((await authStore.readTokenBundle("drive"))?.bundle.metadata).toMatchObject({
         requestedScopes: [
           "openid",
           "profile",
@@ -1306,6 +1306,7 @@ describe("auth helpers", () => {
           },
         },
         {
+          authStore,
           noOpen: true,
           manualInput: "http://127.0.0.1/callback?code=code",
         },
@@ -1358,7 +1359,7 @@ describe("auth helpers", () => {
             },
           },
           {
-            authDir: dir,
+            authStore,
             noOpen: true,
             print: (line) => {
               authorizationUrl = line.match(/https?:\/\/\S+/)?.[0] ?? "";
@@ -1385,16 +1386,13 @@ describe("auth helpers", () => {
   it("matches generic OAuth token bundles against configured client metadata URLs", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
     try {
-      writeTokenBundle(
-        {
-          server: "users",
-          authType: "oauth2",
-          accessToken: "metadata-url-token",
-          clientId: "https://client.example.com/caplets/oauth-client-metadata.json",
-          protectedResourceOrigin: "https://api.example.com",
-        },
-        dir,
-      );
+      await authStore.writeTokenBundle({
+        server: "users",
+        authType: "oauth2",
+        accessToken: "metadata-url-token",
+        clientId: "https://client.example.com/caplets/oauth-client-metadata.json",
+        protectedResourceOrigin: "https://api.example.com",
+      });
 
       expect(
         await genericOAuthHeaders(
@@ -1407,7 +1405,7 @@ describe("auth helpers", () => {
               clientMetadataUrl: "https://client.example.com/caplets/oauth-client-metadata.json",
             },
           },
-          dir,
+          authStore,
         ),
       ).toEqual({ authorization: "Bearer metadata-url-token" });
 
@@ -1422,7 +1420,7 @@ describe("auth helpers", () => {
               clientMetadataUrl: "https://client.example.com/other-client.json",
             },
           },
-          dir,
+          authStore,
         ),
       ).rejects.toMatchObject({ code: "AUTH_REQUIRED" });
     } finally {
@@ -1444,6 +1442,7 @@ describe("auth helpers", () => {
           },
         },
         {
+          authStore,
           noOpen: true,
           manualInput: "http://127.0.0.1/callback?code=code",
         },
@@ -1520,7 +1519,7 @@ describe("auth helpers", () => {
             auth: { type: "oidc", issuer: `${baseUrl}/realms/acme`, clientId: "client" },
           },
           {
-            authDir: dir,
+            authStore,
             noOpen: true,
             print: (line) => {
               authorizationUrl = line.match(/https?:\/\/\S+/)?.[0] ?? "";
@@ -1605,7 +1604,7 @@ describe("auth helpers", () => {
             auth: { type: "oidc", clientId: "client" },
           },
           {
-            authDir: dir,
+            authStore,
             noOpen: true,
             print: (line) => {
               authorizationUrl = line.match(/https?:\/\/\S+/)?.[0] ?? "";
@@ -1667,7 +1666,7 @@ describe("auth helpers", () => {
             },
           },
           {
-            authDir: dir,
+            authStore,
             noOpen: true,
             print: (line) => {
               authorizationUrl = line.match(/https?:\/\/\S+/)?.[0] ?? "";

--- a/packages/core/test/backend-auth-state-table.test.ts
+++ b/packages/core/test/backend-auth-state-table.test.ts
@@ -1,0 +1,133 @@
+import { readFileSync } from "node:fs";
+import BetterSqlite3 from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { BackendAuthStateStore } from "../src/storage/backend-auth";
+import { backendAuthStates, operatorActivity, sqliteSchema } from "../src/storage/schema/sqlite";
+
+describe("BackendAuthStateStore dedicated SQL table", () => {
+  it("keeps CAS state and sanitized activity atomic", async () => {
+    const client = new BetterSqlite3(":memory:");
+    client.exec(`
+      create table backend_auth_states (
+        server text primary key not null,
+        generation integer not null,
+        token_bundle text not null,
+        created_at text not null,
+        updated_at text not null
+      )
+    `);
+    const database = drizzle(client, { schema: sqliteSchema });
+    const store = new BackendAuthStateStore({ dialect: "sqlite", db: database });
+    const bundle = {
+      server: "github",
+      accessToken: "secret-access-token",
+      refreshToken: "secret-refresh-token",
+    };
+
+    try {
+      await expect(
+        store.writeTokenBundle(bundle, { operatorClientId: "operator-1" }),
+      ).rejects.toThrow();
+      await expect(store.readTokenBundle("github")).resolves.toBeUndefined();
+
+      client.exec(`
+        create table operator_activity (
+          activity_key text primary key not null,
+          operator_client_id text not null,
+          action text not null,
+          target_kind text not null,
+          target_key text not null,
+          outcome text not null,
+          metadata text not null,
+          created_at text not null
+        )
+      `);
+      await expect(
+        store.writeTokenBundle(bundle, { operatorClientId: "operator-1" }),
+      ).resolves.toEqual({ bundle, generation: 1 });
+      await expect(
+        store.writeTokenBundle(
+          { ...bundle, accessToken: "stale-secret" },
+          { expectedGeneration: 0, operatorClientId: "operator-1" },
+        ),
+      ).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+        details: { kind: "stale_generation", currentGeneration: 1 },
+      });
+      await expect(store.listTokenBundles()).resolves.toEqual([{ bundle, generation: 1 }]);
+      expect(database.select().from(backendAuthStates).all()).toHaveLength(1);
+      expect(database.select().from(operatorActivity).all()).toMatchObject([
+        {
+          operatorClientId: "operator-1",
+          action: "backend_auth_written",
+          targetKey: "github",
+          metadata: { generation: 1 },
+        },
+      ]);
+      expect(JSON.stringify(database.select().from(operatorActivity).all())).not.toContain(
+        "secret",
+      );
+      await expect(
+        store.deleteTokenBundle("github", {
+          expectedGeneration: 1,
+          operatorClientId: "operator-1",
+        }),
+      ).resolves.toBe(true);
+      await expect(store.readTokenBundle("github")).resolves.toBeUndefined();
+    } finally {
+      client.close();
+    }
+  });
+
+  it("migrates legacy generic backend auth rows into the dedicated table", async () => {
+    const client = new BetterSqlite3(":memory:");
+    const bundle = { server: "github", accessToken: "existing-secret" };
+    client.exec(`
+      create table host_state_records (
+        namespace text not null,
+        state_key text not null,
+        generation integer not null,
+        payload text not null,
+        created_at text not null,
+        updated_at text not null,
+        primary key (namespace, state_key)
+      )
+    `);
+    client
+      .prepare(`
+      insert into host_state_records
+        (namespace, state_key, generation, payload, created_at, updated_at)
+      values (?, ?, ?, ?, ?, ?)
+    `)
+      .run(
+        "backend-auth",
+        "github",
+        3,
+        JSON.stringify(bundle),
+        "2026-07-17T00:00:00.000Z",
+        "2026-07-18T00:00:00.000Z",
+      );
+
+    try {
+      const migration = readFileSync(
+        new URL("../src/storage/drizzle/sqlite/0008_dry_supreme_intelligence.sql", import.meta.url),
+        "utf8",
+      );
+      for (const statement of migration.split("--> statement-breakpoint")) {
+        if (statement.trim()) client.exec(statement);
+      }
+      const database = drizzle(client, { schema: sqliteSchema });
+      const store = new BackendAuthStateStore({ dialect: "sqlite", db: database });
+      await expect(store.readTokenBundle("github")).resolves.toEqual({ bundle, generation: 3 });
+      expect(client.prepare("select count(*) as count from host_state_records").get()).toEqual({
+        count: 0,
+      });
+      expect(database.select().from(backendAuthStates).all()).toMatchObject([
+        { server: "github", generation: 3, tokenBundle: bundle },
+      ]);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/packages/core/test/backend-auth-storage.test.ts
+++ b/packages/core/test/backend-auth-storage.test.ts
@@ -1,0 +1,229 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { genericOAuthHeaders } from "../src/auth";
+import { runCli } from "../src/cli";
+import type { StoredOAuthTokenBundle } from "../src/auth/store";
+import { BackendAuthStateStore } from "../src/storage/backend-auth";
+import { createHostStorage } from "../src/storage";
+import { backendAuthStates, operatorActivity } from "../src/storage/schema/sqlite";
+
+const secretValues = [
+  "plain-access-token",
+  "plain-refresh-token",
+  "plain-id-token",
+  "plain-client-secret",
+  "plain-metadata-secret",
+];
+
+const betaBundle: StoredOAuthTokenBundle = {
+  server: "beta",
+  authType: "oidc",
+  accessToken: secretValues[0]!,
+  refreshToken: secretValues[1]!,
+  tokenType: "Bearer",
+  expiresAt: "2999-01-01T00:00:00.000Z",
+  scope: "openid profile",
+  idToken: secretValues[2]!,
+  issuer: "https://issuer.example",
+  subject: "subject-1",
+  clientId: "client-1",
+  clientSecret: secretValues[3]!,
+  protectedResourceOrigin: "https://api.example",
+  metadata: { providerExtension: secretValues[4]! },
+};
+
+describe("BackendAuthStateStore", () => {
+  it("persists token bundles with ordering, CAS, deletion, and sanitized activity", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-backend-auth-"));
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(directory, "caplets.sqlite3"),
+    });
+    const store = new BackendAuthStateStore(storage.database);
+
+    try {
+      await expect(
+        store.writeTokenBundle(betaBundle, {
+          operatorClientId: "operator-1",
+        }),
+      ).resolves.toEqual({ bundle: betaBundle, generation: 1 });
+      await store.writeTokenBundle({ server: "alpha", accessToken: "alpha-token" });
+
+      await expect(store.readTokenBundle("beta")).resolves.toEqual({
+        bundle: betaBundle,
+        generation: 1,
+      });
+      await expect(store.listTokenBundles()).resolves.toEqual([
+        { bundle: { server: "alpha", accessToken: "alpha-token" }, generation: 1 },
+        { bundle: betaBundle, generation: 1 },
+      ]);
+
+      const updatedBundle = { ...betaBundle, accessToken: "rotated-access-token" };
+      await expect(
+        store.writeTokenBundle(updatedBundle, {
+          expectedGeneration: 1,
+          operatorClientId: "operator-1",
+        }),
+      ).resolves.toEqual({ bundle: updatedBundle, generation: 2 });
+
+      await expect(
+        store.writeTokenBundle(
+          { ...betaBundle, accessToken: "stale-overwrite-token" },
+          { expectedGeneration: 1, operatorClientId: "operator-1" },
+        ),
+      ).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+        details: {
+          kind: "stale_generation",
+          expectedGeneration: 1,
+          currentGeneration: 2,
+        },
+      });
+      await expect(store.readTokenBundle("beta")).resolves.toEqual({
+        bundle: updatedBundle,
+        generation: 2,
+      });
+
+      await expect(
+        store.deleteTokenBundle("alpha", {
+          expectedGeneration: 1,
+          operatorClientId: "operator-1",
+        }),
+      ).resolves.toBe(true);
+      await expect(store.readTokenBundle("alpha")).resolves.toBeUndefined();
+      await expect(store.deleteTokenBundle("alpha")).resolves.toBe(false);
+
+      if (storage.database.dialect !== "sqlite") throw new Error("Expected SQLite storage");
+      expect(storage.database.db.select().from(backendAuthStates).all()).toMatchObject([
+        { server: "beta", generation: 2, tokenBundle: updatedBundle },
+      ]);
+      const activity = storage.database.db.select().from(operatorActivity).all();
+      expect(activity.map(({ action, metadata }) => ({ action, metadata }))).toEqual([
+        { action: "backend_auth_written", metadata: { generation: 1 } },
+        { action: "backend_auth_written", metadata: { generation: 2 } },
+        { action: "backend_auth_deleted", metadata: { generation: 1 } },
+      ]);
+      const activityMetadata = JSON.stringify(activity.map((entry) => entry.metadata));
+      for (const secret of [
+        ...secretValues,
+        "alpha-token",
+        "rotated-access-token",
+        "stale-overwrite-token",
+      ]) {
+        expect(activityMetadata).not.toContain(secret);
+      }
+    } finally {
+      await storage.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("shares SQL auth state across CLI and runtime instances without auth files", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-backend-auth-integration-"));
+    const databasePath = join(directory, "caplets.sqlite3");
+    const configPath = join(directory, "config.json");
+    const legacyAuthDir = join(directory, "legacy-auth");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        storage: { type: "sqlite", path: databasePath },
+        mcpServers: {
+          remote: {
+            name: "Remote",
+            description: "Remote OAuth server",
+            transport: "http",
+            url: "https://api.example/mcp",
+            auth: { type: "oauth2", clientId: "client" },
+          },
+        },
+      }),
+    );
+
+    const seed = await createHostStorage({ type: "sqlite", path: databasePath });
+    try {
+      await seed.backendAuth.writeTokenBundle({
+        server: "remote",
+        authType: "oauth2",
+        accessToken: "shared-runtime-token",
+        tokenType: "Bearer",
+        clientId: "client",
+        protectedResourceOrigin: "https://api.example",
+      });
+    } finally {
+      await seed.close();
+    }
+
+    const runtime = await createHostStorage({ type: "sqlite", path: databasePath });
+    try {
+      const output: string[] = [];
+      await runCli(["auth", "list", "--global", "--json"], {
+        env: { CAPLETS_CONFIG: configPath },
+        authDir: legacyAuthDir,
+        writeOut: (value) => output.push(value),
+        writeErr: (value) => output.push(value),
+        maybePrintUpdateNotice: async () => undefined,
+      });
+      expect(JSON.parse(output.join(""))).toEqual([
+        { server: "remote", status: "authenticated", source: "global" },
+      ]);
+      await expect(
+        genericOAuthHeaders(
+          {
+            server: "remote",
+            backend: "http",
+            url: "https://api.example/mcp",
+            auth: { type: "oauth2", clientId: "client" },
+          },
+          runtime.backendAuth,
+        ),
+      ).resolves.toEqual({ authorization: "Bearer shared-runtime-token" });
+
+      const logoutOutput: string[] = [];
+      await runCli(["auth", "logout", "remote", "--global"], {
+        env: { CAPLETS_CONFIG: configPath },
+        authDir: legacyAuthDir,
+        writeOut: (value) => logoutOutput.push(value),
+        writeErr: (value) => logoutOutput.push(value),
+        maybePrintUpdateNotice: async () => undefined,
+      });
+      expect(logoutOutput.join("")).toContain("Deleted OAuth credentials");
+      await expect(runtime.backendAuth.readTokenBundle("remote")).resolves.toBeUndefined();
+      expect(existsSync(legacyAuthDir)).toBe(false);
+    } finally {
+      await runtime.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects invalid persisted token payloads", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-backend-auth-invalid-"));
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(directory, "caplets.sqlite3"),
+    });
+    const store = new BackendAuthStateStore(storage.database);
+    try {
+      if (storage.database.dialect !== "sqlite") throw new Error("Expected SQLite storage");
+      storage.database.db
+        .insert(backendAuthStates)
+        .values({
+          server: "invalid",
+          generation: 1,
+          tokenBundle: { server: "invalid", accessToken: 42 },
+          createdAt: "2026-07-18T00:00:00.000Z",
+          updatedAt: "2026-07-18T00:00:00.000Z",
+        })
+        .run();
+
+      await expect(store.readTokenBundle("invalid")).rejects.toMatchObject({
+        code: "INTERNAL_ERROR",
+      });
+      await expect(store.listTokenBundles()).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+    } finally {
+      await storage.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/test/caplet-asset-s3.test.ts
+++ b/packages/core/test/caplet-asset-s3.test.ts
@@ -1,12 +1,14 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   CreateBucketCommand,
+  DeleteObjectCommand,
   DeleteBucketCommand,
   DeleteObjectsCommand,
   ListObjectsV2Command,
+  PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
 import { afterEach, expect, it } from "vitest";
@@ -126,6 +128,117 @@ s3It("deduplicates, verifies, and exports S3-compatible Caplet assets", async ()
     ).resolves.toMatchObject({ blobRowsDeleted: 0, objectsDeleted: 0 });
     const cleaned = await client!.send(new ListObjectsV2Command({ Bucket: bucket }));
     expect(cleaned.Contents ?? []).toHaveLength(0);
+  } finally {
+    await storage.close();
+  }
+});
+
+s3It("gates health on current S3 assets without gating on historical assets", async () => {
+  const bucket = `caplets-${randomUUID()}`;
+  buckets.push(bucket);
+  await client!.send(new CreateBucketCommand({ Bucket: bucket }));
+  const directory = mkdtempSync(join(tmpdir(), "caplets-s3-health-"));
+  directories.push(directory);
+  const storage = await createHostStorage({
+    type: "sqlite",
+    path: join(directory, "caplets.sqlite3"),
+    assets: {
+      type: "s3",
+      endpoint,
+      region: "us-east-1",
+      bucket,
+      prefix: "host",
+      forcePathStyle: true,
+      accessKeyId: "caplets",
+      secretAccessKey: "caplets-secret",
+    },
+  });
+  const historicalPayload = Buffer.from("historical asset payload\n");
+  const currentPayload = Buffer.from("current asset payload\n");
+  const input = (payload: Buffer) => ({
+    id: "health-check",
+    operator: { clientId: "operator_import", role: "operator" as const },
+    files: [
+      {
+        path: "CAPLET.md",
+        executable: false,
+        content: Buffer.from(
+          `---
+name: Asset health check
+description: Verify current S3-compatible asset health.
+mcpServer:
+  command: asset-health-mcp
+---
+# Asset health check
+`,
+        ),
+      },
+      { path: "asset.txt", executable: false, content: payload },
+    ],
+  });
+
+  try {
+    await storage.caplets.importBundle(input(historicalPayload));
+    await storage.caplets.updateBundle({
+      ...input(currentPayload),
+      expectedGeneration: 1,
+    });
+    const listed = await client!.send(new ListObjectsV2Command({ Bucket: bucket }));
+    const historicalHash = createHash("sha256").update(historicalPayload).digest("hex");
+    const currentHash = createHash("sha256").update(currentPayload).digest("hex");
+    const historicalKey = listed.Contents?.find(({ Key }) => Key?.includes(historicalHash))?.Key;
+    const currentKey = listed.Contents?.find(({ Key }) => Key?.includes(currentHash))?.Key;
+    expect(historicalKey).toBeTruthy();
+    expect(currentKey).toBeTruthy();
+
+    await expect(storage.health()).resolves.toMatchObject({
+      ready: true,
+      assets: { backend: "s3", ready: true },
+    });
+    await client!.send(new DeleteObjectCommand({ Bucket: bucket, Key: historicalKey }));
+    await expect(storage.health()).resolves.toMatchObject({
+      ready: true,
+      assets: { backend: "s3", ready: true },
+    });
+
+    await client!.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: currentKey,
+        Body: Buffer.alloc(currentPayload.byteLength, "x"),
+        Metadata: { sha256: currentHash },
+      }),
+    );
+    await expect(storage.health()).resolves.toMatchObject({
+      ready: false,
+      reason: "current_record_assets_unavailable",
+      assets: {
+        backend: "s3",
+        ready: false,
+        affectedRecordIds: ["health-check"],
+      },
+    });
+    await expect(
+      storage.caplets.readBundle("health-check", {
+        operator: { clientId: "operator_read", role: "operator" },
+      }),
+    ).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+
+    await client!.send(new DeleteObjectCommand({ Bucket: bucket, Key: currentKey }));
+    await expect(storage.health()).resolves.toMatchObject({
+      ready: false,
+      reason: "current_record_assets_unavailable",
+      assets: {
+        backend: "s3",
+        ready: false,
+        affectedRecordIds: ["health-check"],
+      },
+    });
+    await expect(
+      storage.caplets.readBundle("health-check", {
+        operator: { clientId: "operator_read", role: "operator" },
+      }),
+    ).rejects.toMatchObject({ code: "SERVER_UNAVAILABLE" });
   } finally {
     await storage.close();
   }

--- a/packages/core/test/caplet-asset-s3.test.ts
+++ b/packages/core/test/caplet-asset-s3.test.ts
@@ -1,0 +1,132 @@
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CreateBucketCommand,
+  DeleteBucketCommand,
+  DeleteObjectsCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { afterEach, expect, it } from "vitest";
+import { createHostStorage } from "../src/storage";
+
+const endpoint = process.env.CAPLETS_TEST_S3_ENDPOINT;
+const s3It = endpoint ? it : it.skip;
+const directories: string[] = [];
+const buckets: string[] = [];
+const client = endpoint
+  ? new S3Client({
+      endpoint,
+      region: "us-east-1",
+      forcePathStyle: true,
+      credentials: { accessKeyId: "caplets", secretAccessKey: "caplets-secret" },
+    })
+  : undefined;
+
+afterEach(async () => {
+  for (const directory of directories.splice(0))
+    rmSync(directory, { recursive: true, force: true });
+  if (!client) return;
+  for (const bucket of buckets.splice(0)) {
+    const listed = await client.send(new ListObjectsV2Command({ Bucket: bucket }));
+    if (listed.Contents?.length) {
+      await client.send(
+        new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: { Objects: listed.Contents.map(({ Key }) => ({ Key })) },
+        }),
+      );
+    }
+    await client.send(new DeleteBucketCommand({ Bucket: bucket }));
+  }
+});
+
+s3It("deduplicates, verifies, and exports S3-compatible Caplet assets", async () => {
+  const bucket = `caplets-${randomUUID()}`;
+  buckets.push(bucket);
+  await client!.send(new CreateBucketCommand({ Bucket: bucket }));
+  const directory = mkdtempSync(join(tmpdir(), "caplets-s3-"));
+  directories.push(directory);
+  const storage = await createHostStorage({
+    type: "sqlite",
+    path: join(directory, "caplets.sqlite3"),
+    assets: {
+      type: "s3",
+      endpoint,
+      region: "us-east-1",
+      bucket,
+      prefix: "host",
+      forcePathStyle: true,
+      accessKeyId: "caplets",
+      secretAccessKey: "caplets-secret",
+    },
+  });
+  const payload = Buffer.from("shared object payload\n");
+  const input = (id: string) => ({
+    id,
+    operator: { clientId: "operator_import", role: "operator" as const },
+    files: [
+      {
+        path: "CAPLET.md",
+        executable: false,
+        content: Buffer.from(
+          `---
+  name: ${id}
+  description: Verify S3-compatible asset persistence for ${id}.
+  mcpServer:
+    command: ${id}-mcp
+  ---
+  # ${id}
+  `.replace(/^ {2}/gmu, ""),
+        ),
+      },
+      { path: "asset.txt", executable: false, content: payload },
+    ],
+  });
+
+  try {
+    await storage.caplets.importBundles([input("first"), input("second")]);
+    await expect(storage.caplets.assetStats()).resolves.toEqual({ blobs: 1, entries: 2 });
+    const listed = await client!.send(new ListObjectsV2Command({ Bucket: bucket }));
+    expect(listed.Contents).toHaveLength(1);
+    const destination = join(directory, "exported");
+    await storage.caplets.exportBundle("first", destination, {
+      operator: { clientId: "operator_export", role: "operator" },
+    });
+    expect(readFileSync(join(destination, "asset.txt"))).toEqual(payload);
+    const first = await storage.caplets.get("first");
+    const second = await storage.caplets.get("second");
+    await storage.caplets.deleteRevision({
+      id: "first",
+      revisionKey: first!.currentRevision.revisionKey,
+      expectedGeneration: 1,
+      operator: { clientId: "operator_cleanup", role: "operator" },
+    });
+    await storage.caplets.deleteRevision({
+      id: "second",
+      revisionKey: second!.currentRevision.revisionKey,
+      expectedGeneration: 1,
+      operator: { clientId: "operator_cleanup", role: "operator" },
+    });
+    await expect(
+      storage.maintainAssets({
+        ownerNodeId: "node_cleanup",
+        graceMs: 0,
+        now: new Date(Date.now() + 1_000),
+      }),
+    ).resolves.toMatchObject({ blobRowsDeleted: 1, objectsDeleted: 1 });
+    await expect(
+      storage.maintainAssets({
+        ownerNodeId: "node_cleanup",
+        graceMs: 0,
+        now: new Date(Date.now() + 2_000),
+      }),
+    ).resolves.toMatchObject({ blobRowsDeleted: 0, objectsDeleted: 0 });
+    const cleaned = await client!.send(new ListObjectsV2Command({ Bucket: bucket }));
+    expect(cleaned.Contents ?? []).toHaveLength(0);
+  } finally {
+    await storage.close();
+  }
+});

--- a/packages/core/test/caplet-record-storage.postgres.test.ts
+++ b/packages/core/test/caplet-record-storage.postgres.test.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from "node:crypto";
+import { Pool } from "pg";
+import { afterEach, expect, it, vi } from "vitest";
+import { createHostStorage, migrateHostStorage } from "../src/storage";
+
+const connectionString = process.env.CAPLETS_TEST_POSTGRES_URL;
+const schemas: string[] = [];
+const postgresIt = connectionString ? it : it.skip;
+
+afterEach(async () => {
+  if (!connectionString || schemas.length === 0) return;
+  const client = new Pool({ connectionString });
+  try {
+    for (const schema of schemas.splice(0)) {
+      await client.query(`drop schema if exists "${schema}" cascade`);
+    }
+  } finally {
+    await client.end();
+  }
+});
+
+postgresIt("persists and updates Caplet Records through PostgreSQL", async () => {
+  const schema = `caplets_test_${randomUUID().replaceAll("-", "")}`;
+  schemas.push(schema);
+  const config = { type: "postgres" as const, connectionString: connectionString!, schema };
+  await migrateHostStorage(config);
+  const storage = await createHostStorage(config);
+  const files = (name: string) => [
+    {
+      path: "CAPLET.md",
+      executable: false,
+      content: Buffer.from(`---
+name: ${name}
+description: Exercise PostgreSQL Caplet Record persistence.
+mcpServer:
+  command: postgres-mcp
+---
+# ${name}
+`),
+    },
+    { path: "run.sh", executable: true, content: Buffer.from("#!/bin/sh\n") },
+  ];
+
+  try {
+    const created = await storage.caplets.importBundle({
+      id: "postgres-record",
+      operator: { clientId: "operator_create", role: "operator" },
+      historyLimit: 2,
+      files: files("First"),
+    });
+    const updated = await storage.caplets.updateBundle({
+      id: "postgres-record",
+      operator: { clientId: "operator_update", role: "operator" },
+      expectedGeneration: created.headGeneration,
+      files: files("Second"),
+    });
+    expect(updated).toMatchObject({
+      headGeneration: 2,
+      currentRevision: {
+        name: "Second",
+        bundle: [{ path: "run.sh", executable: true }],
+      },
+    });
+  } finally {
+    await storage.close();
+  }
+});
+
+postgresIt("notifies peer listeners after a committed Caplet Record mutation", async () => {
+  const schema = `caplets_notify_${randomUUID().replaceAll("-", "")}`;
+  schemas.push(schema);
+  const config = { type: "postgres" as const, connectionString: connectionString!, schema };
+  await migrateHostStorage(config);
+  const listener = await createHostStorage(config);
+  const writer = await createHostStorage(config);
+  let markListening: (() => void) | undefined;
+  const listening = new Promise<void>((resolve) => {
+    markListening = resolve;
+  });
+  const currentGeneration = listener.coordination.currentConfigGeneration.bind(
+    listener.coordination,
+  );
+  vi.spyOn(listener.coordination, "currentConfigGeneration").mockImplementation(async () => {
+    const generation = await currentGeneration();
+    markListening?.();
+    return generation;
+  });
+  const nextGeneration = listener.coordination.waitForConfigGeneration(0);
+  try {
+    await listening;
+    const startedAt = Date.now();
+    await writer.caplets.importBundle({
+      id: "notified-record",
+      operator: { clientId: "operator_create", role: "operator" },
+      files: [
+        {
+          path: "CAPLET.md",
+          executable: false,
+          content: Buffer.from(`---
+name: Notified
+description: Exercise transactional PostgreSQL generation notifications.
+mcpServer:
+  command: postgres-mcp
+---
+# Notified
+`),
+        },
+      ],
+    });
+    await expect(nextGeneration).resolves.toBe(1);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  } finally {
+    vi.restoreAllMocks();
+    await listener.close();
+    await writer.close();
+  }
+});

--- a/packages/core/test/caplet-record-storage.test.ts
+++ b/packages/core/test/caplet-record-storage.test.ts
@@ -1,0 +1,508 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseCapletFileDocument } from "../src/caplet-files";
+import { createHostStorage } from "../src/storage";
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("Caplet Record storage", () => {
+  it("persists structured frontmatter and body as a current revision", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-records-"));
+    directories.push(directory);
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(directory, "caplets.sqlite3"),
+    });
+
+    try {
+      const created = await storage.caplets.importBundle({
+        id: "github",
+        operator: { clientId: "operator_test", role: "operator" },
+        files: [
+          {
+            path: "CAPLET.md",
+            executable: false,
+            content: Buffer.from(
+              `---
+      +name: GitHub
+      +description: Manage GitHub repositories and issues.
+      +tags: [source-control, issues]
+      +mcpServer:
+      +  command: github-mcp
+      +---
+      +
+      +# GitHub
+      +
+      +Operator notes.
+      +`.replace(/^ {6}\+/gmu, ""),
+            ),
+          },
+        ],
+      });
+
+      expect(created).toMatchObject({
+        id: "github",
+        headGeneration: 1,
+        currentRevision: {
+          sequence: 1,
+          name: "GitHub",
+          description: "Manage GitHub repositories and issues.",
+          body: "\n# GitHub\n\nOperator notes.\n",
+          tags: ["source-control", "issues"],
+          backends: [{ family: "mcpServer", childId: null, config: { command: "github-mcp" } }],
+          bundle: [],
+        },
+      });
+      expect(created.recordKey).toMatch(/^[0-9a-f-]{36}$/u);
+      await expect(storage.caplets.get("github")).resolves.toEqual(created);
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("round-trips ordered backend children and deduplicated executable bundle assets", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-records-"));
+    directories.push(directory);
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(directory, "caplets.sqlite3"),
+    });
+    const sharedScript = Buffer.from("#!/bin/sh\necho ok\n");
+
+    try {
+      const first = await storage.caplets.importBundle({
+        id: "sources",
+        operator: { clientId: "operator_test", role: "operator" },
+        files: [
+          {
+            path: "CAPLET.md",
+            executable: false,
+            content: Buffer.from(
+              `---
+      name: Sources
+      description: Query source control and issue management systems.
+      exposure: code_mode
+      mcpServers:
+        github:
+          command: github-mcp
+        linear:
+          command: linear-mcp
+      ---
+      # Sources
+      `.replace(/^ {6}/gmu, ""),
+            ),
+          },
+          { path: "scripts/run.sh", executable: true, content: sharedScript },
+          { path: "notes.txt", executable: false, content: Buffer.from("setup notes\n") },
+        ],
+      });
+      await storage.caplets.importBundle({
+        id: "runner",
+        operator: { clientId: "operator_test", role: "operator" },
+        files: [
+          {
+            path: "CAPLET.md",
+            executable: false,
+            content: Buffer.from(
+              `---
+      name: Runner
+      description: Run the shared source control helper script.
+      cliTools:
+        actions:
+          run:
+            command: ./scripts/run.sh
+      ---
+      # Runner
+      `.replace(/^ {6}/gmu, ""),
+            ),
+          },
+          { path: "scripts/run.sh", executable: true, content: sharedScript },
+        ],
+      });
+
+      expect(first.currentRevision).toMatchObject({
+        content: { exposure: "code_mode" },
+        backends: [
+          { family: "mcpServers", childId: "github", config: { command: "github-mcp" } },
+          { family: "mcpServers", childId: "linear", config: { command: "linear-mcp" } },
+        ],
+        bundle: [
+          { path: "notes.txt", executable: false, size: 12 },
+          { path: "scripts/run.sh", executable: true, size: sharedScript.byteLength },
+        ],
+      });
+      await expect(storage.caplets.assetStats()).resolves.toEqual({ blobs: 2, entries: 3 });
+      const destination = join(directory, "exports", "sources");
+      await storage.caplets.exportBundle("sources", destination, {
+        operator: { clientId: "operator_export", role: "operator" },
+      });
+      const exported = parseCapletFileDocument(
+        join(destination, "CAPLET.md"),
+        readFileSync(join(destination, "CAPLET.md"), "utf8"),
+      );
+      expect(exported).toMatchObject({
+        frontmatter: {
+          name: "Sources",
+          description: "Query source control and issue management systems.",
+          exposure: "code_mode",
+          mcpServers: {
+            github: { command: "github-mcp" },
+            linear: { command: "linear-mcp" },
+          },
+        },
+        body: "# Sources\n",
+      });
+      expect(readFileSync(join(destination, "scripts/run.sh"))).toEqual(sharedScript);
+      expect(statSync(join(destination, "scripts/run.sh")).mode & 0o111).not.toBe(0);
+      await expect(
+        storage.caplets.exportBundle("sources", destination, {
+          operator: { clientId: "operator_export", role: "operator" },
+        }),
+      ).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+      });
+      await expect(
+        storage.caplets.exportBundle("sources", destination, {
+          operator: { clientId: "operator_export", role: "operator" },
+          replace: true,
+        }),
+      ).resolves.toBe(undefined);
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("rejects stale updates and prunes revisions to the configured retention count", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-records-"));
+    directories.push(directory);
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(directory, "caplets.sqlite3"),
+    });
+    const files = (name: string) => [
+      {
+        path: "CAPLET.md",
+        executable: false,
+        content: Buffer.from(`---
+name: ${name}
+description: Manage retained Caplet revision history safely.
+mcpServer:
+  command: history-mcp
+---
+# ${name}
+`),
+      },
+    ];
+
+    try {
+      await storage.caplets.importBundle({
+        id: "history",
+        operator: { clientId: "operator_create", role: "operator" },
+        historyLimit: 2,
+        files: files("Revision One"),
+      });
+      const second = await storage.caplets.updateBundle({
+        id: "history",
+        operator: { clientId: "operator_update", role: "operator" },
+        expectedGeneration: 1,
+        files: files("Revision Two"),
+      });
+      expect(second).toMatchObject({
+        headGeneration: 2,
+        currentRevision: { sequence: 2, name: "Revision Two" },
+      });
+      await expect(
+        storage.caplets.updateBundle({
+          id: "history",
+          operator: { clientId: "operator_stale", role: "operator" },
+          expectedGeneration: 1,
+          files: files("Stale Revision"),
+        }),
+      ).rejects.toMatchObject({ code: "REQUEST_INVALID", details: { kind: "stale_generation" } });
+      const third = await storage.caplets.updateBundle({
+        id: "history",
+        operator: { clientId: "operator_update", role: "operator" },
+        expectedGeneration: 2,
+        files: files("Revision Three"),
+      });
+      await expect(
+        storage.caplets.listRevisions("history", {
+          clientId: "operator_history",
+          role: "operator",
+        }),
+      ).resolves.toMatchObject([
+        { sequence: 3, name: "Revision Three" },
+        { sequence: 2, name: "Revision Two" },
+      ]);
+      await expect(
+        storage.caplets.deleteRevision({
+          id: "history",
+          operator: { clientId: "operator_update", role: "operator" },
+          revisionKey: third.currentRevision.revisionKey,
+          expectedGeneration: 3,
+        }),
+      ).resolves.toMatchObject({
+        headGeneration: 4,
+        currentRevision: { sequence: 2, name: "Revision Two" },
+      });
+      const restored = await storage.caplets.restoreRevision({
+        id: "history",
+        operator: { clientId: "operator_restore", role: "operator" },
+        revisionKey: second.currentRevision.revisionKey,
+        expectedGeneration: 4,
+      });
+      expect(restored).toMatchObject({
+        headGeneration: 5,
+        currentRevision: { sequence: 5, name: "Revision Two" },
+      });
+      const retained = await storage.caplets.setRetention({
+        id: "history",
+        operator: { clientId: "operator_retention", role: "operator" },
+        historyLimit: 1,
+        expectedGeneration: 5,
+      });
+      expect(retained).toMatchObject({ headGeneration: 6, historyLimit: 1 });
+      await expect(
+        storage.caplets.listRevisions("history", {
+          clientId: "operator_history",
+          role: "operator",
+        }),
+      ).resolves.toHaveLength(1);
+      const renamed = await storage.caplets.rename({
+        id: "history",
+        newId: "history-renamed",
+        operator: { clientId: "operator_rename", role: "operator" },
+        expectedGeneration: 6,
+      });
+      expect(renamed).toMatchObject({ id: "history-renamed", headGeneration: 7 });
+      await storage.caplets.hardDelete({
+        id: "history-renamed",
+        operator: { clientId: "operator_delete", role: "operator" },
+        expectedGeneration: 7,
+      });
+      await expect(storage.caplets.get("history-renamed")).resolves.toBeUndefined();
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("imports a batch atomically when a later record collides", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-records-"));
+    directories.push(directory);
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(directory, "caplets.sqlite3"),
+    });
+    const input = (id: string) => ({
+      id,
+      operator: { clientId: "operator_import", role: "operator" as const },
+      files: [
+        {
+          path: "CAPLET.md",
+          executable: false,
+          content: Buffer.from(
+            `---
+    name: ${id}
+    description: Import ${id} through an atomic batch operation.
+    mcpServer:
+      command: ${id}-mcp
+    ---
+    # ${id}
+    `.replace(/^ {4}/gmu, ""),
+          ),
+        },
+      ],
+    });
+
+    try {
+      await storage.caplets.importBundle(input("existing"));
+      await expect(
+        storage.caplets.importBundles([input("new-record"), input("existing")]),
+      ).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+      await expect(storage.caplets.get("new-record")).resolves.toBeUndefined();
+      await expect(
+        storage.caplets.importBundles([input("new-record"), input("second-record")]),
+      ).resolves.toMatchObject([{ id: "new-record" }, { id: "second-record" }]);
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("updates source-tracked records and preserves same-content provenance atomically", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-source-update-"));
+    directories.push(directory);
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(directory, "caplets.sqlite3"),
+    });
+    const operator = { clientId: "operator_source", role: "operator" } as const;
+    const files = (name: string) => [
+      {
+        path: "CAPLET.md",
+        executable: false,
+        content: Buffer.from(`---
+name: ${name}
+description: Manage source-tracked Caplet updates transactionally.
+mcpServer:
+  command: source-mcp
+---
+# ${name}
+`),
+      },
+    ];
+
+    try {
+      const created = await storage.caplets.importBundle({
+        id: "tracked",
+        files: files("Revision One"),
+        historyLimit: 2,
+        sourceRevision: "source-v1",
+        sourceContentHash: "source-hash-v1",
+        installation: {
+          sourceKind: "catalog",
+          sourceIdentity: "official/tracked",
+          channel: "stable",
+          risk: { level: "low" },
+        },
+        operator,
+      });
+      expect(await storage.installations.getLatestObservation("tracked")).toMatchObject({
+        resolvedRevision: "source-v1",
+        contentHash: "source-hash-v1",
+        status: "current",
+        risk: { level: "low" },
+      });
+
+      await expect(
+        storage.caplets.updateFromSource({
+          id: "tracked",
+          files: files("Revision Two"),
+          expectedGeneration: 0,
+          expectedInstallationGeneration: 1,
+          sourceRevision: "source-v2",
+          sourceContentHash: "source-hash-v2",
+          observationStatus: "current",
+          risk: { level: "medium" },
+          operator,
+        }),
+      ).rejects.toMatchObject({ details: { kind: "stale_generation" } });
+      await expect(
+        storage.caplets.updateFromSource({
+          id: "tracked",
+          files: files("Revision Two"),
+          expectedGeneration: 1,
+          expectedInstallationGeneration: 0,
+          sourceRevision: "source-v2",
+          sourceContentHash: "source-hash-v2",
+          observationStatus: "current",
+          risk: { level: "medium" },
+          operator,
+        }),
+      ).rejects.toMatchObject({ details: { kind: "stale_generation" } });
+      await expect(storage.installations.listObservations("tracked")).resolves.toHaveLength(1);
+      await expect(storage.installations.getActive("tracked")).resolves.toMatchObject({
+        generation: 1,
+      });
+
+      const changed = await storage.caplets.updateFromSource({
+        id: "tracked",
+        files: files("Revision Two"),
+        expectedGeneration: 1,
+        expectedInstallationGeneration: 1,
+        sourceRevision: "source-v2",
+        sourceContentHash: "source-hash-v2",
+        observationStatus: "current",
+        risk: { level: "medium" },
+        operator,
+      });
+      expect(changed).toMatchObject({
+        headGeneration: 2,
+        currentRevision: { sequence: 2, name: "Revision Two" },
+      });
+      await expect(storage.installations.getActive("tracked")).resolves.toMatchObject({
+        generation: 2,
+      });
+      await expect(storage.coordination.currentConfigGeneration()).resolves.toBe(2);
+
+      const sameContent = await storage.caplets.updateFromSource({
+        id: "tracked",
+        files: files("Revision Two"),
+        expectedGeneration: 2,
+        expectedInstallationGeneration: 2,
+        sourceRevision: "source-v2-metadata",
+        sourceContentHash: "source-hash-v2",
+        observationStatus: "metadata-only",
+        risk: { level: "high" },
+        operator,
+      });
+      expect(sameContent).toMatchObject({
+        headGeneration: 3,
+        currentRevision: {
+          revisionKey: changed.currentRevision.revisionKey,
+          sequence: 2,
+        },
+      });
+      await expect(storage.caplets.listRevisions("tracked", operator)).resolves.toMatchObject([
+        { sequence: 3, name: "Revision Two" },
+        { sequence: 2, name: "Revision Two" },
+      ]);
+      await expect(storage.installations.getLatestObservation("tracked")).resolves.toMatchObject({
+        resolvedRevision: "source-v2-metadata",
+        status: "metadata-only",
+        risk: { level: "high" },
+      });
+      await expect(storage.installations.getActive("tracked")).resolves.toMatchObject({
+        generation: 3,
+      });
+      await expect(storage.coordination.currentConfigGeneration()).resolves.toBe(2);
+
+      const noHistory = await storage.caplets.importBundle({
+        id: "no-history",
+        files: files("Unchanged"),
+        historyLimit: 0,
+        sourceRevision: "source-v1",
+        sourceContentHash: "source-hash-v1",
+        installation: {
+          sourceKind: "catalog",
+          sourceIdentity: "official/no-history",
+          risk: null,
+        },
+        operator,
+      });
+      const observedOnly = await storage.caplets.updateFromSource({
+        id: "no-history",
+        files: files("Unchanged"),
+        expectedGeneration: 1,
+        expectedInstallationGeneration: 1,
+        sourceRevision: "source-v1-metadata",
+        sourceContentHash: "source-hash-v1",
+        observationStatus: "metadata-only",
+        operator,
+      });
+      expect(observedOnly).toMatchObject({
+        headGeneration: 1,
+        currentRevision: { revisionKey: noHistory.currentRevision.revisionKey },
+      });
+      await expect(storage.caplets.listRevisions("no-history", operator)).resolves.toHaveLength(1);
+      await expect(storage.installations.listObservations("no-history")).resolves.toHaveLength(2);
+      await expect(storage.installations.getActive("no-history")).resolves.toMatchObject({
+        generation: 2,
+      });
+
+      expect((await storage.installations.listActivity()).map((entry) => entry.action)).toEqual(
+        expect.arrayContaining(["caplet.source_update"]),
+      );
+      expect(created.recordKey).toBe(changed.recordKey);
+    } finally {
+      await storage.close();
+    }
+  });
+});

--- a/packages/core/test/caplets-lockfile.test.ts
+++ b/packages/core/test/caplets-lockfile.test.ts
@@ -16,7 +16,7 @@ import {
   validateLockfileDestination,
   writeCapletsLockfile,
   type CapletsLockfile,
-} from "../src/cli/lockfile";
+} from "../src/lockfile";
 import type { CapletsError } from "../src/errors";
 
 describe("caplets lockfile", () => {

--- a/packages/core/test/catalog-indexing.test.ts
+++ b/packages/core/test/catalog-indexing.test.ts
@@ -3,8 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { catalogIndexingPayloadForLockEntry } from "../src/catalog-indexing/eligibility";
-import { indexInstalledCapletsFromLockfile } from "../src/cli/install";
-import { writeCapletsLockfile, type CapletsLockEntry } from "../src/cli/lockfile";
+import { indexInstalledCapletsFromLockfile } from "../src/install";
+import { writeCapletsLockfile, type CapletsLockEntry } from "../src/lockfile";
 
 const tempDirs: string[] = [];
 

--- a/packages/core/test/cli-completion.test.ts
+++ b/packages/core/test/cli-completion.test.ts
@@ -49,7 +49,7 @@ describe("CLI completion scripts", () => {
 describe("CLI completion resolver", () => {
   it("suggests top-level commands", async () => {
     await expect(completeCliWords([""])).resolves.toEqual(
-      expect.arrayContaining(["add", "auth", "call-tool", "completion", "serve"]),
+      expect.arrayContaining(["add", "auth", "call-tool", "completion", "serve", "storage"]),
     );
   });
 
@@ -95,6 +95,32 @@ describe("CLI completion resolver", () => {
       "pair",
       "clients",
       "revoke",
+    ]);
+    await expect(completeCliWords(["storage", ""])).resolves.toEqual([
+      "status",
+      "schema-migrate",
+      "migrate-legacy",
+      "records",
+    ]);
+    await expect(completeCliWords(["storage", "records", ""])).resolves.toEqual([
+      "list",
+      "get",
+      "import",
+      "update",
+      "export",
+      "revisions",
+      "restore",
+      "delete-revision",
+      "retention",
+      "rename",
+      "delete",
+      "installation",
+    ]);
+    await expect(completeCliWords(["storage", "records", "installation", ""])).resolves.toEqual([
+      "status",
+      "detach",
+      "observe",
+      "replace",
     ]);
     await expect(completeCliWords(["completion", ""])).resolves.toEqual([
       "bash",

--- a/packages/core/test/cli-install-output.test.ts
+++ b/packages/core/test/cli-install-output.test.ts
@@ -2,13 +2,13 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type * as InstallModule from "../src/cli/install";
+import type * as InstallModule from "../src/install";
 
 const mocks = vi.hoisted(() => ({
   restore: vi.fn(),
 }));
 
-vi.mock("../src/cli/install", async (importOriginal) => ({
+vi.mock("../src/install", async (importOriginal) => ({
   ...(await importOriginal<typeof InstallModule>()),
   restoreCapletsFromLockfile: mocks.restore,
 }));

--- a/packages/core/test/cli-remote.test.ts
+++ b/packages/core/test/cli-remote.test.ts
@@ -10,7 +10,7 @@ import { createRemoteProfileStore } from "../src/remote/profile-store";
 import { remoteProfileKey } from "../src/remote/profiles";
 import { createHttpServeApp, type CapletsHttpApp } from "../src/serve/http";
 import type { HttpServeOptions } from "../src/serve/options";
-import { FileVaultStore } from "../src/vault";
+import { createHostStorage } from "../src/storage";
 
 const dirs: string[] = [];
 
@@ -100,6 +100,7 @@ describe("remote CLI routing", () => {
     writeFileSync(
       context.configPath,
       JSON.stringify({
+        storage: { type: "sqlite", path: context.storagePath },
         googleDiscoveryApis: {
           drive: {
             name: "Drive API",
@@ -239,7 +240,6 @@ describe("remote CLI routing", () => {
     const context = testContext("caplets-cli-remote-vault-");
     const requests: unknown[] = [];
     const out: string[] = [];
-    const localState = join(context.projectConfigPath, "..", "..", "local-state");
     const fetch = vi.fn(
       async (_url: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
         requests.push(JSON.parse(String(init?.body ?? "{}")));
@@ -253,7 +253,7 @@ describe("remote CLI routing", () => {
     await runCli(
       ["vault", "set", "GH_TOKEN_REMOTE", "--remote", "--grant", "github", "--as", "GH_TOKEN"],
       {
-        env: { ...remoteEnv(context), XDG_STATE_HOME: localState },
+        env: remoteEnv(context),
         fetch,
         readStdin: async () => "remote_cli_secret\n",
         writeOut: (value) => out.push(value),
@@ -274,10 +274,15 @@ describe("remote CLI routing", () => {
     ]);
     expect(out.join("")).toContain("Set remote Vault key GH_TOKEN_REMOTE.");
     expect(out.join("")).not.toContain("remote_cli_secret");
-    expect(
-      new FileVaultStore({ env: { XDG_STATE_HOME: localState } }).getStatus("GH_TOKEN_REMOTE")
-        .present,
-    ).toBe(false);
+    const storage = await createHostStorage({ type: "sqlite", path: context.storagePath });
+    try {
+      await expect(storage.vaultValues.getStatus("GH_TOKEN_REMOTE")).resolves.toEqual({
+        key: "GH_TOKEN_REMOTE",
+        present: false,
+      });
+    } finally {
+      await storage.close();
+    }
   });
 
   it("prints remote Vault set JSON when --json is passed", async () => {
@@ -420,7 +425,10 @@ describe("remote CLI routing", () => {
     const err: string[] = [];
     writeFileSync(
       context.configPath,
-      JSON.stringify({ mcpServers: { broken: { name: "Broken" } } }),
+      JSON.stringify({
+        storage: { type: "sqlite", path: context.storagePath },
+        mcpServers: { broken: { name: "Broken" } },
+      }),
       "utf8",
     );
     writeProjectMcpCaplet(context.projectCapletsRoot, "project-only", "Project Only");
@@ -1218,24 +1226,23 @@ describe("remote CLI routing", () => {
       writeOut: (value) => out.push(value),
     });
 
-    expect(
-      readFileSync(join(dirname(context.configPath), "github", "CAPLET.md"), "utf8"),
-    ).toContain("name: GitHub");
+    const storage = await createHostStorage({ type: "sqlite", path: context.storagePath });
+    try {
+      await expect(
+        storage.caplets.getStored("github", { role: "operator", clientId: "cli_test" }),
+      ).resolves.toMatchObject({
+        id: "github",
+        currentRevision: {
+          name: "GitHub",
+          backends: [expect.objectContaining({ family: "mcpServer" })],
+        },
+      });
+    } finally {
+      await storage.close();
+    }
     expect(existsSync(join(context.projectCapletsRoot, "github"))).toBe(false);
-    expect(out.join("")).toContain(
-      `Installed github to global ${join(dirname(context.configPath), "github")}`,
-    );
+    expect(out.join("")).toContain("Installed github to sql://caplet-records/github");
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(
-      JSON.parse(
-        readFileSync(
-          join(dirname(context.configPath), "state", "caplets", "caplets.lock.json"),
-          "utf8",
-        ),
-      ),
-    ).toMatchObject({
-      entries: [expect.objectContaining({ id: "github" })],
-    });
   });
 
   it("routes install through remote control with --remote", async () => {
@@ -1773,6 +1780,7 @@ function writeCliCapletConfig(
   writeFileSync(
     path,
     JSON.stringify({
+      storage: { type: "sqlite", path: join(dir, "host.sqlite3") },
       cliTools: {
         [id]: {
           name,
@@ -1796,6 +1804,7 @@ function writeAuthConfig(path: string, id: string): void {
   writeFileSync(
     path,
     JSON.stringify({
+      storage: { type: "sqlite", path: join(dirname(path), "host.sqlite3") },
       mcpServers: {
         [id]: {
           name: id,
@@ -1815,6 +1824,7 @@ function writeCapletSetConfig(path: string, id: string, name: string): void {
   writeFileSync(
     path,
     JSON.stringify({
+      storage: { type: "sqlite", path: join(dirname(path), "host.sqlite3") },
       capletSets: {
         [id]: {
           name,
@@ -1864,6 +1874,7 @@ function writeInstallableRepo(repo: string): void {
 
 function testContext(prefix: string): {
   configPath: string;
+  storagePath: string;
   projectConfigPath: string;
   projectCapletsRoot: string;
   authDir: string;
@@ -1877,10 +1888,12 @@ function testContext(prefix: string): {
   mkdirSync(userRoot, { recursive: true });
   mkdirSync(projectCapletsRoot, { recursive: true });
   const configPath = join(userRoot, "config.json");
+  const storagePath = join(dir, "host.sqlite3");
   const projectConfigPath = join(projectCapletsRoot, "config.json");
   writeFileSync(
     configPath,
     JSON.stringify({
+      storage: { type: "sqlite", path: storagePath },
       mcpServers: {
         fixture: {
           name: "Fixture",
@@ -1893,7 +1906,14 @@ function testContext(prefix: string): {
     }),
   );
   writeSelfHostedRemoteProfile(authDir);
-  return { configPath, projectConfigPath, projectCapletsRoot, authDir, watch: false };
+  return {
+    configPath,
+    storagePath,
+    projectConfigPath,
+    projectCapletsRoot,
+    authDir,
+    watch: false,
+  };
 }
 
 function writeSelfHostedRemoteProfile(authDir: string): void {

--- a/packages/core/test/cli.test.ts
+++ b/packages/core/test/cli.test.ts
@@ -22,14 +22,65 @@ import {
   readHiddenInputForTest,
   runCli,
 } from "../src/cli";
-import { updateCapletsFromLockfile, type CapletTransactionPhase } from "../src/cli/install";
+import type { StoredOAuthTokenBundle } from "../src/auth/store";
+import { updateCapletsFromLockfile, type CapletTransactionPhase } from "../src/install";
 import { loadConfig, parseConfig, type VaultQuarantineOutcome } from "../src/config";
 import * as configModule from "../src/config";
 import type { CapletsError } from "../src/errors";
-import { readCapletsLockfile } from "../src/cli/lockfile";
-import { readTokenBundle, writeTokenBundle } from "../src/auth";
+import { readCapletsLockfile } from "../src/lockfile";
 import { FileRemoteProfileStore } from "../src/remote/profile-store";
-import { FileVaultStore } from "../src/vault";
+import { createHostStorage } from "../src/storage";
+
+async function seedStoredCaplet(
+  storagePath: string,
+  id: string,
+  environment: Record<string, string> = {},
+): Promise<void> {
+  const storage = await createHostStorage({ type: "sqlite", path: storagePath });
+  try {
+    await storage.caplets.importBundle({
+      id,
+      operator: { role: "operator", clientId: "cli_test" },
+      files: [
+        {
+          path: "CAPLET.md",
+          executable: false,
+          content: Buffer.from(
+            [
+              "---",
+              `name: ${id}`,
+              `description: Stored ${id} test Caplet.`,
+              "mcpServer:",
+              "  command: test-mcp",
+              ...(Object.keys(environment).length === 0
+                ? []
+                : [
+                    "  env:",
+                    ...Object.entries(environment).map(
+                      ([name, value]) => `    ${name}: ${JSON.stringify(value)}`,
+                    ),
+                  ]),
+              "---",
+              `# ${id}`,
+              "",
+            ].join("\n"),
+          ),
+        },
+      ],
+    });
+  } finally {
+    await storage.close();
+  }
+}
+
+async function seedBackendAuth(storagePath: string, bundle: StoredOAuthTokenBundle): Promise<void> {
+  const storage = await createHostStorage({ type: "sqlite", path: storagePath });
+  try {
+    await storage.backendAuth.writeTokenBundle(bundle, { operatorClientId: "cli_test" });
+  } finally {
+    await storage.close();
+  }
+}
 
 describe("cli init", () => {
   const originalMode = process.env.CAPLETS_MODE;
@@ -38,11 +89,20 @@ describe("cli init", () => {
   const originalServerUrl = process.env.CAPLETS_SERVER_URL;
   const originalServerUser = process.env.CAPLETS_SERVER_USER;
   const originalServerPassword = process.env.CAPLETS_SERVER_PASSWORD;
+  const originalStateHome = process.env.XDG_STATE_HOME;
+  let testStateRoot: string;
 
   beforeEach(() => {
+    testStateRoot = mkdtempSync(join(tmpdir(), "caplets-cli-state-"));
+    const configPath = join(testStateRoot, "config.json");
     process.env.CAPLETS_MODE = "local";
-    delete process.env.CAPLETS_CONFIG;
+    process.env.CAPLETS_CONFIG = configPath;
+    process.env.XDG_STATE_HOME = testStateRoot;
     delete process.env.CAPLETS_PROJECT_CONFIG;
+    writeFileSync(
+      configPath,
+      JSON.stringify({ storage: { type: "sqlite", path: join(testStateRoot, "host.sqlite3") } }),
+    );
   });
 
   afterEach(() => {
@@ -77,6 +137,12 @@ describe("cli init", () => {
     } else {
       process.env.CAPLETS_SERVER_PASSWORD = originalServerPassword;
     }
+    if (originalStateHome === undefined) {
+      delete process.env.XDG_STATE_HOME;
+    } else {
+      process.env.XDG_STATE_HOME = originalStateHome;
+    }
+    rmSync(testStateRoot, { recursive: true, force: true });
   });
 
   it("writes a valid starter config and creates parent directories", () => {
@@ -248,25 +314,14 @@ describe("cli init", () => {
   it("rolls back a new local Vault value when set-and-grant fails", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-vault-cli-grant-fail-"));
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const env = {
       ...process.env,
       CAPLETS_CONFIG: configPath,
       XDG_STATE_HOME: join(dir, "state"),
     };
     try {
-      writeFileSync(
-        configPath,
-        JSON.stringify({
-          mcpServers: {
-            github: {
-              name: "GitHub",
-              description: "GitHub access.",
-              command: "github-mcp",
-              env: { GH_TOKEN: "$vault:GH_TOKEN" },
-            },
-          },
-        }),
-      );
+      writeFileSync(configPath, JSON.stringify({ storage: { type: "sqlite", path: storagePath } }));
 
       await expect(
         runCli(["vault", "set", "GH_TOKEN", "--grant", "missing-caplet"], {
@@ -274,12 +329,17 @@ describe("cli init", () => {
           readStdin: async () => "orphaned_secret\n",
           writeOut: () => {},
         }),
-      ).rejects.toMatchObject({ code: "SERVER_NOT_FOUND" } satisfies Partial<CapletsError>);
+      ).rejects.toMatchObject({ code: "REQUEST_INVALID" } satisfies Partial<CapletsError>);
 
-      expect(new FileVaultStore({ env }).getStatus("GH_TOKEN")).toEqual({
-        key: "GH_TOKEN",
-        present: false,
-      });
+      const storage = await createHostStorage({ type: "sqlite", path: storagePath });
+      try {
+        await expect(storage.vaultValues.getStatus("GH_TOKEN")).resolves.toEqual({
+          key: "GH_TOKEN",
+          present: false,
+        });
+      } finally {
+        await storage.close();
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -288,27 +348,22 @@ describe("cli init", () => {
   it("restores the previous local Vault value when force set-and-grant fails", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-vault-cli-grant-force-fail-"));
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const env = {
       ...process.env,
       CAPLETS_CONFIG: configPath,
       XDG_STATE_HOME: join(dir, "state"),
     };
     try {
-      writeFileSync(
-        configPath,
-        JSON.stringify({
-          mcpServers: {
-            github: {
-              name: "GitHub",
-              description: "GitHub access.",
-              command: "github-mcp",
-              env: { GH_TOKEN: "$vault:GH_TOKEN" },
-            },
-          },
-        }),
-      );
-      const store = new FileVaultStore({ env });
-      store.set("GH_TOKEN", "original_secret");
+      writeFileSync(configPath, JSON.stringify({ storage: { type: "sqlite", path: storagePath } }));
+      const seed = await createHostStorage({ type: "sqlite", path: storagePath });
+      try {
+        await seed.vaultValues.set("GH_TOKEN", "original_secret", {
+          operatorClientId: "cli_test",
+        });
+      } finally {
+        await seed.close();
+      }
 
       await expect(
         runCli(["vault", "set", "GH_TOKEN", "--force", "--grant", "missing-caplet"], {
@@ -316,17 +371,23 @@ describe("cli init", () => {
           readStdin: async () => "replacement_secret\n",
           writeOut: () => {},
         }),
-      ).rejects.toMatchObject({ code: "SERVER_NOT_FOUND" } satisfies Partial<CapletsError>);
+      ).rejects.toMatchObject({ code: "REQUEST_INVALID" } satisfies Partial<CapletsError>);
 
-      expect(store.resolveValue("GH_TOKEN")).toBe("original_secret");
+      const storage = await createHostStorage({ type: "sqlite", path: storagePath });
+      try {
+        await expect(storage.vaultValues.resolveValue("GH_TOKEN")).resolves.toBe("original_secret");
+      } finally {
+        await storage.close();
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it("manages local Vault access grants against the active config source", async () => {
+  it("manages SQL Vault access grants for a stored Caplet Record", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-vault-cli-access-"));
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const env = {
       ...process.env,
       CAPLETS_CONFIG: configPath,
@@ -334,20 +395,10 @@ describe("cli init", () => {
     };
     const out: string[] = [];
     try {
-      writeFileSync(
-        configPath,
-        JSON.stringify({
-          mcpServers: {
-            "github-personal": {
-              name: "GitHub Personal",
-              description: "Personal GitHub access.",
-              transport: "http",
-              url: "https://api.githubcopilot.com/mcp",
-              auth: { type: "bearer", token: "$vault:GH_TOKEN" },
-            },
-          },
-        }),
-      );
+      writeFileSync(configPath, JSON.stringify({ storage: { type: "sqlite", path: storagePath } }));
+      await seedStoredCaplet(storagePath, "github-personal", {
+        GH_TOKEN: "$vault:GH_TOKEN",
+      });
 
       await runCli(
         ["vault", "set", "GH_TOKEN_PERSONAL", "--grant", "github-personal", "--as", "GH_TOKEN"],
@@ -373,14 +424,15 @@ describe("cli init", () => {
         },
       );
 
-      const store = new FileVaultStore({ env });
-      expect(
-        store.resolveGrantedValue({
-          referenceName: "GH_TOKEN",
-          capletId: "github-personal",
-          origin: { kind: "global-config", path: configPath },
-        }),
-      ).toMatchObject({ reason: "ungranted" });
+      const storage = await createHostStorage({ type: "sqlite", path: storagePath });
+      try {
+        await expect(storage.vaultValues.resolveValue("GH_TOKEN_PERSONAL")).resolves.toBe(
+          "personal_secret",
+        );
+        await expect(storage.vaultGrants.list("github-personal")).resolves.toEqual([]);
+      } finally {
+        await storage.close();
+      }
       expect(out.join("")).toContain(
         "Granted Vault key GH_TOKEN_PERSONAL to github-personal as GH_TOKEN.",
       );
@@ -393,9 +445,10 @@ describe("cli init", () => {
     }
   });
 
-  it("grants Vault access when unrelated missing env refs would quarantine the Caplet", async () => {
+  it("grants SQL Vault access when unrelated missing env refs would quarantine the Caplet", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-vault-cli-access-env-"));
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const missingEnvName = "CAPLETS_TEST_MISSING_GRANT_ENV";
     const env = {
       ...process.env,
@@ -404,37 +457,31 @@ describe("cli init", () => {
       [missingEnvName]: undefined,
     };
     try {
-      writeFileSync(
-        configPath,
-        JSON.stringify({
-          mcpServers: {
-            github: {
-              name: "GitHub",
-              description: "GitHub access with missing runtime env.",
-              command: "github-mcp",
-              env: {
-                GH_TOKEN: "$vault:GH_TOKEN",
-                OTHER: `$env:${missingEnvName}`,
-              },
-            },
-          },
-        }),
-      );
+      writeFileSync(configPath, JSON.stringify({ storage: { type: "sqlite", path: storagePath } }));
+      await seedStoredCaplet(storagePath, "github", {
+        GH_TOKEN: "$vault:GH_TOKEN",
+        OTHER: `$env:${missingEnvName}`,
+      });
 
       await runCli(["vault", "access", "grant", "GH_TOKEN", "github"], {
         env,
         writeOut: () => undefined,
       });
 
-      const store = new FileVaultStore({ env });
-      expect(store.listAccess({ storedKey: "GH_TOKEN", capletId: "github" })).toEqual([
-        expect.objectContaining({
-          storedKey: "GH_TOKEN",
-          referenceName: "GH_TOKEN",
-          capletId: "github",
-          origin: { kind: "global-config", path: configPath },
-        }),
-      ]);
+      const storage = await createHostStorage({ type: "sqlite", path: storagePath });
+      try {
+        await expect(storage.vaultGrants.list("github")).resolves.toEqual([
+          expect.objectContaining({
+            subjectKind: "record",
+            capletId: "github",
+            vaultKey: "GH_TOKEN",
+            referenceName: "GH_TOKEN",
+            originKind: "stored-record",
+          }),
+        ]);
+      } finally {
+        await storage.close();
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -1462,41 +1509,44 @@ describe("cli init", () => {
     }
   });
 
-  it("installs all Caplets globally when requested", async () => {
+  it("installs all Caplets globally as SQL Caplet Records", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-install-global-"));
     const repo = join(dir, "repo");
     const projectRoot = join(dir, "project");
     const configPath = join(dir, "user", "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const out: string[] = [];
     const cwd = process.cwd();
-    const originalXdgStateHome = process.env.XDG_STATE_HOME;
     try {
       writeInstallableRepo(repo);
       mkdirSync(projectRoot, { recursive: true });
+      mkdirSync(dirname(configPath), { recursive: true });
+      writeFileSync(configPath, JSON.stringify({ storage: { type: "sqlite", path: storagePath } }));
       process.env.CAPLETS_CONFIG = configPath;
-      process.env.XDG_STATE_HOME = join(dir, "state");
       process.chdir(projectRoot);
 
       await runCli(["install", "--global", repo], { writeOut: (value) => out.push(value) });
 
-      expect(readFileSync(join(dir, "user", "filesystem.md"), "utf8")).toContain(
-        "name: Project Files",
-      );
-      expect(readFileSync(join(dir, "user", "github", "CAPLET.md"), "utf8")).toContain(
-        "name: GitHub",
-      );
-      expect(existsSync(join(projectRoot, ".caplets"))).toBe(false);
-      expect(existsSync(join(dir, "state", "caplets", "caplets.lock.json"))).toBe(true);
-      expect(out.join("")).toContain(
-        `Installed filesystem to ${join(dir, "user", "filesystem.md")}`,
-      );
-      expect(out.join("")).toContain(`Installed github to ${join(dir, "user", "github")}`);
-    } finally {
-      if (originalXdgStateHome === undefined) {
-        delete process.env.XDG_STATE_HOME;
-      } else {
-        process.env.XDG_STATE_HOME = originalXdgStateHome;
+      const storage = await createHostStorage({ type: "sqlite", path: storagePath });
+      try {
+        const operator = { role: "operator" as const, clientId: "cli_test" };
+        await expect(storage.caplets.getStored("filesystem", operator)).resolves.toMatchObject({
+          id: "filesystem",
+          currentRevision: { name: "Project Files" },
+        });
+        await expect(storage.caplets.getStored("github", operator)).resolves.toMatchObject({
+          id: "github",
+          currentRevision: { name: "GitHub" },
+        });
+      } finally {
+        await storage.close();
       }
+      expect(existsSync(join(projectRoot, ".caplets"))).toBe(false);
+      expect(existsSync(join(dir, "user", "filesystem.md"))).toBe(false);
+      expect(existsSync(join(dir, "user", "github"))).toBe(false);
+      expect(out.join("")).toContain("Installed filesystem to sql://caplet-records/filesystem");
+      expect(out.join("")).toContain("Installed github to sql://caplet-records/github");
+    } finally {
       process.chdir(cwd);
       rmSync(dir, { recursive: true, force: true });
     }
@@ -4477,13 +4527,14 @@ describe("cli init", () => {
 
   it("lists configured OAuth servers without printing token values", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
-    const authDir = join(dir, "auth");
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const out: string[] = [];
     try {
       writeFileSync(
         configPath,
         JSON.stringify({
+          storage: { type: "sqlite", path: storagePath },
           mcpServers: {
             remote: {
               name: "Remote",
@@ -4516,26 +4567,20 @@ describe("cli init", () => {
         }),
       );
       process.env.CAPLETS_CONFIG = configPath;
-      writeTokenBundle(
-        {
-          server: "remote",
-          accessToken: "secret-access-token",
-          tokenType: "Bearer",
-          expiresAt: "2999-01-01T00:00:00.000Z",
-          scope: "mcp:tools",
-        },
-        authDir,
-      );
-      writeTokenBundle(
-        {
-          server: "expired",
-          accessToken: "expired-secret-access-token",
-          expiresAt: "2000-01-01T00:00:00.000Z",
-        },
-        authDir,
-      );
+      await seedBackendAuth(storagePath, {
+        server: "remote",
+        accessToken: "secret-access-token",
+        tokenType: "Bearer",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        scope: "mcp:tools",
+      });
+      await seedBackendAuth(storagePath, {
+        server: "expired",
+        accessToken: "expired-secret-access-token",
+        expiresAt: "2000-01-01T00:00:00.000Z",
+      });
 
-      await runCli(["auth", "list"], { writeOut: (value) => out.push(value), authDir });
+      await runCli(["auth", "list"], { writeOut: (value) => out.push(value) });
 
       const text = out.join("");
       expect(text).toContain(
@@ -4556,11 +4601,13 @@ describe("cli init", () => {
   it("lists configured GraphQL OAuth endpoints", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const out: string[] = [];
     try {
       writeFileSync(
         configPath,
         JSON.stringify({
+          storage: { type: "sqlite", path: storagePath },
           graphqlEndpoints: {
             catalog: {
               name: "Catalog",
@@ -4585,11 +4632,13 @@ describe("cli init", () => {
   it("formats OAuth auth targets as JSON when requested", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-format-"));
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const out: string[] = [];
     try {
       writeFileSync(
         configPath,
         JSON.stringify({
+          storage: { type: "sqlite", path: storagePath },
           graphqlEndpoints: {
             catalog: {
               name: "Catalog",
@@ -4616,13 +4665,14 @@ describe("cli init", () => {
 
   it("logs out configured OAuth servers", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
-    const authDir = join(dir, "auth");
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const out: string[] = [];
     try {
       writeFileSync(
         configPath,
         JSON.stringify({
+          storage: { type: "sqlite", path: storagePath },
           mcpServers: {
             remote: {
               name: "Remote",
@@ -4635,11 +4685,13 @@ describe("cli init", () => {
         }),
       );
       process.env.CAPLETS_CONFIG = configPath;
-      writeTokenBundle({ server: "remote", accessToken: "secret-access-token" }, authDir);
+      await seedBackendAuth(storagePath, {
+        server: "remote",
+        accessToken: "secret-access-token",
+      });
 
       await runCli(["auth", "logout", "remote"], {
         writeOut: (value) => out.push(value),
-        authDir,
       });
 
       expect(out.join("")).toBe("Deleted OAuth credentials for `remote`.\n");
@@ -4647,7 +4699,6 @@ describe("cli init", () => {
 
       await runCli(["auth", "logout", "remote"], {
         writeOut: (value) => out.push(value),
-        authDir,
       });
 
       expect(out.join("")).toBe("No OAuth credentials found for `remote`.\n");
@@ -4658,8 +4709,8 @@ describe("cli init", () => {
 
   it("refreshes configured OAuth credentials on demand", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-refresh-cli-"));
-    const authDir = join(dir, "auth");
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const out: string[] = [];
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       Response.json({
@@ -4673,6 +4724,7 @@ describe("cli init", () => {
       writeFileSync(
         configPath,
         JSON.stringify({
+          storage: { type: "sqlite", path: storagePath },
           mcpServers: {
             remote: {
               name: "Remote",
@@ -4689,20 +4741,16 @@ describe("cli init", () => {
         }),
       );
       process.env.CAPLETS_CONFIG = configPath;
-      writeTokenBundle(
-        {
-          server: "remote",
-          authType: "oauth2",
-          accessToken: "old-access-token",
-          refreshToken: "old-refresh-token",
-          expiresAt: "2999-01-01T00:00:00.000Z",
-        },
-        authDir,
-      );
+      await seedBackendAuth(storagePath, {
+        server: "remote",
+        authType: "oauth2",
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+      });
 
       await runCli(["auth", "refresh", "remote"], {
         writeOut: (value) => out.push(value),
-        authDir,
       });
 
       expect(out.join("")).toBe("Refreshed OAuth credentials for `remote`.\n");
@@ -4716,11 +4764,18 @@ describe("cli init", () => {
       expect(String(fetchMock.mock.calls[0]?.[1]?.body)).toContain(
         "refresh_token=old-refresh-token",
       );
-      expect(readTokenBundle("remote", authDir)).toMatchObject({
-        accessToken: "new-access-token",
-        refreshToken: "new-refresh-token",
-        tokenType: "Bearer",
-      });
+      const storage = await createHostStorage({ type: "sqlite", path: storagePath });
+      try {
+        await expect(storage.backendAuth.readTokenBundle("remote")).resolves.toMatchObject({
+          bundle: {
+            accessToken: "new-access-token",
+            refreshToken: "new-refresh-token",
+            tokenType: "Bearer",
+          },
+        });
+      } finally {
+        await storage.close();
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -4728,8 +4783,8 @@ describe("cli init", () => {
 
   it("refreshes Google Discovery OAuth credentials with explicit scopes when discovery is unavailable", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-google-refresh-cli-"));
-    const authDir = join(dir, "auth");
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const out: string[] = [];
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
@@ -4746,6 +4801,7 @@ describe("cli init", () => {
       writeFileSync(
         configPath,
         JSON.stringify({
+          storage: { type: "sqlite", path: storagePath },
           googleDiscoveryApis: {
             drive: {
               name: "Google Drive",
@@ -4762,23 +4818,19 @@ describe("cli init", () => {
         }),
       );
       process.env.CAPLETS_CONFIG = configPath;
-      writeTokenBundle(
-        {
-          server: "drive",
-          authType: "oauth2",
-          accessToken: "old-access-token",
-          refreshToken: "old-refresh-token",
-          expiresAt: "2999-01-01T00:00:00.000Z",
-          metadata: {
-            requestedScopes: ["https://www.googleapis.com/auth/drive.readonly"],
-          },
+      await seedBackendAuth(storagePath, {
+        server: "drive",
+        authType: "oauth2",
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        metadata: {
+          requestedScopes: ["https://www.googleapis.com/auth/drive.readonly"],
         },
-        authDir,
-      );
+      });
 
       await runCli(["auth", "refresh", "drive"], {
         writeOut: (value) => out.push(value),
-        authDir,
       });
 
       expect(out.join("")).toBe("Refreshed OAuth credentials for `drive`.\n");
@@ -4797,8 +4849,8 @@ describe("cli init", () => {
 
   it("uses Discovery-derived base URL for Google Discovery OAuth refresh", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-google-base-url-cli-"));
-    const authDir = join(dir, "auth");
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const discoveryPath = join(dir, "drive.discovery.json");
     const out: string[] = [];
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -4832,6 +4884,7 @@ describe("cli init", () => {
       writeFileSync(
         configPath,
         JSON.stringify({
+          storage: { type: "sqlite", path: storagePath },
           googleDiscoveryApis: {
             drive: {
               name: "Google Drive",
@@ -4847,24 +4900,20 @@ describe("cli init", () => {
         }),
       );
       process.env.CAPLETS_CONFIG = configPath;
-      writeTokenBundle(
-        {
-          server: "drive",
-          authType: "oauth2",
-          accessToken: "old-access-token",
-          refreshToken: "old-refresh-token",
-          expiresAt: "2999-01-01T00:00:00.000Z",
-          protectedResourceOrigin: "https://api.example.com",
-          metadata: {
-            requestedScopes: ["https://www.googleapis.com/auth/drive.readonly"],
-          },
+      await seedBackendAuth(storagePath, {
+        server: "drive",
+        authType: "oauth2",
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        protectedResourceOrigin: "https://api.example.com",
+        metadata: {
+          requestedScopes: ["https://www.googleapis.com/auth/drive.readonly"],
         },
-        authDir,
-      );
+      });
 
       await runCli(["auth", "refresh", "drive"], {
         writeOut: (value) => out.push(value),
-        authDir,
       });
 
       expect(out.join("")).toBe("Refreshed OAuth credentials for `drive`.\n");
@@ -4879,8 +4928,8 @@ describe("cli init", () => {
 
   it("uses Discovery-derived base URL for explicit Google Discovery OAuth scopes", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-google-proxy-cli-"));
-    const authDir = join(dir, "auth");
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const out: string[] = [];
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
@@ -4914,6 +4963,7 @@ describe("cli init", () => {
       writeFileSync(
         configPath,
         JSON.stringify({
+          storage: { type: "sqlite", path: storagePath },
           googleDiscoveryApis: {
             drive: {
               name: "Google Drive",
@@ -4930,22 +4980,18 @@ describe("cli init", () => {
         }),
       );
       process.env.CAPLETS_CONFIG = configPath;
-      writeTokenBundle(
-        {
-          server: "drive",
-          authType: "oauth2",
-          accessToken: "old-access-token",
-          refreshToken: "old-refresh-token",
-          expiresAt: "2999-01-01T00:00:00.000Z",
-          protectedResourceOrigin: "https://api.example.com",
-          scope: "https://www.googleapis.com/auth/drive.readonly",
-        },
-        authDir,
-      );
+      await seedBackendAuth(storagePath, {
+        server: "drive",
+        authType: "oauth2",
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        protectedResourceOrigin: "https://api.example.com",
+        scope: "https://www.googleapis.com/auth/drive.readonly",
+      });
 
       await runCli(["auth", "refresh", "drive"], {
         writeOut: (value) => out.push(value),
-        authDir,
       });
 
       expect(out.join("")).toBe("Refreshed OAuth credentials for `drive`.\n");
@@ -4966,13 +5012,14 @@ describe("cli init", () => {
 
   it("logs out configured OpenAPI OAuth endpoints", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
-    const authDir = join(dir, "auth");
     const configPath = join(dir, "config.json");
+    const storagePath = join(dir, "host.sqlite3");
     const out: string[] = [];
     try {
       writeFileSync(
         configPath,
         JSON.stringify({
+          storage: { type: "sqlite", path: storagePath },
           openapiEndpoints: {
             users: {
               name: "Users API",
@@ -4984,11 +5031,13 @@ describe("cli init", () => {
         }),
       );
       process.env.CAPLETS_CONFIG = configPath;
-      writeTokenBundle({ server: "users", accessToken: "secret-access-token" }, authDir);
+      await seedBackendAuth(storagePath, {
+        server: "users",
+        accessToken: "secret-access-token",
+      });
 
       await runCli(["auth", "logout", "users"], {
         writeOut: (value) => out.push(value),
-        authDir,
       });
 
       expect(out.join("")).toBe("Deleted OAuth credentials for `users`.\n");
@@ -5696,6 +5745,7 @@ function writeInspectionConfig(path: string): void {
   writeFileSync(
     path,
     JSON.stringify({
+      storage: { type: "sqlite", path: join(dirname(path), "host.sqlite3") },
       mcpServers: {
         filesystem: {
           name: "Project Files",
@@ -5765,6 +5815,7 @@ function writeOpenApiCompletionConfig(path: string): void {
   writeFileSync(
     path,
     JSON.stringify({
+      storage: { type: "sqlite", path: join(dir, "host.sqlite3") },
       openapiEndpoints: {
         users: {
           name: "Users API",
@@ -5800,6 +5851,7 @@ function writeCliOperationConfig(path: string): void {
   writeFileSync(
     path,
     JSON.stringify({
+      storage: { type: "sqlite", path: join(dir, "host.sqlite3") },
       cliTools: {
         local: {
           name: "Local CLI",

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -187,6 +187,32 @@ describe("config", () => {
     expect(schema).toContain('"upstreams"');
   });
 
+  it("defaults Authoritative Host State to SQLite and validates PostgreSQL configuration", () => {
+    expect(parseConfig({}).storage).toEqual({ type: "sqlite" });
+    expect(
+      parseConfig({
+        storage: {
+          type: "postgres",
+          connectionString: "postgres://caplets@example.com/caplets",
+          schema: "caplets_host",
+        },
+      }).storage,
+    ).toEqual({
+      type: "postgres",
+      connectionString: "postgres://caplets@example.com/caplets",
+      schema: "caplets_host",
+    });
+    expect(() =>
+      parseConfig({
+        storage: {
+          type: "postgres",
+          connectionString: "postgres://caplets@example.com/caplets",
+          schema: "invalid-schema",
+        },
+      }),
+    ).toThrow(CapletsError);
+  });
+
   it("accepts global serve defaults and exposes them in parsed config", () => {
     const config = parseConfig({
       serve: {

--- a/packages/core/test/current-host-administration.test.ts
+++ b/packages/core/test/current-host-administration.test.ts
@@ -12,6 +12,7 @@ import { DashboardActivityLog } from "../src/dashboard/activity-log";
 import { CapletsEngine } from "../src/engine";
 import { CapletsError } from "../src/errors";
 import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
+import { createHostStorage } from "../src/storage";
 
 const dirs: string[] = [];
 
@@ -100,6 +101,115 @@ describe("Current Host administration operations", () => {
       expect(serialized).not.toContain(setup.configPath);
     } finally {
       await setup.engine.close();
+    }
+  });
+
+  it("administers stored Caplet revisions through the operator surface", async () => {
+    const root = tempDir("caplets-current-host-records-");
+    const configPath = join(root, "config.json");
+    const projectConfigPath = join(root, "project", ".caplets", "config.json");
+    const authDir = join(root, "auth");
+    const globalCapletsRoot = join(root, "global-caplets");
+    const globalLockfilePath = join(root, "remote-state", "caplets.lock.json");
+    const databasePath = join(root, "host.sqlite3");
+    mkdirSync(join(root, "project", ".caplets"), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        storage: { type: "sqlite", path: databasePath },
+        httpApis: {
+          status: {
+            name: "Status",
+            description: "Status API.",
+            baseUrl: "http://127.0.0.1:1",
+            auth: { type: "none" },
+            actions: { check: { method: "GET", path: "/check" } },
+          },
+        },
+      }),
+    );
+    const storage = await createHostStorage({ type: "sqlite", path: databasePath });
+    const engine = new CapletsEngine({
+      configPath,
+      projectConfigPath,
+      hostStorage: storage,
+      watch: false,
+    });
+    const credentials = new RemoteServerCredentialStore({ dir: join(root, "remote-state") });
+    const issued = issueOperator(credentials, "Stored Caplet Operator");
+    const activity = new DashboardActivityLog({ dir: join(root, "activity") });
+    const operations = createCurrentHostOperations({
+      engine,
+      control: { configPath, projectConfigPath, authDir, globalCapletsRoot, globalLockfilePath },
+      activityLog: activity,
+      remoteCredentialStore: credentials,
+      capletRecords: storage.caplets,
+      invalidateConfig: async (actor) => {
+        await storage.invalidateConfig(actor);
+        await engine.reload();
+      },
+      version: "test-version",
+    });
+    const principal = {
+      clientId: issued.clientId,
+      clientLabel: issued.clientLabel,
+      hostUrl: issued.hostUrl,
+      role: "operator" as const,
+    };
+
+    try {
+      const imported = await operations.execute(principal, {
+        kind: "stored_caplet_import",
+        id: "stored",
+        document: storedDocument("first"),
+        historyLimit: 3,
+      });
+      if (imported.kind !== "stored_caplet_import") throw new Error("Expected stored import.");
+      const updated = await operations.execute(principal, {
+        kind: "stored_caplet_update",
+        id: "stored",
+        document: storedDocument("second"),
+        expectedGeneration: imported.record.headGeneration,
+      });
+      if (updated.kind !== "stored_caplet_update") throw new Error("Expected stored update.");
+      const revisions = await operations.execute(principal, {
+        kind: "stored_caplet_revisions",
+        id: "stored",
+      });
+      if (revisions.kind !== "stored_caplet_revisions") throw new Error("Expected revisions.");
+      expect(revisions.revisions).toHaveLength(2);
+      const restored = await operations.execute(principal, {
+        kind: "stored_caplet_restore_revision",
+        id: "stored",
+        revisionKey: revisions.revisions[1]!.revisionKey,
+        expectedGeneration: updated.record.headGeneration,
+      });
+      if (restored.kind !== "stored_caplet_restore_revision") {
+        throw new Error("Expected revision restore.");
+      }
+      const read = await operations.execute(principal, {
+        kind: "stored_caplet_get",
+        id: "stored",
+      });
+      expect(read).toMatchObject({
+        kind: "stored_caplet_get",
+        record: { id: "stored", headGeneration: restored.record.headGeneration },
+        document: expect.stringContaining("command: first"),
+      });
+      await operations.execute(principal, {
+        kind: "stored_caplet_delete",
+        id: "stored",
+        expectedGeneration: restored.record.headGeneration,
+      });
+      await expect(operations.execute(principal, { kind: "stored_caplets_list" })).resolves.toEqual(
+        { kind: "stored_caplets_list", records: [] },
+      );
+      expect(
+        (await storage.installations.listActivity()).map((entry) => entry.operatorClientId),
+      ).toEqual(expect.arrayContaining([principal.clientId]));
+    } finally {
+      await engine.close();
+      await storage.close();
     }
   });
 
@@ -634,6 +744,20 @@ function catalogSource(root: string): string {
     ].join("\n"),
   );
   return source;
+}
+
+function storedDocument(command: string): string {
+  return [
+    "---",
+    "name: Stored",
+    "description: Stored Caplet administration fixture.",
+    "mcpServer:",
+    `  command: ${command}`,
+    "---",
+    "",
+    "# Stored",
+    "",
+  ].join("\n");
 }
 
 function tempDir(prefix: string): string {

--- a/packages/core/test/current-host-catalog-operations.test.ts
+++ b/packages/core/test/current-host-catalog-operations.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createCurrentHostCatalogOperations } from "../src/current-host/catalog-operations";
 import type * as CatalogModule from "../src/current-host/catalog";
-import type * as InstallModule from "../src/cli/install";
+import type * as InstallModule from "../src/install";
 import type {
   CurrentHostOperationsDependencies,
   CurrentHostOperatorPrincipal,
@@ -19,7 +19,7 @@ vi.mock("../src/current-host/catalog", async (importOriginal) => ({
   currentHostCatalogDetail: mocks.detail,
 }));
 
-vi.mock("../src/cli/install", async (importOriginal) => ({
+vi.mock("../src/install", async (importOriginal) => ({
   ...(await importOriginal<typeof InstallModule>()),
   installCaplets: mocks.install,
   updateCapletsFromLockfile: mocks.update,

--- a/packages/core/test/dashboard-activity.test.ts
+++ b/packages/core/test/dashboard-activity.test.ts
@@ -2,11 +2,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { DashboardActivityLog } from "../src/dashboard/activity-log";
 import { CapletsEngine } from "../src/engine";
-import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
 import { createHttpServeApp } from "../src/serve/http";
 import type { HttpServeOptions } from "../src/serve/options";
+import { createHostStorage } from "../src/storage";
 
 const dirs: string[] = [];
 
@@ -17,12 +16,12 @@ afterEach(() => {
 describe("dashboard activity and access actions", () => {
   it("approves and denies pending logins through operator actions and records redacted activity", async () => {
     const setup = await authenticatedDashboard();
-    const approveTarget = setup.store.createPendingLogin({
+    const approveTarget = await setup.store.createPendingLogin({
       hostUrl: "http://127.0.0.1:5387/",
       requestedRole: "operator",
       clientLabel: "Tablet",
     });
-    const denyTarget = setup.store.createPendingLogin({
+    const denyTarget = await setup.store.createPendingLogin({
       hostUrl: "http://127.0.0.1:5387/",
       requestedRole: "access",
       clientLabel: "Old laptop",
@@ -55,17 +54,20 @@ describe("dashboard activity and access actions", () => {
     const text = await activity.text();
     expect(text).toContain('"action":"pending_login_approved"');
     expect(text).toContain('"action":"pending_login_denied"');
+    expect(text).toContain('"action":"remote_pending_login_approved"');
+    expect(text).toContain('"action":"remote_pending_login_denied"');
     expect(text).toContain('"actorClientId"');
     expect(text).not.toContain(approveTarget.operatorCode);
     expect(text).not.toContain(approveTarget.pendingCompletionSecret);
     expect(text).not.toContain("cap_remote_access_");
 
     await setup.engine.close();
+    await setup.storage.close();
   });
 
   it("rejects flow-id approval after the visible operator code expires", async () => {
     const setup = await authenticatedDashboard();
-    const expired = setup.store.createPendingLogin({
+    const expired = await setup.store.createPendingLogin({
       hostUrl: "http://127.0.0.1:5387/",
       requestedRole: "operator",
       clientLabel: "Expired browser",
@@ -86,22 +88,26 @@ describe("dashboard activity and access actions", () => {
         message: expect.stringContaining("code has expired"),
       },
     });
-    expect(setup.store.listPendingLogins()).toContainEqual(
+    await expect(setup.store.listPendingLogins()).resolves.toContainEqual(
       expect.objectContaining({ flowId: expired.flowId, status: "pending" }),
     );
 
     await setup.engine.close();
+    await setup.storage.close();
   });
 
   it("revokes and role-changes clients, terminating current operator authority when applicable", async () => {
     const setup = await authenticatedDashboard();
-    const other = setup.store.createPendingLogin({
+    const other = await setup.store.createPendingLogin({
       hostUrl: "http://127.0.0.1:5387/",
       requestedRole: "operator",
       clientLabel: "Second operator",
     });
-    setup.store.approvePendingLogin({ operatorCode: other.operatorCode });
-    const otherCredentials = setup.store.completePendingLogin({
+    await setup.store.approvePendingLogin({
+      operatorClientId: setup.operatorClientId,
+      operatorCode: other.operatorCode,
+    });
+    const otherCredentials = await setup.store.completePendingLogin({
       hostUrl: "http://127.0.0.1:5387/",
       flowId: other.flowId,
       pendingCompletionSecret: other.pendingCompletionSecret,
@@ -138,26 +144,31 @@ describe("dashboard activity and access actions", () => {
     expect(activity.status).toBe(401);
 
     await setup.engine.close();
+    await setup.storage.close();
   });
 
-  it("paginates activity toward older entries and preserves safe valueBytes metadata", () => {
-    const log = new DashboardActivityLog({ dir: tempDir("caplets-dashboard-activity-log-") });
+  it("paginates SQL activity toward older entries and preserves safe valueBytes metadata", async () => {
+    const root = tempDir("caplets-dashboard-activity-log-");
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(root, "host.sqlite3"),
+    });
 
-    log.append({
+    await storage.operatorActivity.append({
       actorClientId: "operator",
       action: "vault_set",
       target: { type: "vault", id: "GH_TOKEN" },
       metadata: { bytesWritten: 42, secretValue: "should-not-log" },
       now: new Date("2026-07-08T10:00:00.000Z"),
     });
-    log.append({
+    await storage.operatorActivity.append({
       actorClientId: "operator",
       action: "catalog_updated",
       target: { type: "catalog", id: "github" },
       now: new Date("2026-07-08T10:01:00.000Z"),
     });
 
-    const firstPage = log.list({ limit: 1 });
+    const firstPage = await storage.operatorActivity.list({ limit: 1 });
     expect(firstPage.entries).toHaveLength(1);
     expect(firstPage.entries[0]).toMatchObject({
       action: "catalog_updated",
@@ -165,7 +176,10 @@ describe("dashboard activity and access actions", () => {
     });
     expect(firstPage.nextCursor).toBe(firstPage.entries[0]?.id);
 
-    const secondPage = log.list({ limit: 1, after: firstPage.nextCursor });
+    const secondPage = await storage.operatorActivity.list({
+      limit: 1,
+      after: firstPage.nextCursor,
+    });
     expect(secondPage.entries).toHaveLength(1);
     expect(secondPage.entries[0]).toMatchObject({
       action: "vault_set",
@@ -173,20 +187,25 @@ describe("dashboard activity and access actions", () => {
       metadata: { bytesWritten: 42 },
     });
     expect(secondPage.entries[0]?.metadata).not.toHaveProperty("secretValue");
+    await storage.close();
   });
 });
 
 type Setup = Awaited<ReturnType<typeof authenticatedDashboard>>;
 
 async function authenticatedDashboard() {
-  const setup = testApp();
+  const setup = await testApp();
   const started = await appPost(setup, "/dashboard/api/login/start", { clientLabel: "Browser" });
   const startBody = (await started.json()) as {
     flowId: string;
     pendingCompletionSecret: string;
     approvalCommand: string;
   };
-  setup.store.approvePendingLogin({ operatorCode: approvalCode(startBody.approvalCommand) });
+  await setup.store.approvePendingLogin({
+    operatorClientId: "bootstrap_test",
+    operatorCode: approvalCode(startBody.approvalCommand),
+    grantedRole: "operator",
+  });
   const completed = await appPost(setup, "/dashboard/api/login/complete", {
     flowId: startBody.flowId,
     pendingCompletionSecret: startBody.pendingCompletionSecret,
@@ -240,21 +259,26 @@ function approvalCode(command: string): string {
   return code;
 }
 
-function testApp() {
+async function testApp() {
   const stateDir = tempDir("caplets-dashboard-activity-state-");
   const context = testContext();
+  const storage = await createHostStorage(
+    { type: "sqlite", path: join(stateDir, "host.sqlite3") },
+    { vaultRoot: join(stateDir, "vault") },
+  );
   const engine = new CapletsEngine({
     configPath: context.configPath,
     projectConfigPath: context.projectConfigPath,
+    hostStorage: storage,
     watch: false,
   });
-  const store = new RemoteServerCredentialStore({ dir: stateDir });
+  const store = storage.remoteSecurity;
   const app = createHttpServeApp(httpOptions(stateDir), engine, {
     writeErr: () => {},
     control: context,
-    remoteCredentialStore: store,
+    authoritativeStorage: storage,
   });
-  return { app, engine, store, stateDir, context };
+  return { app, engine, store, storage, stateDir, context };
 }
 
 function httpOptions(stateDir: string): HttpServeOptions {

--- a/packages/core/test/dashboard-api.test.ts
+++ b/packages/core/test/dashboard-api.test.ts
@@ -3,10 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CapletsEngine } from "../src/engine";
-import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
 import { createHttpServeApp } from "../src/serve/http";
 import type { HttpServeOptions } from "../src/serve/options";
-import { FileVaultStore } from "../src/vault";
+import { createHostStorage } from "../src/storage";
 
 const dirs: string[] = [];
 
@@ -17,7 +16,7 @@ afterEach(() => {
 describe("dashboard API read model", () => {
   it("returns Current Host summary, attention, counts, and redacted section links", async () => {
     const setup = await authenticatedDashboard();
-    setup.store.createPendingLogin({
+    await setup.store.createPendingLogin({
       hostUrl: "http://127.0.0.1:5387/",
       requestedRole: "operator",
       clientLabel: "Waiting Browser",
@@ -46,11 +45,12 @@ describe("dashboard API read model", () => {
     ).not.toContain(setup.context.configPath);
 
     await setup.engine.close();
+    await setup.storage.close();
   });
 
   it("lists clients, pending logins, and Vault metadata without credential or raw Vault values", async () => {
     const setup = await authenticatedDashboard();
-    setup.store.createPendingLogin({
+    await setup.store.createPendingLogin({
       hostUrl: "http://127.0.0.1:5387/",
       requestedRole: "operator",
       clientLabel: "Waiting Browser",
@@ -80,6 +80,7 @@ describe("dashboard API read model", () => {
     expect(vaultText).not.toContain("super-secret-token");
 
     await setup.engine.close();
+    await setup.storage.close();
   });
 
   it("returns Project Binding and runtime placeholders as mobile-friendly objects", async () => {
@@ -107,7 +108,61 @@ describe("dashboard API read model", () => {
     });
 
     await setup.engine.close();
+    await setup.storage.close();
   });
+  it("administers stored Caplet records through authenticated SQL-backed routes", async () => {
+    const setup = await authenticatedStoredDashboard();
+    const firstDocument = storedDocument("first-command");
+    const imported = await dashboardMutation(setup, "/dashboard/api/stored-caplets", "POST", {
+      id: "stored",
+      document: firstDocument,
+      historyLimit: 3,
+    });
+    expect(imported.status).toBe(201);
+    const importedBody = (await imported.json()) as {
+      record: { headGeneration: number };
+    };
+    expect(importedBody.record.headGeneration).toBe(1);
+
+    const listed = await dashboardGet(setup, "/dashboard/api/stored-caplets");
+    await expect(listed.json()).resolves.toMatchObject({
+      records: [{ id: "stored", headGeneration: 1 }],
+    });
+    const updated = await dashboardMutation(setup, "/dashboard/api/stored-caplets/stored", "PUT", {
+      document: storedDocument("second-command"),
+      expectedGeneration: 1,
+    });
+    expect(updated.status).toBe(200);
+    await expect(updated.json()).resolves.toMatchObject({
+      record: { id: "stored", headGeneration: 2 },
+    });
+    const revisions = await dashboardGet(setup, "/dashboard/api/stored-caplets/stored/revisions");
+    await expect(revisions.json()).resolves.toMatchObject({
+      revisions: [{ sequence: 2 }, { sequence: 1 }],
+    });
+    const stale = await dashboardMutation(setup, "/dashboard/api/stored-caplets/stored", "PUT", {
+      document: storedDocument("stale-secret-command"),
+      expectedGeneration: 1,
+    });
+    expect(stale.status).toBe(400);
+    expect(await stale.text()).not.toContain("stale-secret-command");
+    const deleted = await dashboardMutation(
+      setup,
+      "/dashboard/api/stored-caplets/stored",
+      "DELETE",
+      { expectedGeneration: 2 },
+    );
+    expect(deleted.status).toBe(200);
+    await expect(deleted.json()).resolves.toEqual({ deleted: true, id: "stored" });
+    const activity = await setup.storage.installations.listActivity();
+    expect(activity.map((entry) => entry.operatorClientId)).toContain(setup.operatorClientId);
+    expect(JSON.stringify(activity)).not.toContain("first-command");
+    expect(JSON.stringify(activity)).not.toContain("second-command");
+
+    await setup.engine.close();
+    await setup.storage.close();
+  });
+
   it("maps authenticated collaborator faults to internal errors without ending the session", async () => {
     const setup = await authenticatedDashboard();
     vi.spyOn(setup.engine, "enabledServers").mockImplementation(() => {
@@ -127,18 +182,22 @@ describe("dashboard API read model", () => {
     expect(response.headers.get("set-cookie")).toBeNull();
 
     await setup.engine.close();
+    await setup.storage.close();
   });
 });
 
 async function authenticatedDashboard() {
-  const setup = testApp();
-  const vault = new FileVaultStore({ root: join(setup.authDir, "vault") });
-  vault.set("GH_TOKEN", "super-secret-token");
-  vault.grantAccess({
-    storedKey: "GH_TOKEN",
-    referenceName: "GH_TOKEN",
+  const setup = await testApp();
+  await setup.storage.vaultValues.set("GH_TOKEN", "super-secret-token", {
+    operatorClientId: "bootstrap_test",
+  });
+  await setup.storage.vaultGrants.grant({
     capletId: "status",
-    origin: { kind: "global-config", path: setup.context.configPath },
+    vaultKey: "GH_TOKEN",
+    referenceName: "GH_TOKEN",
+    originKind: "global-config",
+    originPath: setup.context.configPath,
+    operator: { role: "operator", clientId: "bootstrap_test" },
   });
   const started = await appPost(setup, "/dashboard/api/login/start", { clientLabel: "Browser" });
   const startBody = (await started.json()) as {
@@ -146,7 +205,11 @@ async function authenticatedDashboard() {
     pendingCompletionSecret: string;
     approvalCommand: string;
   };
-  setup.store.approvePendingLogin({ operatorCode: approvalCode(startBody.approvalCommand) });
+  await setup.store.approvePendingLogin({
+    operatorClientId: "bootstrap_test",
+    operatorCode: approvalCode(startBody.approvalCommand),
+    grantedRole: "operator",
+  });
   const completed = await appPost(setup, "/dashboard/api/login/complete", {
     flowId: startBody.flowId,
     pendingCompletionSecret: startBody.pendingCompletionSecret,
@@ -154,6 +217,77 @@ async function authenticatedDashboard() {
   expect(completed.status).toBe(200);
   const cookie = completed.headers.get("set-cookie") ?? "";
   return { ...setup, cookie };
+}
+async function authenticatedStoredDashboard() {
+  const stateDir = tempDir("caplets-dashboard-stored-state-");
+  const authDir = tempDir("caplets-dashboard-stored-auth-");
+  const context = testContext();
+  const storage = await createHostStorage(
+    { type: "sqlite", path: join(stateDir, "host.sqlite3") },
+    { vaultRoot: join(stateDir, "vault") },
+  );
+  const engine = new CapletsEngine({
+    configPath: context.configPath,
+    projectConfigPath: context.projectConfigPath,
+    authDir,
+    hostStorage: storage,
+    watch: false,
+  });
+  const app = createHttpServeApp(httpOptions(stateDir), engine, {
+    writeErr: () => {},
+    control: { ...context, authDir },
+    authoritativeStorage: storage,
+  });
+  const started = await appPost({ app }, "/dashboard/api/login/start", {
+    clientLabel: "Stored Browser",
+  });
+  const startBody = (await started.json()) as {
+    flowId: string;
+    pendingCompletionSecret: string;
+    approvalCommand: string;
+  };
+  await storage.remoteSecurity.approvePendingLogin({
+    operatorClientId: "bootstrap_test",
+    operatorCode: approvalCode(startBody.approvalCommand),
+    grantedRole: "operator",
+  });
+  const completed = await appPost({ app }, "/dashboard/api/login/complete", {
+    flowId: startBody.flowId,
+    pendingCompletionSecret: startBody.pendingCompletionSecret,
+  });
+  expect(completed.status).toBe(200);
+  const body = (await completed.json()) as {
+    session: { csrfToken: string; operatorClientId: string };
+  };
+  return {
+    app,
+    engine,
+    storage,
+    cookie: completed.headers.get("set-cookie") ?? "",
+    csrfToken: body.session.csrfToken,
+    operatorClientId: body.session.operatorClientId,
+  };
+}
+
+async function dashboardMutation(
+  setup: {
+    app: ReturnType<typeof createHttpServeApp>;
+    cookie: string;
+    csrfToken: string;
+  },
+  path: string,
+  method: "POST" | "PUT" | "DELETE",
+  body: unknown,
+) {
+  return await setup.app.request(`http://127.0.0.1:5387${path}`, {
+    method,
+    headers: {
+      cookie: setup.cookie,
+      "x-caplets-csrf": setup.csrfToken,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
 }
 
 async function dashboardGet(
@@ -183,23 +317,28 @@ function approvalCode(command: string): string {
   return code;
 }
 
-function testApp() {
+async function testApp() {
   const stateDir = tempDir("caplets-dashboard-api-state-");
   const authDir = tempDir("caplets-dashboard-api-auth-");
   const context = testContext();
+  const storage = await createHostStorage(
+    { type: "sqlite", path: join(stateDir, "host.sqlite3") },
+    { vaultRoot: join(stateDir, "vault") },
+  );
   const engine = new CapletsEngine({
     configPath: context.configPath,
     projectConfigPath: context.projectConfigPath,
     authDir,
+    hostStorage: storage,
     watch: false,
   });
-  const store = new RemoteServerCredentialStore({ dir: stateDir });
+  const store = storage.remoteSecurity;
   const app = createHttpServeApp(httpOptions(stateDir), engine, {
     writeErr: () => {},
     control: { ...context, authDir },
-    remoteCredentialStore: store,
+    authoritativeStorage: storage,
   });
-  return { app, engine, store, stateDir, authDir, context };
+  return { app, engine, store, storage, stateDir, authDir, context };
 }
 
 function httpOptions(stateDir: string): HttpServeOptions {
@@ -244,6 +383,20 @@ function testContext(): {
     }),
   );
   return { configPath, projectConfigPath, projectCapletsRoot: projectRoot };
+}
+
+function storedDocument(command: string): string {
+  return [
+    "---",
+    "name: Stored",
+    "description: Stored dashboard fixture.",
+    "mcpServer:",
+    `  command: ${command}`,
+    "---",
+    "",
+    "# Stored",
+    "",
+  ].join("\n");
 }
 
 function tempDir(prefix: string): string {

--- a/packages/core/test/dashboard-catalog.test.ts
+++ b/packages/core/test/dashboard-catalog.test.ts
@@ -1,10 +1,11 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { currentHostCatalogInstallSource } from "../src/current-host/catalog";
 import { CapletsEngine } from "../src/engine";
-import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
+import { createHostStorage, type HostStorage } from "../src/storage";
+import type { RemoteSecurityStore } from "../src/storage/remote-security";
 import { createHttpServeApp, type CapletsHttpApp } from "../src/serve/http";
 import type { HttpServeOptions } from "../src/serve/options";
 
@@ -92,7 +93,7 @@ describe("dashboard caplets and catalog APIs", () => {
       signal: expect.any(AbortSignal),
     });
 
-    await setup.engine.close();
+    await closeDashboard(setup);
   });
 
   it("returns all 150 compact official entries without the former search ceiling", async () => {
@@ -109,7 +110,7 @@ describe("dashboard caplets and catalog APIs", () => {
     expect(body.entries[149]).toMatchObject({ id: "entry-149" });
     expect(body.entries.some((entry) => "contentMarkdown" in entry)).toBe(false);
 
-    await setup.engine.close();
+    await closeDashboard(setup);
   });
 
   it("preserves legacy catalog search limits when query parameters are present", async () => {
@@ -132,7 +133,7 @@ describe("dashboard caplets and catalog APIs", () => {
       expect.objectContaining({ id: "entry-1" }),
     ]);
 
-    await setup.engine.close();
+    await closeDashboard(setup);
   });
 
   it("rejects an official compact index above 10,000 entries as a protocol error", async () => {
@@ -153,7 +154,7 @@ describe("dashboard caplets and catalog APIs", () => {
       error: { code: "DOWNSTREAM_PROTOCOL_ERROR" },
     });
 
-    await setup.engine.close();
+    await closeDashboard(setup);
   });
 
   it("rejects overlong compact fields as a protocol error", async () => {
@@ -173,7 +174,7 @@ describe("dashboard caplets and catalog APIs", () => {
       error: { code: "DOWNSTREAM_PROTOCOL_ERROR" },
     });
 
-    await setup.engine.close();
+    await closeDashboard(setup);
   });
 
   it.each([
@@ -252,7 +253,7 @@ describe("dashboard caplets and catalog APIs", () => {
       ok: false,
       error: { code: "DOWNSTREAM_PROTOCOL_ERROR" },
     });
-    await setup.engine.close();
+    await closeDashboard(setup);
   });
 
   it("pins official installer input to the inspected revision", () => {
@@ -290,7 +291,7 @@ describe("dashboard caplets and catalog APIs", () => {
       ok: false,
       error: { code: "DOWNSTREAM_PROTOCOL_ERROR" },
     });
-    await setup.engine.close();
+    await closeDashboard(setup);
   });
 
   it("searches catalog sources and returns detail readiness, warnings, and install metadata", async () => {
@@ -336,10 +337,10 @@ describe("dashboard caplets and catalog APIs", () => {
       projectScopedInstallAvailable: false,
     });
 
-    await setup.engine.close();
+    await closeDashboard(setup);
   });
 
-  it("installs catalog caplets globally, updates lockfile state, and records activity", async () => {
+  it("installs catalog caplets globally as SQL records and installations", async () => {
     const setup = await authenticatedDashboard();
     const source = catalogSource();
 
@@ -347,40 +348,71 @@ describe("dashboard caplets and catalog APIs", () => {
       source,
       entryKey: await localEntryKey(setup, source),
     });
-    expect(installed.status).toBe(200);
-    await expect(installed.json()).resolves.toMatchObject({
+    expect(installed.status, await installed.clone().text()).toBe(200);
+    const installedBody = (await installed.json()) as {
+      installed: Array<Record<string, unknown>>;
+      setupActions: unknown[];
+    };
+    expect(installedBody).toMatchObject({
       installed: [
         expect.objectContaining({
           id: "sample",
           status: "installed",
-          lockfile: setup.context.globalLockfilePath,
+          destination: "sql://caplet-records/sample",
         }),
       ],
       setupActions: expect.arrayContaining([expect.objectContaining({ kind: "auth" })]),
     });
+    expect(installedBody.installed[0]).not.toHaveProperty("lockfile");
 
-    expect(existsSync(join(setup.context.globalCapletsRoot, "sample.md"))).toBe(true);
-    expect(JSON.parse(readFileSync(setup.context.globalLockfilePath, "utf8"))).toMatchObject({
-      entries: [expect.objectContaining({ id: "sample", destination: "sample.md" })],
+    const record = await setup.storage.caplets.readBundle("sample", {
+      operator: { clientId: setup.operatorClientId, role: "operator" },
     });
+    const installation = await setup.storage.installations.getActive("sample");
+    const observation = await setup.storage.installations.getLatestObservation("sample");
+    expect(record).toMatchObject({
+      record: { id: "sample", headGeneration: 1 },
+      files: [expect.objectContaining({ path: "CAPLET.md" })],
+    });
+    expect(installation).toMatchObject({
+      capletId: "sample",
+      generation: 1,
+      status: "active",
+      sourceKind: "local",
+      sourceIdentity: source,
+    });
+    expect(observation).toMatchObject({
+      status: "current",
+      contentHash: expect.stringMatching(/^sha256:/),
+    });
+    expect(installation?.recordKey).toBe(record?.record.recordKey);
+    expect(existsSync(setup.context.globalCapletsRoot)).toBe(false);
+    expect(existsSync(setup.context.globalLockfilePath)).toBe(false);
+    expect(await setup.storage.installations.listActivity()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operatorClientId: setup.operatorClientId,
+          action: "caplet.import",
+        }),
+      ]),
+    );
 
     const updates = await dashboardGet(setup, "/dashboard/api/catalog/updates");
     expect(updates.status).toBe(200);
-    await expect(updates.json()).resolves.toMatchObject({
-      updates: [expect.objectContaining({ id: "sample", status: "locked" })],
-    });
+    await expect(updates.json()).resolves.toEqual({ updates: [] });
 
     const activity = await dashboardGet(setup, "/dashboard/api/activity?action=catalog_installed");
     expect(activity.status).toBe(200);
     const text = await activity.text();
     expect(text).toContain('"action":"catalog_installed"');
     expect(text).toContain('"id":"sample"');
+    expect(text).toContain(setup.operatorClientId);
     expect(text).not.toContain(source);
 
-    await setup.engine.close();
+    await closeDashboard(setup);
   });
 
-  it("rejects acknowledged catalog updates when installed files have local modifications", async () => {
+  it("requires acknowledgement for SQL catalog updates that increase risk", async () => {
     const setup = await authenticatedDashboard();
     const source = catalogSource();
 
@@ -388,27 +420,58 @@ describe("dashboard caplets and catalog APIs", () => {
       source,
       entryKey: await localEntryKey(setup, source),
     });
-    expect(installed.status).toBe(200);
-    const installedPath = join(setup.context.globalCapletsRoot, "sample.md");
-    const localContents = "# Local changes\n\n";
-    writeFileSync(installedPath, localContents);
+    expect(installed.status, await installed.clone().text()).toBe(200);
+    makeCatalogSourceDestructive(source);
 
-    const update = await dashboardPost(setup, "/dashboard/api/catalog/update", {
+    const rejected = await dashboardPost(setup, "/dashboard/api/catalog/update", {
+      capletId: "sample",
+      acknowledgeRiskIncrease: false,
+    });
+    expect(rejected.status).toBe(400);
+    await expect(rejected.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: "REQUEST_INVALID",
+        message: expect.stringContaining("risk profile"),
+      },
+    });
+    await expect(setup.storage.caplets.get("sample")).resolves.toMatchObject({
+      headGeneration: 1,
+    });
+    await expect(setup.storage.installations.getActive("sample")).resolves.toMatchObject({
+      generation: 1,
+    });
+
+    const updated = await dashboardPost(setup, "/dashboard/api/catalog/update", {
       capletId: "sample",
       acknowledgeRiskIncrease: true,
     });
-
-    expect(update.status).toBe(409);
-    await expect(update.json()).resolves.toMatchObject({
-      ok: false,
-      error: {
-        code: "CONFIG_EXISTS",
-        message: expect.stringContaining("local modifications"),
-      },
+    expect(updated.status).toBe(200);
+    await expect(updated.json()).resolves.toMatchObject({
+      installed: [
+        expect.objectContaining({
+          id: "sample",
+          status: "updated",
+          destination: "sql://caplet-records/sample",
+        }),
+      ],
     });
-    expect(readFileSync(installedPath, "utf8")).toBe(localContents);
+    await expect(setup.storage.caplets.get("sample")).resolves.toMatchObject({
+      headGeneration: 2,
+    });
+    await expect(setup.storage.installations.getActive("sample")).resolves.toMatchObject({
+      generation: 2,
+    });
+    await expect(setup.storage.installations.getLatestObservation("sample")).resolves.toMatchObject(
+      {
+        status: "current",
+        risk: expect.objectContaining({ destructive: true }),
+      },
+    );
+    expect(existsSync(setup.context.globalCapletsRoot)).toBe(false);
+    expect(existsSync(setup.context.globalLockfilePath)).toBe(false);
 
-    await setup.engine.close();
+    await closeDashboard(setup);
   });
 
   it("does not report unavailable catalog update sources as unauthorized", async () => {
@@ -419,7 +482,7 @@ describe("dashboard caplets and catalog APIs", () => {
       source,
       entryKey: await localEntryKey(setup, source),
     });
-    expect(installed.status).toBe(200);
+    expect(installed.status, await installed.clone().text()).toBe(200);
 
     rmSync(source, { recursive: true, force: true });
 
@@ -432,8 +495,13 @@ describe("dashboard caplets and catalog APIs", () => {
       ok: false,
       error: { code: "CONFIG_NOT_FOUND" },
     });
+    await expect(setup.storage.installations.getLatestObservation("sample")).resolves.toMatchObject(
+      {
+        status: "source-unavailable",
+      },
+    );
 
-    await setup.engine.close();
+    await closeDashboard(setup);
   });
   it("rejects dashboard install before an unvalidated source reaches installation", async () => {
     const setup = await authenticatedDashboard();
@@ -449,12 +517,16 @@ describe("dashboard caplets and catalog APIs", () => {
       error: { code: string; message: string };
     };
 
-    const pending = setup.store.createPendingLogin({
+    const pending = await setup.store.createPendingLogin({
       hostUrl: "http://127.0.0.1:5387/",
       requestedRole: "operator",
     });
-    setup.store.approvePendingLogin({ operatorCode: pending.operatorCode });
-    const operator = setup.store.completePendingLogin({
+    await setup.store.approvePendingLogin({
+      operatorClientId: "bootstrap_bearer_test",
+      operatorCode: pending.operatorCode,
+      grantedRole: "operator",
+    });
+    const operator = await setup.store.completePendingLogin({
       hostUrl: "http://127.0.0.1:5387/",
       flowId: pending.flowId,
       pendingCompletionSecret: pending.pendingCompletionSecret,
@@ -484,7 +556,7 @@ describe("dashboard caplets and catalog APIs", () => {
     expect(JSON.stringify({ dashboardError, bearerError })).not.toContain("transport_secret");
     expect(JSON.stringify({ dashboardError, bearerError })).not.toContain("127.0.0.1");
 
-    await setup.engine.close();
+    await closeDashboard(setup);
   });
 });
 
@@ -499,7 +571,8 @@ interface DashboardCatalogTestContext {
 interface TestAppSetup {
   app: CapletsHttpApp;
   engine: CapletsEngine;
-  store: RemoteServerCredentialStore;
+  store: RemoteSecurityStore;
+  storage: HostStorage;
   stateDir: string;
   context: DashboardCatalogTestContext;
 }
@@ -511,14 +584,18 @@ interface AuthenticatedDashboard extends TestAppSetup {
 }
 
 async function authenticatedDashboard(): Promise<AuthenticatedDashboard> {
-  const setup = testApp();
+  const setup = await testApp();
   const started = await appPost(setup, "/dashboard/api/login/start", { clientLabel: "Browser" });
   const startBody = (await started.json()) as {
     flowId: string;
     pendingCompletionSecret: string;
     approvalCommand: string;
   };
-  setup.store.approvePendingLogin({ operatorCode: approvalCode(startBody.approvalCommand) });
+  await setup.store.approvePendingLogin({
+    operatorClientId: "bootstrap_test",
+    operatorCode: approvalCode(startBody.approvalCommand),
+    grantedRole: "operator",
+  });
   const completed = await appPost(setup, "/dashboard/api/login/complete", {
     flowId: startBody.flowId,
     pendingCompletionSecret: startBody.pendingCompletionSecret,
@@ -579,21 +656,30 @@ function approvalCode(command: string): string {
   return code;
 }
 
-function testApp(): TestAppSetup {
+async function testApp(): Promise<TestAppSetup> {
   const stateDir = tempDir("caplets-dashboard-catalog-state-");
   const context = testContext();
+  const storage = await createHostStorage(
+    { type: "sqlite", path: join(stateDir, "host.sqlite3") },
+    { vaultRoot: join(stateDir, "vault") },
+  );
   const engine = new CapletsEngine({
     configPath: context.configPath,
     projectConfigPath: context.projectConfigPath,
+    hostStorage: storage,
     watch: false,
   });
-  const store = new RemoteServerCredentialStore({ dir: stateDir });
+  const store = storage.remoteSecurity;
   const app = createHttpServeApp(httpOptions(stateDir), engine, {
     writeErr: () => {},
     control: context,
-    remoteCredentialStore: store,
+    authoritativeStorage: storage,
   });
-  return { app, engine, store, stateDir, context };
+  return { app, engine, store, storage, stateDir, context };
+}
+async function closeDashboard(setup: TestAppSetup): Promise<void> {
+  await setup.engine.close();
+  await setup.storage.close();
 }
 
 function httpOptions(stateDir: string): HttpServeOptions {
@@ -615,10 +701,8 @@ function testContext(): DashboardCatalogTestContext {
   const dir = tempDir("caplets-dashboard-catalog-");
   const userRoot = join(dir, "user");
   const projectRoot = join(dir, "project", ".caplets");
-  const globalCapletsRoot = join(dir, "global-caplets");
   mkdirSync(userRoot, { recursive: true });
   mkdirSync(projectRoot, { recursive: true });
-  mkdirSync(globalCapletsRoot, { recursive: true });
   const configPath = join(userRoot, "config.json");
   const projectConfigPath = join(projectRoot, "config.json");
   writeFileSync(
@@ -639,17 +723,25 @@ function testContext(): DashboardCatalogTestContext {
     configPath,
     projectConfigPath,
     projectCapletsRoot: projectRoot,
-    globalCapletsRoot,
+    globalCapletsRoot: join(dir, "global-caplets"),
     globalLockfilePath: join(dir, "remote-state", "caplets.lock.json"),
   };
 }
 
 function catalogSource(): string {
   const source = tempDir("caplets-dashboard-catalog-source-");
-  const caplets = join(source, "caplets");
-  mkdirSync(caplets, { recursive: true });
+  mkdirSync(join(source, "caplets"), { recursive: true });
+  writeCatalogSource(source, "POST");
+  return source;
+}
+
+function makeCatalogSourceDestructive(source: string): void {
+  writeCatalogSource(source, "DELETE");
+}
+
+function writeCatalogSource(source: string, method: "POST" | "DELETE"): void {
   writeFileSync(
-    join(caplets, "sample.md"),
+    join(source, "caplets", "sample.md"),
     [
       "---",
       "name: Sample",
@@ -669,7 +761,7 @@ function catalogSource(): string {
       "    token: $env:SAMPLE_TOKEN",
       "  actions:",
       "    create:",
-      "      method: POST",
+      `      method: ${method}`,
       "      path: /items",
       "---",
       "",
@@ -677,7 +769,6 @@ function catalogSource(): string {
       "",
     ].join("\n"),
   );
-  return source;
 }
 
 function officialCompactEntry(index: number) {

--- a/packages/core/test/dashboard-runtime.test.ts
+++ b/packages/core/test/dashboard-runtime.test.ts
@@ -3,8 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { CapletsEngine } from "../src/engine";
-import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
 import { createHttpServeApp } from "../src/serve/http";
+import { createHostStorage } from "../src/storage";
 import type { HttpServeOptions } from "../src/serve/options";
 
 const dirs: string[] = [];
@@ -40,6 +40,7 @@ describe("dashboard runtime, diagnostics, logs, and events APIs", () => {
     });
 
     await setup.engine.close();
+    await setup.storage.close();
   });
 
   it("emits a replayable dashboard event stream snapshot", async () => {
@@ -52,19 +53,23 @@ describe("dashboard runtime, diagnostics, logs, and events APIs", () => {
     expect(text).toContain('"type":"runtime_health"');
     expect(text).toContain('"state":"disconnected"');
     await setup.engine.close();
+    await setup.storage.close();
   });
 });
 type Setup = Awaited<ReturnType<typeof authenticatedDashboard>>;
 
 async function authenticatedDashboard() {
-  const setup = testApp();
+  const setup = await testApp();
   const started = await appPost(setup, "/dashboard/api/login/start", { clientLabel: "Browser" });
   const startBody = (await started.json()) as {
     flowId: string;
     pendingCompletionSecret: string;
     approvalCommand: string;
   };
-  setup.store.approvePendingLogin({ operatorCode: approvalCode(startBody.approvalCommand) });
+  await setup.store.approvePendingLogin({
+    operatorClientId: "bootstrap_test",
+    operatorCode: approvalCode(startBody.approvalCommand),
+  });
   const completed = await appPost(setup, "/dashboard/api/login/complete", {
     flowId: startBody.flowId,
     pendingCompletionSecret: startBody.pendingCompletionSecret,
@@ -118,21 +123,27 @@ function approvalCode(command: string): string {
   return code;
 }
 
-function testApp() {
-  const stateDir = tempDir("caplets-dashboard-catalog-state-");
+async function testApp() {
+  const stateDir = tempDir("caplets-dashboard-runtime-state-");
   const context = testContext();
+  const storage = await createHostStorage(
+    { type: "sqlite", path: join(stateDir, "host.sqlite3") },
+    { vaultRoot: join(stateDir, "vault") },
+  );
   const engine = new CapletsEngine({
     configPath: context.configPath,
     projectConfigPath: context.projectConfigPath,
+    authDir: context.authDir,
+    hostStorage: storage,
     watch: false,
   });
-  const store = new RemoteServerCredentialStore({ dir: stateDir });
+  const store = storage.remoteSecurity;
   const app = createHttpServeApp(httpOptions(stateDir), engine, {
     writeErr: () => {},
     control: context,
-    remoteCredentialStore: store,
+    authoritativeStorage: storage,
   });
-  return { app, engine, store, stateDir, context };
+  return { app, engine, store, storage, stateDir, context };
 }
 
 function httpOptions(stateDir: string): HttpServeOptions {

--- a/packages/core/test/dashboard-session-store.test.ts
+++ b/packages/core/test/dashboard-session-store.test.ts
@@ -1,0 +1,161 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DashboardSessionStore } from "../src/dashboard/session-store";
+import { DASHBOARD_SESSION_COOKIE } from "../src/dashboard/types";
+import { createHostStorage, type HostStorage } from "../src/storage";
+import { DashboardSessionRepository } from "../src/storage/dashboard-sessions";
+import * as sqlite from "../src/storage/schema/sqlite";
+
+const NOW = new Date("2026-07-18T12:00:00.000Z");
+
+let root: string;
+let firstStorage: HostStorage;
+let secondStorage: HostStorage;
+let firstRepository: DashboardSessionRepository;
+let secondRepository: DashboardSessionRepository;
+let authorizedClients: Set<string>;
+let firstStore: DashboardSessionStore;
+let secondStore: DashboardSessionStore;
+
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), "caplets-dashboard-sessions-"));
+  const path = join(root, "caplets.sqlite3");
+  firstStorage = await createHostStorage({ type: "sqlite", path });
+  secondStorage = await createHostStorage({ type: "sqlite", path });
+  firstRepository = new DashboardSessionRepository(firstStorage.database);
+  secondRepository = new DashboardSessionRepository(secondStorage.database);
+  authorizedClients = new Set(["operator_browser"]);
+  firstStore = new DashboardSessionStore({
+    repository: firstRepository,
+    validateOperatorClient: async (clientId) => authorizedClients.has(clientId),
+  });
+  secondStore = new DashboardSessionStore({
+    repository: secondRepository,
+    validateOperatorClient: async (clientId) => authorizedClients.has(clientId),
+  });
+});
+
+afterEach(async () => {
+  await firstStorage.close();
+  await secondStorage.close();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("SQL-backed dashboard sessions", () => {
+  it("creates, validates, and touches a session visible to another SQLite instance", async () => {
+    const created = await firstStore.create({ operatorClientId: "operator_browser", now: NOW });
+    const persisted = await firstRepository.get(created.session.sessionId);
+    if (!persisted) throw new Error("Created dashboard session was not persisted.");
+    await expect(secondRepository.create(persisted)).resolves.toBe(false);
+    const touchedAt = new Date(NOW.getTime() + 30 * 60_000);
+
+    const validated = await secondStore.validate({
+      cookieHeader: cookieHeader(created.cookieValue),
+      csrfToken: created.session.csrfToken,
+      requireCsrf: true,
+      now: touchedAt,
+    });
+
+    expect(validated).toEqual({ ...created.session, lastUsedAt: touchedAt.toISOString() });
+    await expect(firstRepository.get(created.session.sessionId)).resolves.toMatchObject({
+      ...created.session,
+      secretHash: expect.any(String),
+      lastUsedAt: touchedAt.toISOString(),
+    });
+  });
+
+  it("rejects the wrong cookie secret and CSRF token without touching the session", async () => {
+    const created = await firstStore.create({ operatorClientId: "operator_browser", now: NOW });
+    const later = new Date(NOW.getTime() + 5 * 60_000);
+
+    await expect(
+      secondStore.validate({
+        cookieHeader: cookieHeader(`${created.session.sessionId}.wrong-secret`),
+        now: later,
+      }),
+    ).rejects.toMatchObject({ code: "AUTH_FAILED" });
+    await expect(
+      secondStore.validate({
+        cookieHeader: cookieHeader(created.cookieValue),
+        csrfToken: "wrong-csrf",
+        requireCsrf: true,
+        now: later,
+      }),
+    ).rejects.toMatchObject({ code: "REQUEST_INVALID" });
+    await expect(firstRepository.get(created.session.sessionId)).resolves.toMatchObject({
+      lastUsedAt: NOW.toISOString(),
+    });
+  });
+
+  it("deletes absolutely expired and idle-expired sessions", async () => {
+    const absolute = await firstStore.create({ operatorClientId: "operator_browser", now: NOW });
+    await expect(
+      secondStore.validate({
+        cookieHeader: cookieHeader(absolute.cookieValue),
+        now: new Date(NOW.getTime() + 12 * 60 * 60_000),
+      }),
+    ).rejects.toMatchObject({ code: "AUTH_FAILED" });
+    await expect(firstRepository.get(absolute.session.sessionId)).resolves.toBeUndefined();
+
+    const idleCreatedAt = new Date(NOW.getTime() + 13 * 60 * 60_000);
+    const idle = await firstStore.create({
+      operatorClientId: "operator_browser",
+      now: idleCreatedAt,
+    });
+    await expect(
+      secondStore.validate({
+        cookieHeader: cookieHeader(idle.cookieValue),
+        now: new Date(idleCreatedAt.getTime() + 60 * 60_000 + 1),
+      }),
+    ).rejects.toMatchObject({ code: "AUTH_FAILED" });
+    await expect(firstRepository.get(idle.session.sessionId)).resolves.toBeUndefined();
+  });
+
+  it("deletes a session whose remote operator client was revoked", async () => {
+    const created = await firstStore.create({ operatorClientId: "operator_browser", now: NOW });
+    authorizedClients.delete("operator_browser");
+
+    await expect(
+      secondStore.validate({
+        cookieHeader: cookieHeader(created.cookieValue),
+        now: new Date(NOW.getTime() + 1_000),
+      }),
+    ).rejects.toMatchObject({ code: "AUTH_FAILED" });
+    await expect(firstRepository.get(created.session.sessionId)).resolves.toBeUndefined();
+  });
+
+  it("deletes a session on logout and rejects persisted invalid payloads", async () => {
+    const created = await firstStore.create({ operatorClientId: "operator_browser", now: NOW });
+    await expect(secondStore.delete(cookieHeader(created.cookieValue))).resolves.toBe(true);
+    await expect(firstStore.delete(cookieHeader(created.cookieValue))).resolves.toBe(false);
+
+    if (firstStorage.database.dialect !== "sqlite") throw new Error("Expected SQLite storage.");
+    firstStorage.database.db
+      .insert(sqlite.dashboardSessions)
+      .values({
+        sessionId: "dash_invalid",
+        secretHash: "not-used",
+        operatorClientId: "operator_browser",
+        role: "access",
+        csrfToken: "csrf_invalid",
+        createdAt: NOW.toISOString(),
+        expiresAt: new Date(NOW.getTime() + 60_000).toISOString(),
+        lastUsedAt: NOW.toISOString(),
+      })
+      .run();
+
+    await expect(
+      secondStore.validate({
+        cookieHeader: cookieHeader("dash_invalid.secret"),
+        now: NOW,
+      }),
+    ).rejects.toMatchObject({ code: "AUTH_FAILED" });
+    expect(firstStorage.database.db.select().from(sqlite.dashboardSessions).all()).toEqual([]);
+  });
+});
+
+function cookieHeader(cookieValue: string): string {
+  return `${DASHBOARD_SESSION_COOKIE}=${cookieValue}`;
+}

--- a/packages/core/test/dashboard-session.test.ts
+++ b/packages/core/test/dashboard-session.test.ts
@@ -1,21 +1,25 @@
+import BetterSqlite3 from "better-sqlite3";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { CapletsEngine } from "../src/engine";
-import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
 import { createHttpServeApp, type CapletsHttpApp } from "../src/serve/http";
+import { createHostStorage, type HostStorage, type RemoteSecurityStore } from "../src/storage";
 import type { HttpServeOptions } from "../src/serve/options";
 
 const dirs: string[] = [];
+const storages = new Set<HostStorage>();
 
-afterEach(() => {
+afterEach(async () => {
+  await Promise.all([...storages].map(async (storage) => await storage.close()));
+  storages.clear();
   for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
 describe("dashboard sessions", () => {
   it("serves the unauthenticated dashboard shell without operator data", async () => {
-    const { app, engine } = testApp();
+    const { app, engine } = await testApp();
 
     const response = await app.request("http://127.0.0.1:5387/dashboard");
 
@@ -31,7 +35,7 @@ describe("dashboard sessions", () => {
   });
 
   it("requires a session cookie for remote-credential dashboard sessions", async () => {
-    const { app, engine } = testApp();
+    const { app, engine } = await testApp();
 
     const response = await app.request("http://127.0.0.1:5387/dashboard/api/session");
 
@@ -41,7 +45,7 @@ describe("dashboard sessions", () => {
   });
 
   it("serves a development operator session and dashboard data without cookies", async () => {
-    const { app, engine } = developmentTestApp();
+    const { app, engine } = await developmentTestApp();
 
     const session = await app.request("http://127.0.0.1:5387/dashboard/api/session");
     expect(session.status).toBe(200);
@@ -71,7 +75,7 @@ describe("dashboard sessions", () => {
     await engine.close();
   });
   it("denies non-loopback development administration while preserving runtime access", async () => {
-    const { app, engine } = developmentTestApp({ host: "0.0.0.0", loopback: false });
+    const { app, engine } = await developmentTestApp({ host: "0.0.0.0", loopback: false });
     const baseUrl = "http://10.0.0.5:5387";
 
     const session = await app.request(`${baseUrl}/dashboard/api/session`);
@@ -120,7 +124,7 @@ describe("dashboard sessions", () => {
   });
 
   it("logs out development operator sessions without cookie-backed sessions", async () => {
-    const { app, engine } = developmentTestApp();
+    const { app, engine } = await developmentTestApp();
 
     const expectedStatuses = [
       {
@@ -148,7 +152,7 @@ describe("dashboard sessions", () => {
   });
 
   it("starts dashboard authorization as an operator pending login", async () => {
-    const { app, engine, store, stateDir } = testApp();
+    const { app, engine, store } = await testApp();
 
     const response = await app.request("http://127.0.0.1:5387/dashboard/api/login/start", {
       method: "POST",
@@ -167,9 +171,9 @@ describe("dashboard sessions", () => {
       approvalCommand: expect.stringContaining("caplets remote host approve cap_login_"),
       requestedRole: "operator",
     });
-    expect(body.approvalCommand).toContain(`--state-path ${stateDir}`);
+    expect(body.approvalCommand).not.toContain("--state-path");
     expect(body.approvalCommand).toContain("--yes");
-    expect(store.listPendingLogins()).toContainEqual(
+    expect(await store.listPendingLogins()).toContainEqual(
       expect.objectContaining({ clientLabel: "Browser", requestedRole: "operator" }),
     );
 
@@ -177,10 +181,13 @@ describe("dashboard sessions", () => {
   });
 
   it("completes approved dashboard authorization into an HttpOnly session cookie", async () => {
-    const { app, engine, store } = testApp();
+    const { app, engine, store } = await testApp();
     const started = await startDashboardLogin(app);
     const code = approvalCode(started.approvalCommand);
-    store.approvePendingLogin({ operatorCode: code });
+    await store.approvePendingLogin({
+      operatorClientId: "bootstrap_test",
+      operatorCode: code,
+    });
 
     const response = await app.request("http://127.0.0.1:5387/dashboard/api/login/complete", {
       method: "POST",
@@ -216,9 +223,10 @@ describe("dashboard sessions", () => {
   });
 
   it("rejects downgraded dashboard approvals without creating orphaned access clients", async () => {
-    const { app, engine, store } = testApp();
+    const { app, engine, store } = await testApp();
     const started = await startDashboardLogin(app);
-    store.approvePendingLogin({
+    await store.approvePendingLogin({
+      operatorClientId: "bootstrap_test",
       operatorCode: approvalCode(started.approvalCommand),
       grantedRole: "access",
     });
@@ -237,18 +245,21 @@ describe("dashboard sessions", () => {
       ok: false,
       error: { code: "AUTH_FAILED", message: expect.stringContaining("operator role") },
     });
-    expect(store.listClients()).toHaveLength(0);
+    expect(await store.listClients()).toHaveLength(0);
 
     await engine.close();
   });
 
   it("sets a Secure dashboard session cookie when HTTPS public origin fronts HTTP proxy traffic", async () => {
-    const { app, engine, store } = testApp({
+    const { app, engine, store } = await testApp({
       publicOrigin: "https://caplets.example.com",
       trustProxy: true,
     });
     const started = await startDashboardLogin(app);
-    store.approvePendingLogin({ operatorCode: approvalCode(started.approvalCommand) });
+    await store.approvePendingLogin({
+      operatorClientId: "bootstrap_test",
+      operatorCode: approvalCode(started.approvalCommand),
+    });
 
     const response = await app.request("http://10.0.0.5:5387/dashboard/api/login/complete", {
       method: "POST",
@@ -268,20 +279,32 @@ describe("dashboard sessions", () => {
   });
 
   it("returns 503 instead of logging out on dashboard session lock contention", async () => {
-    const setup = testApp();
+    const setup = await testApp();
     const { cookie } = await approvedDashboardSession(setup.app, setup.store);
+    if (setup.storage.database.dialect !== "sqlite") {
+      throw new Error("Expected SQLite HostStorage.");
+    }
+    const sqlite = setup.storage.database.db as unknown as {
+      $client: { pragma(source: string): unknown };
+    };
+    sqlite.$client.pragma("busy_timeout = 1");
+    const lock = new BetterSqlite3(setup.databasePath);
+    try {
+      lock.exec("BEGIN IMMEDIATE");
+      const response = await setup.app.request("http://127.0.0.1:5387/dashboard/api/session", {
+        headers: { cookie },
+      });
 
-    mkdirSync(join(setup.stateDir, "dashboard-sessions.lock"), { recursive: true });
-    const response = await setup.app.request("http://127.0.0.1:5387/dashboard/api/session", {
-      headers: { cookie },
-    });
-
-    expect(response.status).toBe(503);
+      expect(response.status).toBe(503);
+    } finally {
+      lock.exec("ROLLBACK");
+      lock.close();
+    }
     await setup.engine.close();
   });
 
   it("requires a remote-credential session and CSRF on unsafe dashboard APIs and invalidates logout", async () => {
-    const { app, engine, store } = testApp();
+    const { app, engine, store } = await testApp();
     const missingSession = await app.request("http://127.0.0.1:5387/dashboard/api/logout", {
       method: "POST",
     });
@@ -311,15 +334,17 @@ describe("dashboard sessions", () => {
   });
 
   it("reloads durable sessions and rejects them after backing operator revocation", async () => {
-    const setup = testApp();
+    const setup = await testApp();
     const { cookie } = await approvedDashboardSession(setup.app, setup.store);
     await setup.engine.close();
+    await setup.storage.close();
 
-    const reloadedEngine = engineFor(setup.context);
+    const reloadedStorage = await createTestHostStorage(setup.stateDir, setup.databasePath);
+    const reloadedEngine = engineFor(setup.context, reloadedStorage);
     const reloadedApp = createHttpServeApp(httpOptions(setup.stateDir), reloadedEngine, {
       writeErr: () => {},
       control: setup.context,
-      remoteCredentialStore: setup.store,
+      authoritativeStorage: reloadedStorage,
     });
     const restored = await reloadedApp.request("http://127.0.0.1:5387/dashboard/api/session", {
       headers: { cookie },
@@ -327,7 +352,10 @@ describe("dashboard sessions", () => {
     expect(restored.status).toBe(200);
     const restoredBody = (await restored.json()) as { session: { operatorClientId: string } };
 
-    setup.store.revokeClient(restoredBody.session.operatorClientId);
+    await reloadedStorage.remoteSecurity.revokeClient({
+      operatorClientId: "bootstrap_test",
+      clientId: restoredBody.session.operatorClientId,
+    });
     const revoked = await reloadedApp.request("http://127.0.0.1:5387/dashboard/api/session", {
       headers: { cookie },
     });
@@ -357,10 +385,13 @@ async function startDashboardLogin(app: CapletsHttpApp): Promise<{
 
 async function approvedDashboardSession(
   app: CapletsHttpApp,
-  store: RemoteServerCredentialStore,
+  store: RemoteSecurityStore,
 ): Promise<{ cookie: string; csrfToken: string }> {
   const started = await startDashboardLogin(app);
-  store.approvePendingLogin({ operatorCode: approvalCode(started.approvalCommand) });
+  await store.approvePendingLogin({
+    operatorClientId: "bootstrap_test",
+    operatorCode: approvalCode(started.approvalCommand),
+  });
   const response = await app.request("http://127.0.0.1:5387/dashboard/api/login/complete", {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -381,34 +412,51 @@ function approvalCode(command: string): string {
   return code;
 }
 
-function testApp(overrides: Partial<HttpServeOptions> = {}) {
+async function testApp(overrides: Partial<HttpServeOptions> = {}) {
   const stateDir = tempDir("caplets-dashboard-state-");
+  const databasePath = join(stateDir, "host.sqlite3");
   const context = testContext();
-  const engine = engineFor(context);
-  const store = new RemoteServerCredentialStore({ dir: stateDir });
+  const storage = await createTestHostStorage(stateDir, databasePath);
+  const engine = engineFor(context, storage);
+  const store = storage.remoteSecurity;
   const app = createHttpServeApp(httpOptions(stateDir, overrides), engine, {
     writeErr: () => {},
     control: context,
-    remoteCredentialStore: store,
+    authoritativeStorage: storage,
   });
-  return { app, engine, store, stateDir, context };
+  return { app, engine, store, storage, databasePath, stateDir, context };
 }
 
-function developmentTestApp(overrides: Partial<HttpServeOptions> = {}) {
+async function developmentTestApp(overrides: Partial<HttpServeOptions> = {}) {
   const stateDir = tempDir("caplets-dashboard-dev-state-");
   const context = testContext();
-  const engine = engineFor(context);
+  const storage = await createTestHostStorage(stateDir, join(stateDir, "host.sqlite3"));
+  const engine = engineFor(context, storage);
   const app = createHttpServeApp(developmentHttpOptions(stateDir, overrides), engine, {
     writeErr: () => {},
     control: context,
+    authoritativeStorage: storage,
   });
-  return { app, engine, stateDir, context };
+  return { app, engine, storage, stateDir, context };
 }
 
-function engineFor(context: { configPath: string; projectConfigPath: string }): CapletsEngine {
+async function createTestHostStorage(stateDir: string, databasePath: string): Promise<HostStorage> {
+  const storage = await createHostStorage(
+    { type: "sqlite", path: databasePath },
+    { vaultRoot: join(stateDir, "vault") },
+  );
+  storages.add(storage);
+  return storage;
+}
+
+function engineFor(
+  context: { configPath: string; projectConfigPath: string },
+  storage: HostStorage,
+): CapletsEngine {
   return new CapletsEngine({
     configPath: context.configPath,
     projectConfigPath: context.projectConfigPath,
+    hostStorage: storage,
     watch: false,
   });
 }

--- a/packages/core/test/dashboard-static.test.ts
+++ b/packages/core/test/dashboard-static.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { CapletsEngine } from "../src/engine";
 import { createHttpServeApp } from "../src/serve/http";
 import { dashboardStaticResponse } from "../src/dashboard/routes";
+import { createHostStorage } from "../src/storage";
 import type { HttpServeOptions } from "../src/serve/options";
 
 const dirs: string[] = [];
@@ -34,15 +35,12 @@ describe("dashboard static serving", () => {
     writeFileSync(join(dashboardDistDir, "_astro", "client.js"), "console.log('dashboard')");
     writeFileSync(join(dashboardDistDir, "icon.png"), "png");
 
-    const { engine } = testEngine();
-    const app = createHttpServeApp(
-      httpOptions(tempDir("caplets-dashboard-static-state-")),
-      engine,
-      {
-        dashboardDistDir,
-        writeErr: () => {},
-      },
-    );
+    const { engine, storage, stateDir } = await testEngine();
+    const app = createHttpServeApp(httpOptions(stateDir), engine, {
+      authoritativeStorage: storage,
+      dashboardDistDir,
+      writeErr: () => {},
+    });
 
     const overview = await app.request("http://127.0.0.1:5387/dashboard");
     expect(overview.status).toBe(200);
@@ -71,6 +69,7 @@ describe("dashboard static serving", () => {
     expect(session.status).toBe(401);
 
     await engine.close();
+    await storage.close();
   });
 
   it("serves dashboard HTML and immutable assets under a configured base path", async () => {
@@ -88,15 +87,12 @@ describe("dashboard static serving", () => {
     );
     writeFileSync(join(dashboardDistDir, "_astro", "base.js"), "export const base = true;");
 
-    const { engine } = testEngine();
-    const app = createHttpServeApp(
-      { ...httpOptions(tempDir("caplets-dashboard-base-state-")), path: "/caplets" },
-      engine,
-      {
-        dashboardDistDir,
-        writeErr: () => {},
-      },
-    );
+    const { engine, storage, stateDir } = await testEngine();
+    const app = createHttpServeApp({ ...httpOptions(stateDir), path: "/caplets" }, engine, {
+      authoritativeStorage: storage,
+      dashboardDistDir,
+      writeErr: () => {},
+    });
 
     const dashboard = await app.request("http://127.0.0.1:5387/caplets/dashboard");
     expect(dashboard.status).toBe(200);
@@ -114,6 +110,7 @@ describe("dashboard static serving", () => {
     expect(asset.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
 
     await engine.close();
+    await storage.close();
   });
 
   it("does not serve dashboard paths that escape the static dist directory", () => {
@@ -137,7 +134,7 @@ describe("dashboard static serving", () => {
   });
 });
 
-function testEngine() {
+async function testEngine() {
   const dir = tempDir("caplets-dashboard-static-config-");
   const configPath = join(dir, "config.json");
   writeFileSync(
@@ -154,7 +151,15 @@ function testEngine() {
       },
     }),
   );
-  return { engine: new CapletsEngine({ configPath }) };
+  const storage = await createHostStorage(
+    { type: "sqlite", path: join(dir, "host.sqlite3") },
+    { vaultRoot: join(dir, "vault") },
+  );
+  return {
+    engine: new CapletsEngine({ configPath, hostStorage: storage }),
+    storage,
+    stateDir: dir,
+  };
 }
 
 function httpOptions(stateDir: string): HttpServeOptions {

--- a/packages/core/test/dashboard-vault.test.ts
+++ b/packages/core/test/dashboard-vault.test.ts
@@ -3,10 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CapletsEngine } from "../src/engine";
-import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
 import { createHttpServeApp } from "../src/serve/http";
-import { FileVaultStore } from "../src/vault";
 import type { HttpServeOptions } from "../src/serve/options";
+import { createHostStorage, VaultValueStore } from "../src/storage";
 
 const dirs: string[] = [];
 
@@ -68,14 +67,15 @@ describe("dashboard Vault APIs", () => {
     const activity = await dashboardGet(setup, "/dashboard/api/activity");
     expect(activity.status).toBe(200);
     const activityText = await activity.text();
-    expect(activityText).toContain('"action":"vault_set"');
-    expect(activityText).toContain('"action":"vault_grant_added"');
-    expect(activityText).toContain('"action":"vault_grant_revoked"');
-    expect(activityText).toContain('"action":"vault_deleted"');
     expect(activityText).not.toContain(secret);
+    expect(activityText).toContain('"action":"vault_value_written"');
+    expect(activityText).toContain('"action":"vault.grant"');
+    expect(activityText).toContain('"action":"vault.revoke"');
+    expect(activityText).toContain('"action":"vault_value_deleted"');
     expect(activityText).not.toContain(setup.context.configPath);
 
     await setup.engine.close();
+    await setup.storage.close();
   });
 
   it("reveals exactly one confirmed key and redacts reveal activity", async () => {
@@ -108,6 +108,7 @@ describe("dashboard Vault APIs", () => {
     expect(text).not.toContain("remote_secret");
 
     await setup.engine.close();
+    await setup.storage.close();
   });
   it("maps reveal collaborator faults to internal errors without ending the session", async () => {
     const setup = await authenticatedDashboard();
@@ -115,9 +116,9 @@ describe("dashboard Vault APIs", () => {
       key: "GH_TOKEN",
       value: "remote_secret",
     });
-    vi.spyOn(FileVaultStore.prototype, "resolveValue").mockImplementation(() => {
-      throw new Error("Vault read failed at /tmp/private token=cap_remote_access_sensitive_value");
-    });
+    vi.spyOn(VaultValueStore.prototype, "resolveValue").mockRejectedValue(
+      new Error("Vault read failed at /tmp/private token=cap_remote_access_sensitive_value"),
+    );
 
     const response = await dashboardPost(setup, "/dashboard/api/vault/reveal", {
       key: "GH_TOKEN",
@@ -135,6 +136,7 @@ describe("dashboard Vault APIs", () => {
     expect(response.headers.get("set-cookie")).toBeNull();
 
     await setup.engine.close();
+    await setup.storage.close();
   });
   it("preserves identical opaque Vault bytes through dashboard and bearer adapters", async () => {
     const setup = await authenticatedDashboard();
@@ -146,12 +148,15 @@ describe("dashboard Vault APIs", () => {
     });
     expect(dashboardResponse.status).toBe(200);
 
-    const pending = setup.store.createPendingLogin({
+    const pending = await setup.store.createPendingLogin({
       hostUrl: "http://127.0.0.1:5387/",
       requestedRole: "operator",
     });
-    setup.store.approvePendingLogin({ operatorCode: pending.operatorCode });
-    const operator = setup.store.completePendingLogin({
+    await setup.store.approvePendingLogin({
+      operatorClientId: setup.operatorClientId,
+      operatorCode: pending.operatorCode,
+    });
+    const operator = await setup.store.completePendingLogin({
       hostUrl: "http://127.0.0.1:5387/",
       flowId: pending.flowId,
       pendingCompletionSecret: pending.pendingCompletionSecret,
@@ -169,24 +174,30 @@ describe("dashboard Vault APIs", () => {
     });
     expect(bearerResponse.status).toBe(200);
 
-    const vault = new FileVaultStore({ root: join(setup.context.authDir, "vault") });
-    expect(vault.resolveValue("DASHBOARD_WHITESPACE")).toBe(value);
-    expect(vault.resolveValue("BEARER_WHITESPACE")).toBe(value);
+    await expect(setup.storage.vaultValues.resolveValue("DASHBOARD_WHITESPACE")).resolves.toBe(
+      value,
+    );
+    await expect(setup.storage.vaultValues.resolveValue("BEARER_WHITESPACE")).resolves.toBe(value);
 
     await setup.engine.close();
+    await setup.storage.close();
   });
 });
 type Setup = Awaited<ReturnType<typeof authenticatedDashboard>>;
 
 async function authenticatedDashboard() {
-  const setup = testApp();
+  const setup = await testApp();
   const started = await appPost(setup, "/dashboard/api/login/start", { clientLabel: "Browser" });
   const startBody = (await started.json()) as {
     flowId: string;
     pendingCompletionSecret: string;
     approvalCommand: string;
   };
-  setup.store.approvePendingLogin({ operatorCode: approvalCode(startBody.approvalCommand) });
+  await setup.store.approvePendingLogin({
+    operatorClientId: "bootstrap_test",
+    operatorCode: approvalCode(startBody.approvalCommand),
+    grantedRole: "operator",
+  });
   const completed = await appPost(setup, "/dashboard/api/login/complete", {
     flowId: startBody.flowId,
     pendingCompletionSecret: startBody.pendingCompletionSecret,
@@ -240,21 +251,26 @@ function approvalCode(command: string): string {
   return code;
 }
 
-function testApp() {
-  const stateDir = tempDir("caplets-dashboard-catalog-state-");
+async function testApp() {
+  const stateDir = tempDir("caplets-dashboard-vault-state-");
   const context = testContext();
+  const storage = await createHostStorage(
+    { type: "sqlite", path: join(stateDir, "host.sqlite3") },
+    { vaultRoot: join(stateDir, "vault") },
+  );
   const engine = new CapletsEngine({
     configPath: context.configPath,
     projectConfigPath: context.projectConfigPath,
+    hostStorage: storage,
     watch: false,
   });
-  const store = new RemoteServerCredentialStore({ dir: stateDir });
+  const store = storage.remoteSecurity;
   const app = createHttpServeApp(httpOptions(stateDir), engine, {
     writeErr: () => {},
     control: context,
-    remoteCredentialStore: store,
+    authoritativeStorage: storage,
   });
-  return { app, engine, store, stateDir, context };
+  return { app, engine, store, storage, stateDir, context };
 }
 
 function httpOptions(stateDir: string): HttpServeOptions {

--- a/packages/core/test/downstream.test.ts
+++ b/packages/core/test/downstream.test.ts
@@ -8,7 +8,7 @@ import { parseConfig } from "../src/config";
 import { DownstreamManager } from "../src/downstream";
 import { ServerRegistry } from "../src/registry";
 import type { CapletsError } from "../src/errors";
-import { writeTokenBundle } from "../src/auth";
+import { createHostStorage, type HostStorage } from "../src/storage";
 import { handleServerTool } from "../src/tools";
 import type { Tool } from "@modelcontextprotocol/sdk/types";
 import { testBackendOperationRuntime } from "./backend-operation-runtime";
@@ -762,6 +762,7 @@ function projectBindingContext(projectRoot: string, projectFingerprint: string) 
 describe("downstream remote OAuth lifecycle", () => {
   it("surfaces missing OAuth credentials as AUTH_REQUIRED", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
+    const storage = await createTestAuthStorage(dir);
     try {
       const config = parseConfig({
         mcpServers: {
@@ -775,7 +776,7 @@ describe("downstream remote OAuth lifecycle", () => {
         },
       });
       const registry = new ServerRegistry(config);
-      const manager = new DownstreamManager(registry, { authDir: join(dir, "auth") });
+      const manager = new DownstreamManager(registry, { backendAuth: storage.backendAuth });
 
       await expect(manager.listTools(config.mcpServers.remote!)).rejects.toMatchObject({
         code: "AUTH_REQUIRED",
@@ -785,13 +786,14 @@ describe("downstream remote OAuth lifecycle", () => {
       } satisfies Partial<CapletsError>);
       expect(registry.getStatus("remote")).toBe("unavailable");
     } finally {
+      await storage.close();
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
   it("classifies OAuth 403 responses as AUTH_FAILED", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
-    const authDir = join(dir, "auth");
+    const storage = await createTestAuthStorage(dir);
     const server = createServer((request: IncomingMessage, response: ServerResponse) => {
       let body = "";
       request.setEncoding("utf8");
@@ -837,16 +839,13 @@ describe("downstream remote OAuth lifecycle", () => {
       if (!address || typeof address === "string") {
         throw new Error("Could not bind fixture server");
       }
-      writeTokenBundle(
-        {
-          server: "remote",
-          accessToken: "secret-oauth-token",
-          refreshToken: "secret-refresh-token",
-          tokenType: "Bearer",
-          expiresAt: "2999-01-01T00:00:00.000Z",
-        },
-        authDir,
-      );
+      await storage.backendAuth.writeTokenBundle({
+        server: "remote",
+        accessToken: "secret-oauth-token",
+        refreshToken: "secret-refresh-token",
+        tokenType: "Bearer",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+      });
       const config = parseConfig({
         mcpServers: {
           remote: {
@@ -859,7 +858,7 @@ describe("downstream remote OAuth lifecycle", () => {
         },
       });
       const registry = new ServerRegistry(config);
-      const manager = new DownstreamManager(registry, { authDir });
+      const manager = new DownstreamManager(registry, { backendAuth: storage.backendAuth });
 
       try {
         await expect(manager.listTools(config.mcpServers.remote!)).rejects.toMatchObject({
@@ -875,13 +874,14 @@ describe("downstream remote OAuth lifecycle", () => {
       }
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
+      await storage.close();
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
   it("uses the MCP SDK auth provider for stored OAuth tokens", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-auth-"));
-    const authDir = join(dir, "auth");
+    const storage = await createTestAuthStorage(dir);
     const authorizationHeaders: Array<string | undefined> = [];
     let baseUrl = "";
     const server = createServer((request: IncomingMessage, response: ServerResponse) => {
@@ -936,16 +936,13 @@ describe("downstream remote OAuth lifecycle", () => {
         throw new Error("Could not bind fixture server");
       }
       baseUrl = `http://127.0.0.1:${address.port}/mcp`;
-      writeTokenBundle(
-        {
-          server: "remote",
-          accessToken: "secret-oauth-token",
-          refreshToken: "secret-refresh-token",
-          tokenType: "Bearer",
-          expiresAt: "2999-01-01T00:00:00.000Z",
-        },
-        authDir,
-      );
+      await storage.backendAuth.writeTokenBundle({
+        server: "remote",
+        accessToken: "secret-oauth-token",
+        refreshToken: "secret-refresh-token",
+        tokenType: "Bearer",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+      });
       const config = parseConfig({
         mcpServers: {
           remote: {
@@ -958,7 +955,7 @@ describe("downstream remote OAuth lifecycle", () => {
         },
       });
       const registry = new ServerRegistry(config);
-      const manager = new DownstreamManager(registry, { authDir });
+      const manager = new DownstreamManager(registry, { backendAuth: storage.backendAuth });
 
       try {
         await manager.listTools(config.mcpServers.remote!);
@@ -969,6 +966,7 @@ describe("downstream remote OAuth lifecycle", () => {
       expect(authorizationHeaders).toContain("Bearer secret-oauth-token");
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
+      await storage.close();
       rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -996,4 +994,8 @@ async function waitUntil(predicate: () => boolean): Promise<void> {
     }
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
+}
+
+async function createTestAuthStorage(directory: string): Promise<HostStorage> {
+  return createHostStorage({ type: "sqlite", path: join(directory, "host.sqlite3") });
 }

--- a/packages/core/test/exposure-discovery.test.ts
+++ b/packages/core/test/exposure-discovery.test.ts
@@ -240,6 +240,7 @@ function configFor(
 ): CapletsConfig {
   return {
     version: 1,
+    storage: { type: "sqlite" },
     options: {
       defaultSearchLimit: 20,
       maxSearchLimit: 50,

--- a/packages/core/test/google-discovery.test.ts
+++ b/packages/core/test/google-discovery.test.ts
@@ -10,7 +10,7 @@ import {
   GoogleDiscoveryManager,
   googleDiscoveryScopesForOperations,
 } from "../src/google-discovery";
-import { writeTokenBundle } from "../src/auth";
+import { createHostStorage, type HostStorage } from "../src/storage";
 import { parseConfig } from "../src/config";
 import { DownstreamManager } from "../src/downstream";
 import { ServerRegistry } from "../src/registry";
@@ -771,6 +771,7 @@ describe("GoogleDiscoveryManager", () => {
 
   it("fetches public remote Discovery documents before requiring OAuth credentials", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-google-public-discovery-"));
+    const storage = await createTestAuthStorage(dir);
     const config = parseConfig({
       googleDiscoveryApis: {
         drive: {
@@ -786,7 +787,9 @@ describe("GoogleDiscoveryManager", () => {
         },
       },
     });
-    const manager = new GoogleDiscoveryManager(new ServerRegistry(config), { authDir: dir });
+    const manager = new GoogleDiscoveryManager(new ServerRegistry(config), {
+      backendAuth: storage.backendAuth,
+    });
 
     try {
       await expect(manager.listTools(config.googleDiscoveryApis.drive!)).resolves.toEqual(
@@ -796,12 +799,14 @@ describe("GoogleDiscoveryManager", () => {
         requests.find((request) => request.url === "/drive.discovery.json")?.headers,
       ).not.toHaveProperty("authorization");
     } finally {
+      await storage.close();
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
   it("sends stored OAuth credentials for private remote Discovery documents without baseUrl", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-google-private-discovery-"));
+    const storage = await createTestAuthStorage(dir);
     const config = parseConfig({
       googleDiscoveryApis: {
         drive: {
@@ -816,19 +821,18 @@ describe("GoogleDiscoveryManager", () => {
         },
       },
     });
-    writeTokenBundle(
-      {
-        server: "drive",
-        authType: "oauth2",
-        accessToken: "private-discovery-token",
-        tokenType: "Bearer",
-        expiresAt: "2999-01-01T00:00:00.000Z",
-        clientId: "client",
-        protectedResourceOrigin: baseUrl,
-      },
-      dir,
-    );
-    const manager = new GoogleDiscoveryManager(new ServerRegistry(config), { authDir: dir });
+    await storage.backendAuth.writeTokenBundle({
+      server: "drive",
+      authType: "oauth2",
+      accessToken: "private-discovery-token",
+      tokenType: "Bearer",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      clientId: "client",
+      protectedResourceOrigin: baseUrl,
+    });
+    const manager = new GoogleDiscoveryManager(new ServerRegistry(config), {
+      backendAuth: storage.backendAuth,
+    });
 
     try {
       await expect(manager.listTools(config.googleDiscoveryApis.drive!)).resolves.toEqual(
@@ -838,12 +842,14 @@ describe("GoogleDiscoveryManager", () => {
         requests.find((request) => request.url === "/private.discovery.json")?.headers,
       ).toHaveProperty("authorization", "Bearer private-discovery-token");
     } finally {
+      await storage.close();
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
   it("does not send API OAuth credentials to cross-origin Discovery documents", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-google-cross-origin-discovery-"));
+    const storage = await createTestAuthStorage(dir);
     const config = parseConfig({
       googleDiscoveryApis: {
         drive: {
@@ -859,19 +865,18 @@ describe("GoogleDiscoveryManager", () => {
         },
       },
     });
-    writeTokenBundle(
-      {
-        server: "drive",
-        authType: "oauth2",
-        accessToken: "api-origin-token",
-        tokenType: "Bearer",
-        expiresAt: "2999-01-01T00:00:00.000Z",
-        clientId: "client",
-        protectedResourceOrigin: "https://www.googleapis.com",
-      },
-      dir,
-    );
-    const manager = new GoogleDiscoveryManager(new ServerRegistry(config), { authDir: dir });
+    await storage.backendAuth.writeTokenBundle({
+      server: "drive",
+      authType: "oauth2",
+      accessToken: "api-origin-token",
+      tokenType: "Bearer",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      clientId: "client",
+      protectedResourceOrigin: "https://www.googleapis.com",
+    });
+    const manager = new GoogleDiscoveryManager(new ServerRegistry(config), {
+      backendAuth: storage.backendAuth,
+    });
 
     try {
       await expect(manager.listTools(config.googleDiscoveryApis.drive!)).resolves.toEqual(
@@ -881,12 +886,14 @@ describe("GoogleDiscoveryManager", () => {
         requests.find((request) => request.url === "/drive.discovery.json")?.headers,
       ).not.toHaveProperty("authorization");
     } finally {
+      await storage.close();
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
   it("refreshes expired OAuth credentials before protected Discovery document fetches", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-google-private-discovery-refresh-"));
+    const storage = await createTestAuthStorage(dir);
     const config = parseConfig({
       googleDiscoveryApis: {
         drive: {
@@ -901,20 +908,19 @@ describe("GoogleDiscoveryManager", () => {
         },
       },
     });
-    writeTokenBundle(
-      {
-        server: "drive",
-        authType: "oauth2",
-        accessToken: "expired-discovery-token",
-        refreshToken: "old-discovery-refresh-token",
-        tokenType: "Bearer",
-        expiresAt: "2000-01-01T00:00:00.000Z",
-        clientId: "client",
-        protectedResourceOrigin: baseUrl,
-      },
-      dir,
-    );
-    const manager = new GoogleDiscoveryManager(new ServerRegistry(config), { authDir: dir });
+    await storage.backendAuth.writeTokenBundle({
+      server: "drive",
+      authType: "oauth2",
+      accessToken: "expired-discovery-token",
+      refreshToken: "old-discovery-refresh-token",
+      tokenType: "Bearer",
+      expiresAt: "2000-01-01T00:00:00.000Z",
+      clientId: "client",
+      protectedResourceOrigin: baseUrl,
+    });
+    const manager = new GoogleDiscoveryManager(new ServerRegistry(config), {
+      backendAuth: storage.backendAuth,
+    });
 
     try {
       await expect(manager.listTools(config.googleDiscoveryApis.drive!)).resolves.toEqual(
@@ -927,6 +933,7 @@ describe("GoogleDiscoveryManager", () => {
       );
       expect(discovery?.headers.authorization).toBe("Bearer refreshed-discovery-token");
     } finally {
+      await storage.close();
       rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -1541,6 +1548,7 @@ describe("GoogleDiscoveryManager", () => {
 
   it("preserves OAuth authorization on resumable upload session requests", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-google-resumable-auth-"));
+    const storage = await createTestAuthStorage(dir);
     const config = parseConfig({
       googleDiscoveryApis: {
         drive: {
@@ -1555,19 +1563,18 @@ describe("GoogleDiscoveryManager", () => {
         },
       },
     });
-    writeTokenBundle(
-      {
-        server: "drive",
-        authType: "oauth2",
-        accessToken: "upload-token",
-        tokenType: "Bearer",
-        expiresAt: "2999-01-01T00:00:00.000Z",
-        clientId: "client",
-        protectedResourceOrigin: baseUrl,
-      },
-      dir,
-    );
-    const manager = new GoogleDiscoveryManager(new ServerRegistry(config), { authDir: dir });
+    await storage.backendAuth.writeTokenBundle({
+      server: "drive",
+      authType: "oauth2",
+      accessToken: "upload-token",
+      tokenType: "Bearer",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      clientId: "client",
+      protectedResourceOrigin: baseUrl,
+    });
+    const manager = new GoogleDiscoveryManager(new ServerRegistry(config), {
+      backendAuth: storage.backendAuth,
+    });
 
     try {
       await manager.callTool(config.googleDiscoveryApis.drive!, "drive.files.create", {
@@ -1580,6 +1587,7 @@ describe("GoogleDiscoveryManager", () => {
       expect(start?.headers.authorization).toBe("Bearer upload-token");
       expect(upload?.headers.authorization).toBe("Bearer upload-token");
     } finally {
+      await storage.close();
       rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -1610,6 +1618,7 @@ describe("GoogleDiscoveryManager", () => {
 
   it("surfaces Google OAuth failures as auth-required errors", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-google-auth-error-"));
+    const storage = await createTestAuthStorage(dir);
     const config = parseConfig({
       googleDiscoveryApis: {
         drive: {
@@ -1624,22 +1633,21 @@ describe("GoogleDiscoveryManager", () => {
         },
       },
     });
-    writeTokenBundle(
-      {
-        server: "drive",
-        authType: "oauth2",
-        accessToken: "expired-access-token",
-        tokenType: "Bearer",
-        expiresAt: "2999-01-01T00:00:00.000Z",
-        clientId: "client",
-        protectedResourceOrigin: baseUrl,
-        metadata: {
-          requestedScopes: ["https://www.googleapis.com/auth/drive.readonly"],
-        },
+    await storage.backendAuth.writeTokenBundle({
+      server: "drive",
+      authType: "oauth2",
+      accessToken: "expired-access-token",
+      tokenType: "Bearer",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      clientId: "client",
+      protectedResourceOrigin: baseUrl,
+      metadata: {
+        requestedScopes: ["https://www.googleapis.com/auth/drive.readonly"],
       },
-      dir,
-    );
-    const manager = new GoogleDiscoveryManager(new ServerRegistry(config), { authDir: dir });
+    });
+    const manager = new GoogleDiscoveryManager(new ServerRegistry(config), {
+      backendAuth: storage.backendAuth,
+    });
 
     try {
       await expect(
@@ -1654,6 +1662,7 @@ describe("GoogleDiscoveryManager", () => {
         },
       });
     } finally {
+      await storage.close();
       rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -1675,4 +1684,8 @@ function artifactByteLength(result: unknown): number {
     return result.structuredContent.byteLength;
   }
   throw new Error("expected an artifact result");
+}
+
+async function createTestAuthStorage(directory: string): Promise<HostStorage> {
+  return createHostStorage({ type: "sqlite", path: join(directory, "host.sqlite3") });
 }

--- a/packages/core/test/host-coordination.test.ts
+++ b/packages/core/test/host-coordination.test.ts
@@ -1,0 +1,264 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHostStorage, HostCoordinationStore, HostStorage } from "../src/storage";
+import type { HostDatabase } from "../src/storage/types";
+
+const directories: string[] = [];
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    rmSync(directory, { recursive: true, force: true });
+});
+
+describe("host coordination", () => {
+  it("rejects node parity drift and fences concurrent maintenance", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-coordination-"));
+    directories.push(root);
+    const path = join(root, "caplets.sqlite3");
+    const first = await createHostStorage({ type: "sqlite", path });
+    const second = await createHostStorage({ type: "sqlite", path });
+    const now = new Date("2026-07-18T12:00:00.000Z");
+    try {
+      const nodeA = await first.coordination.registerNode({
+        nodeId: "node-a",
+        globalFileManifest: "manifest-a",
+        runtimeFingerprint: "runtime-a",
+        now,
+      });
+      const nodeB = await second.coordination.registerNode({
+        nodeId: "node-b",
+        globalFileManifest: "manifest-a",
+        runtimeFingerprint: "runtime-a",
+        now,
+      });
+      expect(nodeB).toMatchObject({ hostId: nodeA.hostId, ready: true, conflict: null });
+
+      await expect(
+        second.coordination.heartbeat({
+          nodeId: "node-b",
+          globalFileManifest: "manifest-b",
+          runtimeFingerprint: "runtime-a",
+          now,
+        }),
+      ).resolves.toMatchObject({ ready: false, conflict: "global_file_manifest" });
+      await expect(
+        second.coordination.heartbeat({
+          nodeId: "node-b",
+          globalFileManifest: "manifest-a",
+          runtimeFingerprint: "runtime-a",
+          now,
+        }),
+      ).resolves.toMatchObject({ ready: true, conflict: null });
+
+      await expect(first.coordination.publishConfigGeneration("config-a", "node-a")).resolves.toBe(
+        1,
+      );
+      await expect(second.coordination.currentConfigGeneration()).resolves.toBe(1);
+      await expect(second.coordination.publishConfigGeneration("config-b", "node-b")).resolves.toBe(
+        2,
+      );
+      await expect(first.coordination.currentConfigGeneration()).resolves.toBe(2);
+
+      const leaseA = await first.coordination.acquireLease({
+        leaseName: "asset-gc",
+        ownerNodeId: "node-a",
+        ttlMs: 5_000,
+        now,
+      });
+      expect(leaseA).toMatchObject({ ownerNodeId: "node-a", fencingToken: 1 });
+      await expect(
+        second.coordination.acquireLease({
+          leaseName: "asset-gc",
+          ownerNodeId: "node-b",
+          ttlMs: 5_000,
+          now,
+        }),
+      ).resolves.toBeUndefined();
+
+      const afterExpiry = new Date(now.getTime() + 6_000);
+      const leaseB = await second.coordination.acquireLease({
+        leaseName: "asset-gc",
+        ownerNodeId: "node-b",
+        ttlMs: 5_000,
+        now: afterExpiry,
+      });
+      expect(leaseB).toMatchObject({ ownerNodeId: "node-b", fencingToken: 2 });
+      await expect(
+        first.coordination.checkpointLease({
+          leaseName: "asset-gc",
+          ownerNodeId: "node-a",
+          fencingToken: 1,
+          cursor: "obsolete",
+          now: afterExpiry,
+        }),
+      ).rejects.toMatchObject({ details: { kind: "stale_lease" } });
+      await expect(
+        second.coordination.checkpointLease({
+          leaseName: "asset-gc",
+          ownerNodeId: "node-b",
+          fencingToken: 2,
+          cursor: "batch-1",
+          now: afterExpiry,
+        }),
+      ).resolves.toBeUndefined();
+    } finally {
+      await first.close();
+      await second.close();
+    }
+  });
+
+  it("establishes LISTEN before reading the authoritative generation and wakes on notification", async () => {
+    const fixture = fakePostgresCoordination();
+    const wait = fixture.store.waitForConfigGeneration(0);
+    await fixture.firstSelect.promise;
+    expect(fixture.events.slice(0, 2)).toEqual([
+      "LISTEN caplets_config_generation",
+      "SELECT generation",
+    ]);
+
+    fixture.setGeneration(1);
+    fixture.client.notify("caplets_config_generation");
+
+    await expect(wait).resolves.toBe(1);
+    expect(fixture.events).toContain("UNLISTEN caplets_config_generation");
+    expect(fixture.client.released).toBe(true);
+    await fixture.store.close();
+  });
+
+  it("polls after five seconds when a PostgreSQL notification is missed", async () => {
+    vi.useFakeTimers();
+    try {
+      const fixture = fakePostgresCoordination();
+      const wait = fixture.store.waitForConfigGeneration(0);
+      let settled = false;
+      void wait.then(() => {
+        settled = true;
+      });
+      await fixture.firstSelect.promise;
+      await Promise.resolve();
+      fixture.setGeneration(2);
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+
+      await expect(wait).resolves.toBe(2);
+      expect(fixture.client.released).toBe(true);
+      await fixture.store.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("unlistens and releases the pinned PostgreSQL client when storage closes", async () => {
+    const fixture = fakePostgresCoordination();
+    const closeDatabase = vi.fn(async () => {
+      fixture.events.push("CLOSE database");
+    });
+    const storage = new HostStorage(
+      fixture.database,
+      closeDatabase,
+      { type: "postgres", connectionString: "postgres://unused" },
+      {},
+      fixture.pool as never,
+    );
+    const wait = storage.coordination.waitForConfigGeneration(0);
+    const rejected = expect(wait).rejects.toMatchObject({ name: "AbortError" });
+    await fixture.firstSelect.promise;
+
+    await storage.close();
+
+    await rejected;
+    expect(fixture.events).toContain("UNLISTEN caplets_config_generation");
+    expect(fixture.events.indexOf("UNLISTEN caplets_config_generation")).toBeLessThan(
+      fixture.events.indexOf("CLOSE database"),
+    );
+    expect(fixture.client.listenerCount).toBe(0);
+    expect(fixture.client.released).toBe(true);
+    expect(closeDatabase).toHaveBeenCalledOnce();
+  });
+});
+
+class FakePostgresListenerClient {
+  readonly queries: string[];
+  released = false;
+  private readonly listeners = new Set<(notification: { channel: string }) => void>();
+
+  constructor(queries: string[]) {
+    this.queries = queries;
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+
+  async query(queryText: string): Promise<void> {
+    this.queries.push(queryText);
+  }
+
+  on(_event: "notification", listener: (notification: { channel: string }) => void): void {
+    this.listeners.add(listener);
+  }
+
+  removeListener(
+    _event: "notification",
+    listener: (notification: { channel: string }) => void,
+  ): void {
+    this.listeners.delete(listener);
+  }
+
+  notify(channel: string): void {
+    for (const listener of this.listeners) listener({ channel });
+  }
+
+  release(): void {
+    this.released = true;
+  }
+}
+
+function fakePostgresCoordination(): {
+  store: HostCoordinationStore;
+  database: HostDatabase;
+  pool: { connect: () => Promise<FakePostgresListenerClient> };
+  client: FakePostgresListenerClient;
+  events: string[];
+  firstSelect: PromiseWithResolvers<void>;
+  setGeneration: (generation: number) => void;
+} {
+  let generation = 0;
+  const events: string[] = [];
+  const firstSelect = Promise.withResolvers<void>();
+  const client = new FakePostgresListenerClient(events);
+  const database = {
+    dialect: "postgres",
+    schema: "caplets",
+    db: {
+      select: () => ({
+        from: () => ({
+          orderBy: () => ({
+            limit: async () => {
+              events.push("SELECT generation");
+              firstSelect.resolve();
+              return [{ generation }];
+            },
+          }),
+        }),
+      }),
+    },
+  } as unknown as HostDatabase;
+  const pool = {
+    connect: async () => client,
+  };
+  return {
+    store: new HostCoordinationStore(database, pool),
+    database,
+    pool,
+    client,
+    events,
+    firstSelect,
+    setGeneration: (nextGeneration) => {
+      generation = nextGeneration;
+    },
+  };
+}

--- a/packages/core/test/host-storage-config.test.ts
+++ b/packages/core/test/host-storage-config.test.ts
@@ -2,9 +2,14 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { loadConfigWithHostStorage, resolveCapletsRoot } from "../src/config";
+import {
+  loadConfigWithHostStorage,
+  loadConfigWithSources,
+  resolveCapletsRoot,
+} from "../src/config";
 import { CapletsEngine } from "../src/engine";
 import { createHostStorage } from "../src/storage";
+import { hostNodes } from "../src/storage/schema/sqlite";
 
 const directories: string[] = [];
 
@@ -148,6 +153,173 @@ describe("stored Caplet source", () => {
     }
   });
 
+  it("persists keyed runtime parity while manifesting only global Caplet Files", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-cluster-parity-"));
+    directories.push(root);
+    const databasePath = join(root, "caplets.sqlite3");
+    const previousStateHome = process.env.XDG_STATE_HOME;
+    const previousEncryptionKey = process.env.CAPLETS_ENCRYPTION_KEY;
+    process.env.XDG_STATE_HOME = join(root, "state");
+    process.env.CAPLETS_ENCRYPTION_KEY = Buffer.alloc(32, 1).toString("base64url");
+    const engines: CapletsEngine[] = [];
+    const writeNode = (
+      name: string,
+      port: number,
+      command: string,
+      runtimeOptions: Record<string, unknown> = {},
+    ) => {
+      const nodeRoot = join(root, name);
+      const configPath = join(nodeRoot, "config.json");
+      const projectConfigPath = join(nodeRoot, "project", ".caplets", "config.json");
+      mkdirSync(nodeRoot, { recursive: true });
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          storage: { type: "sqlite", path: databasePath },
+          serve: { host: "127.0.0.1", port },
+          ...runtimeOptions,
+        }),
+      );
+      writeFileSync(join(nodeRoot, "github.md"), caplet(command));
+      return { configPath, projectConfigPath, watch: false as const };
+    };
+    const firstNode = writeNode("node-a", 4101, "shared-command");
+    const localConfigChanged = writeNode("node-b", 4102, "shared-command");
+    const runtimeConfigChanged = writeNode("node-d", 4104, "shared-command", {
+      defaultSearchLimit: 10,
+    });
+    const capletFileChanged = writeNode("node-c", 4103, "changed-command");
+    const inspector = await createHostStorage({ type: "sqlite", path: databasePath });
+    if (inspector.database.dialect !== "sqlite") throw new Error("Expected SQLite storage");
+    const sqliteDatabase = inspector.database;
+    const persistedNodes = () => sqliteDatabase.db.select().from(hostNodes).all();
+
+    try {
+      const first = await CapletsEngine.create(firstNode);
+      engines.push(first);
+      const [firstPersisted] = persistedNodes();
+      expect(firstPersisted?.runtimeFingerprint).toMatch(/^hmac-sha256:[a-f0-9]{64}$/u);
+      expect(firstPersisted?.runtimeFingerprint).not.toBe(
+        loadConfigWithSources(firstNode.configPath, firstNode.projectConfigPath).runtimeFingerprint
+          ?.hostConfigurationFingerprint,
+      );
+
+      const sameKeyAndConfig = await CapletsEngine.create(firstNode);
+      engines.push(sameKeyAndConfig);
+      expect(persistedNodes()).toHaveLength(2);
+      expect(
+        persistedNodes().every(
+          (node) =>
+            node.globalFileManifest === firstPersisted?.globalFileManifest &&
+            node.runtimeFingerprint === firstPersisted?.runtimeFingerprint,
+        ),
+      ).toBe(true);
+
+      const nodeWithLocalConfigChange = await CapletsEngine.create(localConfigChanged);
+      engines.push(nodeWithLocalConfigChange);
+      const afterLocalConfigChange = persistedNodes();
+      expect(afterLocalConfigChange).toHaveLength(3);
+      expect(
+        afterLocalConfigChange.every(
+          (node) =>
+            node.globalFileManifest === firstPersisted?.globalFileManifest &&
+            node.runtimeFingerprint === firstPersisted?.runtimeFingerprint,
+        ),
+      ).toBe(true);
+
+      await expect(CapletsEngine.create(runtimeConfigChanged)).rejects.toMatchObject({
+        details: { conflict: "runtime_fingerprint" },
+      });
+      expect(new Set(persistedNodes().map((node) => node.runtimeFingerprint))).toHaveLength(2);
+
+      process.env.CAPLETS_ENCRYPTION_KEY = Buffer.alloc(32, 2).toString("base64url");
+      await expect(CapletsEngine.create(firstNode)).rejects.toMatchObject({
+        details: { conflict: "runtime_fingerprint" },
+      });
+      const sameManifest = persistedNodes().filter(
+        (node) => node.globalFileManifest === firstPersisted?.globalFileManifest,
+      );
+      expect(sameManifest).toHaveLength(5);
+      expect(new Set(sameManifest.map((node) => node.runtimeFingerprint))).toHaveLength(3);
+
+      process.env.CAPLETS_ENCRYPTION_KEY = Buffer.alloc(32, 1).toString("base64url");
+      await expect(CapletsEngine.create(capletFileChanged)).rejects.toMatchObject({
+        details: { conflict: "global_file_manifest" },
+      });
+      expect(new Set(persistedNodes().map((node) => node.globalFileManifest))).toHaveLength(2);
+    } finally {
+      await inspector.close();
+      await Promise.all(engines.map(async (engine) => await engine.close()));
+      if (previousStateHome === undefined) delete process.env.XDG_STATE_HOME;
+      else process.env.XDG_STATE_HOME = previousStateHome;
+      if (previousEncryptionKey === undefined) delete process.env.CAPLETS_ENCRYPTION_KEY;
+      else process.env.CAPLETS_ENCRYPTION_KEY = previousEncryptionKey;
+    }
+  });
+
+  it("keeps project overlays out of heartbeat parity and refreshes global parity on reload", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-parity-reload-"));
+    directories.push(root);
+    const databasePath = join(root, "caplets.sqlite3");
+    const configPath = join(root, "config.json");
+    const globalFilePath = join(root, "github.md");
+    const projectConfigPath = join(root, "project", ".caplets", "config.json");
+    const projectFilePath = join(dirname(projectConfigPath), "github.md");
+    const previousStateHome = process.env.XDG_STATE_HOME;
+    const previousEncryptionKey = process.env.CAPLETS_ENCRYPTION_KEY;
+    process.env.XDG_STATE_HOME = join(root, "state");
+    process.env.CAPLETS_ENCRYPTION_KEY = Buffer.alloc(32, 3).toString("base64url");
+    mkdirSync(dirname(projectFilePath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ storage: { type: "sqlite", path: databasePath } }));
+    writeFileSync(globalFilePath, caplet("global-v1"));
+    writeFileSync(projectFilePath, caplet("project-v1"));
+    const engine = await CapletsEngine.create({ configPath, projectConfigPath, watch: false });
+    const inspector = await createHostStorage({ type: "sqlite", path: databasePath });
+    if (inspector.database.dialect !== "sqlite") throw new Error("Expected SQLite storage");
+    const sqliteDatabase = inspector.database;
+
+    try {
+      const initial = sqliteDatabase.db.select().from(hostNodes).get();
+      expect(initial?.runtimeFingerprint).toMatch(/^hmac-sha256:[a-f0-9]{64}$/u);
+      await expect
+        .poll(() => sqliteDatabase.db.select().from(hostNodes).get()?.heartbeatAt, {
+          timeout: 2_500,
+          interval: 50,
+        })
+        .not.toBe(initial?.heartbeatAt);
+      expect(sqliteDatabase.db.select().from(hostNodes).get()?.runtimeFingerprint).toBe(
+        initial?.runtimeFingerprint,
+      );
+
+      writeFileSync(projectFilePath, caplet("project-v2"));
+      await expect(engine.reload()).resolves.toBe(true);
+      expect(engine.currentConfig().mcpServers.github?.command).toBe("project-v2");
+      expect(sqliteDatabase.db.select().from(hostNodes).get()).toMatchObject({
+        globalFileManifest: initial?.globalFileManifest,
+        runtimeFingerprint: initial?.runtimeFingerprint,
+      });
+
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          storage: { type: "sqlite", path: databasePath },
+          defaultSearchLimit: 10,
+        }),
+      );
+      await expect(engine.reload()).resolves.toBe(true);
+      expect(engine.currentConfig().mcpServers.github?.command).toBe("project-v2");
+      const afterGlobalReload = sqliteDatabase.db.select().from(hostNodes).get();
+      expect(afterGlobalReload?.globalFileManifest).toBe(initial?.globalFileManifest);
+      expect(afterGlobalReload?.runtimeFingerprint).not.toBe(initial?.runtimeFingerprint);
+    } finally {
+      await engine.close();
+      await inspector.close();
+      if (previousStateHome === undefined) delete process.env.XDG_STATE_HOME;
+      else process.env.XDG_STATE_HOME = previousStateHome;
+      if (previousEncryptionKey === undefined) delete process.env.CAPLETS_ENCRYPTION_KEY;
+      else process.env.CAPLETS_ENCRYPTION_KEY = previousEncryptionKey;
+    }
+  });
   it("converges peer engine snapshots after a committed record generation", async () => {
     const root = mkdtempSync(join(tmpdir(), "caplets-sql-convergence-"));
     directories.push(root);

--- a/packages/core/test/host-storage-config.test.ts
+++ b/packages/core/test/host-storage-config.test.ts
@@ -1,0 +1,200 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadConfigWithHostStorage, resolveCapletsRoot } from "../src/config";
+import { CapletsEngine } from "../src/engine";
+import { createHostStorage } from "../src/storage";
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    rmSync(directory, { recursive: true, force: true });
+});
+
+function caplet(command: string): string {
+  return `---
+name: GitHub
+description: Manage GitHub repositories from the selected source.
+mcpServer:
+  command: ${command}
+---
+# GitHub
+`;
+}
+
+describe("stored Caplet source", () => {
+  it("resolves project files over global files over stored records", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-layers-"));
+    directories.push(root);
+    const userConfigPath = join(root, "user", "config.json");
+    const globalFilePath = join(resolveCapletsRoot(userConfigPath), "github.md");
+    const projectConfigPath = join(root, "project", ".caplets", "config.json");
+    const projectFilePath = join(dirname(projectConfigPath), "github.md");
+    mkdirSync(dirname(userConfigPath), { recursive: true });
+    mkdirSync(dirname(globalFilePath), { recursive: true });
+    mkdirSync(dirname(projectConfigPath), { recursive: true });
+    writeFileSync(userConfigPath, "{}");
+    writeFileSync(projectConfigPath, "{}");
+    writeFileSync(globalFilePath, caplet("global-github"));
+    writeFileSync(projectFilePath, caplet("project-github"));
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(root, "caplets.sqlite3"),
+    });
+
+    try {
+      await storage.caplets.importBundle({
+        id: "github",
+        operator: { clientId: "operator_import", role: "operator" },
+        files: [
+          {
+            path: "CAPLET.md",
+            executable: false,
+            content: Buffer.from(caplet("stored-github")),
+          },
+        ],
+      });
+      const options = { recordCacheRoot: join(root, "record-cache") };
+      const project = await loadConfigWithHostStorage(
+        storage,
+        userConfigPath,
+        projectConfigPath,
+        options,
+      );
+      expect(project.config.mcpServers.github?.command).toBe("project-github");
+      expect(project.sources.github?.kind).toBe("project-file");
+      expect(project.shadows.github?.map((source) => source.kind)).toEqual([
+        "stored-record",
+        "global-file",
+      ]);
+      await expect(storage.caplets.list()).resolves.toMatchObject([
+        {
+          id: "github",
+          currentRevision: {
+            backends: [{ family: "mcpServer", config: { command: "stored-github" } }],
+          },
+        },
+      ]);
+
+      rmSync(projectFilePath);
+      const global = await loadConfigWithHostStorage(
+        storage,
+        userConfigPath,
+        projectConfigPath,
+        options,
+      );
+      expect(global.config.mcpServers.github?.command).toBe("global-github");
+      expect(global.sources.github?.kind).toBe("global-file");
+
+      rmSync(globalFilePath);
+      const stored = await loadConfigWithHostStorage(
+        storage,
+        userConfigPath,
+        projectConfigPath,
+        options,
+      );
+      expect(stored.config.mcpServers.github?.command).toBe("stored-github");
+      expect(stored.sources.github?.kind).toBe("stored-record");
+      const engine = new CapletsEngine({
+        initialConfig: stored.config,
+        hostStorage: storage,
+        watch: false,
+      });
+      await storage.close();
+      const outcome = (await engine.execute("github", {
+        operation: "list_tools",
+      })) as { structuredContent?: { error?: unknown } };
+      expect(outcome.structuredContent?.error).toMatchObject({
+        code: "SERVER_UNAVAILABLE",
+      });
+      await engine.close();
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("starts from SQLite-backed Caplet Records without filesystem Caplet files", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-sql-runtime-"));
+    directories.push(root);
+    const databasePath = join(root, "caplets.sqlite3");
+    const configPath = join(root, "config.json");
+    const projectConfigPath = join(root, "project", ".caplets", "config.json");
+    writeFileSync(configPath, JSON.stringify({ storage: { type: "sqlite", path: databasePath } }));
+    const storage = await createHostStorage({ type: "sqlite", path: databasePath });
+    await storage.caplets.importBundle({
+      id: "github",
+      operator: { clientId: "operator_import", role: "operator" },
+      files: [
+        {
+          path: "CAPLET.md",
+          executable: false,
+          content: Buffer.from(caplet("stored-github")),
+        },
+      ],
+    });
+    await storage.close();
+
+    const engine = await CapletsEngine.create({
+      configPath,
+      projectConfigPath,
+      watch: false,
+    });
+    try {
+      expect(engine.currentConfig().mcpServers.github?.command).toBe("stored-github");
+    } finally {
+      await engine.close();
+    }
+  });
+
+  it("converges peer engine snapshots after a committed record generation", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-sql-convergence-"));
+    directories.push(root);
+    const databasePath = join(root, "caplets.sqlite3");
+    const configPath = join(root, "config.json");
+    const projectConfigPath = join(root, "project", ".caplets", "config.json");
+    writeFileSync(configPath, JSON.stringify({ storage: { type: "sqlite", path: databasePath } }));
+    const seed = await createHostStorage({ type: "sqlite", path: databasePath });
+    await seed.caplets.importBundle({
+      id: "github",
+      operator: { clientId: "operator_import", role: "operator" },
+      files: [
+        {
+          path: "CAPLET.md",
+          executable: false,
+          content: Buffer.from(caplet("stored-v1")),
+        },
+      ],
+    });
+    await seed.close();
+    const first = await CapletsEngine.create({ configPath, projectConfigPath, watch: false });
+    const second = await CapletsEngine.create({ configPath, projectConfigPath, watch: false });
+    const writer = await createHostStorage({ type: "sqlite", path: databasePath });
+    try {
+      await writer.caplets.updateBundle({
+        id: "github",
+        operator: { clientId: "operator_update", role: "operator" },
+        expectedGeneration: 1,
+        files: [
+          {
+            path: "CAPLET.md",
+            executable: false,
+            content: Buffer.from(caplet("stored-v2")),
+          },
+        ],
+      });
+      await expect
+        .poll(() => second.currentConfig().mcpServers.github?.command, {
+          timeout: 6_000,
+          interval: 100,
+        })
+        .toBe("stored-v2");
+      expect(first.currentConfig().mcpServers.github?.command).toBe("stored-v2");
+    } finally {
+      await writer.close();
+      await first.close();
+      await second.close();
+    }
+  }, 8_000);
+});

--- a/packages/core/test/host-storage-domain-parity.postgres.test.ts
+++ b/packages/core/test/host-storage-domain-parity.postgres.test.ts
@@ -542,47 +542,92 @@ postgresIt(
     currentGenerationSpy.mockRestore();
     await expect(first.coordination.currentConfigGeneration()).resolves.toBe(1);
 
-    const leaseA = await first.coordination.acquireLease({
-      leaseName: "asset-gc",
-      ownerNodeId: "node-a",
-      ttlMs: 1_000,
-      now,
-    });
-    expect(leaseA).toMatchObject({ ownerNodeId: "node-a", fencingToken: 1 });
-    await expect(
-      second.coordination.acquireLease({
-        leaseName: "asset-gc",
-        ownerNodeId: "node-b",
-        ttlMs: 1_000,
-        now,
-      }),
-    ).resolves.toBeUndefined();
-    const afterExpiry = new Date(now.getTime() + 1_001);
-    const leaseB = await second.coordination.acquireLease({
-      leaseName: "asset-gc",
-      ownerNodeId: "node-b",
-      ttlMs: 1_000,
-      now: afterExpiry,
-    });
-    expect(leaseB).toMatchObject({ ownerNodeId: "node-b", fencingToken: 2 });
-    await expect(
-      first.coordination.checkpointLease({
+    const authority = new Pool({ connectionString });
+    const farPast = new Date("1900-01-01T00:00:00.000Z");
+    const farFuture = new Date("2999-01-01T00:00:00.000Z");
+    const leaseTtlMs = 250;
+    try {
+      const beforeAcquire = (
+        await authority.query<{ now: Date }>("select clock_timestamp() as now")
+      ).rows[0]!.now;
+      const leaseA = await first.coordination.acquireLease({
         leaseName: "asset-gc",
         ownerNodeId: "node-a",
-        fencingToken: 1,
-        cursor: "stale",
-        now: afterExpiry,
-      }),
-    ).rejects.toMatchObject({ details: { kind: "stale_lease" } });
-    await expect(
-      second.coordination.checkpointLease({
+        ttlMs: leaseTtlMs,
+        now: farPast,
+      });
+      const afterAcquire = (await authority.query<{ now: Date }>("select clock_timestamp() as now"))
+        .rows[0]!.now;
+      expect(leaseA).toMatchObject({ ownerNodeId: "node-a", fencingToken: 1 });
+      expect(Date.parse(leaseA!.expiresAt)).toBeGreaterThanOrEqual(
+        beforeAcquire.getTime() + leaseTtlMs,
+      );
+      expect(Date.parse(leaseA!.expiresAt)).toBeLessThanOrEqual(
+        afterAcquire.getTime() + leaseTtlMs,
+      );
+      await expect(
+        second.coordination.acquireLease({
+          leaseName: "asset-gc",
+          ownerNodeId: "node-b",
+          ttlMs: leaseTtlMs,
+          now: farFuture,
+        }),
+      ).resolves.toBeUndefined();
+
+      const beforeRenew = (await authority.query<{ now: Date }>("select clock_timestamp() as now"))
+        .rows[0]!.now;
+      const renewed = await first.coordination.acquireLease({
+        leaseName: "asset-gc",
+        ownerNodeId: "node-a",
+        ttlMs: leaseTtlMs,
+        now: farFuture,
+      });
+      const afterRenew = (await authority.query<{ now: Date }>("select clock_timestamp() as now"))
+        .rows[0]!.now;
+      expect(renewed).toMatchObject({ ownerNodeId: "node-a", fencingToken: 2 });
+      expect(Date.parse(renewed!.expiresAt)).toBeGreaterThanOrEqual(
+        beforeRenew.getTime() + leaseTtlMs,
+      );
+      expect(Date.parse(renewed!.expiresAt)).toBeLessThanOrEqual(afterRenew.getTime() + leaseTtlMs);
+      await expect(
+        first.coordination.checkpointLease({
+          leaseName: "asset-gc",
+          ownerNodeId: "node-a",
+          fencingToken: 2,
+          cursor: "batch-1",
+          now: farFuture,
+        }),
+      ).resolves.toBeUndefined();
+
+      await authority.query("select pg_sleep(0.3)");
+      const leaseB = await second.coordination.acquireLease({
         leaseName: "asset-gc",
         ownerNodeId: "node-b",
-        fencingToken: 2,
-        cursor: "batch-1",
-        now: afterExpiry,
-      }),
-    ).resolves.toBeUndefined();
+        ttlMs: leaseTtlMs,
+        now: farFuture,
+      });
+      expect(leaseB).toMatchObject({ ownerNodeId: "node-b", fencingToken: 3 });
+      await expect(
+        first.coordination.checkpointLease({
+          leaseName: "asset-gc",
+          ownerNodeId: "node-a",
+          fencingToken: 2,
+          cursor: "stale",
+          now: farPast,
+        }),
+      ).rejects.toMatchObject({ details: { kind: "stale_lease" } });
+      await expect(
+        second.coordination.checkpointLease({
+          leaseName: "asset-gc",
+          ownerNodeId: "node-b",
+          fencingToken: 3,
+          cursor: "batch-2",
+          now: farFuture,
+        }),
+      ).resolves.toBeUndefined();
+    } finally {
+      await authority.end();
+    }
 
     await second.coordination.unregisterNode("node-b");
     await expect(first.coordination.nodeReady("node-b")).resolves.toBe(false);

--- a/packages/core/test/host-storage-domain-parity.postgres.test.ts
+++ b/packages/core/test/host-storage-domain-parity.postgres.test.ts
@@ -634,6 +634,28 @@ postgresIt(
   },
 );
 
+postgresIt("serializes concurrent node heartbeats without deadlocks", async () => {
+  const { first, second } = await openPair("heartbeat_race");
+  const input = {
+    globalFileManifest: "manifest",
+    runtimeFingerprint: "runtime",
+  };
+  await first.coordination.registerNode({ ...input, nodeId: "node-a" });
+  await second.coordination.registerNode({ ...input, nodeId: "node-b" });
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await expect(
+      Promise.all([
+        first.coordination.heartbeat({ ...input, nodeId: "node-a" }),
+        second.coordination.heartbeat({ ...input, nodeId: "node-b" }),
+      ]),
+    ).resolves.toEqual([
+      expect.objectContaining({ nodeId: "node-a", ready: true }),
+      expect.objectContaining({ nodeId: "node-b", ready: true }),
+    ]);
+  }
+});
+
 function setupAttempt(attemptId: string, now: Date): SetupAttempt {
   return {
     attemptId,

--- a/packages/core/test/host-storage-domain-parity.postgres.test.ts
+++ b/packages/core/test/host-storage-domain-parity.postgres.test.ts
@@ -481,18 +481,19 @@ postgresIt(
   "shares host identity, enforces node parity, notifies peers, and fences expired leases",
   async () => {
     const { first, second } = await openPair("coordination");
-    const now = new Date();
+    const farPast = new Date("1900-01-01T00:00:00.000Z");
+    const farFuture = new Date("2999-01-01T00:00:00.000Z");
     const nodeA = await first.coordination.registerNode({
       nodeId: "node-a",
       globalFileManifest: "manifest-a",
       runtimeFingerprint: "runtime-a",
-      now,
+      now: farPast,
     });
     const nodeB = await second.coordination.registerNode({
       nodeId: "node-b",
       globalFileManifest: "manifest-a",
       runtimeFingerprint: "runtime-a",
-      now,
+      now: farFuture,
     });
     expect(nodeB).toMatchObject({ hostId: nodeA.hostId, ready: true, conflict: null });
     await expect(first.coordination.activeNodeCount(60_000)).resolves.toBe(2);
@@ -501,7 +502,7 @@ postgresIt(
         nodeId: "node-b",
         globalFileManifest: "manifest-b",
         runtimeFingerprint: "runtime-a",
-        now,
+        now: farPast,
       }),
     ).resolves.toMatchObject({ ready: false, conflict: "global_file_manifest" });
     await expect(
@@ -509,7 +510,7 @@ postgresIt(
         nodeId: "node-b",
         globalFileManifest: "manifest-a",
         runtimeFingerprint: "runtime-b",
-        now,
+        now: farFuture,
       }),
     ).resolves.toMatchObject({ ready: false, conflict: "runtime_fingerprint" });
     await expect(second.coordination.nodeReady("node-b")).resolves.toBe(false);
@@ -518,7 +519,7 @@ postgresIt(
         nodeId: "node-b",
         globalFileManifest: "manifest-a",
         runtimeFingerprint: "runtime-a",
-        now,
+        now: farPast,
       }),
     ).resolves.toMatchObject({ ready: true, conflict: null });
 
@@ -543,8 +544,6 @@ postgresIt(
     await expect(first.coordination.currentConfigGeneration()).resolves.toBe(1);
 
     const authority = new Pool({ connectionString });
-    const farPast = new Date("1900-01-01T00:00:00.000Z");
-    const farFuture = new Date("2999-01-01T00:00:00.000Z");
     const leaseTtlMs = 250;
     try {
       const beforeAcquire = (

--- a/packages/core/test/host-storage-domain-parity.postgres.test.ts
+++ b/packages/core/test/host-storage-domain-parity.postgres.test.ts
@@ -1,0 +1,614 @@
+import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
+import { Pool } from "pg";
+import { afterEach, expect, it, vi } from "vitest";
+import type { StoredOAuthTokenBundle } from "../src/auth/store";
+import { DashboardSessionStore } from "../src/dashboard/session-store";
+import { DASHBOARD_SESSION_COOKIE } from "../src/dashboard/types";
+import {
+  createHostStorage,
+  migrateHostStorage,
+  type HostStorage,
+  type PostgresHostStorageConfig,
+} from "../src/storage";
+import type { SetupAttempt } from "../src/setup/types";
+
+const connectionString = process.env.CAPLETS_TEST_POSTGRES_URL;
+const postgresIt = connectionString ? it : it.skip;
+const schemas = new Set<string>();
+const storages = new Set<HostStorage>();
+const originalEncryptionKey = process.env.CAPLETS_ENCRYPTION_KEY;
+
+const operator = { clientId: "operator-postgres", role: "operator" } as const;
+
+async function openPair(domain: string): Promise<{
+  schema: string;
+  first: HostStorage;
+  second: HostStorage;
+}> {
+  const schema = `caplets_pg_${domain}_${randomUUID().replaceAll("-", "")}`;
+  schemas.add(schema);
+  const config: PostgresHostStorageConfig = {
+    type: "postgres",
+    connectionString: connectionString!,
+    schema,
+  };
+  await migrateHostStorage(config);
+  const first = await createHostStorage(config);
+  storages.add(first);
+  const second = await createHostStorage(config);
+  storages.add(second);
+  return { schema, first, second };
+}
+
+afterEach(async () => {
+  if (originalEncryptionKey === undefined) delete process.env.CAPLETS_ENCRYPTION_KEY;
+  else process.env.CAPLETS_ENCRYPTION_KEY = originalEncryptionKey;
+
+  await Promise.allSettled([...storages].map(async (storage) => await storage.close()));
+  storages.clear();
+  if (!connectionString || schemas.size === 0) return;
+
+  const pool = new Pool({ connectionString });
+  try {
+    for (const schema of schemas) {
+      await pool.query(`drop schema if exists "${schema}" cascade`);
+    }
+  } finally {
+    schemas.clear();
+    await pool.end();
+  }
+});
+
+postgresIt(
+  "keeps backend auth CAS, ordering, deletion, and activity secret-safe on PostgreSQL",
+  async () => {
+    const { first, second } = await openPair("auth");
+    const accessToken = "postgres-plain-access-token";
+    const refreshToken = "postgres-plain-refresh-token";
+    const bundle: StoredOAuthTokenBundle = {
+      server: "beta",
+      authType: "oauth2",
+      accessToken,
+      refreshToken,
+      clientId: "client-1",
+      clientSecret: "postgres-plain-client-secret",
+      protectedResourceOrigin: "https://api.example.test",
+    };
+
+    await expect(
+      first.backendAuth.writeTokenBundle(bundle, { operatorClientId: operator.clientId }),
+    ).resolves.toEqual({ bundle, generation: 1 });
+    await second.backendAuth.writeTokenBundle({ server: "alpha", accessToken: "alpha-secret" });
+
+    await expect(second.backendAuth.readTokenBundle("beta")).resolves.toEqual({
+      bundle,
+      generation: 1,
+    });
+    await expect(first.backendAuth.listTokenBundles()).resolves.toEqual([
+      { bundle: { server: "alpha", accessToken: "alpha-secret" }, generation: 1 },
+      { bundle, generation: 1 },
+    ]);
+
+    const rotated = { ...bundle, accessToken: "postgres-rotated-access-token" };
+    await expect(
+      second.backendAuth.writeTokenBundle(rotated, {
+        expectedGeneration: 1,
+        operatorClientId: operator.clientId,
+      }),
+    ).resolves.toEqual({ bundle: rotated, generation: 2 });
+    await expect(
+      first.backendAuth.writeTokenBundle(bundle, { expectedGeneration: 1 }),
+    ).rejects.toMatchObject({
+      code: "REQUEST_INVALID",
+      details: { kind: "stale_generation", expectedGeneration: 1, currentGeneration: 2 },
+    });
+
+    await expect(
+      second.backendAuth.deleteTokenBundle("alpha", { expectedGeneration: 1 }),
+    ).resolves.toBe(true);
+    await expect(first.backendAuth.readTokenBundle("alpha")).resolves.toBeUndefined();
+    await expect(first.backendAuth.deleteTokenBundle("alpha")).resolves.toBe(false);
+
+    const activityPayload = JSON.stringify((await first.operatorActivity.list()).entries);
+    for (const secret of [
+      accessToken,
+      refreshToken,
+      bundle.clientSecret!,
+      "alpha-secret",
+      rotated.accessToken,
+    ]) {
+      expect(activityPayload).not.toContain(secret);
+    }
+  },
+);
+
+postgresIt(
+  "keeps Vault values and file grants coherent, encrypted, and revocable on PostgreSQL",
+  async () => {
+    process.env.CAPLETS_ENCRYPTION_KEY = Buffer.alloc(32, 17).toString("base64url");
+    const { schema, first, second } = await openPair("vault");
+    const plaintext = "postgres-vault-plaintext";
+    const rotatedPlaintext = "postgres-vault-rotated";
+
+    await expect(
+      first.vaultValues.set("API_TOKEN", plaintext, {
+        expectedGeneration: 0,
+        operatorClientId: operator.clientId,
+      }),
+    ).resolves.toMatchObject({ key: "API_TOKEN", present: true, generation: 1 });
+    await expect(second.vaultValues.resolveValue("API_TOKEN")).resolves.toBe(plaintext);
+    await expect(second.vaultValues.set("API_TOKEN", "collision-secret")).rejects.toMatchObject({
+      code: "CONFIG_EXISTS",
+    });
+    await expect(
+      second.vaultValues.set("API_TOKEN", rotatedPlaintext, {
+        force: true,
+        expectedGeneration: 1,
+        operatorClientId: operator.clientId,
+      }),
+    ).resolves.toMatchObject({ generation: 2 });
+    await expect(
+      first.vaultValues.set("API_TOKEN", "stale-secret", {
+        force: true,
+        expectedGeneration: 1,
+      }),
+    ).rejects.toMatchObject({
+      code: "REQUEST_INVALID",
+      details: { kind: "stale_generation", expectedGeneration: 1, currentGeneration: 2 },
+    });
+    await expect(first.vaultValues.listValues()).resolves.toEqual([
+      expect.objectContaining({ key: "API_TOKEN", present: true, generation: 2 }),
+    ]);
+
+    const pool = new Pool({ connectionString: connectionString! });
+    try {
+      const columns = await pool.query<{ column_name: string }>(
+        "select column_name from information_schema.columns where table_schema = $1 and table_name = 'vault_values'",
+        [schema],
+      );
+      expect(columns.rows.map((row) => row.column_name)).toEqual(
+        expect.arrayContaining(["ciphertext", "nonce", "auth_tag"]),
+      );
+      expect(columns.rows.map((row) => row.column_name)).not.toContain("value");
+      const encrypted = await pool.query<{ ciphertext_safe: boolean }>(
+        `select position($1 in ciphertext) = 0 as ciphertext_safe from "${schema}".vault_values where vault_key = 'API_TOKEN'`,
+        [rotatedPlaintext],
+      );
+      expect(encrypted.rows).toEqual([{ ciphertext_safe: true }]);
+    } finally {
+      await pool.end();
+    }
+
+    await first.vaultValues.set("GRANT_A", "grant-secret-a", { expectedGeneration: 0 });
+    await first.vaultValues.set("GRANT_B", "grant-secret-b", { expectedGeneration: 0 });
+    const originPath = "/project/.caplets/shared.md";
+    await first.vaultGrants.grant({
+      capletId: "shared",
+      vaultKey: "GRANT_A",
+      referenceName: "TOKEN",
+      originKind: "project-file",
+      originPath,
+      operator,
+    });
+    await second.vaultGrants.grant({
+      capletId: "shared",
+      vaultKey: "GRANT_B",
+      referenceName: "TOKEN",
+      originKind: "project-file",
+      originPath,
+      operator,
+    });
+    await expect(first.vaultGrants.list("shared")).resolves.toEqual([
+      expect.objectContaining({
+        subjectKind: "file",
+        capletId: "shared",
+        vaultKey: "GRANT_B",
+        referenceName: "TOKEN",
+        originKind: "project-file",
+        originPath,
+      }),
+    ]);
+    const revoke = {
+      capletId: "shared",
+      vaultKey: "GRANT_B",
+      referenceName: "TOKEN",
+      originKind: "project-file" as const,
+      originPath,
+      operator,
+    };
+    await expect(second.vaultGrants.revoke(revoke)).resolves.toBe(true);
+    await expect(first.vaultGrants.revoke(revoke)).resolves.toBe(false);
+    await expect(second.vaultGrants.list("shared")).resolves.toEqual([]);
+
+    await expect(
+      second.vaultValues.delete("API_TOKEN", {
+        expectedGeneration: 1,
+        operatorClientId: operator.clientId,
+      }),
+    ).rejects.toMatchObject({ details: { kind: "stale_generation" } });
+    await expect(
+      first.vaultValues.delete("API_TOKEN", {
+        expectedGeneration: 2,
+        operatorClientId: operator.clientId,
+      }),
+    ).resolves.toEqual({ key: "API_TOKEN", deleted: true, generation: 2 });
+    await expect(second.vaultValues.resolveValue("API_TOKEN")).rejects.toMatchObject({
+      code: "CONFIG_INVALID",
+    });
+
+    const activityPayload = JSON.stringify((await first.operatorActivity.list()).entries);
+    for (const secret of [
+      plaintext,
+      rotatedPlaintext,
+      "collision-secret",
+      "stale-secret",
+      "grant-secret-a",
+      "grant-secret-b",
+    ]) {
+      expect(activityPayload).not.toContain(secret);
+    }
+    expect(activityPayload).not.toContain(originPath);
+  },
+);
+
+postgresIt(
+  "creates, validates, expires, and deletes dashboard sessions across PostgreSQL instances",
+  async () => {
+    const { first, second } = await openPair("dashboard");
+    const firstStore = new DashboardSessionStore({
+      repository: first.dashboardSessions,
+      validateOperatorClient: async (clientId) => clientId === operator.clientId,
+    });
+    const secondStore = new DashboardSessionStore({
+      repository: second.dashboardSessions,
+      validateOperatorClient: async (clientId) => clientId === operator.clientId,
+    });
+    const now = new Date("2026-07-18T12:00:00.000Z");
+    const created = await firstStore.create({ operatorClientId: operator.clientId, now });
+    const persisted = await second.dashboardSessions.get(created.session.sessionId);
+    expect(persisted).toMatchObject({
+      ...created.session,
+      secretHash: expect.any(String),
+    });
+    const cookieSecret = created.cookieValue.split(".", 2)[1]!;
+    expect(JSON.stringify(persisted)).not.toContain(cookieSecret);
+    await expect(second.dashboardSessions.create(persisted!)).resolves.toBe(false);
+
+    const touchedAt = new Date(now.getTime() + 30_000);
+    await expect(
+      secondStore.validate({
+        cookieHeader: `${DASHBOARD_SESSION_COOKIE}=${created.cookieValue}`,
+        csrfToken: created.session.csrfToken,
+        requireCsrf: true,
+        now: touchedAt,
+      }),
+    ).resolves.toEqual({ ...created.session, lastUsedAt: touchedAt.toISOString() });
+    await expect(
+      firstStore.validate({
+        cookieHeader: `${DASHBOARD_SESSION_COOKIE}=${created.cookieValue}`,
+        csrfToken: "wrong-csrf",
+        requireCsrf: true,
+        now: new Date(touchedAt.getTime() + 1_000),
+      }),
+    ).rejects.toMatchObject({ code: "REQUEST_INVALID" });
+
+    await expect(
+      firstStore.validate({
+        cookieHeader: `${DASHBOARD_SESSION_COOKIE}=${created.cookieValue}`,
+        now: new Date(now.getTime() + 13 * 60 * 60_000),
+      }),
+    ).rejects.toMatchObject({ code: "AUTH_FAILED" });
+    await expect(second.dashboardSessions.get(created.session.sessionId)).resolves.toBeUndefined();
+
+    const logout = await secondStore.create({
+      operatorClientId: operator.clientId,
+      now: new Date(now.getTime() + 14 * 60 * 60_000),
+    });
+    const cookie = `${DASHBOARD_SESSION_COOKIE}=${logout.cookieValue}`;
+    await expect(firstStore.delete(cookie)).resolves.toBe(true);
+    await expect(secondStore.delete(cookie)).resolves.toBe(false);
+  },
+);
+
+postgresIt(
+  "shares setup approvals and attempt CAS, retention, and clearing on PostgreSQL",
+  async () => {
+    const { first, second } = await openPair("setup");
+    const now = new Date();
+    const approval = {
+      projectFingerprint: "project-postgres",
+      capletId: "ast-grep",
+      contentHash: "sha256:postgres-content",
+      targetKind: "remote_host" as const,
+      approvedAt: now.toISOString(),
+      actor: "ui" as const,
+    };
+    await expect(
+      first.setupState.approve(approval, { operatorClientId: operator.clientId }),
+    ).resolves.toEqual(approval);
+    await expect(
+      second.setupState.getApproval(
+        approval.projectFingerprint,
+        approval.capletId,
+        approval.contentHash,
+        approval.targetKind,
+      ),
+    ).resolves.toEqual(approval);
+    await expect(
+      second.setupState.approve({ ...approval, actor: "automation" }, { expectedGeneration: 0 }),
+    ).rejects.toMatchObject({
+      code: "REQUEST_INVALID",
+      details: expect.objectContaining({ kind: "stale_generation" }),
+    });
+
+    const firstAttempt = setupAttempt("attempt-1", now);
+    const secondAttempt = setupAttempt("attempt-2", new Date(now.getTime() + 1));
+    await first.setupState.recordAttempt(firstAttempt, {
+      operatorClientId: operator.clientId,
+    });
+    await second.setupState.recordAttempt(secondAttempt, {
+      expectedGeneration: 1,
+      operatorClientId: operator.clientId,
+    });
+    await expect(
+      first.setupState.recordAttempt(setupAttempt("attempt-stale", now), {
+        expectedGeneration: 1,
+      }),
+    ).rejects.toMatchObject({ details: expect.objectContaining({ kind: "stale_generation" }) });
+    await expect(
+      second.setupState.listAttempts(approval.projectFingerprint, approval.capletId),
+    ).resolves.toEqual([firstAttempt, secondAttempt]);
+    await expect(
+      first.setupState.getAttempt(approval.projectFingerprint, approval.capletId, "attempt-2"),
+    ).resolves.toEqual(secondAttempt);
+    await expect(
+      second.setupState.clearAttempts(approval.projectFingerprint, approval.capletId, {
+        expectedGeneration: 2,
+        operatorClientId: operator.clientId,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      first.setupState.listAttempts(approval.projectFingerprint, approval.capletId),
+    ).resolves.toEqual([]);
+    await expect(
+      first.setupState.clearAttempts(approval.projectFingerprint, approval.capletId),
+    ).resolves.toBe(false);
+  },
+);
+
+postgresIt(
+  "fences Project Binding ownership, uniqueness, CAS, end, and lease expiry on PostgreSQL",
+  async () => {
+    const { first, second } = await openPair("binding");
+    const input = {
+      bindingId: "binding-postgres",
+      sessionId: "session-a",
+      projectFingerprint: "sha256:postgres-project",
+      projectRoot: "/client/project",
+      serverProjectRoot: "/host/project",
+      ownerNodeId: "node-a",
+    };
+    const created = await first.projectBindings.create(input);
+    expect(created).toMatchObject({ generation: 1, state: "attaching", active: true });
+    await expect(second.projectBindings.create(input)).rejects.toMatchObject({
+      code: "CONFIG_EXISTS",
+    });
+    await expect(second.projectBindings.get(input.bindingId)).resolves.toEqual(created);
+    await expect(first.projectBindings.list()).resolves.toEqual([created]);
+
+    const ready = await second.projectBindings.heartbeat({
+      bindingId: input.bindingId,
+      ownerNodeId: input.ownerNodeId,
+      sessionId: input.sessionId,
+      expectedGeneration: created.generation,
+      state: "ready",
+      syncState: "idle",
+    });
+    expect(ready).toMatchObject({ generation: 2, readiness: "ready" });
+    await expect(
+      first.projectBindings.heartbeat({
+        bindingId: input.bindingId,
+        ownerNodeId: input.ownerNodeId,
+        expectedGeneration: created.generation,
+        state: "degraded",
+        syncState: "failed",
+      }),
+    ).rejects.toMatchObject({ details: expect.objectContaining({ kind: "stale_generation" }) });
+
+    const ended = await first.projectBindings.end({
+      bindingId: input.bindingId,
+      ownerNodeId: input.ownerNodeId,
+      expectedGeneration: ready.generation,
+    });
+    expect(ended).toMatchObject({ generation: 3, state: "ended", active: false });
+
+    const expiring = await first.projectBindings.create({
+      ...input,
+      bindingId: "binding-expiring",
+      sessionId: "session-expiring",
+      leaseTtlMs: 0.001,
+    });
+    await expect(
+      second.projectBindings.heartbeat({
+        bindingId: expiring.bindingId,
+        ownerNodeId: expiring.ownerNodeId,
+        expectedGeneration: expiring.generation,
+        state: "ready",
+        syncState: "idle",
+      }),
+    ).rejects.toMatchObject({ projectBindingCode: "lease_expired" });
+  },
+);
+
+postgresIt("appends, filters, and pages redacted Operator Activity on PostgreSQL", async () => {
+  const { first, second } = await openPair("activity");
+  const oldest = await first.operatorActivity.append({
+    actorClientId: operator.clientId,
+    action: "vault_set",
+    target: { type: "vault", id: "API_TOKEN", label: "API token" },
+    metadata: {
+      bytesWritten: 23,
+      secretValue: "activity-secret-must-not-appear",
+      note: "cap_remote_access_activity-secret",
+    },
+    now: new Date("2026-07-18T10:00:00.000Z"),
+  });
+  const newest = await second.operatorActivity.append({
+    actorClientId: "operator-peer",
+    action: "caplet.install",
+    outcome: "failure",
+    target: { type: "installation", id: "installation-1" },
+    now: new Date("2026-07-18T10:01:00.000Z"),
+  });
+
+  await expect(first.operatorActivity.list({ limit: 1 })).resolves.toEqual({
+    entries: [newest],
+    nextCursor: newest.id,
+  });
+  await expect(second.operatorActivity.list({ limit: 1, after: newest.id })).resolves.toEqual({
+    entries: [oldest],
+  });
+  await expect(first.operatorActivity.list({ action: "vault_set" })).resolves.toEqual({
+    entries: [oldest],
+  });
+  expect(JSON.stringify((await second.operatorActivity.list()).entries)).not.toContain(
+    "activity-secret",
+  );
+});
+
+postgresIt(
+  "shares host identity, enforces node parity, notifies peers, and fences expired leases",
+  async () => {
+    const { first, second } = await openPair("coordination");
+    const now = new Date();
+    const nodeA = await first.coordination.registerNode({
+      nodeId: "node-a",
+      globalFileManifest: "manifest-a",
+      runtimeFingerprint: "runtime-a",
+      now,
+    });
+    const nodeB = await second.coordination.registerNode({
+      nodeId: "node-b",
+      globalFileManifest: "manifest-a",
+      runtimeFingerprint: "runtime-a",
+      now,
+    });
+    expect(nodeB).toMatchObject({ hostId: nodeA.hostId, ready: true, conflict: null });
+    await expect(first.coordination.activeNodeCount(60_000)).resolves.toBe(2);
+    await expect(
+      second.coordination.heartbeat({
+        nodeId: "node-b",
+        globalFileManifest: "manifest-b",
+        runtimeFingerprint: "runtime-a",
+        now,
+      }),
+    ).resolves.toMatchObject({ ready: false, conflict: "global_file_manifest" });
+    await expect(
+      second.coordination.heartbeat({
+        nodeId: "node-b",
+        globalFileManifest: "manifest-a",
+        runtimeFingerprint: "runtime-b",
+        now,
+      }),
+    ).resolves.toMatchObject({ ready: false, conflict: "runtime_fingerprint" });
+    await expect(second.coordination.nodeReady("node-b")).resolves.toBe(false);
+    await expect(
+      second.coordination.heartbeat({
+        nodeId: "node-b",
+        globalFileManifest: "manifest-a",
+        runtimeFingerprint: "runtime-a",
+        now,
+      }),
+    ).resolves.toMatchObject({ ready: true, conflict: null });
+
+    const generationRead = Promise.withResolvers<void>();
+    const currentConfigGeneration = first.coordination.currentConfigGeneration.bind(
+      first.coordination,
+    );
+    const currentGenerationSpy = vi
+      .spyOn(first.coordination, "currentConfigGeneration")
+      .mockImplementation(async () => {
+        const generation = await currentConfigGeneration();
+        generationRead.resolve();
+        return generation;
+      });
+    const wait = first.coordination.waitForConfigGeneration(0, { pollIntervalMs: 10_000 });
+    await generationRead.promise;
+    await expect(second.coordination.publishConfigGeneration("config-a", "node-b")).resolves.toBe(
+      1,
+    );
+    await expect(wait).resolves.toBe(1);
+    currentGenerationSpy.mockRestore();
+    await expect(first.coordination.currentConfigGeneration()).resolves.toBe(1);
+
+    const leaseA = await first.coordination.acquireLease({
+      leaseName: "asset-gc",
+      ownerNodeId: "node-a",
+      ttlMs: 1_000,
+      now,
+    });
+    expect(leaseA).toMatchObject({ ownerNodeId: "node-a", fencingToken: 1 });
+    await expect(
+      second.coordination.acquireLease({
+        leaseName: "asset-gc",
+        ownerNodeId: "node-b",
+        ttlMs: 1_000,
+        now,
+      }),
+    ).resolves.toBeUndefined();
+    const afterExpiry = new Date(now.getTime() + 1_001);
+    const leaseB = await second.coordination.acquireLease({
+      leaseName: "asset-gc",
+      ownerNodeId: "node-b",
+      ttlMs: 1_000,
+      now: afterExpiry,
+    });
+    expect(leaseB).toMatchObject({ ownerNodeId: "node-b", fencingToken: 2 });
+    await expect(
+      first.coordination.checkpointLease({
+        leaseName: "asset-gc",
+        ownerNodeId: "node-a",
+        fencingToken: 1,
+        cursor: "stale",
+        now: afterExpiry,
+      }),
+    ).rejects.toMatchObject({ details: { kind: "stale_lease" } });
+    await expect(
+      second.coordination.checkpointLease({
+        leaseName: "asset-gc",
+        ownerNodeId: "node-b",
+        fencingToken: 2,
+        cursor: "batch-1",
+        now: afterExpiry,
+      }),
+    ).resolves.toBeUndefined();
+
+    await second.coordination.unregisterNode("node-b");
+    await expect(first.coordination.nodeReady("node-b")).resolves.toBe(false);
+    await expect(first.coordination.activeNodeCount(60_000)).resolves.toBe(1);
+  },
+);
+
+function setupAttempt(attemptId: string, now: Date): SetupAttempt {
+  return {
+    attemptId,
+    projectFingerprint: "project-postgres",
+    capletId: "ast-grep",
+    contentHash: "sha256:postgres-content",
+    targetKind: "remote_host",
+    actor: "automation",
+    status: "succeeded",
+    phase: "commands",
+    commandLabel: attemptId,
+    argv: ["echo", attemptId],
+    exitCode: 0,
+    durationMs: 1,
+    startedAt: now.toISOString(),
+    finishedAt: now.toISOString(),
+    stdout: "ok",
+    stderr: "",
+    redacted: true,
+    retention: { maxAttempts: 3, days: 7 },
+  };
+}

--- a/packages/core/test/host-storage.test.ts
+++ b/packages/core/test/host-storage.test.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Pool } from "pg";
+import { afterEach, describe, expect, it } from "vitest";
+import { HOST_STORAGE_SCHEMA_VERSION, createHostStorage, migrateHostStorage } from "../src/storage";
+
+const directories: string[] = [];
+const postgresUrl = process.env.CAPLETS_TEST_POSTGRES_URL;
+const postgresSchemas: string[] = [];
+const postgresIt = postgresUrl ? it : it.skip;
+
+afterEach(async () => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+  if (postgresUrl && postgresSchemas.length > 0) {
+    const client = new Pool({ connectionString: postgresUrl });
+    try {
+      for (const schema of postgresSchemas.splice(0)) {
+        await client.query(`drop schema if exists "${schema}" cascade`);
+      }
+    } finally {
+      await client.end();
+    }
+  }
+});
+
+describe("host storage", () => {
+  it("creates a ready migrated SQLite store by default", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-storage-"));
+    directories.push(directory);
+
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(directory, "caplets.sqlite3"),
+    });
+
+    try {
+      await expect(storage.health()).resolves.toEqual({
+        backend: "sqlite",
+        ready: true,
+        schemaVersion: HOST_STORAGE_SCHEMA_VERSION,
+        assets: { backend: "sql", ready: true },
+      });
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("rejects invalid and unavailable PostgreSQL storage", async () => {
+    await expect(
+      createHostStorage({
+        type: "postgres",
+        connectionString: "postgres://127.0.0.1:1/caplets?connect_timeout=1",
+        schema: "invalid-schema",
+      }),
+    ).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+    await expect(
+      createHostStorage({
+        type: "postgres",
+        connectionString: "postgres://127.0.0.1:1/caplets?connect_timeout=1",
+      }),
+    ).rejects.toMatchObject({ code: "SERVER_UNAVAILABLE" });
+  });
+
+  postgresIt("refuses an unmigrated PostgreSQL schema", async () => {
+    const schema = `caplets_test_${randomUUID().replaceAll("-", "")}`;
+    postgresSchemas.push(schema);
+    await expect(
+      createHostStorage({
+        type: "postgres",
+        connectionString: postgresUrl!,
+        schema,
+      }),
+    ).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+  });
+
+  postgresIt("migrates PostgreSQL before opening runtime storage", async () => {
+    const schema = `caplets_test_${randomUUID().replaceAll("-", "")}`;
+    postgresSchemas.push(schema);
+    const config = {
+      type: "postgres" as const,
+      connectionString: postgresUrl!,
+      schema,
+    };
+
+    await migrateHostStorage(config);
+    const storage = await createHostStorage(config);
+    try {
+      await expect(storage.health()).resolves.toEqual({
+        backend: "postgres",
+        ready: true,
+        schemaVersion: HOST_STORAGE_SCHEMA_VERSION,
+        assets: { backend: "sql", ready: true },
+      });
+    } finally {
+      await storage.close();
+    }
+  });
+});

--- a/packages/core/test/host-storage.test.ts
+++ b/packages/core/test/host-storage.test.ts
@@ -1,3 +1,4 @@
+import BetterSqlite3 from "better-sqlite3";
 import { randomUUID } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -47,6 +48,65 @@ describe("host storage", () => {
     } finally {
       await storage.close();
     }
+  });
+
+  it("tracks SQLite migrations with integer keys and immutable hashes", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-storage-"));
+    directories.push(directory);
+    const path = join(directory, "caplets.sqlite3");
+    const config = { type: "sqlite" as const, path };
+
+    await migrateHostStorage(config);
+    const database = new BetterSqlite3(path);
+    try {
+      const idColumn = (
+        database.pragma("table_info(caplets_migrations)") as Array<{
+          name: string;
+          type: string;
+          pk: number;
+        }>
+      ).find((column) => column.name === "id");
+      expect(idColumn).toMatchObject({ type: "INTEGER", pk: 1 });
+      const rows = database
+        .prepare("SELECT id, hash FROM caplets_migrations ORDER BY created_at")
+        .all() as Array<{ id: number; hash: string }>;
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows.every((row) => Number.isInteger(row.id))).toBe(true);
+      database
+        .prepare(
+          "UPDATE caplets_migrations SET hash = 'tampered' WHERE created_at = (SELECT MIN(created_at) FROM caplets_migrations)",
+        )
+        .run();
+    } finally {
+      database.close();
+    }
+
+    await expect(migrateHostStorage(config)).rejects.toMatchObject({
+      code: "CONFIG_INVALID",
+    });
+  });
+
+  it("rejects gaps in SQLite migration history", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-storage-"));
+    directories.push(directory);
+    const path = join(directory, "caplets.sqlite3");
+    const config = { type: "sqlite" as const, path };
+
+    await migrateHostStorage(config);
+    const database = new BetterSqlite3(path);
+    try {
+      database
+        .prepare(
+          "DELETE FROM caplets_migrations WHERE created_at = (SELECT MIN(created_at) FROM caplets_migrations)",
+        )
+        .run();
+    } finally {
+      database.close();
+    }
+
+    await expect(migrateHostStorage(config)).rejects.toMatchObject({
+      code: "CONFIG_INVALID",
+    });
   });
 
   it("rejects invalid and unavailable PostgreSQL storage", async () => {

--- a/packages/core/test/installation-storage.test.ts
+++ b/packages/core/test/installation-storage.test.ts
@@ -1,0 +1,279 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHostStorage } from "../src/storage";
+
+const directories: string[] = [];
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    rmSync(directory, { recursive: true, force: true });
+});
+
+function document(): Buffer {
+  return Buffer.from(`---
+name: GitHub
+description: Manage GitHub repositories.
+mcpServer:
+  command: github-mcp
+---
+# GitHub
+`);
+}
+
+describe("Caplet installation storage", () => {
+  it("tracks provenance, requires an Operator Client, and audits detach", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-installations-"));
+    directories.push(root);
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(root, "caplets.sqlite3"),
+    });
+    try {
+      await expect(
+        storage.caplets.importBundle({
+          id: "forbidden",
+          operator: { clientId: "access-client", role: "access" },
+          files: [{ path: "CAPLET.md", content: document(), executable: false }],
+        }),
+      ).rejects.toMatchObject({ code: "AUTH_REQUIRED" });
+      await storage.caplets.importBundle({
+        id: "github",
+        operator: { clientId: "operator-import", role: "operator" },
+        files: [{ path: "CAPLET.md", content: document(), executable: false }],
+      });
+      await expect(
+        storage.vaultGrants.grant({
+          capletId: "github",
+          vaultKey: "github-token",
+          originKind: "stored-record",
+          operator: { clientId: "access-client", role: "access" },
+        }),
+      ).rejects.toMatchObject({ code: "AUTH_REQUIRED" });
+      await storage.vaultGrants.grant({
+        capletId: "github",
+        vaultKey: "github-token",
+        originKind: "stored-record",
+        operator: { clientId: "operator-client", role: "operator" },
+      });
+      const [grantBeforeUpdate] = await storage.vaultGrants.list("github");
+      expect(grantBeforeUpdate?.recordKey).toBe((await storage.caplets.get("github"))?.recordKey);
+      await expect(
+        storage.installations.install({
+          capletId: "github",
+          sourceKind: "catalog",
+          sourceIdentity: "official/github",
+          channel: "stable",
+          operator: { clientId: "access-client", role: "access" },
+        }),
+      ).rejects.toMatchObject({ code: "AUTH_REQUIRED" });
+
+      const installed = await storage.installations.install({
+        capletId: "github",
+        sourceKind: "catalog",
+        sourceIdentity: "official/github",
+        channel: "stable",
+        operator: { clientId: "operator-client", role: "operator" },
+      });
+      expect(installed).toMatchObject({
+        capletId: "github",
+        generation: 1,
+        status: "active",
+        sourceKind: "catalog",
+        sourceIdentity: "official/github",
+        channel: "stable",
+      });
+      await expect(
+        storage.installations.detach({
+          capletId: "github",
+          expectedGeneration: 0,
+          operator: { clientId: "operator-client", role: "operator" },
+        }),
+      ).rejects.toMatchObject({ code: "REQUEST_INVALID" });
+
+      await expect(
+        storage.caplets.updateBundle({
+          id: "github",
+          operator: { clientId: "operator-client", role: "operator" },
+          expectedGeneration: 1,
+          files: [{ path: "CAPLET.md", content: document(), executable: false }],
+        }),
+      ).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+        details: { kind: "tracked_installation" },
+      });
+      await storage.caplets.updateBundle({
+        id: "github",
+        operator: { clientId: "operator-client", role: "operator" },
+        expectedGeneration: 1,
+        detachInstallation: true,
+        files: [{ path: "CAPLET.md", content: document(), executable: false }],
+      });
+      await expect(storage.installations.getActive("github")).resolves.toBeUndefined();
+      await expect(storage.vaultGrants.list("github")).resolves.toMatchObject([
+        { recordKey: grantBeforeUpdate?.recordKey, vaultKey: "github-token" },
+      ]);
+      const actions = (await storage.installations.listActivity()).map((entry) => entry.action);
+      expect(actions).toEqual(
+        expect.arrayContaining([
+          "caplet.import",
+          "caplet.install",
+          "caplet.detach_for_overwrite",
+          "caplet.update",
+        ]),
+      );
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("retains unavailable sources and explicitly replaces detached installations", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-installation-lifecycle-"));
+    directories.push(root);
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(root, "caplets.sqlite3"),
+    });
+    const operator = { clientId: "operator-client", role: "operator" } as const;
+    try {
+      await storage.caplets.importBundle({
+        id: "github",
+        operator,
+        files: [{ path: "CAPLET.md", content: document(), executable: false }],
+      });
+      await expect(storage.coordination.currentConfigGeneration()).resolves.toBe(1);
+      const recordBefore = await storage.caplets.get("github");
+      const installed = await storage.installations.install({
+        capletId: "github",
+        sourceKind: "catalog",
+        sourceIdentity: "official/github",
+        channel: "stable",
+        operator,
+      });
+      await expect(storage.coordination.currentConfigGeneration()).resolves.toBe(2);
+
+      await storage.installations.appendObservation({
+        capletId: "github",
+        expectedGeneration: 1,
+        status: "current",
+        resolvedRevision: "v1.0.0",
+        contentHash: "content-v1",
+        risk: { level: "low" },
+        operator,
+      });
+      await storage.installations.appendObservation({
+        capletId: "github",
+        expectedGeneration: 2,
+        status: "metadata-only",
+        resolvedRevision: "v1.1.0",
+        risk: { level: "medium" },
+        operator,
+      });
+      await expect(
+        storage.installations.appendObservation({
+          capletId: "github",
+          expectedGeneration: 2,
+          status: "source-unavailable",
+          operator,
+        }),
+      ).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+        details: { kind: "stale_generation" },
+      });
+      await storage.installations.appendObservation({
+        capletId: "github",
+        expectedGeneration: 3,
+        status: "source-unavailable",
+        operator,
+      });
+
+      const retained = await storage.installations.getActive("github");
+      expect(retained).toMatchObject({
+        installationKey: installed.installationKey,
+        recordKey: installed.recordKey,
+        generation: 4,
+        status: "active",
+      });
+      expect((await storage.caplets.get("github"))?.recordKey).toBe(recordBefore?.recordKey);
+      await expect(storage.installations.getLatestObservation("github")).resolves.toMatchObject({
+        status: "source-unavailable",
+        resolvedRevision: null,
+        contentHash: null,
+      });
+      const observations = await storage.installations.listObservations("github");
+      expect(observations.map((observation) => observation.status)).toEqual([
+        "source-unavailable",
+        "metadata-only",
+        "current",
+      ]);
+      expect(observations[0]!.observedAt > observations[1]!.observedAt).toBe(true);
+      expect(observations[1]!.observedAt > observations[2]!.observedAt).toBe(true);
+      await expect(storage.coordination.currentConfigGeneration()).resolves.toBe(2);
+
+      await expect(
+        storage.installations.detach({
+          capletId: "github",
+          expectedGeneration: 3,
+          operator,
+        }),
+      ).rejects.toMatchObject({ details: { kind: "stale_generation" } });
+      const detached = await storage.installations.detach({
+        capletId: "github",
+        expectedGeneration: 4,
+        operator,
+      });
+      expect(detached).toMatchObject({
+        installationKey: installed.installationKey,
+        generation: 5,
+        status: "detached",
+      });
+      await expect(storage.coordination.currentConfigGeneration()).resolves.toBe(3);
+      await expect(
+        storage.installations.install({
+          capletId: "github",
+          sourceKind: "catalog",
+          sourceIdentity: "community/github",
+          operator,
+        }),
+      ).rejects.toMatchObject({
+        details: { kind: "detached_installation_replacement_required" },
+      });
+      await expect(
+        storage.installations.replaceDetached({
+          capletId: "github",
+          detachedInstallationKey: installed.installationKey,
+          expectedGeneration: 4,
+          sourceKind: "catalog",
+          sourceIdentity: "community/github",
+          operator,
+        }),
+      ).rejects.toMatchObject({ details: { kind: "stale_generation" } });
+
+      const replacement = await storage.installations.replaceDetached({
+        capletId: "github",
+        detachedInstallationKey: installed.installationKey,
+        expectedGeneration: 5,
+        sourceKind: "catalog",
+        sourceIdentity: "community/github",
+        channel: "stable",
+        operator,
+      });
+      expect(replacement).toMatchObject({ generation: 1, status: "active" });
+      expect(replacement.installationKey).not.toBe(installed.installationKey);
+      await expect(storage.coordination.currentConfigGeneration()).resolves.toBe(4);
+      await expect(storage.installations.list("github")).resolves.toMatchObject([
+        { installationKey: replacement.installationKey, status: "active" },
+        { installationKey: installed.installationKey, status: "detached" },
+      ]);
+      expect((await storage.installations.listActivity()).map((entry) => entry.action)).toEqual(
+        expect.arrayContaining([
+          "caplet.observe_source",
+          "caplet.detach",
+          "caplet.replace_installation",
+        ]),
+      );
+    } finally {
+      await storage.close();
+    }
+  });
+});

--- a/packages/core/test/legacy-migration.test.ts
+++ b/packages/core/test/legacy-migration.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { writeTokenBundle, type StoredOAuthTokenBundle } from "../src/auth/store";
 import { installCaplets } from "../src/install";
 import { DashboardActivityLog } from "../src/dashboard/activity-log";
@@ -13,6 +13,7 @@ import {
   migrateLegacyHostState,
   type LegacyMigrationOptions,
 } from "../src/storage/legacy-migration";
+import { OperatorActivityStore } from "../src/storage/operator-activity";
 import { FileVaultStore } from "../src/vault";
 
 const directories: string[] = [];
@@ -356,6 +357,63 @@ describe("legacy host-state migration", () => {
     expect(existsSync(join(fixture.vaultRoot, "values", "GITHUB_TOKEN.json"))).toBe(true);
     expect(existsSync(join(fixture.remoteDir, "remote-server-credentials.json"))).toBe(true);
     expect(existsSync(fixture.backupRoot)).toBe(false);
+  });
+
+  it("rolls every imported SQL domain back when a late domain fails, then resumes", async () => {
+    const fixture = await createFullLegacyFixture();
+    const failure = vi
+      .spyOn(OperatorActivityStore.prototype, "importLegacyEntriesInTransaction")
+      .mockImplementationOnce(() => {
+        throw new Error("injected late-domain import failure");
+      });
+
+    await expect(migrateLegacyHostState(fixture.options)).rejects.toThrow(
+      "injected late-domain import failure",
+    );
+    failure.mockRestore();
+
+    const storage = await createHostStorage(
+      { type: "sqlite", path: fixture.databasePath },
+      { vaultRoot: fixture.options.targetVaultRoot },
+    );
+    try {
+      await expect(storage.caplets.get("github")).resolves.toBeUndefined();
+      await expect(storage.installations.getActive("github")).resolves.toBeUndefined();
+      await expect(storage.backendAuth.readTokenBundle("github")).resolves.toBeUndefined();
+      await expect(storage.vaultValues.getStatus("GITHUB_TOKEN")).resolves.toEqual({
+        key: "GITHUB_TOKEN",
+        present: false,
+      });
+      await expect(storage.vaultGrants.list()).resolves.toEqual([]);
+      await expect(storage.remoteSecurity.dumpForTest()).resolves.toMatchObject({
+        pairingCodes: [],
+        pendingLogins: [],
+        clients: [],
+      });
+      await expect(
+        storage.setupState.getApproval(
+          "project-fingerprint",
+          "github",
+          "sha256:setup-content",
+          "local_host",
+        ),
+      ).resolves.toBeUndefined();
+      await expect(
+        storage.setupState.getAttempt(
+          "project-fingerprint",
+          "github",
+          fixture.setupAttempt.attemptId,
+        ),
+      ).resolves.toBeUndefined();
+      await expect(storage.operatorActivity.list()).resolves.toEqual({ entries: [] });
+    } finally {
+      await storage.close();
+    }
+
+    await expect(migrateLegacyHostState(fixture.options)).resolves.toMatchObject({
+      status: "migrated",
+      domains: expectedDomainReport(),
+    });
   });
 
   it("rolls every source move back when backup fails and resumes from imported SQL", async () => {

--- a/packages/core/test/legacy-migration.test.ts
+++ b/packages/core/test/legacy-migration.test.ts
@@ -1,0 +1,484 @@
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeTokenBundle, type StoredOAuthTokenBundle } from "../src/auth/store";
+import { installCaplets } from "../src/install";
+import { DashboardActivityLog } from "../src/dashboard/activity-log";
+import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
+import { LocalSetupStore } from "../src/setup/local-store";
+import type { SetupAttempt } from "../src/setup/types";
+import { createHostStorage } from "../src/storage";
+import {
+  migrateLegacyHostState,
+  type LegacyMigrationOptions,
+} from "../src/storage/legacy-migration";
+import { FileVaultStore } from "../src/vault";
+
+const directories: string[] = [];
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function document(): string {
+  return `---
+name: GitHub
+description: Manage GitHub repositories.
+mcpServers:
+  github:
+    command: github-mcp
+---
+
+# GitHub
+
+Operator notes.
+`;
+}
+
+type FullLegacyFixture = {
+  root: string;
+  options: LegacyMigrationOptions;
+  capletsRoot: string;
+  lockfilePath: string;
+  databasePath: string;
+  authDir: string;
+  vaultRoot: string;
+  remoteDir: string;
+  setupDir: string;
+  activityDir: string;
+  backupRoot: string;
+  authBundle: StoredOAuthTokenBundle;
+  vaultPlaintext: string;
+  hostUrl: string;
+  remoteAccessToken: string;
+  remoteClientId: string;
+  pendingFlowId: string;
+  pendingCompletionSecret: string;
+  unusedPairingCode: string;
+  setupAttempt: SetupAttempt;
+  activityId: string;
+};
+
+async function createFullLegacyFixture(): Promise<FullLegacyFixture> {
+  const root = mkdtempSync(join(tmpdir(), "caplets-full-legacy-migration-"));
+  directories.push(root);
+  const repository = join(root, "repository");
+  const source = join(repository, "caplets", "github");
+  const capletsRoot = join(root, "host", "caplets");
+  const lockfilePath = join(root, "host", "caplets.lock.json");
+  const databasePath = join(root, "sql", "caplets.sqlite3");
+  const authDir = join(root, "legacy", "auth");
+  const vaultRoot = join(root, "legacy", "vault");
+  const remoteDir = join(root, "legacy", "remote");
+  const setupDir = join(root, "legacy", "setup");
+  const activityDir = join(root, "legacy", "activity");
+  const targetVaultRoot = join(root, "sql", "vault");
+  const backupRoot = join(root, "backup");
+  mkdirSync(source, { recursive: true });
+  writeFileSync(join(source, "CAPLET.md"), document());
+  writeFileSync(join(source, "script.sh"), "#!/bin/sh\necho github\n", { mode: 0o755 });
+  installCaplets(repository, {
+    capletIds: ["github"],
+    destinationRoot: capletsRoot,
+    lockfilePath,
+  });
+
+  const authBundle: StoredOAuthTokenBundle = {
+    server: "github",
+    authType: "oauth2",
+    accessToken: "legacy_oauth_access_secret",
+    refreshToken: "legacy_oauth_refresh_secret",
+    tokenType: "Bearer",
+    expiresAt: "2099-07-18T00:00:00.000Z",
+    metadata: { audience: "github" },
+  };
+  writeTokenBundle(authBundle, authDir);
+
+  const vaultPlaintext = "legacy_vault_plaintext_secret";
+  const vault = new FileVaultStore({ root: vaultRoot, env: {} });
+  vault.set("GITHUB_TOKEN", vaultPlaintext, { now: new Date("2026-07-18T10:00:00.000Z") });
+  vault.grantAccess({
+    storedKey: "GITHUB_TOKEN",
+    referenceName: "TOKEN",
+    capletId: "github",
+    origin: { kind: "global-file", path: join(capletsRoot, "github", "CAPLET.md") },
+    now: new Date("2026-07-18T10:01:00.000Z"),
+  });
+
+  const hostUrl = "https://host.example.test/caplets";
+  const remoteNow = new Date();
+  const remote = new RemoteServerCredentialStore({ dir: remoteDir });
+  const usedPairing = remote.createPairingCode({
+    hostUrl,
+    clientLabel: "Migrated client",
+    ttlMs: 60 * 60_000,
+    now: remoteNow,
+  });
+  const credentials = remote.exchangePairingCode({
+    hostUrl,
+    code: usedPairing.code,
+    clientLabel: "Migrated client",
+    now: remoteNow,
+  });
+  const unusedPairing = remote.createPairingCode({
+    hostUrl,
+    clientLabel: "Pair after migration",
+    ttlMs: 60 * 60_000,
+    now: remoteNow,
+  });
+  const pending = remote.createPendingLogin({
+    hostUrl,
+    clientLabel: "Pending client",
+    sourceHint: "migration-test",
+    now: remoteNow,
+  });
+
+  const setup = new LocalSetupStore({
+    baseDir: setupDir,
+    now: () => new Date("2026-07-18T10:10:00.000Z"),
+  });
+  await setup.approve({
+    projectFingerprint: "project-fingerprint",
+    capletId: "github",
+    contentHash: "sha256:setup-content",
+    targetKind: "local_host",
+    approvedAt: "2026-07-18T10:02:00.000Z",
+    actor: "automation",
+  });
+  const setupAttempt: SetupAttempt = {
+    attemptId: "setup-attempt-legacy",
+    projectFingerprint: "project-fingerprint",
+    capletId: "github",
+    contentHash: "sha256:setup-content",
+    setupHash: "sha256:setup-plan",
+    targetKind: "local_host",
+    actor: "automation",
+    status: "succeeded",
+    phase: "verify",
+    commandLabel: "verify installation",
+    argv: ["verify"],
+    exitCode: 0,
+    durationMs: 12,
+    startedAt: "2026-07-18T10:03:00.000Z",
+    finishedAt: "2026-07-18T10:03:01.000Z",
+    stdout: "[redacted]",
+    stderr: "",
+    redacted: true,
+    retention: { maxAttempts: 3, days: 7 },
+  };
+  await setup.recordAttempt(setupAttempt);
+
+  const activity = new DashboardActivityLog({ dir: activityDir }).append({
+    actorClientId: "legacy_operator",
+    action: "catalog_installed",
+    target: { type: "catalog", id: "github", label: "GitHub" },
+    metadata: { source: "legacy" },
+    now: new Date("2026-07-18T10:04:00.000Z"),
+  });
+
+  return {
+    root,
+    options: {
+      storage: { type: "sqlite", path: databasePath },
+      capletsRoot,
+      lockfilePath,
+      operatorClientId: "operator_migration",
+      backupRoot,
+      backendAuthDir: authDir,
+      legacyVaultRoot: vaultRoot,
+      targetVaultRoot,
+      remoteSecurityDir: remoteDir,
+      setupStateDir: setupDir,
+      operatorActivityDir: activityDir,
+    },
+    capletsRoot,
+    lockfilePath,
+    databasePath,
+    authDir,
+    vaultRoot,
+    remoteDir,
+    setupDir,
+    activityDir,
+    backupRoot,
+    authBundle,
+    vaultPlaintext,
+    hostUrl,
+    remoteAccessToken: credentials.accessToken,
+    remoteClientId: credentials.clientId,
+    pendingFlowId: pending.flowId,
+    pendingCompletionSecret: pending.pendingCompletionSecret,
+    unusedPairingCode: unusedPairing.code,
+    setupAttempt,
+    activityId: activity.id,
+  };
+}
+
+function expectedDomainReport() {
+  return {
+    backendAuthTokenBundles: 1,
+    vaultValues: 1,
+    vaultGrants: 1,
+    remotePairingCodes: 2,
+    remoteClients: 1,
+    remotePendingLogins: 1,
+    setupApprovals: 1,
+    setupAttempts: 1,
+    operatorActivityEntries: 1,
+    dashboardSessions: "not_applicable_no_legacy_format",
+    projectBindings: "not_applicable_no_legacy_format",
+  };
+}
+
+describe("legacy host-state migration", () => {
+  it("verifies tracked artifacts, imports provenance, and preserves a recoverable backup", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-legacy-migration-"));
+    directories.push(root);
+    const repository = join(root, "repository");
+    const source = join(repository, "caplets", "github");
+    const capletsRoot = join(root, "host", "caplets");
+    const lockfilePath = join(root, "host", "caplets.lock.json");
+    const backupRoot = join(root, "backup");
+    const databasePath = join(root, "host", "caplets.sqlite3");
+    mkdirSync(source, { recursive: true });
+    writeFileSync(join(source, "CAPLET.md"), document());
+    writeFileSync(join(source, "script.sh"), "#!/bin/sh\necho github\n", { mode: 0o755 });
+    installCaplets(repository, {
+      capletIds: ["github"],
+      destinationRoot: capletsRoot,
+      lockfilePath,
+    });
+    writeFileSync(join(capletsRoot, "untracked.md"), document().replaceAll("github", "local"));
+
+    const report = await migrateLegacyHostState({
+      storage: { type: "sqlite", path: databasePath },
+      capletsRoot,
+      lockfilePath,
+      operatorClientId: "operator_migration",
+      backupRoot,
+    });
+
+    expect(report).toEqual({
+      status: "migrated",
+      records: 1,
+      installations: 1,
+      backupPath: backupRoot,
+    });
+    expect(existsSync(join(capletsRoot, "github"))).toBe(false);
+    expect(existsSync(join(capletsRoot, "untracked.md"))).toBe(true);
+    expect(existsSync(join(backupRoot, "caplets", "github", "CAPLET.md"))).toBe(true);
+    expect(existsSync(join(backupRoot, "caplets.lock.json"))).toBe(true);
+
+    const storage = await createHostStorage({ type: "sqlite", path: databasePath });
+    try {
+      const record = await storage.caplets.get("github");
+      expect(record?.currentRevision.sourceContentHash).toMatch(/^sha256:/);
+      expect(record?.currentRevision.bundle.map((entry) => entry.path)).toEqual(["script.sh"]);
+      await expect(storage.installations.getActive("github")).resolves.toMatchObject({
+        sourceKind: "local",
+        status: "active",
+      });
+      await expect(storage.installations.listActivity()).resolves.toMatchObject([
+        {
+          operatorClientId: "operator_migration",
+          action: "caplet.import",
+          outcome: "succeeded",
+        },
+      ]);
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("dry-runs every applicable legacy domain without SQL state writes or source moves", async () => {
+    const fixture = await createFullLegacyFixture();
+    const report = await migrateLegacyHostState({ ...fixture.options, dryRun: true });
+
+    expect(report).toEqual({
+      status: "verified",
+      records: 1,
+      installations: 1,
+      backupPath: null,
+      domains: expectedDomainReport(),
+    });
+    expect(JSON.stringify(report)).not.toContain("secret");
+    expect(existsSync(join(fixture.capletsRoot, "github", "CAPLET.md"))).toBe(true);
+    expect(existsSync(fixture.lockfilePath)).toBe(true);
+    expect(existsSync(join(fixture.authDir, "github.json"))).toBe(true);
+    expect(existsSync(join(fixture.vaultRoot, "values", "GITHUB_TOKEN.json"))).toBe(true);
+    expect(existsSync(join(fixture.remoteDir, "remote-server-credentials.json"))).toBe(true);
+    expect(existsSync(join(fixture.setupDir, "approvals.json"))).toBe(true);
+    expect(existsSync(join(fixture.activityDir, "dashboard-activity.jsonl"))).toBe(true);
+    expect(existsSync(fixture.backupRoot)).toBe(false);
+
+    const storage = await createHostStorage(
+      { type: "sqlite", path: fixture.databasePath },
+      { vaultRoot: fixture.options.targetVaultRoot },
+    );
+    try {
+      await expect(storage.caplets.list()).resolves.toEqual([]);
+      await expect(storage.backendAuth.listTokenBundles()).resolves.toEqual([]);
+      await expect(storage.vaultValues.listValues()).resolves.toEqual([]);
+      await expect(storage.remoteSecurity.listClients()).resolves.toEqual([]);
+      await expect(
+        storage.setupState.getApproval(
+          "project-fingerprint",
+          "github",
+          "sha256:setup-content",
+          "local_host",
+        ),
+      ).resolves.toBeUndefined();
+      await expect(storage.operatorActivity.list()).resolves.toEqual({ entries: [] });
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("refuses non-identical target state without moving any source", async () => {
+    const fixture = await createFullLegacyFixture();
+    const storage = await createHostStorage({ type: "sqlite", path: fixture.databasePath });
+    try {
+      await storage.backendAuth.writeTokenBundle({
+        ...fixture.authBundle,
+        accessToken: "different_target_secret",
+      });
+    } finally {
+      await storage.close();
+    }
+
+    await expect(migrateLegacyHostState(fixture.options)).rejects.toMatchObject({
+      code: "CONFIG_EXISTS",
+    });
+    expect(existsSync(join(fixture.capletsRoot, "github", "CAPLET.md"))).toBe(true);
+    expect(existsSync(fixture.lockfilePath)).toBe(true);
+    expect(existsSync(join(fixture.authDir, "github.json"))).toBe(true);
+    expect(existsSync(join(fixture.vaultRoot, "values", "GITHUB_TOKEN.json"))).toBe(true);
+    expect(existsSync(join(fixture.remoteDir, "remote-server-credentials.json"))).toBe(true);
+    expect(existsSync(fixture.backupRoot)).toBe(false);
+  });
+
+  it("rolls every source move back when backup fails and resumes from imported SQL", async () => {
+    const fixture = await createFullLegacyFixture();
+    mkdirSync(fixture.backupRoot, { recursive: true });
+    const blocker = join(fixture.backupRoot, "backend-auth");
+    writeFileSync(blocker, "not a directory");
+
+    await expect(migrateLegacyHostState(fixture.options)).rejects.toBeDefined();
+    expect(existsSync(join(fixture.capletsRoot, "github", "CAPLET.md"))).toBe(true);
+    expect(existsSync(fixture.lockfilePath)).toBe(true);
+    expect(existsSync(join(fixture.authDir, "github.json"))).toBe(true);
+    expect(existsSync(join(fixture.vaultRoot, "values", "GITHUB_TOKEN.json"))).toBe(true);
+    expect(existsSync(join(fixture.remoteDir, "remote-server-credentials.json"))).toBe(true);
+    expect(existsSync(join(fixture.setupDir, "approvals.json"))).toBe(true);
+    expect(existsSync(join(fixture.activityDir, "dashboard-activity.jsonl"))).toBe(true);
+    expect(existsSync(join(fixture.backupRoot, "caplets", "github"))).toBe(false);
+    expect(existsSync(join(fixture.backupRoot, "caplets.lock.json"))).toBe(false);
+
+    rmSync(blocker);
+    await expect(migrateLegacyHostState(fixture.options)).resolves.toMatchObject({
+      status: "migrated",
+      domains: expectedDomainReport(),
+    });
+  });
+
+  it("migrates, verifies, backs up, reruns safely, and preserves behavioral security state", async () => {
+    const fixture = await createFullLegacyFixture();
+    const report = await migrateLegacyHostState(fixture.options);
+
+    expect(report).toEqual({
+      status: "migrated",
+      records: 1,
+      installations: 1,
+      backupPath: fixture.backupRoot,
+      domains: expectedDomainReport(),
+    });
+    expect(JSON.stringify(report)).not.toContain("secret");
+    expect(existsSync(join(fixture.capletsRoot, "github"))).toBe(false);
+    expect(existsSync(fixture.lockfilePath)).toBe(false);
+    expect(existsSync(join(fixture.authDir, "github.json"))).toBe(false);
+    expect(existsSync(join(fixture.vaultRoot, "values", "GITHUB_TOKEN.json"))).toBe(false);
+    expect(existsSync(join(fixture.remoteDir, "remote-server-credentials.json"))).toBe(false);
+    expect(existsSync(join(fixture.setupDir, "approvals.json"))).toBe(false);
+    expect(existsSync(join(fixture.activityDir, "dashboard-activity.jsonl"))).toBe(false);
+    expect(existsSync(join(fixture.backupRoot, "caplets", "github", "CAPLET.md"))).toBe(true);
+    expect(existsSync(join(fixture.backupRoot, "backend-auth", "github.json"))).toBe(true);
+    expect(existsSync(join(fixture.backupRoot, "vault", "values", "GITHUB_TOKEN.json"))).toBe(true);
+    expect(
+      existsSync(join(fixture.backupRoot, "remote-security", "remote-server-credentials.json")),
+    ).toBe(true);
+    expect(existsSync(join(fixture.backupRoot, "setup-state", "approvals.json"))).toBe(true);
+    expect(
+      existsSync(join(fixture.backupRoot, "operator-activity", "dashboard-activity.jsonl")),
+    ).toBe(true);
+
+    await expect(migrateLegacyHostState(fixture.options)).resolves.toEqual(report);
+
+    const storage = await createHostStorage(
+      { type: "sqlite", path: fixture.databasePath },
+      { vaultRoot: fixture.options.targetVaultRoot },
+    );
+    try {
+      await expect(storage.backendAuth.readTokenBundle("github")).resolves.toMatchObject({
+        bundle: fixture.authBundle,
+        generation: 1,
+      });
+      await expect(storage.vaultValues.resolveValue("GITHUB_TOKEN")).resolves.toBe(
+        fixture.vaultPlaintext,
+      );
+      await expect(storage.vaultGrants.list("github")).resolves.toContainEqual(
+        expect.objectContaining({
+          subjectKind: "record",
+          capletId: "github",
+          vaultKey: "GITHUB_TOKEN",
+          referenceName: "TOKEN",
+          originKind: "stored-record",
+          originPath: null,
+        }),
+      );
+      await expect(
+        storage.remoteSecurity.validateAccessToken({
+          hostUrl: fixture.hostUrl,
+          accessToken: fixture.remoteAccessToken,
+        }),
+      ).resolves.toMatchObject({ clientId: fixture.remoteClientId, role: "access" });
+      await expect(
+        storage.remoteSecurity.pollPendingLogin({
+          flowId: fixture.pendingFlowId,
+          pendingCompletionSecret: fixture.pendingCompletionSecret,
+        }),
+      ).resolves.toEqual({ flowId: fixture.pendingFlowId, status: "pending" });
+      await expect(
+        storage.remoteSecurity.exchangePairingCode({
+          hostUrl: fixture.hostUrl,
+          code: fixture.unusedPairingCode,
+          clientLabel: "Post-migration client",
+        }),
+      ).resolves.toMatchObject({ hostUrl: fixture.hostUrl, role: "access" });
+      await expect(
+        storage.setupState.getApproval(
+          "project-fingerprint",
+          "github",
+          "sha256:setup-content",
+          "local_host",
+        ),
+      ).resolves.toMatchObject({ actor: "automation" });
+      await expect(
+        storage.setupState.getAttempt(
+          "project-fingerprint",
+          "github",
+          fixture.setupAttempt.attemptId,
+        ),
+      ).resolves.toEqual(fixture.setupAttempt);
+      await expect(storage.operatorActivity.list({ action: "catalog_installed" })).resolves.toEqual(
+        {
+          entries: [
+            expect.objectContaining({ id: fixture.activityId, actorClientId: "legacy_operator" }),
+          ],
+        },
+      );
+    } finally {
+      await storage.close();
+    }
+  });
+});

--- a/packages/core/test/openapi.test.ts
+++ b/packages/core/test/openapi.test.ts
@@ -8,7 +8,7 @@ import { ServerRegistry } from "../src/registry";
 import { DownstreamManager } from "../src/downstream";
 import { OpenApiManager } from "../src/openapi";
 import { handleServerTool } from "../src/tools";
-import { writeTokenBundle } from "../src/auth";
+import { createHostStorage, type HostStorage } from "../src/storage";
 import { testBackendOperationRuntime } from "./backend-operation-runtime";
 
 describe("native OpenAPI Caplets", () => {
@@ -798,20 +798,17 @@ describe("native OpenAPI Caplets", () => {
 
   it("applies stored OAuth tokens to remote specs and OpenAPI requests", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-openapi-auth-"));
-    const authDir = join(dir, "auth");
+    const storage = await createTestAuthStorage(dir);
     try {
-      writeTokenBundle(
-        {
-          server: "remote",
-          accessToken: "secret-openapi-access-token",
-          authType: "oauth2",
-          tokenType: "Bearer",
-          expiresAt: "2999-01-01T00:00:00.000Z",
-          clientId: "client",
-          protectedResourceOrigin: baseUrl,
-        },
-        authDir,
-      );
+      await storage.backendAuth.writeTokenBundle({
+        server: "remote",
+        accessToken: "secret-openapi-access-token",
+        authType: "oauth2",
+        tokenType: "Bearer",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        clientId: "client",
+        protectedResourceOrigin: baseUrl,
+      });
       requests.length = 0;
       const endpoint = {
         server: "remote",
@@ -827,6 +824,7 @@ describe("native OpenAPI Caplets", () => {
       };
       const registry = new ServerRegistry({
         version: 1,
+        storage: { type: "sqlite" },
         options: {
           defaultSearchLimit: 20,
           maxSearchLimit: 50,
@@ -849,7 +847,7 @@ describe("native OpenAPI Caplets", () => {
         cliTools: {},
         capletSets: {},
       });
-      const openapi = new OpenApiManager(registry, { authDir });
+      const openapi = new OpenApiManager(registry, { backendAuth: storage.backendAuth });
 
       await openapi.listTools(endpoint);
       await openapi.callTool(endpoint, "GET /users/{id}", {
@@ -863,13 +861,14 @@ describe("native OpenAPI Caplets", () => {
         ),
       ).toBe(true);
     } finally {
+      await storage.close();
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
   it("redacts OpenAPI auth failures without returning downstream error bodies", async () => {
     const dir = mkdtempSync(join(tmpdir(), "caplets-openapi-auth-failure-"));
-    const authDir = join(dir, "auth");
+    const storage = await createTestAuthStorage(dir);
     const specPath = join(dir, "openapi.json");
     writeFileSync(
       specPath,
@@ -899,19 +898,16 @@ describe("native OpenAPI Caplets", () => {
       },
     });
     const registry = new ServerRegistry(config);
-    writeTokenBundle(
-      {
-        server: "protectedApi",
-        accessToken: "expired-downstream-token",
-        authType: "oauth2",
-        tokenType: "Bearer",
-        expiresAt: "2999-01-01T00:00:00.000Z",
-        clientId: "client",
-        protectedResourceOrigin: baseUrl,
-      },
-      authDir,
-    );
-    const openapi = new OpenApiManager(registry, { authDir });
+    await storage.backendAuth.writeTokenBundle({
+      server: "protectedApi",
+      accessToken: "expired-downstream-token",
+      authType: "oauth2",
+      tokenType: "Bearer",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      clientId: "client",
+      protectedResourceOrigin: baseUrl,
+    });
+    const openapi = new OpenApiManager(registry, { backendAuth: storage.backendAuth });
 
     try {
       await expect(
@@ -927,6 +923,7 @@ describe("native OpenAPI Caplets", () => {
         },
       });
     } finally {
+      await storage.close();
       rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -1297,4 +1294,8 @@ function localArtifactPath(result: unknown): string {
     return result.structuredContent.path;
   }
   throw new Error("expected a local artifact result");
+}
+
+async function createTestAuthStorage(directory: string): Promise<HostStorage> {
+  return createHostStorage({ type: "sqlite", path: join(directory, "host.sqlite3") });
 }

--- a/packages/core/test/operator-activity-storage.test.ts
+++ b/packages/core/test/operator-activity-storage.test.ts
@@ -1,0 +1,89 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createHostStorage } from "../src/storage";
+import { OperatorActivityStore } from "../src/storage/operator-activity";
+
+describe("OperatorActivityStore", () => {
+  it("appends and deterministically pages safe SQL activity across SQLite instances", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-operator-activity-"));
+    const path = join(directory, "caplets.sqlite3");
+    const firstStorage = await createHostStorage({ type: "sqlite", path });
+    const secondStorage = await createHostStorage({ type: "sqlite", path });
+    const first = new OperatorActivityStore(firstStorage.database);
+    const second = new OperatorActivityStore(secondStorage.database);
+
+    try {
+      const oldest = await first.append({
+        actorClientId: "operator-1",
+        action: "vault_set",
+        target: { type: "vault", id: "GH_TOKEN", label: "GitHub token" },
+        metadata: {
+          bytesWritten: 42,
+          secretValue: "must-not-appear",
+          note: "cap_remote_access_must-not-appear",
+        },
+        now: new Date("2026-07-18T10:00:00.000Z"),
+      });
+      const middle = await first.append({
+        actorClientId: "operator-1",
+        action: "caplet.install",
+        outcome: "failure",
+        target: { type: "installation", id: "installation-1" },
+        now: new Date("2026-07-18T10:01:00.000Z"),
+      });
+
+      await expect(second.list()).resolves.toMatchObject({
+        entries: [
+          { id: middle.id, action: "caplet.install", outcome: "failure" },
+          {
+            id: oldest.id,
+            action: "vault_set",
+            outcome: "success",
+            target: { type: "vault", id: "GH_TOKEN", label: "GitHub token" },
+            metadata: { bytesWritten: 42 },
+          },
+        ],
+      });
+
+      const newest = await second.append({
+        actorClientId: "operator-2",
+        action: "vault_set",
+        target: { type: "vault", id: "NPM_TOKEN" },
+        now: new Date("2026-07-18T10:02:00.000Z"),
+      });
+      const firstPage = await first.list({ limit: 2 });
+      expect(firstPage).toEqual({
+        entries: [newest, middle],
+        nextCursor: middle.id,
+      });
+      await expect(first.list({ limit: 2, after: firstPage.nextCursor })).resolves.toEqual({
+        entries: [oldest],
+      });
+      await expect(first.list({ action: "vault_set" })).resolves.toEqual({
+        entries: [newest, oldest],
+      });
+      await expect(first.list({ action: "caplet.install" })).resolves.toEqual({
+        entries: [middle],
+      });
+
+      for (let index = 0; index < 501; index += 1) {
+        await first.append({
+          actorClientId: "bulk-operator",
+          action: "bulk.activity",
+          target: { type: "bulk", id: String(index) },
+          now: new Date(1_000 + index),
+        });
+      }
+      const boundedPage = await first.list({ limit: 10_000 });
+      expect(boundedPage.entries).toEqual(expect.arrayContaining([newest, middle, oldest]));
+      expect(boundedPage.entries).toHaveLength(500);
+      expect((await first.list({ limit: 0 })).entries).toHaveLength(1);
+    } finally {
+      await secondStorage.close();
+      await firstStorage.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/test/package-boundaries.test.ts
+++ b/packages/core/test/package-boundaries.test.ts
@@ -45,6 +45,19 @@ describe("package boundaries", () => {
     expect(violations).toEqual([]);
   });
 
+  it("keeps storage independent of CLI modules", () => {
+    const storageRoot = resolve(packagesRoot, "core/src/storage");
+    const violations = scanFiles([storageRoot]).flatMap((filePath) => {
+      const source = readFileSync(filePath, "utf8");
+      return importSpecifiers(source)
+        .filter((specifier) => specifier.startsWith("."))
+        .filter((specifier) => /(?:^|\/)cli(?:\/|$)/.test(specifier))
+        .map((specifier) => `${formatPath(filePath)} imports CLI module ${specifier}`);
+    });
+
+    expect(violations).toEqual([]);
+  });
+
   it("imports workspace packages through declared package exports", () => {
     const exportedCoreSpecifiers = new Set(
       Object.keys(corePackage.exports).map((specifier) =>

--- a/packages/core/test/project-binding-storage.test.ts
+++ b/packages/core/test/project-binding-storage.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHostStorage } from "../src/storage/database";
+import { ProjectBindingStore } from "../src/storage/project-bindings";
+import * as sqlite from "../src/storage/schema/sqlite";
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("SQL Project Binding metadata", () => {
+  it("creates, heartbeats, quarantines, and explicitly rebinds with CAS fencing", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-project-binding-state-"));
+    directories.push(root);
+    const firstStorage = await createHostStorage({
+      type: "sqlite",
+      path: join(root, "caplets.sqlite3"),
+    });
+    let now = new Date("2026-07-18T12:00:00.000Z");
+    const first = new ProjectBindingStore(firstStorage.database, {
+      now: () => now,
+      leaseTtlMs: 60_000,
+    });
+    const second = new ProjectBindingStore(firstStorage.database, {
+      now: () => now,
+      leaseTtlMs: 60_000,
+    });
+
+    try {
+      const created = await first.create({
+        bindingId: "binding-1",
+        sessionId: "session-1",
+        projectFingerprint: "sha256:project",
+        projectRoot: "/client/project",
+        serverProjectRoot: "/host/workspaces/project",
+        ownerNodeId: "node-a",
+      });
+      expect(created).toMatchObject({
+        bindingId: "binding-1",
+        ownerNodeId: "node-a",
+        generation: 1,
+        revision: 1,
+        state: "attaching",
+        readiness: "not_ready",
+        active: true,
+      });
+
+      now = new Date("2026-07-18T12:00:10.000Z");
+      const ready = await second.heartbeat({
+        bindingId: "binding-1",
+        ownerNodeId: "node-a",
+        sessionId: "session-1",
+        expectedGeneration: created.generation,
+        state: "ready",
+        syncState: "idle",
+      });
+      expect(ready).toMatchObject({
+        generation: 2,
+        revision: 2,
+        state: "ready",
+        readiness: "ready",
+        lastHeartbeatAt: now.toISOString(),
+      });
+      expect(Date.parse(ready.expiresAt)).toBe(now.getTime() + 60_000);
+
+      await expect(
+        first.heartbeat({
+          bindingId: "binding-1",
+          ownerNodeId: "node-a",
+          expectedGeneration: 1,
+          state: "degraded",
+          syncState: "failed",
+        }),
+      ).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+        details: expect.objectContaining({ kind: "stale_generation" }),
+      });
+
+      now = new Date("2026-07-18T12:00:20.000Z");
+      const quarantined = await first.quarantineOwnerLoss({
+        bindingId: "binding-1",
+        ownerNodeId: "node-a",
+        expectedGeneration: ready.generation,
+      });
+      expect(quarantined).toMatchObject({
+        ownerNodeId: "node-a",
+        generation: 3,
+        revision: 3,
+        state: "offline",
+        readiness: "quarantined",
+        active: false,
+        quarantineReason: "owner_lost",
+        quarantinedAt: now.toISOString(),
+      });
+
+      await expect(
+        second.rebind({
+          bindingId: "binding-1",
+          expectedGeneration: ready.generation,
+          newOwnerNodeId: "node-b",
+          operatorClientId: "operator-1",
+        }),
+      ).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+        details: expect.objectContaining({ kind: "stale_generation" }),
+      });
+
+      now = new Date("2026-07-18T12:00:30.000Z");
+      const rebound = await second.rebind({
+        bindingId: "binding-1",
+        expectedGeneration: quarantined.generation,
+        newOwnerNodeId: "node-b",
+        sessionId: "session-2",
+        operatorClientId: "operator-1",
+      });
+      expect(rebound).toMatchObject({
+        ownerNodeId: "node-b",
+        sessionId: "session-2",
+        generation: 4,
+        revision: 4,
+        state: "attaching",
+        syncState: "pending",
+        readiness: "not_ready",
+        active: true,
+      });
+      expect(rebound).not.toHaveProperty("quarantinedAt");
+      expect(rebound).not.toHaveProperty("quarantineReason");
+
+      await expect(
+        first.heartbeat({
+          bindingId: "binding-1",
+          ownerNodeId: "node-a",
+          expectedGeneration: rebound.generation,
+          state: "ready",
+          syncState: "idle",
+        }),
+      ).rejects.toMatchObject({ code: "AUTH_FAILED" });
+      await expect(first.get("binding-1")).resolves.toEqual(rebound);
+
+      const activity = await firstStorage.installations.listActivity();
+      expect(activity).toMatchObject([
+        {
+          operatorClientId: "operator-1",
+          action: "project_binding.rebind",
+          targetKind: "project_binding",
+          targetKey: "binding-1",
+        },
+      ]);
+
+      const expiring = await first.create({
+        bindingId: "binding-expiring",
+        sessionId: "session-expiring",
+        projectFingerprint: "sha256:expiring",
+        projectRoot: "/client/expiring",
+        serverProjectRoot: "/host/workspaces/expiring",
+        ownerNodeId: "node-a",
+        leaseTtlMs: 1_000,
+      });
+      now = new Date(now.getTime() + 1_001);
+      await expect(
+        second.heartbeat({
+          bindingId: expiring.bindingId,
+          ownerNodeId: expiring.ownerNodeId,
+          expectedGeneration: expiring.generation,
+          state: "ready",
+          syncState: "idle",
+        }),
+      ).rejects.toMatchObject({
+        projectBindingCode: "lease_expired",
+      });
+      if (firstStorage.database.dialect !== "sqlite") {
+        throw new Error("Expected SQLite storage.");
+      }
+      expect(firstStorage.database.db.select().from(sqlite.projectBindings).all()).toHaveLength(2);
+    } finally {
+      await firstStorage.close();
+    }
+  });
+});

--- a/packages/core/test/remote-control-dispatch.test.ts
+++ b/packages/core/test/remote-control-dispatch.test.ts
@@ -10,18 +10,19 @@ vi.mock("@modelcontextprotocol/sdk/client/auth", async (importOriginal) => ({
   auth: mockMcpAuth,
 }));
 
-import { readTokenBundle, writeTokenBundle } from "../src/auth";
 import { RemoteAuthFlowStore } from "../src/remote-control/auth-flow";
 import { dispatchRemoteCliRequest } from "../src/remote-control/dispatch";
 import { createCurrentHostOperations } from "../src/current-host/operations";
 import { DashboardActivityLog } from "../src/dashboard/activity-log";
-import { FileVaultStore } from "../src/vault";
+import { createHostStorage, type HostStorage } from "../src/storage";
 
 const dirs: string[] = [];
+const storages: HostStorage[] = [];
 
-afterEach(() => {
+afterEach(async () => {
   vi.restoreAllMocks();
   mockMcpAuth.mockReset();
+  await Promise.allSettled(storages.splice(0).map(async (storage) => await storage.close()));
   for (const dir of dirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -173,6 +174,9 @@ describe("dispatchRemoteCliRequest", () => {
         },
       }),
     );
+    const storage = await configuredTestStorage({ ...context, authDir });
+    const dispatchContext = { ...context, authDir, hostStorage: storage };
+    const administration = currentHostAdministration({ ...context, authDir, storage });
 
     const set = await dispatchRemoteCliRequest(
       {
@@ -185,26 +189,27 @@ describe("dispatchRemoteCliRequest", () => {
           force: false,
         },
       },
-      { ...context, authDir },
-      currentHostAdministration({ ...context, authDir }),
+      dispatchContext,
+      administration,
     );
     const list = await dispatchRemoteCliRequest(
       { command: "vault_access_list", arguments: {} },
-      { ...context, authDir },
-      currentHostAdministration({ ...context, authDir }),
+      dispatchContext,
+      administration,
     );
     const inspect = await dispatchRemoteCliRequest(
       {
         command: "inspect",
         arguments: { caplet: "github", request: { operation: "inspect" } },
       },
-      { ...context, authDir },
+      dispatchContext,
     );
 
-    const store = new FileVaultStore({ root: join(authDir, "vault") });
     expect(set).toMatchObject({ ok: true, result: { key: "GH_TOKEN_REMOTE", present: true } });
     expect(JSON.stringify(set)).not.toContain("remote_dispatch_secret");
-    expect(store.resolveValue("GH_TOKEN_REMOTE")).toBe("remote_dispatch_secret");
+    await expect(storage.vaultValues.resolveValue("GH_TOKEN_REMOTE")).resolves.toBe(
+      "remote_dispatch_secret",
+    );
     expect(list).toMatchObject({
       ok: true,
       result: [
@@ -229,6 +234,9 @@ describe("dispatchRemoteCliRequest", () => {
   it("does not retain a remote Vault value when set-and-grant fails", async () => {
     const context = testContext();
     const authDir = join(context.tempRoot, "auth");
+    const storage = await configuredTestStorage({ ...context, authDir });
+    const dispatchContext = { ...context, authDir, hostStorage: storage };
+    const administration = currentHostAdministration({ ...context, authDir, storage });
 
     const response = await dispatchRemoteCliRequest(
       {
@@ -240,21 +248,25 @@ describe("dispatchRemoteCliRequest", () => {
           force: false,
         },
       },
-      { ...context, authDir },
-      currentHostAdministration({ ...context, authDir }),
+      dispatchContext,
+      administration,
     );
 
-    const store = new FileVaultStore({ root: join(authDir, "vault") });
     expect(response).toMatchObject({ ok: false });
-    expect(store.getStatus("GH_TOKEN")).toEqual({ key: "GH_TOKEN", present: false });
+    await expect(storage.vaultValues.getStatus("GH_TOKEN")).resolves.toEqual({
+      key: "GH_TOKEN",
+      present: false,
+    });
     expect(JSON.stringify(response)).not.toContain("remote_orphan_secret");
   });
 
   it("restores the previous remote Vault value when force set-and-grant fails", async () => {
     const context = testContext();
     const authDir = join(context.tempRoot, "auth");
-    const store = new FileVaultStore({ root: join(authDir, "vault") });
-    store.set("GH_TOKEN", "original_secret");
+    const storage = await configuredTestStorage({ ...context, authDir });
+    await storage.vaultValues.set("GH_TOKEN", "original_secret");
+    const dispatchContext = { ...context, authDir, hostStorage: storage };
+    const administration = currentHostAdministration({ ...context, authDir, storage });
 
     const response = await dispatchRemoteCliRequest(
       {
@@ -266,19 +278,18 @@ describe("dispatchRemoteCliRequest", () => {
           force: true,
         },
       },
-      { ...context, authDir },
-      currentHostAdministration({ ...context, authDir }),
+      dispatchContext,
+      administration,
     );
 
     expect(response).toMatchObject({ ok: false });
-    expect(store.resolveValue("GH_TOKEN")).toBe("original_secret");
+    await expect(storage.vaultValues.resolveValue("GH_TOKEN")).resolves.toBe("original_secret");
     expect(JSON.stringify(response)).not.toContain("replacement_secret");
   });
 
   it("rejects forged remote Vault raw reveal requests", async () => {
     const context = testContext();
     const authDir = join(context.tempRoot, "auth");
-    new FileVaultStore({ root: join(authDir, "vault") }).set("GH_TOKEN", "remote_secret");
 
     const response = await dispatchRemoteCliRequest(
       {
@@ -624,6 +635,12 @@ describe("dispatchRemoteCliRequest", () => {
 
   it("lists, refreshes, and logs out server-side auth credentials", async () => {
     const fixture = remoteFixtureWithOAuth();
+    const storage = await configuredTestStorage(fixture.context);
+    const dispatchContext = {
+      ...fixture.context,
+      hostStorage: storage,
+      backendAuthStore: storage.backendAuth,
+    };
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       Response.json({
         access_token: "new-access-token",
@@ -632,19 +649,16 @@ describe("dispatchRemoteCliRequest", () => {
         expires_in: 3600,
       }),
     );
-    writeTokenBundle(
-      {
-        server: "remote",
-        accessToken: "secret-access-token",
-        refreshToken: "old-refresh-token",
-        expiresAt: "2999-01-01T00:00:00.000Z",
-      },
-      fixture.context.authDir,
-    );
+    await storage.backendAuth.writeTokenBundle({
+      server: "remote",
+      accessToken: "secret-access-token",
+      refreshToken: "old-refresh-token",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+    });
 
     const listed = await dispatchRemoteCliRequest(
       { command: "auth_list", arguments: {} },
-      fixture.context,
+      dispatchContext,
     );
     expect(listed).toEqual({
       ok: true,
@@ -653,7 +667,7 @@ describe("dispatchRemoteCliRequest", () => {
 
     const refreshed = await dispatchRemoteCliRequest(
       { command: "auth_refresh", arguments: { server: "remote" } },
-      fixture.context,
+      dispatchContext,
     );
     expect(refreshed).toEqual({
       ok: true,
@@ -666,19 +680,22 @@ describe("dispatchRemoteCliRequest", () => {
         body: expect.stringContaining("refresh_token=old-refresh-token"),
       }),
     );
-    expect(readTokenBundle("remote", fixture.context.authDir)).toMatchObject({
-      accessToken: "new-access-token",
-      refreshToken: "new-refresh-token",
+    await expect(storage.backendAuth.readTokenBundle("remote")).resolves.toMatchObject({
+      bundle: {
+        accessToken: "new-access-token",
+        refreshToken: "new-refresh-token",
+      },
     });
 
     const loggedOut = await dispatchRemoteCliRequest(
       { command: "auth_logout", arguments: { server: "remote" } },
-      fixture.context,
+      dispatchContext,
     );
     expect(loggedOut).toEqual({
       ok: true,
       result: { server: "remote", deleted: true },
     });
+    await expect(storage.backendAuth.readTokenBundle("remote")).resolves.toBeUndefined();
   });
 
   it("resolves Google Discovery scopes before starting remote OAuth login", async () => {
@@ -729,15 +746,19 @@ describe("dispatchRemoteCliRequest", () => {
         },
       }),
     );
+    const storage = await configuredTestStorage({ ...context, authDir });
+    const dispatchContext = {
+      ...context,
+      authDir,
+      hostStorage: storage,
+      backendAuthStore: storage.backendAuth,
+      controlCallbackBaseUrl: "http://127.0.0.1:5387/control",
+      authFlowStore,
+    };
 
     const response = await dispatchRemoteCliRequest(
       { command: "auth_login_start", arguments: { server: "drive" } },
-      {
-        ...context,
-        authDir,
-        controlCallbackBaseUrl: "http://127.0.0.1:5387/control",
-        authFlowStore,
-      },
+      dispatchContext,
     );
 
     expect(response).toMatchObject({ ok: true });
@@ -765,12 +786,7 @@ describe("dispatchRemoteCliRequest", () => {
           callbackUrl: `http://127.0.0.1/callback?code=code&state=${authorizationUrl.searchParams.get("state")}`,
         },
       },
-      {
-        ...context,
-        authDir,
-        authFlowStore,
-        controlCallbackBaseUrl: "http://127.0.0.1:5387/control",
-      },
+      dispatchContext,
     );
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -780,11 +796,13 @@ describe("dispatchRemoteCliRequest", () => {
         body: expect.stringContaining("code=code"),
       }),
     );
-    expect(readTokenBundle("drive", authDir)).toMatchObject({
-      protectedResourceOrigin: "https://www.googleapis.com",
-      metadata: {
-        protectedResource: "https://www.googleapis.com/drive/v3/",
-        requestedScopes: ["https://www.googleapis.com/auth/drive.metadata.readonly"],
+    await expect(storage.backendAuth.readTokenBundle("drive")).resolves.toMatchObject({
+      bundle: {
+        protectedResourceOrigin: "https://www.googleapis.com",
+        metadata: {
+          protectedResource: "https://www.googleapis.com/drive/v3/",
+          requestedScopes: ["https://www.googleapis.com/auth/drive.metadata.readonly"],
+        },
       },
     });
   });
@@ -792,16 +810,20 @@ describe("dispatchRemoteCliRequest", () => {
   it("does not create a pending auth flow when MCP auth is already authorized", async () => {
     const fixture = remoteFixtureWithOAuth();
     const authFlowStore = new RemoteAuthFlowStore();
+    const storage = await configuredTestStorage(fixture.context);
+    const dispatchContext = {
+      ...fixture.context,
+      hostStorage: storage,
+      backendAuthStore: storage.backendAuth,
+      controlCallbackBaseUrl: "http://127.0.0.1:5387/control",
+      authFlowStore,
+    };
     const create = vi.spyOn(authFlowStore, "create");
     mockMcpAuth.mockResolvedValueOnce("AUTHORIZED");
 
     const response = await dispatchRemoteCliRequest(
       { command: "auth_login_start", arguments: { server: "remote" } },
-      {
-        ...fixture.context,
-        controlCallbackBaseUrl: "http://127.0.0.1:5387/control",
-        authFlowStore,
-      },
+      dispatchContext,
     );
 
     expect(response).toEqual({ ok: true, result: { server: "remote", authenticated: true } });
@@ -850,6 +872,273 @@ describe("dispatchRemoteCliRequest", () => {
     expect(response).toMatchObject({ ok: false });
     expect(authFlowStore.get(flow.id)).toBeUndefined();
   });
+  it("rejects a forged Access principal for stored record administration", async () => {
+    const context = testContext();
+    const administration = currentHostAdministration(context);
+    Object.defineProperty(administration.principal, "role", { value: "access" });
+
+    await expect(
+      dispatchRemoteCliRequest(
+        { command: "storage_records_list", arguments: {} },
+        context,
+        administration,
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "AUTH_FAILED",
+        message: "Current Host administration requires an Operator principal.",
+      },
+    });
+  });
+
+  it("administers complete stored bundles and installation lifecycles", async () => {
+    const context = testContext();
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(context.tempRoot, "records.sqlite3"),
+    });
+    const activateConfig = vi.fn(async () => undefined);
+    const administration = {
+      ...currentHostAdministration(context),
+      storage,
+      activateConfig,
+    };
+    const document = (command: string, title: string) =>
+      Buffer.from(
+        `---\nname: Remote Record\ndescription: Remote bundle fixture.\nmcpServer:\n  command: ${command}\n---\n# ${title}\n`,
+      );
+    const wireFiles = (command: string, title: string) => [
+      {
+        path: "CAPLET.md",
+        contentBase64: document(command, title).toString("base64"),
+        executable: false,
+      },
+      {
+        path: "bin/run",
+        contentBase64: Buffer.from([0, 1, 2, 255]).toString("base64"),
+        executable: true,
+      },
+    ];
+
+    try {
+      const imported = await dispatchRemoteCliRequest(
+        {
+          command: "storage_records_import",
+          arguments: {
+            id: "remote-record",
+            files: wireFiles("first", "First"),
+            historyLimit: 4,
+          },
+        },
+        context,
+        administration,
+      );
+      expect(imported).toMatchObject({
+        ok: true,
+        result: { id: "remote-record", headGeneration: 1 },
+      });
+
+      const read = await dispatchRemoteCliRequest(
+        { command: "storage_records_get", arguments: { id: "remote-record" } },
+        context,
+        administration,
+      );
+      expect(read).toMatchObject({
+        ok: true,
+        result: {
+          record: { id: "remote-record" },
+          files: expect.arrayContaining([
+            {
+              path: "bin/run",
+              contentBase64: Buffer.from([0, 1, 2, 255]).toString("base64"),
+              executable: true,
+            },
+          ]),
+        },
+      });
+
+      const updated = await dispatchRemoteCliRequest(
+        {
+          command: "storage_records_update",
+          arguments: {
+            id: "remote-record",
+            files: wireFiles("second", "Second"),
+            expectedGeneration: 1,
+          },
+        },
+        context,
+        administration,
+      );
+      expect(updated).toMatchObject({ ok: true, result: { headGeneration: 2 } });
+      await expect(
+        dispatchRemoteCliRequest(
+          {
+            command: "storage_records_update",
+            arguments: {
+              id: "remote-record",
+              files: wireFiles("stale", "Stale"),
+              expectedGeneration: 1,
+            },
+          },
+          context,
+          administration,
+        ),
+      ).resolves.toMatchObject({
+        ok: false,
+        error: { code: "REQUEST_INVALID", message: expect.stringContaining("reload and retry") },
+      });
+      await storage.installations.install({
+        capletId: "remote-record",
+        sourceKind: "git",
+        sourceIdentity: "https://example.test/remote.git",
+        operator: { role: "operator", clientId: "test" },
+      });
+
+      const revisions = await storage.caplets.listRevisions("remote-record", {
+        role: "operator",
+        clientId: "test",
+      });
+      const oldRevision = revisions.find((revision) => revision.sequence === 1);
+      expect(oldRevision).toBeDefined();
+
+      const retained = await dispatchRemoteCliRequest(
+        {
+          command: "storage_records_retention",
+          arguments: { id: "remote-record", historyLimit: 3, expectedGeneration: 2 },
+        },
+        context,
+        administration,
+      );
+      expect(retained).toMatchObject({ ok: true, result: { headGeneration: 3, historyLimit: 3 } });
+      const renamed = await dispatchRemoteCliRequest(
+        {
+          command: "storage_records_rename",
+          arguments: { id: "remote-record", newId: "renamed-record", expectedGeneration: 3 },
+        },
+        context,
+        administration,
+      );
+      expect(renamed).toMatchObject({ ok: true, result: { id: "renamed-record" } });
+
+      const status = await dispatchRemoteCliRequest(
+        {
+          command: "storage_records_installation_status",
+          arguments: { id: "renamed-record" },
+        },
+        context,
+        administration,
+      );
+      expect(status).toMatchObject({
+        ok: true,
+        result: { installations: [{ status: "active", generation: 1 }], observations: [] },
+      });
+      await expect(
+        dispatchRemoteCliRequest(
+          {
+            command: "storage_records_installation_observe",
+            arguments: {
+              id: "renamed-record",
+              expectedGeneration: 1,
+              status: "metadata-only",
+              resolvedRevision: "abc123",
+              risk: { network: "low" },
+            },
+          },
+          context,
+          administration,
+        ),
+      ).resolves.toMatchObject({ ok: true, result: { status: "metadata-only" } });
+      const detached = await dispatchRemoteCliRequest(
+        {
+          command: "storage_records_installation_detach",
+          arguments: { id: "renamed-record", expectedGeneration: 2 },
+        },
+        context,
+        administration,
+      );
+      expect(detached).toMatchObject({
+        ok: true,
+        result: { status: "detached", generation: 3 },
+      });
+      const detachedInstallationKey =
+        detached.ok &&
+        detached.result &&
+        typeof detached.result === "object" &&
+        "installationKey" in detached.result &&
+        typeof detached.result.installationKey === "string"
+          ? detached.result.installationKey
+          : "";
+      await expect(
+        dispatchRemoteCliRequest(
+          {
+            command: "storage_records_installation_replace",
+            arguments: {
+              id: "renamed-record",
+              expectedGeneration: 3,
+              sourceKind: "git",
+              sourceIdentity: "https://example.test/replacement.git",
+              detachedInstallationKey,
+            },
+          },
+          context,
+          administration,
+        ),
+      ).resolves.toMatchObject({ ok: true, result: { status: "active", generation: 1 } });
+
+      const restored = await dispatchRemoteCliRequest(
+        {
+          command: "storage_records_restore",
+          arguments: {
+            id: "renamed-record",
+            revisionKey: oldRevision!.revisionKey,
+            expectedGeneration: 4,
+          },
+        },
+        context,
+        administration,
+      );
+      expect(restored).toMatchObject({ ok: true, result: { headGeneration: 5 } });
+      const afterRestore = await storage.caplets.listRevisions("renamed-record", {
+        role: "operator",
+        clientId: "test",
+      });
+      const deletable = afterRestore.find((revision) => revision.sequence !== 3);
+      expect(deletable).toBeDefined();
+      const deletedRevision = await dispatchRemoteCliRequest(
+        {
+          command: "storage_records_delete_revision",
+          arguments: {
+            id: "renamed-record",
+            revisionKey: deletable!.revisionKey,
+            expectedGeneration: 5,
+          },
+        },
+        context,
+        administration,
+      );
+      expect(deletedRevision).toMatchObject({
+        ok: true,
+        result: { deleted: true, record: { headGeneration: 6 } },
+      });
+      await expect(
+        dispatchRemoteCliRequest(
+          {
+            command: "storage_records_delete",
+            arguments: { id: "renamed-record", expectedGeneration: 6 },
+          },
+          context,
+          administration,
+        ),
+      ).resolves.toEqual({
+        ok: true,
+        result: { deleted: true, id: "renamed-record" },
+      });
+      expect(activateConfig).toHaveBeenCalledTimes(7);
+    } finally {
+      await storage.close();
+    }
+  });
 });
 
 function testContext(options: { writeConfig?: boolean } = {}) {
@@ -893,6 +1182,7 @@ type DispatchAdministrationContext = {
   authDir?: string | undefined;
   globalCapletsRoot?: string | undefined;
   globalLockfilePath?: string | undefined;
+  storage?: HostStorage | undefined;
 };
 
 function currentHostAdministration(context: DispatchAdministrationContext) {
@@ -908,14 +1198,38 @@ function currentHostAdministration(context: DispatchAdministrationContext) {
           context.globalLockfilePath ?? join(context.tempRoot, "remote-state", "caplets.lock.json"),
       },
       activityLog: new DashboardActivityLog({ dir: join(context.tempRoot, "activity") }),
+      ...(context.storage
+        ? {
+            capletRecords: context.storage.caplets,
+            catalogStorage: context.storage,
+            vaultGrants: context.storage.vaultGrants,
+            vaultValues: context.storage.vaultValues,
+          }
+        : {}),
       version: "test-version",
     }),
+    ...(context.storage ? { storage: context.storage } : {}),
     principal: {
       clientId: "rcli_abcdefghijklmnop",
       hostUrl: "http://127.0.0.1:5387/",
       role: "operator" as const,
     },
   };
+}
+
+async function configuredTestStorage(context: DispatchAdministrationContext): Promise<HostStorage> {
+  const databasePath = join(context.tempRoot, "host-state.sqlite3");
+  const config = existsSync(context.configPath)
+    ? (JSON.parse(readFileSync(context.configPath, "utf8")) as Record<string, unknown>)
+    : {};
+  config.storage = { type: "sqlite", path: databasePath };
+  writeFileSync(context.configPath, JSON.stringify(config));
+  const storage = await createHostStorage(
+    { type: "sqlite", path: databasePath },
+    { vaultRoot: join(context.authDir ?? context.tempRoot, "vault") },
+  );
+  storages.push(storage);
+  return storage;
 }
 
 function remoteFixtureWithOAuth() {

--- a/packages/core/test/remote-login-cli.test.ts
+++ b/packages/core/test/remote-login-cli.test.ts
@@ -1,33 +1,27 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { runCli } from "../src/cli";
 import { FileRemoteProfileStore } from "../src/remote/profile-store";
 import { RemoteServerCredentialStore } from "../src/remote/server-credential-store";
+import { createHostStorage, type HostStorage, type RemoteSecurityStore } from "../src/storage";
 
 const dirs: string[] = [];
+const storages = new Set<HostStorage>();
 
-afterEach(() => {
+afterEach(async () => {
+  await Promise.all([...storages].map(async (storage) => await storage.close()));
+  storages.clear();
   for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
 describe("caplets remote CLI", () => {
   it("reports migration guidance instead of minting Pairing Codes", async () => {
-    const serverStateDir = tempDir("caplets-remote-cli-server-");
     const out: string[] = [];
 
     await runCli(
-      [
-        "remote",
-        "host",
-        "pair",
-        "--host-url",
-        "https://caplets.example.com/caplets",
-        "--state-path",
-        serverStateDir,
-        "--json",
-      ],
+      ["remote", "host", "pair", "--host-url", "https://caplets.example.com/caplets", "--json"],
       { writeOut: (value) => out.push(value) },
     );
 
@@ -38,7 +32,6 @@ describe("caplets remote CLI", () => {
       message: expect.stringContaining("Pairing Code bootstrap is no longer supported"),
     });
     expect(out.join("")).not.toContain("cap_pair_");
-    expect(existsSync(join(serverStateDir, "remote-server-credentials.json"))).toBe(false);
   });
 
   it("hides legacy Pairing Code login flags from help", async () => {
@@ -276,7 +269,6 @@ describe("caplets remote CLI", () => {
           serverApprovalCommand = [
             "sudo -u caplets caplets remote host approve",
             pending.operatorCode,
-            "--state-path /srv/caplets/remote-state",
             "--yes",
           ].join(" ");
           return Response.json({ ...pending, approvalCommand: serverApprovalCommand });
@@ -963,17 +955,17 @@ describe("caplets remote CLI", () => {
   });
 
   it("prints paired self-hosted client labels without terminal control bytes", async () => {
-    const serverStateDir = tempDir("caplets-remote-cli-server-");
-    const server = new RemoteServerCredentialStore({ dir: serverStateDir });
-    const issued = server.createPairingCode({ hostUrl: "https://caplets.example.com" });
-    server.exchangePairingCode({
+    const { env, store } = await remoteSecurityFixture();
+    const issued = await store.createPairingCode({ hostUrl: "https://caplets.example.com" });
+    await store.exchangePairingCode({
       hostUrl: "https://caplets.example.com",
       code: issued.code,
       clientLabel: `Bad${String.fromCharCode(0x1b)}[31mName${String.fromCharCode(0x07)}`,
     });
     const out: string[] = [];
 
-    await runCli(["remote", "host", "clients", "--state-path", serverStateDir], {
+    await runCli(["remote", "host", "clients"], {
+      env,
       writeOut: (value) => out.push(value),
     });
 
@@ -983,9 +975,8 @@ describe("caplets remote CLI", () => {
   });
 
   it("lists and approves pending self-hosted logins from server state", async () => {
-    const serverStateDir = tempDir("caplets-remote-cli-server-");
-    const server = new RemoteServerCredentialStore({ dir: serverStateDir });
-    const pending = server.createPendingLogin({
+    const { env, store } = await remoteSecurityFixture();
+    const pending = await store.createPendingLogin({
       hostUrl: "https://caplets.example.com",
       clientLabel: `Bad${String.fromCharCode(0x1b)}[31mDevice`,
       clientFingerprint: "fp_test",
@@ -993,7 +984,8 @@ describe("caplets remote CLI", () => {
     });
     const listOut: string[] = [];
 
-    await runCli(["remote", "host", "logins", "--state-path", serverStateDir, "--json"], {
+    await runCli(["remote", "host", "logins", "--json"], {
+      env,
       writeOut: (value) => listOut.push(value),
     });
 
@@ -1013,26 +1005,18 @@ describe("caplets remote CLI", () => {
     expect(listOut.join("")).not.toContain(pending.pendingRefreshSecret);
     expect(listOut.join("")).not.toContain(pending.pendingCompletionSecret);
     const plainListOut: string[] = [];
-    await runCli(["remote", "host", "logins", "--state-path", serverStateDir], {
+    await runCli(["remote", "host", "logins"], {
+      env,
       writeOut: (value) => plainListOut.push(value),
     });
     expect(plainListOut.join("")).toContain(pending.operatorCodeFingerprint);
     expect(plainListOut.join("")).not.toContain(pending.operatorCode);
 
     const approveOut: string[] = [];
-    await runCli(
-      [
-        "remote",
-        "host",
-        "approve",
-        pending.operatorCode,
-        "--state-path",
-        serverStateDir,
-        "--yes",
-        "--json",
-      ],
-      { writeOut: (value) => approveOut.push(value) },
-    );
+    await runCli(["remote", "host", "approve", pending.operatorCode, "--yes", "--json"], {
+      env,
+      writeOut: (value) => approveOut.push(value),
+    });
 
     expect(JSON.parse(approveOut.join(""))).toMatchObject({
       flowId: pending.flowId,
@@ -1042,7 +1026,7 @@ describe("caplets remote CLI", () => {
       clientLabel: `Bad${String.fromCharCode(0x1b)}[31mDevice`,
     });
     expect(
-      server.completePendingLogin({
+      await store.completePendingLogin({
         hostUrl: "https://caplets.example.com",
         flowId: pending.flowId,
         pendingCompletionSecret: pending.pendingCompletionSecret,
@@ -1051,9 +1035,8 @@ describe("caplets remote CLI", () => {
   });
 
   it("allows host approval to override requested login roles", async () => {
-    const serverStateDir = tempDir("caplets-remote-cli-server-");
-    const server = new RemoteServerCredentialStore({ dir: serverStateDir });
-    const pending = server.createPendingLogin({
+    const { env, store } = await remoteSecurityFixture();
+    const pending = await store.createPendingLogin({
       hostUrl: "https://caplets.example.com",
       requestedRole: "operator",
       clientLabel: "Dashboard",
@@ -1061,19 +1044,8 @@ describe("caplets remote CLI", () => {
     const approveOut: string[] = [];
 
     await runCli(
-      [
-        "remote",
-        "host",
-        "approve",
-        pending.operatorCode,
-        "--state-path",
-        serverStateDir,
-        "--role",
-        "access",
-        "--yes",
-        "--json",
-      ],
-      { writeOut: (value) => approveOut.push(value) },
+      ["remote", "host", "approve", pending.operatorCode, "--role", "access", "--yes", "--json"],
+      { env, writeOut: (value) => approveOut.push(value) },
     );
 
     expect(JSON.parse(approveOut.join(""))).toMatchObject({
@@ -1082,7 +1054,7 @@ describe("caplets remote CLI", () => {
       grantedRole: "access",
     });
     expect(
-      server.completePendingLogin({
+      await store.completePendingLogin({
         hostUrl: "https://caplets.example.com",
         flowId: pending.flowId,
         pendingCompletionSecret: pending.pendingCompletionSecret,
@@ -1246,6 +1218,19 @@ describe("caplets remote CLI", () => {
     expect(out.join("")).not.toContain("beta-refresh");
   });
 });
+
+async function remoteSecurityFixture(): Promise<{
+  env: { CAPLETS_CONFIG: string };
+  store: RemoteSecurityStore;
+}> {
+  const root = tempDir("caplets-remote-cli-server-");
+  const databasePath = join(root, "host.sqlite3");
+  const configPath = join(root, "config.json");
+  writeFileSync(configPath, JSON.stringify({ storage: { type: "sqlite", path: databasePath } }));
+  const storage = await createHostStorage({ type: "sqlite", path: databasePath });
+  storages.add(storage);
+  return { env: { CAPLETS_CONFIG: configPath }, store: storage.remoteSecurity };
+}
 
 function tempDir(prefix: string): string {
   const dir = mkdtempSync(join(tmpdir(), prefix));

--- a/packages/core/test/remote-security-storage.postgres.test.ts
+++ b/packages/core/test/remote-security-storage.postgres.test.ts
@@ -1,0 +1,55 @@
+import { randomUUID } from "node:crypto";
+import { Pool } from "pg";
+import { afterEach, expect, it } from "vitest";
+import { createHostStorage, migrateHostStorage } from "../src/storage";
+import { RemoteSecurityStore } from "../src/storage/remote-security";
+
+const postgresUrl = process.env.CAPLETS_TEST_POSTGRES_URL;
+const postgresIt = postgresUrl ? it : it.skip;
+const schemas: string[] = [];
+
+afterEach(async () => {
+  if (!postgresUrl) return;
+  const pool = new Pool({ connectionString: postgresUrl });
+  try {
+    for (const schema of schemas.splice(0)) {
+      await pool.query(`drop schema if exists "${schema}" cascade`);
+    }
+  } finally {
+    await pool.end();
+  }
+});
+
+postgresIt("keeps pairing exchange and refresh rotation one-time on PostgreSQL", async () => {
+  const schema = `caplets_remote_security_${randomUUID().replaceAll("-", "")}`;
+  schemas.push(schema);
+  const config = {
+    type: "postgres" as const,
+    connectionString: postgresUrl!,
+    schema,
+  };
+  await migrateHostStorage(config);
+  const storage = await createHostStorage(config);
+  try {
+    const security = new RemoteSecurityStore(storage.database);
+    const hostUrl = "https://remote.example.test";
+    const pairing = await security.createPairingCode({ hostUrl });
+    const exchanges = await Promise.allSettled([
+      security.exchangePairingCode({ hostUrl, code: pairing.code }),
+      security.exchangePairingCode({ hostUrl, code: pairing.code }),
+    ]);
+    const issued = exchanges.find((result) => result.status === "fulfilled");
+    expect(issued?.status).toBe("fulfilled");
+    expect(exchanges.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    if (!issued || issued.status !== "fulfilled") throw new Error("Pairing did not succeed.");
+
+    const refreshes = await Promise.allSettled([
+      security.refreshClientCredentials({ hostUrl, refreshToken: issued.value.refreshToken }),
+      security.refreshClientCredentials({ hostUrl, refreshToken: issued.value.refreshToken }),
+    ]);
+    expect(refreshes.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(refreshes.filter((result) => result.status === "rejected")).toHaveLength(1);
+  } finally {
+    await storage.close();
+  }
+});

--- a/packages/core/test/remote-security-storage.test.ts
+++ b/packages/core/test/remote-security-storage.test.ts
@@ -1,0 +1,146 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createHostStorage, type HostStorage } from "../src/storage";
+import { RemoteSecurityStore } from "../src/storage/remote-security";
+import * as sqlite from "../src/storage/schema/sqlite";
+
+const hostUrl = "https://remote.example.test";
+let storage: HostStorage;
+let security: RemoteSecurityStore;
+
+beforeEach(async () => {
+  storage = await createHostStorage({ type: "sqlite", path: ":memory:" });
+  security = new RemoteSecurityStore(storage.database);
+});
+
+afterEach(async () => {
+  await storage.close();
+});
+
+describe("RemoteSecurityStore", () => {
+  it("exchanges a pairing code exactly once under concurrent requests", async () => {
+    const pairing = await security.createPairingCode({ hostUrl });
+
+    const attempts = await Promise.allSettled([
+      security.exchangePairingCode({ hostUrl, code: pairing.code }),
+      security.exchangePairingCode({ hostUrl, code: pairing.code }),
+    ]);
+
+    expect(attempts.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(attempts.filter((result) => result.status === "rejected")).toHaveLength(1);
+    expect(await security.listClients()).toHaveLength(1);
+    if (storage.database.dialect !== "sqlite") throw new Error("Expected SQLite test storage.");
+    expect(storage.database.db.select().from(sqlite.remoteClients).all()).toHaveLength(1);
+    expect(storage.database.db.select().from(sqlite.remotePairingCodes).all()[0]?.usedAt).toEqual(
+      expect.any(String),
+    );
+  });
+
+  it("rotates refresh material and revokes the family after replay outside the grace window", async () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const pairing = await security.createPairingCode({ hostUrl, now });
+    const issued = await security.exchangePairingCode({ hostUrl, code: pairing.code, now });
+    const rotated = await security.refreshClientCredentials({
+      hostUrl,
+      refreshToken: issued.refreshToken,
+      now,
+    });
+
+    await expect(
+      security.refreshClientCredentials({
+        hostUrl,
+        refreshToken: issued.refreshToken,
+        now: new Date(now.getTime() + 30_001),
+      }),
+    ).rejects.toMatchObject({ code: "REMOTE_CREDENTIALS_REVOKED" });
+    await expect(
+      security.validateAccessToken({ hostUrl, accessToken: rotated.accessToken, now }),
+    ).rejects.toMatchObject({ code: "REMOTE_CREDENTIALS_REVOKED" });
+  });
+
+  it("approves and completes a pending login with idempotent completion replay", async () => {
+    const pending = await security.createPendingLogin({
+      hostUrl,
+      requestedRole: "operator",
+      clientLabel: "CLI",
+    });
+
+    const approved = await security.approvePendingLogin({
+      operatorClientId: "rcli_admin",
+      operatorCode: pending.operatorCode,
+    });
+    const credentials = await security.completePendingLogin({
+      flowId: pending.flowId,
+      pendingCompletionSecret: pending.pendingCompletionSecret,
+      hostUrl,
+      requiredRole: "operator",
+    });
+    const replayed = await security.completePendingLogin({
+      flowId: pending.flowId,
+      pendingCompletionSecret: pending.pendingCompletionSecret,
+      hostUrl,
+      requiredRole: "operator",
+    });
+
+    expect(approved).toMatchObject({ status: "approved", grantedRole: "operator" });
+    expect(replayed).toEqual(credentials);
+    await expect(
+      security.pollPendingLogin({
+        flowId: pending.flowId,
+        pendingCompletionSecret: pending.pendingCompletionSecret,
+      }),
+    ).resolves.toEqual({ flowId: pending.flowId, status: "exchanged" });
+  });
+
+  it("serializes concurrent refresh rotation without issuing two live descendants", async () => {
+    const pairing = await security.createPairingCode({ hostUrl });
+    const issued = await security.exchangePairingCode({ hostUrl, code: pairing.code });
+
+    const attempts = await Promise.allSettled([
+      security.refreshClientCredentials({ hostUrl, refreshToken: issued.refreshToken }),
+      security.refreshClientCredentials({ hostUrl, refreshToken: issued.refreshToken }),
+    ]);
+
+    expect(attempts.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(attempts.filter((result) => result.status === "rejected")).toHaveLength(1);
+    expect(await security.listClients()).toHaveLength(1);
+  });
+
+  it("records approve, deny, revoke, and role changes in their state transactions", async () => {
+    const approvedFlow = await security.createPendingLogin({ hostUrl });
+    await security.approvePendingLogin({
+      operatorClientId: "rcli_admin",
+      operatorCode: approvedFlow.operatorCode,
+    });
+    const credentials = await security.completePendingLogin({
+      flowId: approvedFlow.flowId,
+      pendingCompletionSecret: approvedFlow.pendingCompletionSecret,
+      hostUrl,
+    });
+    await security.changeClientRole({
+      operatorClientId: "rcli_admin",
+      clientId: credentials.clientId,
+      role: "operator",
+    });
+    await security.revokeClient({ operatorClientId: "rcli_admin", clientId: credentials.clientId });
+    const deniedFlow = await security.createPendingLogin({ hostUrl });
+    await security.denyPendingLogin({
+      operatorClientId: "rcli_admin",
+      operatorCode: deniedFlow.operatorCode,
+    });
+
+    if (storage.database.dialect !== "sqlite") throw new Error("Expected SQLite test storage.");
+    const activities = storage.database.db
+      .select()
+      .from(sqlite.operatorActivity)
+      .where(eq(sqlite.operatorActivity.operatorClientId, "rcli_admin"))
+      .all();
+    expect(activities.map((activity) => activity.action)).toEqual([
+      "remote_pending_login_approved",
+      "remote_client_role_changed",
+      "remote_client_revoked",
+      "remote_pending_login_denied",
+    ]);
+    expect(activities.every((activity) => activity.outcome === "succeeded")).toBe(true);
+  });
+});

--- a/packages/core/test/runtime-fingerprint.test.ts
+++ b/packages/core/test/runtime-fingerprint.test.ts
@@ -2,7 +2,6 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
-  readFileSync,
   rmSync,
   symlinkSync,
   unlinkSync,
@@ -24,6 +23,7 @@ import { createCloudRuntimeAdapter } from "../src/cloud/runtime-adapter";
 import { loadConfigWithSources } from "../src/config";
 import { LocalSetupStore } from "../src/setup/local-store";
 import { parseConfig } from "../src/config-runtime";
+import { createHostStorage } from "../src/storage";
 
 const tempDirs: string[] = [];
 
@@ -1062,17 +1062,28 @@ ${body}
       const expected = first.runtimeFingerprint?.caplets.tool?.fingerprint;
       expect(expected).toMatch(/^[a-f0-9]{64}$/u);
 
-      const localStoreRoot = join(root, "local-setup");
-      await runCapletSetupCli("tool", {
-        yes: true,
-        configPath,
-        projectConfigPath,
-        baseDir: localStoreRoot,
-        spawn: async () => ({ exitCode: 0, stdout: "", stderr: "", durationMs: 1 }),
+      const localStorage = await createHostStorage({
+        type: "sqlite",
+        path: join(root, "local-setup.sqlite"),
       });
-      const approvals = JSON.parse(
-        readFileSync(join(localStoreRoot, "approvals.json"), "utf8"),
-      ) as Array<{ contentHash: string }>;
+      let approval;
+      try {
+        await runCapletSetupCli("tool", {
+          yes: true,
+          configPath,
+          projectConfigPath,
+          hostStorage: localStorage,
+          spawn: async () => ({ exitCode: 0, stdout: "", stderr: "", durationMs: 1 }),
+        });
+        approval = await localStorage.setupState.getApproval(
+          "default",
+          "tool",
+          expected!,
+          "local_host",
+        );
+      } finally {
+        await localStorage.close();
+      }
 
       const hosted = createCloudRuntimeAdapter({
         configPath,
@@ -1088,7 +1099,7 @@ ${body}
       writeFileSync(capletPath, capletFile("# Different README"), "utf8");
       const second = loadConfigWithSources(configPath, projectConfigPath);
 
-      expect(approvals[0]?.contentHash).toBe(expected);
+      expect(approval?.contentHash).toBe(expected);
       expect(hostedPlan.contentHash).toBe(expected);
       expect(hostedPlan.persistenceEligible).toBe(true);
       expect(second.runtimeFingerprint?.caplets.tool?.fingerprint).toBe(expected);
@@ -1102,21 +1113,33 @@ ${body}
       writeFileSync(capletPath, capletFile("# Literal README", "literal-secret"), "utf8");
       const liveOnly = loadConfigWithSources(configPath, projectConfigPath);
       expect(liveOnly.runtimeFingerprint?.caplets.tool?.persistenceEligible).toBe(false);
-      const liveOnlyStoreRoot = join(root, "live-only-setup");
-      await runCapletSetupCli("tool", {
-        yes: true,
-        configPath,
-        projectConfigPath,
-        baseDir: liveOnlyStoreRoot,
-        spawn: async () => ({ exitCode: 0, stdout: "", stderr: "", durationMs: 1 }),
+      const liveOnlyStorage = await createHostStorage({
+        type: "sqlite",
+        path: join(root, "live-only-setup.sqlite"),
       });
-      expect(existsSync(join(liveOnlyStoreRoot, "approvals.json"))).toBe(false);
-      const liveOnlyAttempt = readFileSync(
-        join(liveOnlyStoreRoot, "projects", "default", "attempts", "tool.jsonl"),
-        "utf8",
-      );
-      expect(liveOnlyAttempt).toContain('"contentHash":"live-only"');
-      expect(liveOnlyAttempt).not.toContain("literal-secret");
+      let liveOnlyAttempts;
+      try {
+        await runCapletSetupCli("tool", {
+          yes: true,
+          configPath,
+          projectConfigPath,
+          hostStorage: liveOnlyStorage,
+          spawn: async () => ({ exitCode: 0, stdout: "", stderr: "", durationMs: 1 }),
+        });
+        expect(
+          await liveOnlyStorage.setupState.getApproval(
+            "default",
+            "tool",
+            "live-only",
+            "local_host",
+          ),
+        ).toBeUndefined();
+        liveOnlyAttempts = await liveOnlyStorage.setupState.listAttempts("default", "tool");
+      } finally {
+        await liveOnlyStorage.close();
+      }
+      expect(JSON.stringify(liveOnlyAttempts)).toContain('"contentHash":"live-only"');
+      expect(JSON.stringify(liveOnlyAttempts)).not.toContain("literal-secret");
 
       const liveHostedRoot = join(root, "live-only-hosted");
       const liveHosted = createCloudRuntimeAdapter({

--- a/packages/core/test/serve-http.test.ts
+++ b/packages/core/test/serve-http.test.ts
@@ -4,6 +4,8 @@ import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { serve, type WebSocketServerLike } from "@hono/node-server";
+import BetterSqlite3 from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import WebSocket, { WebSocketServer } from "ws";
 import { CapletsEngine } from "../src/engine";
@@ -25,13 +27,17 @@ import type { HttpAttachSessionFactory, HttpMcpSessionFactory } from "../src/ser
 import { CAPLETS_ATTACH_SESSION_HEADER, type AttachManifest } from "../src/attach/api";
 import { buildManifestExposureProjection } from "../src/exposure/projection";
 import type { HttpServeOptions } from "../src/serve/options";
+import { BackendAuthStateStore } from "../src/storage/backend-auth";
+import { sqliteSchema } from "../src/storage/schema/sqlite";
 
 const dirs: string[] = [];
+const backendAuthDatabases: Array<InstanceType<typeof BetterSqlite3>> = [];
 
 afterEach(() => {
   for (const dir of dirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
+  for (const database of backendAuthDatabases.splice(0)) database.close();
 });
 
 it("forces remote artifact paths off after caller engine options", () => {
@@ -94,6 +100,7 @@ describe("createHttpServeApp", () => {
     expect(health.status).toBe(200);
     await expect(health.json()).resolves.toEqual({
       status: "ok",
+      ready: true,
     });
 
     await engine.close();
@@ -2565,7 +2572,7 @@ describe("createHttpServeApp", () => {
 
     const health = await app.request("http://127.0.0.1:5387/caplets/v1/healthz");
     expect(health.status).toBe(200);
-    await expect(health.json()).resolves.toEqual({ status: "ok" });
+    await expect(health.json()).resolves.toEqual({ status: "ok", ready: true });
 
     await engine.close();
   });
@@ -2710,6 +2717,7 @@ describe("createHttpServeApp", () => {
     });
     const app = createHttpServeApp(httpOptions({ path: "/control-api" }), engine, {
       writeErr: () => {},
+      backendAuthStore: testBackendAuthStore(),
       control: context,
     });
 
@@ -2743,6 +2751,7 @@ describe("createHttpServeApp", () => {
       engine,
       {
         writeErr: () => {},
+        backendAuthStore: testBackendAuthStore(),
         control: context,
       },
     );
@@ -2779,6 +2788,7 @@ describe("createHttpServeApp", () => {
       engine,
       {
         writeErr: () => {},
+        backendAuthStore: testBackendAuthStore(),
         control: context,
         remoteCredentialStore: store,
       },
@@ -2821,6 +2831,7 @@ describe("createHttpServeApp", () => {
       engine,
       {
         writeErr: () => {},
+        backendAuthStore: testBackendAuthStore(),
         control: context,
         remoteCredentialStore: store,
       },
@@ -2867,6 +2878,7 @@ describe("createHttpServeApp", () => {
       engine,
       {
         writeErr: () => {},
+        backendAuthStore: testBackendAuthStore(),
         control: context,
         remoteCredentialStore: store,
       },
@@ -4444,6 +4456,32 @@ function tempDir(prefix: string): string {
   const dir = mkdtempSync(join(tmpdir(), prefix));
   dirs.push(dir);
   return dir;
+}
+
+function testBackendAuthStore(): BackendAuthStateStore {
+  const sqlite = new BetterSqlite3(":memory:");
+  backendAuthDatabases.push(sqlite);
+  sqlite.exec(`
+    create table backend_auth_states (
+      server text primary key not null,
+      generation integer not null,
+      token_bundle text not null,
+      created_at text not null,
+      updated_at text not null
+    );
+    create table operator_activity (
+      activity_key text primary key not null,
+      operator_client_id text not null,
+      action text not null,
+      target_kind text not null,
+      target_key text not null,
+      outcome text not null,
+      metadata text not null,
+      created_at text not null
+    )
+  `);
+  const database = drizzle(sqlite, { schema: sqliteSchema });
+  return new BackendAuthStateStore({ dialect: "sqlite", db: database });
 }
 
 function testEngine(config: Record<string, unknown> = {}): {

--- a/packages/core/test/serve-http.test.ts
+++ b/packages/core/test/serve-http.test.ts
@@ -150,7 +150,7 @@ describe("createHttpServeApp", () => {
     await engine.close();
   });
 
-  it("uses issued remote credentials for protected self-hosted route classes", async () => {
+  it("treats operator credentials as a superset of access credentials", async () => {
     const context = testContext();
     const engine = new CapletsEngine({
       configPath: context.configPath,
@@ -226,13 +226,13 @@ describe("createHttpServeApp", () => {
     const operatorAttach = await app.request("http://127.0.0.1:5387/v1/attach/manifest", {
       headers: { authorization: `Bearer ${operatorCredentials.accessToken}` },
     });
-    expect(operatorAttach.status).toBe(403);
+    expect(operatorAttach.status).toBe(200);
 
     const operatorProjectBinding = await app.request(
       "http://127.0.0.1:5387/v1/attach/project-bindings/bind_123/status",
       { headers: { authorization: `Bearer ${operatorCredentials.accessToken}` } },
     );
-    expect(operatorProjectBinding.status).toBe(403);
+    expect(operatorProjectBinding.status).toBe(200);
 
     const operatorMcp = await app.request("http://127.0.0.1:5387/v1/mcp", {
       method: "POST",
@@ -253,7 +253,7 @@ describe("createHttpServeApp", () => {
         },
       }),
     });
-    expect(operatorMcp.status).toBe(403);
+    expect(operatorMcp.status).toBe(200);
     await engine.close();
   });
 
@@ -2068,7 +2068,7 @@ describe("createHttpServeApp", () => {
     }
   });
 
-  it("rechecks role loss after a queued first heartbeat commits but before the next mutation starts", async () => {
+  it("rechecks credential revocation after a queued first heartbeat commits but before the next mutation starts", async () => {
     const { engine } = testEngine();
     const store = remoteCredentialStore();
     const workspaceRoot = mkdtempSync(join(tmpdir(), "caplets-binding-workspaces-"));
@@ -2107,7 +2107,7 @@ describe("createHttpServeApp", () => {
         await withTimeout(nextSocketJson(socket), "receive Project Binding ready");
         workspaces.deferNextWrite();
         workspaces.runAfterNextWritePostCommit(() => {
-          store.changeClientRole(credentials.clientId, "operator");
+          store.revokeClient(credentials.clientId);
         });
         const closed = waitForSocketClose(socket);
         socket.send(
@@ -2172,7 +2172,7 @@ describe("createHttpServeApp", () => {
     }
   });
 
-  it("rejects in-flight heartbeat state after post-write durable role loss", async () => {
+  it("rejects in-flight heartbeat state after post-write credential revocation", async () => {
     const { engine } = testEngine();
     const store = remoteCredentialStore();
     const workspaceRoot = mkdtempSync(join(tmpdir(), "caplets-binding-workspaces-"));
@@ -2221,7 +2221,7 @@ describe("createHttpServeApp", () => {
           }),
         );
         await withTimeout(workspaces.nextWriteStarted, "start in-flight candidate lease write");
-        store.changeClientRole(credentials.clientId, "operator");
+        store.revokeClient(credentials.clientId);
         workspaces.releaseNextWrite();
 
         await expect(withTimeout(closed, "close post-write demoted socket")).resolves.toMatchObject(
@@ -2256,7 +2256,7 @@ describe("createHttpServeApp", () => {
     }
   });
 
-  it("does not return a successful HTTP end after post-write role loss", async () => {
+  it("does not return a successful HTTP end after post-write credential revocation", async () => {
     const { engine } = testEngine();
     const store = remoteCredentialStore();
     const workspaceRoot = mkdtempSync(join(tmpdir(), "caplets-binding-workspaces-"));
@@ -2297,7 +2297,7 @@ describe("createHttpServeApp", () => {
         },
       );
       await workspaces.nextWriteStarted;
-      store.changeClientRole(credentials.clientId, "operator");
+      store.revokeClient(credentials.clientId);
       workspaces.releaseNextWrite();
 
       expect((await ending).status).toBe(403);
@@ -2378,7 +2378,7 @@ describe("createHttpServeApp", () => {
     }
   });
 
-  it("does not acknowledge a socket end after post-write durable role loss", async () => {
+  it("does not acknowledge a socket end after post-write credential revocation", async () => {
     const { engine } = testEngine();
     const store = remoteCredentialStore();
     const workspaceRoot = mkdtempSync(join(tmpdir(), "caplets-binding-workspaces-"));
@@ -2430,7 +2430,7 @@ describe("createHttpServeApp", () => {
           }),
         );
         await withTimeout(workspaces.nextWriteStarted, "start in-flight terminal lease write");
-        store.changeClientRole(credentials.clientId, "operator");
+        store.revokeClient(credentials.clientId);
         workspaces.releaseNextWrite();
 
         await expect(

--- a/packages/core/test/setup-state-storage.test.ts
+++ b/packages/core/test/setup-state-storage.test.ts
@@ -1,0 +1,128 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHostStorage } from "../src/storage/database";
+import { SetupStateStore } from "../src/storage/setup-state";
+import type { SetupAttempt } from "../src/setup/types";
+import * as sqlite from "../src/storage/schema/sqlite";
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("SQL setup state", () => {
+  it("shares approvals and retained attempts across repository instances", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-setup-state-"));
+    directories.push(root);
+    const firstStorage = await createHostStorage({
+      type: "sqlite",
+      path: join(root, "caplets.sqlite3"),
+    });
+    const now = new Date("2026-07-18T12:00:00.000Z");
+    const first = new SetupStateStore(firstStorage.database, {
+      now: () => now,
+      maxAttempts: 2,
+      retentionDays: 7,
+    });
+    const second = new SetupStateStore(firstStorage.database, {
+      now: () => now,
+      maxAttempts: 2,
+      retentionDays: 7,
+    });
+
+    try {
+      await first.approve({
+        projectFingerprint: "project-a",
+        capletId: "ast-grep",
+        contentHash: "sha256:content",
+        targetKind: "remote_host",
+        approvedAt: now.toISOString(),
+        actor: "ui",
+      });
+
+      await expect(
+        second.getApproval("project-a", "ast-grep", "sha256:content", "remote_host"),
+      ).resolves.toEqual({
+        projectFingerprint: "project-a",
+        capletId: "ast-grep",
+        contentHash: "sha256:content",
+        targetKind: "remote_host",
+        approvedAt: now.toISOString(),
+        actor: "ui",
+      });
+
+      await expect(
+        first.approve(
+          {
+            projectFingerprint: "project-a",
+            capletId: "ast-grep",
+            contentHash: "sha256:content",
+            targetKind: "remote_host",
+            approvedAt: now.toISOString(),
+            actor: "automation",
+          },
+          { expectedGeneration: 0 },
+        ),
+      ).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+        details: expect.objectContaining({ kind: "stale_generation" }),
+      });
+
+      await first.recordAttempt(attempt("attempt-1", "first", now));
+      await second.recordAttempt(attempt("attempt-2", "second", now));
+      await first.recordAttempt(attempt("attempt-3", "third", now));
+      await expect(
+        second.recordAttempt(attempt("attempt-stale", "stale", now), {
+          expectedGeneration: 2,
+        }),
+      ).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+        details: expect.objectContaining({ kind: "stale_generation" }),
+      });
+
+      await expect(second.listAttempts("project-a", "ast-grep")).resolves.toMatchObject([
+        { attemptId: "attempt-2", commandLabel: "second" },
+        { attemptId: "attempt-3", commandLabel: "third" },
+      ]);
+      await expect(first.getAttempt("project-a", "ast-grep", "attempt-3")).resolves.toMatchObject({
+        commandLabel: "third",
+      });
+      await expect(second.clearAttempts("project-a", "ast-grep")).resolves.toBe(true);
+      await expect(first.listAttempts("project-a", "ast-grep")).resolves.toEqual([]);
+      if (firstStorage.database.dialect !== "sqlite") {
+        throw new Error("Expected SQLite storage.");
+      }
+      expect(firstStorage.database.db.select().from(sqlite.setupApprovals).all()).toHaveLength(1);
+    } finally {
+      await firstStorage.close();
+    }
+  });
+});
+
+function attempt(attemptId: string, commandLabel: string, now: Date): SetupAttempt {
+  return {
+    attemptId,
+    projectFingerprint: "project-a",
+    capletId: "ast-grep",
+    contentHash: "sha256:content",
+    targetKind: "remote_host",
+    actor: "automation",
+    status: "succeeded",
+    phase: "commands",
+    commandLabel,
+    argv: ["echo", commandLabel],
+    exitCode: 0,
+    durationMs: 1,
+    startedAt: now.toISOString(),
+    finishedAt: now.toISOString(),
+    stdout: "ok",
+    stderr: "",
+    redacted: true,
+    retention: { maxAttempts: 2, days: 7 },
+  };
+}

--- a/packages/core/test/storage-catalog-cli.test.ts
+++ b/packages/core/test/storage-catalog-cli.test.ts
@@ -1,0 +1,131 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCli } from "../src/cli";
+import { defaultCapletsLockfilePath } from "../src/config";
+import { createHostStorage } from "../src/storage";
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function bundle(command: string): string {
+  return `---\nname: SQL Catalog\ndescription: SQL catalog lifecycle fixture.\nmcpServer:\n  command: ${command}\n---\n# SQL Catalog\n`;
+}
+
+describe("global SQL catalog lifecycle", () => {
+  it("installs and updates complete bundles without global Caplet files or lockfiles", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-storage-catalog-cli-"));
+    directories.push(root);
+    const configPath = join(root, "config", "config.json");
+    const databasePath = join(root, "state", "caplets.sqlite3");
+    const repository = join(root, "repository");
+    const capletPath = join(repository, "caplets", "catalog-demo");
+    mkdirSync(join(root, "config"), { recursive: true });
+    mkdirSync(capletPath, { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ storage: { type: "sqlite", path: databasePath } }));
+    writeFileSync(join(capletPath, "CAPLET.md"), bundle("catalog-v1"));
+    writeFileSync(join(capletPath, "support.txt"), "first support\n");
+    const env = {
+      CAPLETS_CONFIG: configPath,
+      CAPLETS_DISABLE_CATALOG_INDEXING: "1",
+      XDG_CONFIG_HOME: join(root, "xdg-config"),
+      XDG_STATE_HOME: join(root, "xdg-state"),
+    };
+
+    const run = async (args: string[]): Promise<string> => {
+      const output: string[] = [];
+      await runCli(args, { env, writeOut: (value) => output.push(value) });
+      return output.join("");
+    };
+    const invoke = async (args: string[]): Promise<{ entries: Array<Record<string, unknown>> }> =>
+      JSON.parse(await run(args)) as { entries: Array<Record<string, unknown>> };
+
+    const installed = await invoke(["install", repository, "catalog-demo", "--global", "--json"]);
+    expect(installed.entries).toMatchObject([
+      {
+        id: "catalog-demo",
+        status: "installed",
+        destination: "sql://caplet-records/catalog-demo",
+        source: repository,
+        catalogIndexing: { status: "ineligible", reason: "catalog_indexing_disabled" },
+        vaultSetup: { status: "ready" },
+      },
+    ]);
+    expect(existsSync(join(configPath, "..", "catalog-demo"))).toBe(false);
+    expect(existsSync(join(configPath, "..", "catalog-demo.md"))).toBe(false);
+    expect(existsSync(defaultCapletsLockfilePath(env))).toBe(false);
+
+    const storage = await createHostStorage({ type: "sqlite", path: databasePath });
+    let recordKey: string;
+    let installationKey: string;
+    try {
+      const record = await storage.caplets.readBundle("catalog-demo", {
+        operator: { clientId: "test_reader", role: "operator" },
+      });
+      const installation = await storage.installations.getActive("catalog-demo");
+      const observation = await storage.installations.getLatestObservation("catalog-demo");
+      expect(record?.record.headGeneration).toBe(1);
+      expect(record?.files.map((file) => file.path)).toEqual(["CAPLET.md", "support.txt"]);
+      expect(record?.files.find((file) => file.path === "support.txt")?.content.toString()).toBe(
+        "first support\n",
+      );
+      expect(installation).toMatchObject({
+        generation: 1,
+        status: "active",
+        sourceKind: "local",
+        sourceIdentity: repository,
+      });
+      expect(observation).toMatchObject({
+        status: "current",
+        contentHash: expect.any(String),
+        risk: { backendFamilies: ["mcp"] },
+      });
+      recordKey = record!.record.recordKey;
+      installationKey = installation!.installationKey;
+    } finally {
+      await storage.close();
+    }
+
+    writeFileSync(join(capletPath, "CAPLET.md"), bundle("catalog-v2"));
+    writeFileSync(join(capletPath, "support.txt"), "second support\n");
+    const updated = await run(["update", "catalog-demo", "--global"]);
+    expect(updated).toContain("Updated catalog-demo at sql://caplet-records/catalog-demo\n");
+
+    const forced = await invoke([
+      "install",
+      repository,
+      "catalog-demo",
+      "--global",
+      "--force",
+      "--json",
+    ]);
+    expect(forced.entries).toMatchObject([{ id: "catalog-demo", status: "noop" }]);
+
+    const finalStorage = await createHostStorage({ type: "sqlite", path: databasePath });
+    try {
+      const record = await finalStorage.caplets.readBundle("catalog-demo", {
+        operator: { clientId: "test_reader", role: "operator" },
+      });
+      const installation = await finalStorage.installations.getActive("catalog-demo");
+      expect(record?.record.recordKey).toBe(recordKey);
+      expect(record?.record.headGeneration).toBe(3);
+      expect(record?.files.find((file) => file.path === "support.txt")?.content.toString()).toBe(
+        "second support\n",
+      );
+      expect(installation?.installationKey).toBe(installationKey);
+      expect(installation?.generation).toBe(3);
+      await expect(finalStorage.coordination.currentConfigGeneration()).resolves.toBeGreaterThan(0);
+    } finally {
+      await finalStorage.close();
+    }
+    expect(existsSync(join(configPath, "..", "catalog-demo"))).toBe(false);
+    expect(existsSync(join(configPath, "..", "catalog-demo.md"))).toBe(false);
+    expect(existsSync(defaultCapletsLockfilePath(env))).toBe(false);
+  });
+});

--- a/packages/core/test/storage-records-cli.test.ts
+++ b/packages/core/test/storage-records-cli.test.ts
@@ -1,0 +1,300 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCli } from "../src/cli";
+import { installCaplets } from "../src/install";
+import { hostConfigGenerations } from "../src/storage/schema/sqlite";
+import { createHostStorage } from "../src/storage";
+
+const directories: string[] = [];
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function caplet(command: string, body: string): string {
+  return `---\nname: Stored CLI\ndescription: Stored record command fixture.\nmcpServer:\n  command: ${command}\n---\n# ${body}\n`;
+}
+
+function writeBundle(path: string, command: string, body: string): void {
+  mkdirSync(path, { recursive: true });
+  writeFileSync(join(path, "CAPLET.md"), caplet(command, body));
+  writeFileSync(join(path, "support.txt"), `${body}\n`);
+}
+
+describe("stored Caplet Record CLI", () => {
+  it("administers record revisions and installation lifecycles through configured SQL storage", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-storage-records-cli-"));
+    directories.push(root);
+    const databasePath = join(root, "state", "caplets.sqlite3");
+    const configPath = join(root, "config.json");
+    const firstBundle = join(root, "first");
+    const secondBundle = join(root, "second");
+    const exportPath = join(root, "exported");
+    writeFileSync(configPath, JSON.stringify({ storage: { type: "sqlite", path: databasePath } }));
+    writeBundle(firstBundle, "first-command", "First");
+    writeBundle(secondBundle, "second-command", "Second");
+
+    const invoke = async (args: string[]): Promise<unknown> => {
+      const output: string[] = [];
+      await runCli(args, {
+        env: { CAPLETS_CONFIG: configPath },
+        writeOut: (value) => output.push(value),
+      });
+      return JSON.parse(output.join("")) as unknown;
+    };
+
+    await expect(invoke(["storage", "schema-migrate"])).resolves.toEqual({
+      migrated: true,
+      backend: "sqlite",
+    });
+    await expect(invoke(["storage", "status", "--json"])).resolves.toMatchObject({
+      backend: "sqlite",
+      ready: true,
+      records: 0,
+    });
+    await expect(invoke(["storage", "records", "list"])).rejects.toMatchObject({
+      code: "REQUEST_INVALID",
+    });
+
+    const imported = (await invoke([
+      "storage",
+      "records",
+      "import",
+      firstBundle,
+      "--id",
+      "stored-cli",
+      "--history-limit",
+      "3",
+      "--source-kind",
+      "git",
+      "--source-identity",
+      "https://example.test/repository.git",
+      "--channel",
+      "main",
+    ])) as { id: string; headGeneration: number; currentRevision: { revisionKey: string } };
+    expect(imported).toMatchObject({ id: "stored-cli", headGeneration: 1 });
+    await expect(invoke(["storage", "records", "list", "--stored"])).resolves.toMatchObject([
+      { id: "stored-cli", headGeneration: 1 },
+    ]);
+    await expect(
+      invoke(["storage", "records", "get", "stored-cli", "--stored"]),
+    ).resolves.toMatchObject({
+      id: "stored-cli",
+      currentRevision: { body: "# First\n" },
+    });
+    await expect(invoke(["list", "--json"])).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ server: "stored-cli", source: "stored-record" }),
+      ]),
+    );
+    const globalCapletsRoot = root;
+    writeFileSync(
+      join(globalCapletsRoot, "stored-cli.md"),
+      caplet("shadow-command", "Global overlay"),
+    );
+    await expect(invoke(["list", "--stored", "--json"])).resolves.toMatchObject([
+      {
+        id: "stored-cli",
+        shadowed: true,
+        shadowSource: { kind: "global-file" },
+      },
+    ]);
+    rmSync(join(globalCapletsRoot, "stored-cli.md"));
+
+    const updated = (await invoke([
+      "storage",
+      "records",
+      "update",
+      "stored-cli",
+      secondBundle,
+      "--generation",
+      "1",
+      "--detach-installation",
+    ])) as { headGeneration: number };
+    expect(updated.headGeneration).toBe(2);
+    await expect(
+      invoke(["storage", "records", "update", "stored-cli", firstBundle, "--generation", "1"]),
+    ).rejects.toMatchObject({ details: { kind: "stale_generation" } });
+
+    const revisions = (await invoke(["storage", "records", "revisions", "stored-cli"])) as Array<{
+      revisionKey: string;
+      sequence: number;
+    }>;
+    expect(revisions.map(({ sequence }) => sequence)).toEqual([2, 1]);
+    await invoke([
+      "storage",
+      "records",
+      "export",
+      "stored-cli",
+      exportPath,
+      "--revision",
+      revisions[1]!.revisionKey,
+    ]);
+    expect(readFileSync(join(exportPath, "CAPLET.md"), "utf8")).toBe(
+      caplet("first-command", "First"),
+    );
+    expect(readFileSync(join(exportPath, "support.txt"), "utf8")).toBe("First\n");
+
+    const restored = (await invoke([
+      "storage",
+      "records",
+      "restore",
+      "stored-cli",
+      revisions[1]!.revisionKey,
+      "--generation",
+      "2",
+    ])) as { headGeneration: number; currentRevision: { body: string } };
+    expect(restored).toMatchObject({ headGeneration: 3, currentRevision: { body: "# First\n" } });
+    await expect(
+      invoke([
+        "storage",
+        "records",
+        "delete-revision",
+        "stored-cli",
+        revisions[0]!.revisionKey,
+        "--generation",
+        "3",
+      ]),
+    ).resolves.toMatchObject({ deleted: true, record: { headGeneration: 4 } });
+    const retained = (await invoke([
+      "storage",
+      "records",
+      "retention",
+      "stored-cli",
+      "1",
+      "--generation",
+      "4",
+    ])) as { headGeneration: number; historyLimit: number };
+    expect(retained).toMatchObject({ headGeneration: 5, historyLimit: 1 });
+    const renamed = (await invoke([
+      "storage",
+      "records",
+      "rename",
+      "stored-cli",
+      "renamed-cli",
+      "--generation",
+      "5",
+    ])) as { id: string; headGeneration: number };
+    expect(renamed).toMatchObject({ id: "renamed-cli", headGeneration: 6 });
+
+    const installationStatus = (await invoke([
+      "storage",
+      "records",
+      "installation",
+      "status",
+      "renamed-cli",
+    ])) as { installations: Array<{ generation: number; status: string }> };
+    expect(installationStatus.installations).toMatchObject([
+      { generation: 2, status: "detached", sourceKind: "git" },
+    ]);
+    const replacement = (await invoke([
+      "storage",
+      "records",
+      "installation",
+      "replace",
+      "renamed-cli",
+      "--generation",
+      "2",
+      "--source-kind",
+      "registry",
+      "--source-identity",
+      "official/renamed-cli",
+    ])) as { generation: number; status: string };
+    expect(replacement).toMatchObject({ generation: 1, status: "active" });
+    await expect(
+      invoke([
+        "storage",
+        "records",
+        "installation",
+        "observe",
+        "renamed-cli",
+        "--generation",
+        "1",
+        "--status",
+        "current",
+        "--resolved-revision",
+        "rev-1",
+        "--content-hash",
+        "sha256:test",
+        "--risk-json",
+        '{"level":"low"}',
+      ]),
+    ).resolves.toMatchObject({ status: "current", risk: { level: "low" } });
+    await expect(
+      invoke(["storage", "records", "installation", "detach", "renamed-cli", "--generation", "2"]),
+    ).resolves.toMatchObject({ status: "detached", generation: 3 });
+
+    await expect(
+      invoke(["storage", "records", "delete", "renamed-cli", "--generation", "6"]),
+    ).resolves.toEqual({ deleted: true, id: "renamed-cli" });
+    expect(existsSync(exportPath)).toBe(true);
+    await expect(invoke(["storage", "records", "list", "--stored"])).resolves.toEqual([]);
+
+    const storage = await createHostStorage({ type: "sqlite", path: databasePath });
+    try {
+      const activity = await storage.installations.listActivity();
+      await expect(storage.coordination.currentConfigGeneration()).resolves.toBe(8);
+      if (storage.database.dialect !== "sqlite") throw new Error("Expected SQLite test storage.");
+      const invalidations = storage.database.db
+        .select()
+        .from(hostConfigGenerations)
+        .all()
+        .filter(({ contentHash }) => contentHash.startsWith("mutation:"));
+      expect(invalidations).toEqual([]);
+      expect(activity.length).toBeGreaterThan(10);
+      expect(activity.every((entry) => entry.operatorClientId === "local_cli")).toBe(true);
+      expect(JSON.stringify(activity)).not.toContain("first-command");
+      expect(JSON.stringify(activity)).not.toContain("second-command");
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it("requires explicit legacy Caplet paths for storage migrate-legacy", async () => {
+    const root = mkdtempSync(join(tmpdir(), "caplets-storage-migrate-legacy-cli-"));
+    directories.push(root);
+    const repository = join(root, "repository");
+    const source = join(repository, "caplets", "legacy-cli");
+    const capletsRoot = join(root, "legacy-host", "caplets");
+    const lockfilePath = join(root, "legacy-host", "caplets.lock.json");
+    const databasePath = join(root, "state", "caplets.sqlite3");
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, JSON.stringify({ storage: { type: "sqlite", path: databasePath } }));
+    writeBundle(source, "legacy-command", "Legacy");
+    installCaplets(repository, {
+      capletIds: ["legacy-cli"],
+      destinationRoot: capletsRoot,
+      lockfilePath,
+    });
+
+    const output: string[] = [];
+    await runCli(
+      [
+        "storage",
+        "migrate-legacy",
+        "--caplets-root",
+        capletsRoot,
+        "--lockfile",
+        lockfilePath,
+        "--dry-run",
+      ],
+      {
+        env: { CAPLETS_CONFIG: configPath },
+        writeOut: (value) => output.push(value),
+      },
+    );
+
+    expect(JSON.parse(output.join(""))).toEqual({
+      status: "verified",
+      records: 1,
+      installations: 1,
+      backupPath: null,
+    });
+    expect(existsSync(join(capletsRoot, "legacy-cli", "CAPLET.md"))).toBe(true);
+    expect(existsSync(lockfilePath)).toBe(true);
+  });
+});

--- a/packages/core/test/vault-grant-storage.test.ts
+++ b/packages/core/test/vault-grant-storage.test.ts
@@ -1,0 +1,215 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createHostStorage, createHostStorageVaultResolver } from "../src/storage";
+import { operatorActivity } from "../src/storage/schema/sqlite";
+
+const operator = { clientId: "operator-1", role: "operator" } as const;
+
+function capletDocument(): Buffer {
+  return Buffer.from(`---
+name: Shared
+description: Shared fixture.
+mcpServer:
+  command: shared-mcp
+  env:
+    TOKEN: \${vault.TOKEN}
+---
+# Shared
+`);
+}
+
+describe("VaultGrantStore", () => {
+  it("isolates record and filesystem grants by immutable subject and exact active origin", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-vault-grants-"));
+    const firstPath = join(directory, "global", "shared", "CAPLET.md");
+    const secondPath = join(directory, "project", "shared", "CAPLET.md");
+    const storage = await createHostStorage(
+      { type: "sqlite", path: join(directory, "caplets.sqlite3") },
+      { vaultRoot: join(directory, "vault") },
+    );
+
+    try {
+      await storage.caplets.importBundle({
+        id: "shared",
+        operator,
+        files: [{ path: "CAPLET.md", content: capletDocument(), executable: false }],
+      });
+      await storage.vaultValues.set("RECORD_TOKEN", "record-secret");
+      await storage.vaultValues.set("FILE_TOKEN", "file-secret");
+      await storage.vaultValues.set("ROTATED_FILE_TOKEN", "rotated-file-secret");
+
+      await storage.vaultGrants.grant({
+        capletId: "shared",
+        vaultKey: "RECORD_TOKEN",
+        referenceName: "TOKEN",
+        originKind: "stored-record",
+        operator,
+      });
+      await storage.vaultGrants.grant({
+        capletId: "shared",
+        vaultKey: "FILE_TOKEN",
+        referenceName: "TOKEN",
+        originKind: "global-file",
+        originPath: firstPath,
+        operator,
+      });
+      await storage.vaultGrants.grant({
+        capletId: "shared",
+        vaultKey: "FILE_TOKEN",
+        referenceName: "TOKEN",
+        originKind: "project-file",
+        originPath: secondPath,
+        operator,
+      });
+
+      const initialGrants = await storage.vaultGrants.list("shared");
+      expect(initialGrants).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            subjectKind: "record",
+            recordKey: (await storage.caplets.get("shared"))?.recordKey,
+            capletId: "shared",
+            vaultKey: "RECORD_TOKEN",
+            referenceName: "TOKEN",
+          }),
+          expect.objectContaining({
+            subjectKind: "file",
+            recordKey: null,
+            capletId: "shared",
+            originKind: "global-file",
+            originPath: firstPath,
+          }),
+          expect.objectContaining({
+            subjectKind: "file",
+            recordKey: null,
+            capletId: "shared",
+            originKind: "project-file",
+            originPath: secondPath,
+          }),
+        ]),
+      );
+
+      let resolver = await createHostStorageVaultResolver(storage);
+      expect(
+        resolver({
+          capletId: "shared",
+          referenceName: "TOKEN",
+          origin: { kind: "stored-record", path: "sql:shared" },
+          path: "mcpServers.shared.env.TOKEN",
+        }),
+      ).toEqual({ storedKey: "RECORD_TOKEN", value: "record-secret" });
+      expect(
+        resolver({
+          capletId: "shared",
+          referenceName: "TOKEN",
+          origin: { kind: "global-file", path: firstPath },
+          path: "mcpServers.shared.env.TOKEN",
+        }),
+      ).toEqual({ storedKey: "FILE_TOKEN", value: "file-secret" });
+      expect(
+        resolver({
+          capletId: "shared",
+          referenceName: "TOKEN",
+          origin: { kind: "global-file", path: secondPath },
+          path: "mcpServers.shared.env.TOKEN",
+        }),
+      ).toMatchObject({ reason: "ungranted" });
+      expect(
+        resolver({
+          capletId: "shared",
+          referenceName: "TOKEN",
+          origin: { kind: "project-file", path: firstPath },
+          path: "mcpServers.shared.env.TOKEN",
+        }),
+      ).toMatchObject({ reason: "ungranted" });
+
+      await storage.vaultGrants.grant({
+        capletId: "shared",
+        vaultKey: "ROTATED_FILE_TOKEN",
+        referenceName: "TOKEN",
+        originKind: "global-file",
+        originPath: firstPath,
+        operator,
+      });
+      expect(
+        (await storage.vaultGrants.list("shared")).filter(
+          (grant) => grant.originKind === "global-file" && grant.originPath === firstPath,
+        ),
+      ).toEqual([
+        expect.objectContaining({ vaultKey: "ROTATED_FILE_TOKEN", referenceName: "TOKEN" }),
+      ]);
+
+      const renamed = await storage.caplets.rename({
+        id: "shared",
+        newId: "renamed",
+        expectedGeneration: 1,
+        operator,
+      });
+      expect(await storage.vaultGrants.list("renamed")).toEqual([
+        expect.objectContaining({ subjectKind: "record", vaultKey: "RECORD_TOKEN" }),
+      ]);
+      resolver = await createHostStorageVaultResolver(storage);
+      expect(
+        resolver({
+          capletId: "renamed",
+          referenceName: "TOKEN",
+          origin: { kind: "stored-record", path: "sql:renamed" },
+          path: "mcpServers.renamed.env.TOKEN",
+        }),
+      ).toEqual({ storedKey: "RECORD_TOKEN", value: "record-secret" });
+      expect(
+        resolver({
+          capletId: "renamed",
+          referenceName: "TOKEN",
+          origin: { kind: "global-file", path: firstPath },
+          path: "mcpServers.renamed.env.TOKEN",
+        }),
+      ).toMatchObject({ reason: "ungranted" });
+
+      await storage.caplets.hardDelete({
+        id: "renamed",
+        expectedGeneration: renamed.headGeneration,
+        operator,
+      });
+      await storage.caplets.importBundle({
+        id: "renamed",
+        operator,
+        files: [{ path: "CAPLET.md", content: capletDocument(), executable: false }],
+      });
+      expect(await storage.vaultGrants.list("renamed")).toEqual([]);
+
+      await expect(
+        storage.vaultGrants.revoke({
+          capletId: "shared",
+          vaultKey: "ROTATED_FILE_TOKEN",
+          referenceName: "TOKEN",
+          originKind: "global-file",
+          originPath: firstPath,
+          operator,
+        }),
+      ).resolves.toBe(true);
+      expect(await storage.vaultGrants.list("shared")).toEqual([
+        expect.objectContaining({ originKind: "project-file", originPath: secondPath }),
+      ]);
+
+      if (storage.database.dialect !== "sqlite") throw new Error("Expected SQLite storage");
+      const activities = storage.database.db
+        .select()
+        .from(operatorActivity)
+        .all()
+        .filter((entry) => entry.targetKind === "vault_grant");
+      expect(activities).toHaveLength(5);
+      const activityPayload = JSON.stringify(activities);
+      expect(activityPayload).not.toContain(firstPath);
+      expect(activityPayload).not.toContain(secondPath);
+      expect(activityPayload).not.toContain("record-secret");
+      expect(activityPayload).not.toContain("file-secret");
+      expect(activityPayload).not.toContain("rotated-file-secret");
+    } finally {
+      await storage.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/test/vault-value-storage.test.ts
+++ b/packages/core/test/vault-value-storage.test.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { createHmac } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -167,6 +168,44 @@ describe("VaultValueStore", () => {
       }
     } finally {
       await firstStorage.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("derives host runtime parity with the Vault encryption key", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-runtime-fingerprint-"));
+    const storage = await createHostStorage({
+      type: "sqlite",
+      path: join(directory, "caplets.sqlite3"),
+    });
+    const firstKey = Buffer.alloc(32, 1);
+    const secondKey = Buffer.alloc(32, 2);
+    const first = new VaultValueStore(storage.database, {
+      env: { CAPLETS_ENCRYPTION_KEY: firstKey.toString("base64url") },
+    });
+    const sameKey = new VaultValueStore(storage.database, {
+      env: { CAPLETS_ENCRYPTION_KEY: firstKey.toString("base64url") },
+    });
+    const rotatedKey = new VaultValueStore(storage.database, {
+      env: { CAPLETS_ENCRYPTION_KEY: secondKey.toString("base64url") },
+    });
+    const hostConfigurationFingerprint = "low-entropy-runtime-shape";
+
+    try {
+      const fingerprint = first.hostRuntimeFingerprint(hostConfigurationFingerprint);
+      const expected = createHmac("sha256", firstKey)
+        .update("caplets-host-runtime-fingerprint-v1")
+        .update("\0")
+        .update(hostConfigurationFingerprint)
+        .digest("hex");
+
+      expect(fingerprint).toBe(`hmac-sha256:${expected}`);
+      expect(sameKey.hostRuntimeFingerprint(hostConfigurationFingerprint)).toBe(fingerprint);
+      expect(rotatedKey.hostRuntimeFingerprint(hostConfigurationFingerprint)).not.toBe(fingerprint);
+      expect(first.hostRuntimeFingerprint("changed-runtime-shape")).not.toBe(fingerprint);
+      expect(fingerprint).not.toContain(hostConfigurationFingerprint);
+    } finally {
+      await storage.close();
       rmSync(directory, { recursive: true, force: true });
     }
   });

--- a/packages/core/test/vault-value-storage.test.ts
+++ b/packages/core/test/vault-value-storage.test.ts
@@ -1,0 +1,173 @@
+import { Buffer } from "node:buffer";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createHostStorage } from "../src/storage";
+import { VaultValueStore } from "../src/storage/vault-values";
+import { operatorActivity, vaultValues } from "../src/storage/schema/sqlite";
+import { VAULT_MAX_VALUE_BYTES } from "../src/vault";
+
+describe("VaultValueStore", () => {
+  it("keeps encrypted Vault values coherent, secret-safe, and fail-closed", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "caplets-vault-values-"));
+    const databasePath = join(directory, "caplets.sqlite3");
+    const env = {
+      CAPLETS_ENCRYPTION_KEY: Buffer.alloc(32, 7).toString("base64url"),
+    };
+    const firstStorage = await createHostStorage({ type: "sqlite", path: databasePath });
+    if (firstStorage.database.dialect !== "sqlite") throw new Error("Expected SQLite storage");
+    const first = new VaultValueStore(firstStorage.database, { env });
+    const second = new VaultValueStore(firstStorage.database, { env });
+    const plaintext = "plain-text-vault-secret";
+    const rotatedPlaintext = "rotated-vault-secret";
+
+    try {
+      await expect(first.getStatus("API_TOKEN")).resolves.toEqual({
+        key: "API_TOKEN",
+        present: false,
+      });
+      await expect(first.getStatus("invalid-name")).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+      });
+      await expect(
+        first.set("TOO_LARGE", "x".repeat(VAULT_MAX_VALUE_BYTES + 1)),
+      ).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+      });
+
+      await expect(
+        first.set("API_TOKEN", plaintext, {
+          expectedGeneration: 0,
+          operatorClientId: "operator-1",
+          now: new Date("2026-07-18T10:00:00.000Z"),
+        }),
+      ).resolves.toEqual({
+        key: "API_TOKEN",
+        present: true,
+        generation: 1,
+        valueBytes: Buffer.byteLength(plaintext),
+        createdAt: "2026-07-18T10:00:00.000Z",
+        updatedAt: "2026-07-18T10:00:00.000Z",
+      });
+
+      const persisted = firstStorage.database.db.select().from(vaultValues).get();
+      expect(persisted).toMatchObject({ vaultKey: "API_TOKEN", generation: 1 });
+      expect(JSON.stringify(persisted)).not.toContain(plaintext);
+      expect(persisted).not.toHaveProperty("value");
+
+      await expect(second.resolveValue("API_TOKEN")).resolves.toBe(plaintext);
+      await expect(second.getStatus("API_TOKEN")).resolves.toMatchObject({
+        key: "API_TOKEN",
+        present: true,
+        generation: 1,
+      });
+      await expect(second.set("API_TOKEN", "collision-secret")).rejects.toMatchObject({
+        code: "CONFIG_EXISTS",
+      });
+      await expect(second.resolveValue("API_TOKEN")).resolves.toBe(plaintext);
+
+      await expect(
+        second.set("API_TOKEN", rotatedPlaintext, {
+          force: true,
+          expectedGeneration: 1,
+          operatorClientId: "operator-2",
+          now: new Date("2026-07-18T10:01:00.000Z"),
+        }),
+      ).resolves.toMatchObject({
+        key: "API_TOKEN",
+        present: true,
+        generation: 2,
+        createdAt: "2026-07-18T10:00:00.000Z",
+        updatedAt: "2026-07-18T10:01:00.000Z",
+      });
+      await expect(
+        first.set("API_TOKEN", "stale-secret", { force: true, expectedGeneration: 1 }),
+      ).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+        details: {
+          kind: "stale_generation",
+          expectedGeneration: 1,
+          currentGeneration: 2,
+        },
+      });
+      await expect(first.resolveValue("API_TOKEN")).resolves.toBe(rotatedPlaintext);
+
+      await first.set("ANOTHER_TOKEN", "another-secret", { expectedGeneration: 0 });
+      await expect(second.listValues()).resolves.toEqual([
+        expect.objectContaining({ key: "ANOTHER_TOKEN", present: true, generation: 1 }),
+        expect.objectContaining({ key: "API_TOKEN", present: true, generation: 2 }),
+      ]);
+
+      await expect(
+        second.delete("API_TOKEN", {
+          expectedGeneration: 1,
+          operatorClientId: "operator-2",
+        }),
+      ).rejects.toMatchObject({
+        code: "REQUEST_INVALID",
+        details: {
+          kind: "stale_generation",
+          expectedGeneration: 1,
+          currentGeneration: 2,
+        },
+      });
+      await expect(first.resolveValue("API_TOKEN")).resolves.toBe(rotatedPlaintext);
+
+      await expect(
+        second.delete("API_TOKEN", {
+          expectedGeneration: 2,
+          operatorClientId: "operator-2",
+        }),
+      ).resolves.toEqual({ key: "API_TOKEN", deleted: true, generation: 2 });
+      await expect(first.getStatus("API_TOKEN")).resolves.toEqual({
+        key: "API_TOKEN",
+        present: false,
+      });
+      await expect(first.delete("API_TOKEN", { expectedGeneration: 0 })).resolves.toEqual({
+        key: "API_TOKEN",
+        deleted: false,
+      });
+      await expect(first.resolveValue("API_TOKEN")).rejects.toMatchObject({
+        code: "CONFIG_INVALID",
+      });
+
+      firstStorage.database.db
+        .insert(vaultValues)
+        .values({
+          vaultKey: "BROKEN_TOKEN",
+          generation: 1,
+          version: 1,
+          algorithm: "aes-256-gcm",
+          nonce: "not-valid-base64url!",
+          ciphertext: plaintext,
+          authTag: "invalid",
+          valueBytes: plaintext.length,
+          createdAt: "not-a-date",
+          updatedAt: "not-a-date",
+        })
+        .run();
+      await expect(second.getStatus("BROKEN_TOKEN")).rejects.toMatchObject({
+        code: "CONFIG_INVALID",
+      });
+      await expect(second.resolveValue("BROKEN_TOKEN")).rejects.toMatchObject({
+        code: "CONFIG_INVALID",
+      });
+      await expect(second.listValues()).rejects.toMatchObject({ code: "CONFIG_INVALID" });
+
+      const activity = firstStorage.database.db.select().from(operatorActivity).all();
+      expect(activity.map(({ action, metadata }) => ({ action, metadata }))).toEqual([
+        { action: "vault_value_written", metadata: { generation: 1 } },
+        { action: "vault_value_written", metadata: { generation: 2 } },
+        { action: "vault_value_deleted", metadata: { generation: 2 } },
+      ]);
+      const activityPayload = JSON.stringify(activity);
+      for (const secret of [plaintext, rotatedPlaintext, "collision-secret", "stale-secret"]) {
+        expect(activityPayload).not.toContain(secret);
+      }
+    } finally {
+      await firstStorage.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/opencode/test/opencode.test.ts
+++ b/packages/opencode/test/opencode.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createCapletsOpenCodeHooks } from "../src/hooks";
 
 vi.mock("@opencode-ai/plugin", () => ({
   tool: Object.assign((definition: unknown) => definition, {
@@ -47,7 +48,6 @@ vi.mock("@opencode-ai/plugin", () => ({
 
 describe("@caplets/opencode", () => {
   it("registers one prefixed native tool per Caplet plus Code Mode", async () => {
-    const { createCapletsOpenCodeHooks } = await import("../src/hooks");
     const service = {
       listTools: () => [
         {
@@ -153,7 +153,6 @@ describe("@caplets/opencode", () => {
   });
 
   it("returns stable text when tool result serialization fails", async () => {
-    const { createCapletsOpenCodeHooks } = await import("../src/hooks");
     const service = {
       listTools: () => [
         {
@@ -182,7 +181,6 @@ describe("@caplets/opencode", () => {
   });
 
   it("uses direct native input schemas without progressive operation args", async () => {
-    const { createCapletsOpenCodeHooks } = await import("../src/hooks");
     const service = {
       listTools: () => [
         {
@@ -231,7 +229,6 @@ describe("@caplets/opencode", () => {
   });
 
   it("returns stable text when JSON.stringify returns undefined", async () => {
-    const { createCapletsOpenCodeHooks } = await import("../src/hooks");
     const service = {
       listTools: () => [
         {
@@ -257,7 +254,6 @@ describe("@caplets/opencode", () => {
   });
 
   it("refreshes system guidance for remaining registered tools only", async () => {
-    const { createCapletsOpenCodeHooks } = await import("../src/hooks");
     let tools = [
       {
         caplet: "git-hub",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 7.0.0-dev.20260628.1
       alchemy:
         specifier: 0.93.12
-        version: 0.93.12(@cloudflare/vite-plugin@1.42.3(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260625.1)(wrangler@4.105.0(@cloudflare/workers-types@4.20260628.1)))(@opentelemetry/api@1.9.1)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260625.1)
+        version: 0.93.12(@aws-sdk/client-s3@3.1089.0)(@cloudflare/vite-plugin@1.42.3(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260625.1)(wrangler@4.105.0(@cloudflare/workers-types@4.20260628.1)))(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(kysely@0.29.3)(pg@8.22.0)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260625.1)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -343,6 +343,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
     devDependencies:
       '@types/node':
         specifier: ^22.18.0
@@ -365,6 +368,9 @@ importers:
       '@apidevtools/swagger-parser':
         specifier: ^12.1.0
         version: 12.1.0(openapi-types@12.1.3)
+      '@aws-sdk/client-s3':
+        specifier: ^3.1089.0
+        version: 3.1089.0
       '@babel/parser':
         specifier: ^8.0.0
         version: 8.0.0
@@ -392,9 +398,15 @@ importers:
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
+      better-sqlite3:
+        specifier: ^12.11.1
+        version: 12.11.1
       commander:
         specifier: ^15.0.0
         version: 15.0.0
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@cloudflare/workers-types@4.20260628.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(kysely@0.29.3)(pg@8.22.0)
       formdata-node:
         specifier: ^6.0.3
         version: 6.0.3
@@ -410,6 +422,9 @@ importers:
       jsonc-parser:
         specifier: ^3.3.1
         version: 3.3.1
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
       posthog-node:
         specifier: ^5.38.6
         version: 5.38.6
@@ -444,9 +459,15 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^22.18.0
         version: 22.20.0
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
@@ -456,6 +477,9 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260628.1
         version: 7.0.0-dev.20260628.1
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
       rolldown:
         specifier: ^1.1.3
         version: 1.1.3
@@ -747,6 +771,10 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/checksums@3.1000.18':
+    resolution: {integrity: sha512-IImkbEyXdV6/uaF5r6Wkk+8718mQw1ll83j0a4a30R3JM/rHVFdWAiT4jtJpFjJiIwM/oJ6SxIxr0z2TaQUGqw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-bedrock-runtime@3.1048.0':
     resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
     engines: {node: '>=20.0.0'}
@@ -755,8 +783,16 @@ packages:
     resolution: {integrity: sha512-typFcdyFwIPt86QPKsO7xwcsYoEmNcDpoNqn0tqa4+Lss7niNKQzPe/765XNgAHO3I1ixiT1OKv8KD6M+CKw2w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-s3@3.1089.0':
+    resolution: {integrity: sha512-Sc+JOtNeP+v+XdP9Rb4Hh+uhiNO2hh/CZQbKYooNakhOIgK6/K0cjoDCEGeFmkG0vf2DopTmSctzKlcKwy1BPw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.974.23':
     resolution: {integrity: sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.975.3':
+    resolution: {integrity: sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-cognito-identity@3.972.48':
@@ -767,32 +803,64 @@ packages:
     resolution: {integrity: sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.59':
+    resolution: {integrity: sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.51':
     resolution: {integrity: sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.61':
+    resolution: {integrity: sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.56':
     resolution: {integrity: sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.973.4':
+    resolution: {integrity: sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.55':
     resolution: {integrity: sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.66':
+    resolution: {integrity: sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.58':
     resolution: {integrity: sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.70':
+    resolution: {integrity: sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.49':
     resolution: {integrity: sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.59':
+    resolution: {integrity: sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.55':
     resolution: {integrity: sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.3':
+    resolution: {integrity: sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.55':
     resolution: {integrity: sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.65':
+    resolution: {integrity: sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-providers@3.1075.0':
@@ -807,6 +875,10 @@ packages:
     resolution: {integrity: sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-s3@3.972.64':
+    resolution: {integrity: sha512-RBi43anhDBUv+HCfxCOXwGOE7GmT4n7ChV04Mwr22RhXTNcamW/iWnJlOotDPCZSrJ4dEvhZSiWWQMwLX+ZhFA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-websocket@3.972.31':
     resolution: {integrity: sha512-ps1rumU1LybSFHaW9dTDgkhCMJLVaedEY78kKSzUDDY+b9974/g6aiaYYA0U9WV0oL4CJCJrVWG+EZ/qr4or7g==}
     engines: {node: '>= 14.0.0'}
@@ -815,8 +887,16 @@ packages:
     resolution: {integrity: sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.33':
+    resolution: {integrity: sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.35':
     resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.41':
+    resolution: {integrity: sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1048.0':
@@ -827,8 +907,16 @@ packages:
     resolution: {integrity: sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1088.0':
+    resolution: {integrity: sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.13':
     resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.8':
@@ -839,8 +927,16 @@ packages:
     resolution: {integrity: sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/xml-builder@3.972.36':
+    resolution: {integrity: sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
@@ -1264,6 +1360,9 @@ packages:
   '@dotenvx/primitives@0.8.0':
     resolution: {integrity: sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg==}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@earendil-works/pi-agent-core@0.80.2':
     resolution: {integrity: sha512-BF9WPhixIFjT6Kp3Iz3H6ugkU+4AWotM8py96XE5pIK0arJbQKMWbR+dXSWWDEmR5yc/aFQODnuyowOEzMGO7Q==}
     engines: {node: '>=22.19.0'}
@@ -1312,6 +1411,14 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -1324,6 +1431,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -1334,6 +1447,12 @@ packages:
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -1348,6 +1467,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -1360,6 +1485,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -1370,6 +1501,12 @@ packages:
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -1384,6 +1521,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -1394,6 +1537,12 @@ packages:
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -1408,6 +1557,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -1418,6 +1573,12 @@ packages:
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -1432,6 +1593,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -1442,6 +1609,12 @@ packages:
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -1456,6 +1629,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -1466,6 +1645,12 @@ packages:
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -1480,6 +1665,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -1492,6 +1683,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -1502,6 +1699,12 @@ packages:
     resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -1528,6 +1731,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -1550,6 +1759,12 @@ packages:
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -1576,6 +1791,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -1587,6 +1808,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -1600,6 +1827,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -1610,6 +1843,12 @@ packages:
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -2951,12 +3190,24 @@ packages:
     resolution: {integrity: sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.29.5':
+    resolution: {integrity: sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.10':
+    resolution: {integrity: sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.2':
     resolution: {integrity: sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.5.2':
     resolution: {integrity: sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.7':
+    resolution: {integrity: sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -2975,12 +3226,24 @@ packages:
     resolution: {integrity: sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.9.7':
+    resolution: {integrity: sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/signature-v4@5.5.2':
     resolution: {integrity: sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.6.6':
+    resolution: {integrity: sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/types@4.15.0':
     resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
@@ -3162,6 +3425,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -3209,6 +3475,9 @@ packages:
 
   '@types/node@26.0.1':
     resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -3608,8 +3877,18 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
@@ -3643,9 +3922,15 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   buffer-image-size@0.6.4:
     resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
     engines: {node: '>=4.0'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -3710,6 +3995,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -3887,6 +4175,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
     peerDependencies:
@@ -3894,6 +4186,10 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -3982,6 +4278,10 @@ packages:
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
+
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
 
   drizzle-orm@0.45.2:
     resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
@@ -4114,6 +4414,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
@@ -4172,6 +4475,11 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -4253,6 +4561,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
 
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
@@ -4342,6 +4654,9 @@ packages:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -4399,6 +4714,9 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@11.3.6:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
@@ -4463,9 +4781,15 @@ packages:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   get-tsconfig@5.0.0-beta.4:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
     engines: {node: '>=20.20.0'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -4668,6 +4992,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -4689,6 +5016,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ini@7.0.0:
     resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
@@ -4926,6 +5256,10 @@ packages:
 
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
+
+  kysely@0.29.3:
+    resolution: {integrity: sha512-VHtBdW6XB/pgoTSqraM3UAa2rYoYdNXqnNPpX+8XXP+cwYbVEFuAp3HyPt1vpNfU9l7Y2kpUrA9QDPsy8uUqOQ==}
+    engines: {node: '>=22.0.0'}
 
   libsodium-wrappers@0.8.4:
     resolution: {integrity: sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==}
@@ -5306,6 +5640,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   mini-svg-data-uri@1.4.4:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
@@ -5334,6 +5672,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
@@ -5367,6 +5708,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -5387,6 +5731,10 @@ packages:
 
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
+
+  node-abi@3.94.0:
+    resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
+    engines: {node: '>=10'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -5674,6 +6022,40 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -5718,6 +6100,22 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
   posthog-js@1.395.0:
     resolution: {integrity: sha512-5iTb00CGt2eQUUiBQysQiX89RAbCN6wK2sDNzvs9zv0alaY8mJ0ZySrUD3LQ+XyLhgM5pCpacBuUwChqiYDLDw==}
 
@@ -5736,6 +6134,12 @@ packages:
 
   preact@10.29.3:
     resolution: {integrity: sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
 
   prettier-plugin-astro@0.14.1:
     resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
@@ -5791,6 +6195,9 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -5829,6 +6236,10 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
@@ -5848,6 +6259,10 @@ packages:
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -6119,6 +6534,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -6153,6 +6574,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -6166,6 +6590,10 @@ packages:
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -6237,6 +6665,10 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strnum@2.4.1:
     resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
 
@@ -6286,6 +6718,13 @@ packages:
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
   term-size@2.2.1:
@@ -6366,6 +6805,9 @@ packages:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo@2.10.0:
     resolution: {integrity: sha512-o016H9PPtuH2deb3mh3Vci3Avfi9UYgM/RONQisY7HnloupP0IFSbFS3gFYJgFJP8nwBrByHWFQIDa8T2zIXPw==}
@@ -6907,6 +7349,10 @@ packages:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
@@ -7349,6 +7795,14 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
+  '@aws-sdk/checksums@3.1000.18':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/client-bedrock-runtime@3.1048.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -7362,7 +7816,7 @@ snapshots:
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.26.0
       '@smithy/fetch-http-handler': 5.5.2
-      '@smithy/node-http-handler': 4.7.3
+      '@smithy/node-http-handler': 4.8.2
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -7379,6 +7833,20 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-s3@3.1089.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.18
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-node': 3.972.70
+      '@aws-sdk/middleware-sdk-s3': 3.972.64
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.23':
     dependencies:
       '@aws-sdk/types': 3.973.13
@@ -7387,6 +7855,17 @@ snapshots:
       '@smithy/core': 3.26.0
       '@smithy/signature-v4': 5.5.2
       '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.975.3':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.36
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.5
+      '@smithy/signature-v4': 5.6.6
+      '@smithy/types': 4.16.1
       bowser: 2.14.1
       tslib: 2.8.1
 
@@ -7406,6 +7885,14 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.51':
     dependencies:
       '@aws-sdk/core': 3.974.23
@@ -7414,6 +7901,16 @@ snapshots:
       '@smithy/fetch-http-handler': 5.5.2
       '@smithy/node-http-handler': 4.8.2
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.56':
@@ -7432,6 +7929,22 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.4':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-login': 3.972.66
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/credential-provider-imds': 4.4.10
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.55':
     dependencies:
       '@aws-sdk/core': 3.974.23
@@ -7439,6 +7952,15 @@ snapshots:
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.66':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.58':
@@ -7455,12 +7977,34 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.70':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-ini': 3.973.4
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/credential-provider-imds': 4.4.10
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.49':
     dependencies:
       '@aws-sdk/core': 3.974.23
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.55':
@@ -7473,6 +8017,16 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.3':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/token-providers': 3.1088.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.55':
     dependencies:
       '@aws-sdk/core': 3.974.23
@@ -7480,6 +8034,15 @@ snapshots:
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-providers@3.1075.0':
@@ -7516,6 +8079,15 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-s3@3.972.64':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-websocket@3.972.31':
     dependencies:
       '@aws-sdk/core': 3.974.23
@@ -7539,11 +8111,29 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.33':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.35':
     dependencies:
       '@aws-sdk/types': 3.973.13
       '@smithy/signature-v4': 5.5.2
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.41':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1048.0':
@@ -7564,9 +8154,23 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1088.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.13':
     dependencies:
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.8':
@@ -7578,7 +8182,14 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/xml-builder@3.972.36':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -8117,6 +8728,8 @@ snapshots:
 
   '@dotenvx/primitives@0.8.0': {}
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@earendil-works/pi-agent-core@0.80.2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-ai': 0.80.2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
@@ -8226,10 +8839,23 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.14.0
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -8238,10 +8864,16 @@ snapshots:
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -8250,10 +8882,16 @@ snapshots:
   '@esbuild/android-x64@0.28.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -8262,10 +8900,16 @@ snapshots:
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -8274,10 +8918,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -8286,10 +8936,16 @@ snapshots:
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -8298,10 +8954,16 @@ snapshots:
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -8310,16 +8972,25 @@ snapshots:
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -8334,6 +9005,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -8344,6 +9018,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -8358,10 +9035,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -8370,10 +9053,16 @@ snapshots:
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -9469,6 +10158,17 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/core@3.29.5':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.10':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.2':
     dependencies:
       '@smithy/core': 3.26.0
@@ -9479,6 +10179,12 @@ snapshots:
     dependencies:
       '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.7':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -9502,13 +10208,29 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.9.7':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/signature-v4@5.5.2':
     dependencies:
       '@smithy/core': 3.26.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.6.6':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/types@4.15.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
     dependencies:
       tslib: 2.8.1
 
@@ -9663,6 +10385,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.20.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -9714,6 +10440,12 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.20.0
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -9726,7 +10458,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 22.20.0
 
   '@types/semver@7.7.1': {}
 
@@ -9957,7 +10689,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alchemy@0.93.12(@cloudflare/vite-plugin@1.42.3(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260625.1)(wrangler@4.105.0(@cloudflare/workers-types@4.20260628.1)))(@opentelemetry/api@1.9.1)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260625.1):
+  alchemy@0.93.12(@aws-sdk/client-s3@3.1089.0)(@cloudflare/vite-plugin@1.42.3(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260625.1)(wrangler@4.105.0(@cloudflare/workers-types@4.20260628.1)))(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(kysely@0.29.3)(pg@8.22.0)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260625.1):
     dependencies:
       '@aws-sdk/credential-providers': 3.1075.0
       '@cloudflare/unenv-preset': 2.7.7(unenv@2.0.0-rc.21)(workerd@1.20260625.1)
@@ -9967,7 +10699,7 @@ snapshots:
       '@smithy/node-config-provider': 4.5.2
       '@smithy/types': 4.15.0
       aws4fetch: 1.0.20
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260628.1)(@opentelemetry/api@1.9.1)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260628.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(kysely@0.29.3)(pg@8.22.0)
       env-paths: 3.0.0
       esbuild: 0.25.12
       execa: 9.6.1
@@ -9990,6 +10722,7 @@ snapshots:
       ws: 8.21.0
       yaml: 2.9.0
     optionalDependencies:
+      '@aws-sdk/client-s3': 3.1089.0
       '@cloudflare/vite-plugin': 1.42.3(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(workerd@1.20260625.1)(wrangler@4.105.0(@cloudflare/workers-types@4.20260628.1))
       vite: 8.1.0(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -10205,7 +10938,22 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@12.11.1:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   bignumber.js@9.3.1: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   blake3-wasm@2.1.5: {}
 
@@ -10249,9 +10997,16 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  buffer-from@1.1.2: {}
+
   buffer-image-size@0.6.4:
     dependencies:
       '@types/node': 22.20.0
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-name@4.1.0:
     dependencies:
@@ -10303,6 +11058,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@1.1.4: {}
 
   ci-info@4.4.0: {}
 
@@ -10454,7 +11211,13 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   dedent@1.7.2: {}
+
+  deep-extend@0.6.0: {}
 
   deepmerge@4.3.1: {}
 
@@ -10525,10 +11288,22 @@ snapshots:
 
   dotenv@17.4.2: {}
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260628.1)(@opentelemetry/api@1.9.1):
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.22.4
+
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260628.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(kysely@0.29.3)(pg@8.22.0):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260628.1
       '@opentelemetry/api': 1.9.1
+      '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.20.0
+      better-sqlite3: 12.11.1
+      kysely: 0.29.3
+      pg: 8.22.0
 
   dset@3.1.4: {}
 
@@ -10573,6 +11348,10 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -10625,6 +11404,31 @@ snapshots:
       acorn: 8.17.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -10770,6 +11574,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  expand-template@2.0.3: {}
+
   expect-type@1.4.0: {}
 
   express-rate-limit@8.5.2(express@5.2.1):
@@ -10888,6 +11694,8 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -10949,6 +11757,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  fs-constants@1.0.0: {}
 
   fs-extra@11.3.6:
     dependencies:
@@ -11024,9 +11834,15 @@ snapshots:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   get-tsconfig@5.0.0-beta.4:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
 
@@ -11377,6 +12193,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -11396,6 +12214,8 @@ snapshots:
       module-details-from-path: 1.0.4
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ini@7.0.0: {}
 
@@ -11575,6 +12395,9 @@ snapshots:
   klona@2.0.6: {}
 
   kubernetes-types@1.30.0: {}
+
+  kysely@0.29.3:
+    optional: true
 
   libsodium-wrappers@0.8.4:
     dependencies:
@@ -12208,6 +13031,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@3.1.0: {}
+
   mini-svg-data-uri@1.4.4: {}
 
   miniflare@4.20260424.0:
@@ -12246,6 +13071,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mkdirp-classic@0.5.3: {}
+
   module-details-from-path@1.0.4: {}
 
   mri@1.2.0: {}
@@ -12276,6 +13103,8 @@ snapshots:
 
   nanoid@3.3.15: {}
 
+  napi-build-utils@2.0.0: {}
+
   negotiator@1.0.0: {}
 
   neotraverse@0.6.18: {}
@@ -12292,6 +13121,10 @@ snapshots:
   nlcst-to-string@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
+
+  node-abi@3.94.0:
+    dependencies:
+      semver: 7.8.5
 
   node-domexception@1.0.0: {}
 
@@ -12594,6 +13427,41 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
+  pg-protocol@1.15.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
@@ -12631,6 +13499,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
   posthog-js@1.395.0:
     dependencies:
       '@posthog/core': 1.38.0
@@ -12649,6 +13527,21 @@ snapshots:
   powershell-utils@0.1.0: {}
 
   preact@10.29.3: {}
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.94.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.5
+      tunnel-agent: 0.6.0
 
   prettier-plugin-astro@0.14.1:
     dependencies:
@@ -12696,7 +13589,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 26.0.1
+      '@types/node': 22.20.0
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -12705,6 +13598,11 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -12744,6 +13642,13 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
   react-dom@19.2.7(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -12767,6 +13672,12 @@ snapshots:
       isarray: 1.0.0
       process-nextick-args: 2.0.1
       safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
@@ -13249,6 +14160,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   sisteransi@1.0.5: {}
 
   sitemap@9.0.1:
@@ -13279,6 +14198,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
   source-map@0.6.1: {}
 
   source-map@0.7.6: {}
@@ -13289,6 +14213,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
 
@@ -13356,6 +14282,8 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
   strnum@2.4.1:
     dependencies:
       anynum: 1.0.1
@@ -13401,6 +14329,21 @@ snapshots:
   tailwindcss@4.3.1: {}
 
   tapable@2.3.3: {}
+
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   term-size@2.2.1: {}
 
@@ -13463,6 +14406,10 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   turbo@2.10.0:
     optionalDependencies:
@@ -13988,6 +14935,8 @@ snapshots:
       powershell-utils: 0.1.0
 
   xml-naming@0.1.0: {}
+
+  xtend@4.0.2: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
 allowBuilds:
   "@google/genai": true
   "@sentry/cli": true
+  better-sqlite3: true
   core-js: true
   esbuild: true
   koffi: true

--- a/schemas/caplets-config.schema.json
+++ b/schemas/caplets-config.schema.json
@@ -33,6 +33,194 @@
       "description": "Set false to disable anonymous Caplets telemetry for this user config.",
       "type": "boolean"
     },
+    "storage": {
+      "default": {
+        "type": "sqlite"
+      },
+      "description": "Authoritative Host State backend. SQLite is used when omitted.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "sqlite"
+            },
+            "path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "assets": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "sql"
+                    }
+                  },
+                  "required": ["type"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "s3"
+                    },
+                    "endpoint": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "region": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "bucket": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "prefix": {
+                      "type": "string"
+                    },
+                    "forcePathStyle": {
+                      "type": "boolean"
+                    },
+                    "accessKeyId": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "secretAccessKey": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": ["type", "region", "bucket"],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "bundleLimits": {
+              "type": "object",
+              "properties": {
+                "maxFiles": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 100000
+                },
+                "maxFileBytes": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "maxTotalBytes": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["type"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "postgres"
+            },
+            "connectionString": {
+              "type": "string",
+              "minLength": 1
+            },
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z_][a-z0-9_]{0,62}$"
+            },
+            "assets": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "sql"
+                    }
+                  },
+                  "required": ["type"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "s3"
+                    },
+                    "endpoint": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "region": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "bucket": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "prefix": {
+                      "type": "string"
+                    },
+                    "forcePathStyle": {
+                      "type": "boolean"
+                    },
+                    "accessKeyId": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "secretAccessKey": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": ["type", "region", "bucket"],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "bundleLimits": {
+              "type": "object",
+              "properties": {
+                "maxFiles": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 100000
+                },
+                "maxFileBytes": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "maxTotalBytes": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["type", "connectionString"],
+          "additionalProperties": false
+        }
+      ]
+    },
     "serve": {
       "description": "User-owned HTTP serve defaults. Ignored from project config for security.",
       "type": "object",

--- a/scripts/verify-sqlite-postgres-transfer.sh
+++ b/scripts/verify-sqlite-postgres-transfer.sh
@@ -1,0 +1,189 @@
+#!/bin/sh
+set -eu
+
+PGLOADER_IMAGE=${PGLOADER_IMAGE:-ghcr.io/dimitri/pgloader@sha256:f4d2e2d7229980516da69b1eb73d9e11f97fb567fce7421f5a0bc70cbe6c76bf}
+PSQL_IMAGE=${PSQL_IMAGE:-postgres:17.6-bookworm}
+schema=${CAPLETS_POSTGRES_SCHEMA:-caplets}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+[ "${CAPLETS_SQL_TRANSFER_CONFIRM:-}" = "offline-empty-target" ] || fail \
+  "set CAPLETS_SQL_TRANSFER_CONFIRM=offline-empty-target after stopping every Host Node and preparing an empty migrated target"
+: "${CAPLETS_SQLITE_SNAPSHOT:?CAPLETS_SQLITE_SNAPSHOT must name the offline SQLite backup}"
+: "${CAPLETS_TEST_POSTGRES_URL:?CAPLETS_TEST_POSTGRES_URL must use the target data-transfer role}"
+[ -f "$CAPLETS_SQLITE_SNAPSHOT" ] || fail "SQLite snapshot not found: $CAPLETS_SQLITE_SNAPSHOT"
+
+for command in sqlite3 docker; do
+  command -v "$command" >/dev/null 2>&1 || fail "$command is required"
+done
+if ! command -v psql >/dev/null 2>&1; then
+  psql() {
+    docker run --rm --network host "$PSQL_IMAGE" psql "$@"
+  }
+fi
+
+case "$schema" in
+  [a-z_]* ) ;;
+  * ) fail "CAPLETS_POSTGRES_SCHEMA must start with a lowercase letter or underscore" ;;
+esac
+case "$schema" in
+  *[!a-z0-9_]* ) fail "CAPLETS_POSTGRES_SCHEMA contains an invalid character" ;;
+esac
+[ "${#schema}" -le 63 ] || fail "CAPLETS_POSTGRES_SCHEMA must not exceed 63 characters"
+case "$CAPLETS_TEST_POSTGRES_URL" in
+  *"
+"* ) fail "CAPLETS_TEST_POSTGRES_URL must not contain a newline" ;;
+esac
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/caplets-sql-transfer.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+chmod 700 "$work"
+cp "$CAPLETS_SQLITE_SNAPSHOT" "$work/source.sqlite3"
+chmod 600 "$work/source.sqlite3"
+
+integrity=$(sqlite3 "$work/source.sqlite3" 'PRAGMA integrity_check;')
+[ "$integrity" = "ok" ] || fail "SQLite integrity_check failed: $integrity"
+foreign_key_errors=$(sqlite3 "$work/source.sqlite3" 'PRAGMA foreign_key_check;')
+[ -z "$foreign_key_errors" ] || fail "SQLite foreign_key_check reported violations"
+
+source_version=$(sqlite3 "$work/source.sqlite3" \
+  'SELECT version FROM caplets_schema WHERE singleton = 1;')
+target_schema=$(psql "$CAPLETS_TEST_POSTGRES_URL" -X -qAt -v ON_ERROR_STOP=1 \
+  -c 'SELECT current_schema();')
+[ "$target_schema" = "$schema" ] || fail \
+  "target role current_schema() is $target_schema, expected $schema; set its database search_path before loading"
+target_version=$(psql "$CAPLETS_TEST_POSTGRES_URL" -X -qAt -v ON_ERROR_STOP=1 \
+  -c "SELECT version FROM \"$schema\".caplets_schema WHERE singleton = 1;")
+[ -n "$source_version" ] || fail "source schema version is missing"
+[ "$source_version" = "$target_version" ] || fail \
+  "released schema versions differ (SQLite $source_version, PostgreSQL $target_version)"
+
+source_tables=$(sqlite3 "$work/source.sqlite3" \
+  "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT IN ('caplets_migrations', 'caplets_schema') ORDER BY name;")
+target_tables=$(psql "$CAPLETS_TEST_POSTGRES_URL" -X -qAt -v ON_ERROR_STOP=1 \
+  -c "SELECT table_name FROM information_schema.tables WHERE table_schema = '$schema' AND table_type = 'BASE TABLE' AND table_name NOT IN ('caplets_migrations', 'caplets_schema') ORDER BY table_name;")
+[ "$source_tables" = "$target_tables" ] || {
+  echo "SQLite application tables:" >&2
+  echo "$source_tables" >&2
+  echo "PostgreSQL application tables:" >&2
+  echo "$target_tables" >&2
+  fail "source and target application table sets differ"
+}
+
+for table in $target_tables; do
+  case "$table" in
+    [a-z_]* ) ;;
+    * ) fail "unexpected target table name: $table" ;;
+  esac
+  case "$table" in
+    *[!a-z0-9_]* ) fail "unexpected target table name: $table" ;;
+  esac
+  rows=$(psql "$CAPLETS_TEST_POSTGRES_URL" -X -qAt -v ON_ERROR_STOP=1 \
+    -c "SELECT count(*) FROM \"$schema\".\"$table\";")
+  [ "$rows" = "0" ] || fail "target table $schema.$table is not empty ($rows rows)"
+done
+
+load_file="$work/sqlite-data-only.load"
+: >"$load_file"
+loaded_tables=" "
+remaining_tables=$source_tables
+while [ -n "$remaining_tables" ]; do
+  ready_tables=
+  for table in $remaining_tables; do
+    dependencies=$(sqlite3 "$work/source.sqlite3" \
+      "SELECT DISTINCT \"table\" FROM pragma_foreign_key_list('$table') WHERE \"table\" <> '$table' AND \"table\" NOT IN ('caplets_migrations', 'caplets_schema') ORDER BY \"table\";")
+    blocked=false
+    for dependency in $dependencies; do
+      case "$loaded_tables" in
+        *" $dependency "* ) ;;
+        * ) blocked=true ;;
+      esac
+    done
+    [ "$blocked" = true ] || ready_tables="$ready_tables $table"
+  done
+  [ -n "$ready_tables" ] || fail "application table foreign keys contain a dependency cycle"
+
+  next_remaining=
+  for table in $remaining_tables; do
+    case " $ready_tables " in
+      *" $table "* ) ;;
+      * ) next_remaining="$next_remaining $table" ;;
+    esac
+  done
+  remaining_tables=$next_remaining
+
+  for table in $ready_tables; do
+    cat >>"$load_file" <<EOF
+LOAD DATABASE
+     FROM sqlite:///work/source.sqlite3
+     INTO $CAPLETS_TEST_POSTGRES_URL
+
+ WITH data only,
+      include no drop,
+      no truncate,
+      reset no sequences,
+      no foreign keys,
+      downcase identifiers
+
+ INCLUDING ONLY TABLE NAMES LIKE '$table'
+ ALTER SCHEMA 'public' RENAME TO '$schema'
+ EXCLUDING TABLE NAMES LIKE 'caplets_migrations', 'caplets_schema';
+
+EOF
+    loaded_tables="$loaded_tables$table "
+  done
+done
+chmod 600 "$work/sqlite-data-only.load"
+
+docker run --rm --network host \
+  --mount "type=bind,src=$work,dst=/work" \
+  "$PGLOADER_IMAGE" \
+  pgloader /work/sqlite-data-only.load
+
+for table in $source_tables; do
+  source_count=$(sqlite3 "$work/source.sqlite3" "SELECT count(*) FROM \"$table\";")
+  target_count=$(psql "$CAPLETS_TEST_POSTGRES_URL" -X -qAt -v ON_ERROR_STOP=1 \
+    -c "SELECT count(*) FROM \"$schema\".\"$table\";")
+  [ "$source_count" = "$target_count" ] || fail \
+    "row count mismatch for $table (SQLite $source_count, PostgreSQL $target_count)"
+  printf '%-48s %s\n' "$table" "$source_count"
+done
+
+compare_hash_projection() {
+  label=$1
+  sqlite_query=$2
+  postgres_query=$3
+  sqlite_projection=$(sqlite3 "$work/source.sqlite3" "$sqlite_query")
+  postgres_projection=$(psql "$CAPLETS_TEST_POSTGRES_URL" -X -qAt -v ON_ERROR_STOP=1 \
+    -c "$postgres_query")
+  [ "$sqlite_projection" = "$postgres_projection" ] || fail \
+    "durable content hash projection differs for $label"
+  echo "verified durable content hashes: $label"
+}
+
+compare_hash_projection caplet_revisions \
+  "SELECT revision_key, record_key, sequence, content_hash, ifnull(source_content_hash, '') FROM caplet_revisions ORDER BY revision_key;" \
+  "SELECT revision_key, record_key, sequence, content_hash, coalesce(source_content_hash, '') FROM \"$schema\".caplet_revisions ORDER BY revision_key;"
+compare_hash_projection caplet_asset_blobs \
+  "SELECT hash, size, lower(hex(payload)), ifnull(object_key, ''), verification_status FROM caplet_asset_blobs ORDER BY hash;" \
+  "SELECT hash, size, encode(payload, 'hex'), coalesce(object_key, ''), verification_status FROM \"$schema\".caplet_asset_blobs ORDER BY hash;"
+compare_hash_projection caplet_bundle_entries \
+  "SELECT revision_key, path, blob_hash, size FROM caplet_bundle_entries ORDER BY revision_key, path;" \
+  "SELECT revision_key, path, blob_hash, size FROM \"$schema\".caplet_bundle_entries ORDER BY revision_key, path;"
+compare_hash_projection caplet_installation_observations \
+  "SELECT observation_key, ifnull(content_hash, '') FROM caplet_installation_observations ORDER BY observation_key;" \
+  "SELECT observation_key, coalesce(content_hash, '') FROM \"$schema\".caplet_installation_observations ORDER BY observation_key;"
+
+unvalidated_fks=$(psql "$CAPLETS_TEST_POSTGRES_URL" -X -qAt -v ON_ERROR_STOP=1 \
+  -c "SELECT count(*) FROM pg_constraint WHERE connamespace = '$schema'::regnamespace AND contype = 'f' AND NOT convalidated;")
+[ "$unvalidated_fks" = "0" ] || fail "PostgreSQL has $unvalidated_fks unvalidated foreign keys"
+
+sequences=$(psql "$CAPLETS_TEST_POSTGRES_URL" -X -qAt -v ON_ERROR_STOP=1 \
+  -c "SELECT count(*) FROM pg_class sequence JOIN pg_namespace namespace ON namespace.oid = sequence.relnamespace WHERE sequence.relkind = 'S' AND namespace.nspname = '$schema' AND NOT EXISTS (SELECT 1 FROM pg_depend dependency JOIN pg_class owner_table ON owner_table.oid = dependency.refobjid WHERE dependency.objid = sequence.oid AND owner_table.relname IN ('caplets_migrations', 'caplets_schema'));")
+[ "$sequences" = "0" ] || fail \
+  "target has $sequences sequences; run the release-specific identity reset procedure and verify next values"
+
+echo "offline transfer verified; run 'caplets storage status --json' with the target runtime config before cutover"


### PR DESCRIPTION
## Summary
- make SQLite the default authoritative host-state backend and support PostgreSQL for clustered deployments
- persist Caplet records, revisions, installations, security state, Vault state, coordination, and operator activity through relational storage
- add deterministic Markdown import/export, filesystem overlay precedence, legacy migration, dashboard/CLI administration, S3 asset verification, and deployment guidance
- harden cluster parity, database-time leases, transaction boundaries, and fail-closed readiness
- clarify issue-tracker and triage guidance

## Verification
- `pnpm verify`
- focused SQLite/PostgreSQL storage and parity tests
- live PostgreSQL lease/fencing checks
- live S3 current-asset health checks
- Docker Compose PostgreSQL migration/runtime/health smoke test