### PR TITLE
fix(native): resolve platform runtime dependencies

### DIFF
--- a/.changeset/fix-native-core-runtime.md
+++ b/.changeset/fix-native-core-runtime.md
@@ -1,0 +1,6 @@
+---
+"@caplets/pi": patch
+"@caplets/opencode": patch
+---
+
+Load Caplets core through its declared package exports so the Pi and OpenCode integrations resolve platform-specific runtime dependencies correctly.

--- a/packages/opencode/rolldown.config.ts
+++ b/packages/opencode/rolldown.config.ts
@@ -11,5 +11,10 @@ export default defineConfig({
   plugins: runtimeSentryPlugins("opencode"),
   platform: "node",
   tsconfig: true,
-  external: ["@opencode-ai/plugin", "jsonc-parser"],
+  external: [
+    "@caplets/core/generated-tool-input-schema",
+    "@caplets/core/native",
+    "@opencode-ai/plugin",
+    "jsonc-parser",
+  ],
 });

--- a/packages/pi/rolldown.config.ts
+++ b/packages/pi/rolldown.config.ts
@@ -11,5 +11,10 @@ export default defineConfig({
   plugins: runtimeSentryPlugins("pi"),
   platform: "node",
   tsconfig: true,
-  external: ["@earendil-works/pi-coding-agent", "jsonc-parser"],
+  external: [
+    "@caplets/core/generated-tool-input-schema",
+    "@caplets/core/native",
+    "@earendil-works/pi-coding-agent",
+    "jsonc-parser",
+  ],
 });


### PR DESCRIPTION
## Summary

- externalize the declared `@caplets/core` runtime exports from the Pi bundle
- apply the same packaging boundary to the OpenCode integration
- add patch changesets for both native packages

## Problem

Bundling Caplets core into the native integration artifacts moved libSQL's dynamic native-module load into each integration bundle. Node then resolved from the integration package root and could not find `@libsql/linux-x64-gnu`, preventing Pi and OpenCode from loading.

## Verification

- `pi` starts with the Caplets extension enabled (`caplets ✓`)
- built Pi and OpenCode bundles import successfully under Node
- `pnpm --filter @caplets/pi test` (47 passed)
- `pnpm --filter @caplets/pi typecheck`
- `pnpm --filter @caplets/opencode test` (10 passed)
- `pnpm --filter @caplets/opencode typecheck`
- pre-push `pnpm verify` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform-specific runtime resolution for Pi and OpenCode integrations.
  * Fixed packaging so native runtime components and generated tool schemas load correctly.

* **Chores**
  * Updated patch release metadata for the Pi and OpenCode packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->